### PR TITLE
feat: implement jump list navigation (Ctrl+O/Ctrl+I)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ All notable changes to Reovim will be documented in this file.
 
 ### Fixed
 
+- **Jump list navigation (Ctrl+O/Ctrl+I)** - Fixed non-functional jump navigation (#4)
+  - Added Tab as fallback keybinding for jump-newer (works in all terminals)
+  - Enabled Kitty keyboard enhancement protocol for modern terminals (kitty, WezTerm, foot)
+  - Added Ctrl+O/Ctrl+I/Tab bindings to insert mode (jump navigation works during editing)
+  - Jump points recorded when **leaving** insert mode (records where editing finished, not started)
+  - Fixed `current_index` calculation bug where first Ctrl+O did nothing
+  - Fixed duplicate detection causing `current_index` to become invalid
+  - Fixed duplicate detection truncating jump history (entries were lost on subsequent pushes)
+  - Fixed INSERT LEAVE truncating all previous jump entries (now preserves full history)
+  - Fixed Ctrl+O requiring double press (now automatically skips current position)
+  - Marked LSP goto definition/references commands as jumps (gd, gr)
+  - Marked leap and buffer navigation commands as jump-recording actions (s/S, H/L)
+  - Root cause: Ctrl+I was indistinguishable from Tab in traditional terminals
+  - UX improvement: Jump back to where you **finished** editing, not where you started
+
 - **Landing page animation alignment** - All frame lines now have consistent widths to prevent horizontal shifting during animation
 
 - **Landing page size thresholds** - Adjusted thresholds so "Large" requires actually large terminals (50×24+), "Medium" for normal windows (35×16+)

--- a/lib/core/src/bind/mod.rs
+++ b/lib/core/src/bind/mod.rs
@@ -590,6 +590,13 @@ impl KeyMap {
             keys![(Ctrl 'i')],
             KeyMapInner::with_command_id(builtin::JUMP_NEWER).with_category("jump"),
         );
+        // Tab fallback: In terminals without keyboard enhancement protocol,
+        // Ctrl+I is indistinguishable from Tab. Since Tab has no other use
+        // in normal mode, we bind it to jump-newer as a vim-compatible fallback.
+        normal.insert(
+            keys![Tab],
+            KeyMapInner::with_command_id(builtin::JUMP_NEWER).with_category("jump"),
+        );
 
         // Undo/Redo
         normal
@@ -713,6 +720,19 @@ impl KeyMap {
         insert
             .insert(keys![Backspace], KeyMapInner::with_command_id(builtin::DELETE_CHAR_BACKWARD));
         insert.insert(keys![Enter], KeyMapInner::with_command_id(builtin::INSERT_NEWLINE));
+        // Jump list navigation (works in insert mode too)
+        insert.insert(
+            keys![(Ctrl 'o')],
+            KeyMapInner::with_command_id(builtin::JUMP_OLDER).with_category("jump"),
+        );
+        insert.insert(
+            keys![(Ctrl 'i')],
+            KeyMapInner::with_command_id(builtin::JUMP_NEWER).with_category("jump"),
+        );
+        insert.insert(
+            keys![Tab],
+            KeyMapInner::with_command_id(builtin::JUMP_NEWER).with_category("jump"),
+        );
         // Completion keybindings are registered by the completion plugin
 
         // Editor Visual mode

--- a/lib/core/src/command/builtin/buffer.rs
+++ b/lib/core/src/command/builtin/buffer.rs
@@ -31,6 +31,10 @@ impl CommandTrait for BufferPrevCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn is_jump(&self) -> bool {
+        true
+    }
 }
 
 /// Switch to next buffer (L or ]b)
@@ -56,6 +60,10 @@ impl CommandTrait for BufferNextCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn is_jump(&self) -> bool {
+        true
     }
 }
 

--- a/lib/core/src/jumplist/mod.rs
+++ b/lib/core/src/jumplist/mod.rs
@@ -34,15 +34,18 @@ impl JumpList {
     /// Record a new position in the jump list
     ///
     /// This truncates any "future" entries if we're not at the end.
-    pub fn push(&mut self, buffer_id: usize, position: Position) {
+    /// Returns `true` if the entry was added, `false` if it was a duplicate.
+    pub fn push(&mut self, buffer_id: usize, position: Position) -> bool {
         let entry = JumpEntry {
             buffer_id,
             position,
         };
 
         // Don't add duplicate if same as last entry
+        // But DO update current_index to point past it
         if self.entries.last() == Some(&entry) {
-            return;
+            self.current_index = self.entries.len();
+            return false;
         }
 
         // Truncate any entries after current position
@@ -58,6 +61,7 @@ impl JumpList {
 
         // Update index to point to end
         self.current_index = self.entries.len();
+        true
     }
 
     /// Jump to older position (Ctrl-O)
@@ -89,6 +93,41 @@ impl JumpList {
     #[must_use]
     pub const fn current_index(&self) -> usize {
         self.current_index
+    }
+
+    /// Push a jump entry representing the current position (no truncation)
+    ///
+    /// Used when recording where you ARE (e.g., INSERT LEAVE), not where you're jumping FROM.
+    /// Unlike `push()`, this doesn't truncate history - it only appends.
+    /// Sets `current_index` to point at the new entry (not past it).
+    pub fn push_current(&mut self, buffer_id: usize, position: Position) -> bool {
+        let entry = JumpEntry {
+            buffer_id,
+            position,
+        };
+
+        // Don't add duplicate if same as last entry
+        if self.entries.last() == Some(&entry) {
+            // Point at the last entry (not past it)
+            if !self.entries.is_empty() {
+                self.current_index = self.entries.len() - 1;
+            }
+            return false;
+        }
+
+        // DON'T truncate - just append to preserve history
+        self.entries.push(entry);
+
+        // Enforce max size
+        if self.entries.len() > MAX_JUMP_LIST_SIZE {
+            self.entries.remove(0);
+        }
+
+        // Point PAST the current entry so first Ctrl+O goes to previous
+        // This matches the semantics of regular jumps - you're at the last position,
+        // and Ctrl+O takes you to the position before it
+        self.current_index = self.entries.len();
+        true
     }
 
     /// Get total entries for debugging/display

--- a/lib/core/src/landing/frames.rs
+++ b/lib/core/src/landing/frames.rs
@@ -239,12 +239,8 @@ pub const SMALL_FRAME_3: &[&str] = &[
 ];
 
 /// All small lion frames for breathing animation
-pub static SMALL_BREATHING_FRAMES: &[&[&str]] = &[
-    SMALL_FRAME_0,
-    SMALL_FRAME_1,
-    SMALL_FRAME_2,
-    SMALL_FRAME_3,
-];
+pub static SMALL_BREATHING_FRAMES: &[&[&str]] =
+    &[SMALL_FRAME_0, SMALL_FRAME_1, SMALL_FRAME_2, SMALL_FRAME_3];
 
 // =============================================================================
 // SIZE SELECTION

--- a/lib/core/src/landing/mod.rs
+++ b/lib/core/src/landing/mod.rs
@@ -8,8 +8,10 @@
 mod frames;
 mod sprite;
 
-pub use frames::LogoSize;
-pub use sprite::{AnimationMode, AsciiSprite};
+pub use {
+    frames::LogoSize,
+    sprite::{AnimationMode, AsciiSprite},
+};
 
 use frames::{LARGE_ROAR_FRAMES, MEDIUM_SLEEP_FRAMES, SMALL_BREATHING_FRAMES};
 
@@ -32,12 +34,8 @@ impl LandingState {
             LogoSize::Small => (SMALL_BREATHING_FRAMES, AnimationMode::Loop),
         };
 
-        let sprite = AsciiSprite::new(
-            frames,
-            size.frame_duration_ms(),
-            size.pause_duration_ms(),
-            mode,
-        );
+        let sprite =
+            AsciiSprite::new(frames, size.frame_duration_ms(), size.pause_duration_ms(), mode);
 
         Self { sprite, size }
     }

--- a/lib/core/src/landing/sprite.rs
+++ b/lib/core/src/landing/sprite.rs
@@ -136,10 +136,7 @@ impl AsciiSprite {
     /// Get current frame content
     #[must_use]
     pub fn current_frame(&self) -> &'static [&'static str] {
-        self.frames
-            .get(self.current_frame)
-            .copied()
-            .unwrap_or(&[])
+        self.frames.get(self.current_frame).copied().unwrap_or(&[])
     }
 
     /// Get current frame index

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -441,6 +441,28 @@ impl Runtime {
                 });
         }
 
+        // Enable keyboard enhancement protocol if supported
+        // This allows terminals (kitty, WezTerm, foot) to disambiguate Ctrl+I from Tab
+        if reovim_sys::terminal::supports_keyboard_enhancement().unwrap_or(false) {
+            use reovim_sys::{
+                ExecutableCommand,
+                event::{KeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+            };
+
+            match std::io::stdout().execute(PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+            )) {
+                Ok(_) => {
+                    tracing::info!("Keyboard enhancement protocol enabled");
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to enable keyboard enhancement: {}", e);
+                }
+            }
+        } else {
+            tracing::debug!("Keyboard enhancement not supported by terminal");
+        }
+
         runtime
     }
 
@@ -481,9 +503,13 @@ impl Runtime {
                 buf.begin_batch();
             }
         } else if was_insert && !is_insert {
-            // Leaving insert mode: flush batch
+            // Leaving insert mode: flush batch and record jump position
             if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
                 buf.flush_batch();
+                // Record current position as a jump point when leaving insert mode
+                // This allows navigating back to where editing was completed
+                // Use push_current() which doesn't truncate (preserves jump history)
+                self.jump_list.push_current(self.active_buffer_id, buf.cur);
             }
         }
 
@@ -1165,9 +1191,13 @@ impl super::RuntimeContext for Runtime {
                 buf.begin_batch();
             }
         } else if was_insert && !is_insert {
-            // Leaving insert mode: flush batch
+            // Leaving insert mode: flush batch and record jump position
             if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
                 buf.flush_batch();
+                // Record current position as a jump point when leaving insert mode
+                // This allows navigating back to where editing was completed
+                // Use push_current() which doesn't truncate (preserves jump history)
+                self.jump_list.push_current(self.active_buffer_id, buf.cur);
             }
         }
 
@@ -1177,5 +1207,14 @@ impl super::RuntimeContext for Runtime {
 
     fn screen_size(&self) -> (u16, u16) {
         (self.screen.width(), self.screen.height())
+    }
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        // Clean up keyboard enhancement protocol
+        use reovim_sys::{ExecutableCommand, event::PopKeyboardEnhancementFlags};
+
+        let _ = std::io::stdout().execute(PopKeyboardEnhancementFlags);
     }
 }

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -95,10 +95,8 @@ impl Runtime {
                 self.screen.width(),
                 self.screen.height().saturating_sub(1), // Reserve status line
             );
-            let landing_content = landing_state.generate(
-                self.screen.width(),
-                self.screen.height().saturating_sub(1),
-            );
+            let landing_content =
+                landing_state.generate(self.screen.width(), self.screen.height().saturating_sub(1));
             buffer.set_content(&landing_content);
             self.landing_state = Some(landing_state);
             self.showing_landing_page = true;
@@ -196,10 +194,8 @@ impl Runtime {
                 self.screen.width(),
                 self.screen.height().saturating_sub(1), // Reserve status line
             );
-            let landing_content = landing_state.generate(
-                self.screen.width(),
-                self.screen.height().saturating_sub(1),
-            );
+            let landing_content =
+                landing_state.generate(self.screen.width(), self.screen.height().saturating_sub(1));
             buffer.set_content(&landing_content);
             self.landing_state = Some(landing_state);
             self.showing_landing_page = true;

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -449,22 +449,84 @@ impl Runtime {
                             return should_quit;
                         }
                         DeferredAction::JumpOlder => {
-                            if let Some(entry) = self.jump_list.jump_older() {
+                            tracing::debug!(
+                                "JumpOlder: current_index={}, list_len={}",
+                                self.jump_list.current_index(),
+                                self.jump_list.len()
+                            );
+
+                            // Get current position to skip if jump returns the same position
+                            let current_buf_id = self.active_buffer_id;
+                            let current_pos = self.buffers.get(&current_buf_id).map(|b| b.cur);
+
+                            // Try to jump older, skipping current position if needed
+                            let mut found_different = false;
+                            while let Some(entry) = self.jump_list.jump_older() {
+                                let is_current = entry.buffer_id == current_buf_id
+                                    && current_pos == Some(entry.position);
+
+                                if is_current {
+                                    tracing::debug!("JumpOlder: skipping current position");
+                                    continue;
+                                }
+
+                                // Found a different position, jump to it
+                                tracing::debug!(
+                                    "JumpOlder: jumping to buffer={}, pos=({}, {})",
+                                    entry.buffer_id,
+                                    entry.position.y,
+                                    entry.position.x
+                                );
                                 let target_pos = entry.position;
                                 let target_buf_id = entry.buffer_id;
                                 if let Some(buf) = self.buffers.get_mut(&target_buf_id) {
                                     buf.cur = target_pos;
+                                    found_different = true;
+                                    break;
                                 }
+                                tracing::warn!("JumpOlder: buffer {} not found", target_buf_id);
+                            }
+
+                            if !found_different {
+                                tracing::debug!("JumpOlder: no different position found");
                             }
                             self.request_render();
                         }
                         DeferredAction::JumpNewer => {
-                            if let Some(entry) = self.jump_list.jump_newer() {
+                            // Get current position to skip if jump returns the same position
+                            let current_buf_id = self.active_buffer_id;
+                            let current_pos = self.buffers.get(&current_buf_id).map(|b| b.cur);
+
+                            // Try to jump newer, skipping current position if needed
+                            let mut found_different = false;
+                            while let Some(entry) = self.jump_list.jump_newer() {
+                                let is_current = entry.buffer_id == current_buf_id
+                                    && current_pos == Some(entry.position);
+
+                                if is_current {
+                                    tracing::debug!("JumpNewer: skipping current position");
+                                    continue;
+                                }
+
+                                // Found a different position, jump to it
+                                tracing::debug!(
+                                    "JumpNewer: jumping to buffer={}, pos=({}, {})",
+                                    entry.buffer_id,
+                                    entry.position.y,
+                                    entry.position.x
+                                );
                                 let target_pos = entry.position;
                                 let target_buf_id = entry.buffer_id;
                                 if let Some(buf) = self.buffers.get_mut(&target_buf_id) {
                                     buf.cur = target_pos;
+                                    found_different = true;
+                                    break;
                                 }
+                                tracing::warn!("JumpNewer: buffer {} not found", target_buf_id);
+                            }
+
+                            if !found_different {
+                                tracing::debug!("JumpNewer: no different position found");
                             }
                             self.request_render();
                         }

--- a/lib/core/src/testing/server.rs
+++ b/lib/core/src/testing/server.rs
@@ -67,8 +67,8 @@ impl ServerTestHarness {
             .stderr(Stdio::null())
             .spawn()?;
 
-        // Wait for server to be ready
-        sleep(Duration::from_millis(100)).await;
+        // Wait for server to be ready (longer on slower machines)
+        sleep(Duration::from_millis(200)).await;
 
         Ok(Self { process, port })
     }
@@ -100,8 +100,8 @@ impl ServerTestHarness {
             .stderr(Stdio::null())
             .spawn()?;
 
-        // Wait for server to be ready
-        sleep(Duration::from_millis(100)).await;
+        // Wait for server to be ready (longer on slower machines)
+        sleep(Duration::from_millis(200)).await;
 
         Ok(Self { process, port })
     }
@@ -112,12 +112,15 @@ impl ServerTestHarness {
     ///
     /// Returns an error if the connection fails.
     pub async fn client(&self) -> Result<TestClient, Box<dyn std::error::Error + Send + Sync>> {
-        // Retry connection a few times in case server isn't ready yet
-        for _ in 0..10 {
-            match TestClient::connect("127.0.0.1", self.port).await {
-                Ok(client) => return Ok(client),
-                Err(_) => sleep(Duration::from_millis(50)).await,
+        // Retry connection with exponential backoff in case server isn't ready yet
+        // This is more resilient on slower machines or under system load
+        for attempt in 0..20 {
+            if let Ok(client) = TestClient::connect("127.0.0.1", self.port).await {
+                return Ok(client);
             }
+            // Exponential backoff: 50ms, 100ms, 150ms, ..., up to 200ms
+            let delay = std::cmp::min(50 + attempt * 50, 200);
+            sleep(Duration::from_millis(delay)).await;
         }
         TestClient::connect("127.0.0.1", self.port)
             .await

--- a/plugins/features/leap/src/commands.rs
+++ b/plugins/features/leap/src/commands.rs
@@ -40,6 +40,10 @@ impl CommandTrait for LeapForwardCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn is_jump(&self) -> bool {
+        true
+    }
 }
 
 /// Leap backward command - starts leap mode searching backward
@@ -65,6 +69,10 @@ impl CommandTrait for LeapBackwardCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn is_jump(&self) -> bool {
+        true
     }
 }
 

--- a/plugins/features/lsp/src/command.rs
+++ b/plugins/features/lsp/src/command.rs
@@ -105,6 +105,10 @@ impl CommandTrait for LspGotoDefinitionCommand {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn is_jump(&self) -> bool {
+        true
+    }
 }
 
 /// Command: Find all references to symbol under cursor
@@ -137,6 +141,10 @@ impl CommandTrait for LspGotoReferencesCommand {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn is_jump(&self) -> bool {
+        true
     }
 }
 

--- a/plugins/features/microscope/src/microscope/picker/mod.rs
+++ b/plugins/features/microscope/src/microscope/picker/mod.rs
@@ -15,9 +15,7 @@ pub use registry::PickerRegistry;
 use std::{future::Future, path::PathBuf, pin::Pin};
 
 use reovim_core::{
-    command::CommandId,
-    decoration::SharedDecorationFactory,
-    highlight::ThemeName,
+    command::CommandId, decoration::SharedDecorationFactory, highlight::ThemeName,
     syntax::SharedSyntaxFactory,
 };
 

--- a/plugins/features/microscope/src/microscope/picker/registry.rs
+++ b/plugins/features/microscope/src/microscope/picker/registry.rs
@@ -125,6 +125,7 @@ mod tests {
         fn preview(
             &self,
             _item: &MicroscopeItem,
+            _ctx: &super::super::PickerContext,
         ) -> Pin<Box<dyn Future<Output = Option<PreviewContent>> + Send + '_>> {
             Box::pin(async { None })
         }

--- a/plugins/features/pickers/src/syntax_helper.rs
+++ b/plugins/features/pickers/src/syntax_helper.rs
@@ -1,7 +1,9 @@
 //! Syntax highlighting helper for microscope previews
 
-use reovim_core::{highlight::Highlight, syntax::SyntaxFactory};
-use reovim_plugin_microscope::microscope::StyledSpan;
+use {
+    reovim_core::{highlight::Highlight, syntax::SyntaxFactory},
+    reovim_plugin_microscope::microscope::StyledSpan,
+};
 
 /// Compute styled lines for preview content
 ///
@@ -93,8 +95,10 @@ fn convert_highlights_to_spans(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use reovim_core::highlight::{Span, Style};
+    use {
+        super::*,
+        reovim_core::highlight::{HighlightGroup, Span, Style},
+    };
 
     #[test]
     fn test_single_line_highlight() {
@@ -107,6 +111,7 @@ mod tests {
                 end_col: 2,
             },
             style: Style::default(),
+            group: HighlightGroup::Syntax,
         }];
 
         let spans = convert_highlights_to_spans(highlights, &lines);
@@ -131,6 +136,7 @@ mod tests {
                 end_col: 10,
             },
             style: Style::default(),
+            group: HighlightGroup::Syntax,
         }];
 
         let spans = convert_highlights_to_spans(highlights, &lines);

--- a/plugins/features/treesitter/src/theme.rs
+++ b/plugins/features/treesitter/src/theme.rs
@@ -9,8 +9,10 @@
 
 use std::collections::HashMap;
 
-use reovim_core::highlight::{Style, ThemeName};
-use reovim_sys::style::Color;
+use {
+    reovim_core::highlight::{Style, ThemeName},
+    reovim_sys::style::Color,
+};
 
 // =============================================================================
 // REO COLOR PALETTE
@@ -26,109 +28,277 @@ mod palette {
     // -------------------------------------------------------------------------
 
     /// #f38ba8 - HSL(343°, 81%, 75%) - Danger, mut, unsafe
-    pub const RED: Color = Color::Rgb { r: 243, g: 139, b: 168 };
+    pub const RED: Color = Color::Rgb {
+        r: 243,
+        g: 139,
+        b: 168,
+    };
     /// #ff6b6b - HSL(0°, 100%, 71%) - Errors, critical
-    pub const RED_BRIGHT: Color = Color::Rgb { r: 255, g: 107, b: 107 };
+    pub const RED_BRIGHT: Color = Color::Rgb {
+        r: 255,
+        g: 107,
+        b: 107,
+    };
     /// #eba0ac - HSL(350°, 65%, 77%) - Alt red, warnings
-    pub const MAROON: Color = Color::Rgb { r: 235, g: 160, b: 172 };
+    pub const MAROON: Color = Color::Rgb {
+        r: 235,
+        g: 160,
+        b: 172,
+    };
     /// #ff8a80 - HSL(5°, 100%, 75%) - HTML tags
-    pub const CORAL: Color = Color::Rgb { r: 255, g: 138, b: 128 };
+    pub const CORAL: Color = Color::Rgb {
+        r: 255,
+        g: 138,
+        b: 128,
+    };
     /// #fab387 - HSL(23°, 92%, 75%) - Constants, numbers
-    pub const ORANGE: Color = Color::Rgb { r: 250, g: 179, b: 135 };
+    pub const ORANGE: Color = Color::Rgb {
+        r: 250,
+        g: 179,
+        b: 135,
+    };
     /// #ffb86c - HSL(27°, 100%, 71%) - Float numbers
-    pub const PEACH: Color = Color::Rgb { r: 255, g: 184, b: 108 };
+    pub const PEACH: Color = Color::Rgb {
+        r: 255,
+        g: 184,
+        b: 108,
+    };
     /// #f9e2af - HSL(41°, 86%, 83%) - Integers, booleans
-    pub const GOLD: Color = Color::Rgb { r: 249, g: 226, b: 175 };
+    pub const GOLD: Color = Color::Rgb {
+        r: 249,
+        g: 226,
+        b: 175,
+    };
     /// #e5c07b - HSL(39°, 67%, 69%) - Parameters, type params
-    pub const YELLOW: Color = Color::Rgb { r: 229, g: 192, b: 123 };
+    pub const YELLOW: Color = Color::Rgb {
+        r: 229,
+        g: 192,
+        b: 123,
+    };
     /// #f0d9a0 - HSL(42°, 71%, 78%) - Patterns
-    pub const YELLOW_SOFT: Color = Color::Rgb { r: 240, g: 217, b: 160 };
+    pub const YELLOW_SOFT: Color = Color::Rgb {
+        r: 240,
+        g: 217,
+        b: 160,
+    };
 
     // -------------------------------------------------------------------------
     // GREEN CLUSTER (90-150° Hue) - Strings, properties, success
     // -------------------------------------------------------------------------
 
     /// #98c379 - HSL(95°, 38%, 62%) - Strings
-    pub const GREEN: Color = Color::Rgb { r: 152, g: 195, b: 121 };
+    pub const GREEN: Color = Color::Rgb {
+        r: 152,
+        g: 195,
+        b: 121,
+    };
     /// #a6e3a1 - HSL(115°, 54%, 76%) - Success, diff add
-    pub const GREEN_BRIGHT: Color = Color::Rgb { r: 166, g: 227, b: 161 };
+    pub const GREEN_BRIGHT: Color = Color::Rgb {
+        r: 166,
+        g: 227,
+        b: 161,
+    };
     /// #c3e88d - HSL(82°, 68%, 73%) - String interpolation
-    pub const LIME: Color = Color::Rgb { r: 195, g: 232, b: 141 };
+    pub const LIME: Color = Color::Rgb {
+        r: 195,
+        g: 232,
+        b: 141,
+    };
     /// #56b6c2 - HSL(187°, 47%, 55%) - Properties, fields
-    pub const TEAL: Color = Color::Rgb { r: 86, g: 182, b: 194 };
+    pub const TEAL: Color = Color::Rgb {
+        r: 86,
+        g: 182,
+        b: 194,
+    };
     /// #1abc9c - HSL(168°, 76%, 42%) - Lifetimes, hints
-    pub const TEAL_DARK: Color = Color::Rgb { r: 26, g: 188, b: 156 };
+    pub const TEAL_DARK: Color = Color::Rgb {
+        r: 26,
+        g: 188,
+        b: 156,
+    };
     /// #94e2d5 - HSL(170°, 57%, 73%) - Character literals
-    pub const MINT: Color = Color::Rgb { r: 148, g: 226, b: 213 };
+    pub const MINT: Color = Color::Rgb {
+        r: 148,
+        g: 226,
+        b: 213,
+    };
 
     // -------------------------------------------------------------------------
     // COOL CLUSTER (170-240° Hue) - Types, functions, imports
     // -------------------------------------------------------------------------
 
     /// #7dcfff - HSL(197°, 100%, 74%) - Attributes, imports
-    pub const CYAN: Color = Color::Rgb { r: 125, g: 207, b: 255 };
+    pub const CYAN: Color = Color::Rgb {
+        r: 125,
+        g: 207,
+        b: 255,
+    };
     /// #89dceb - HSL(189°, 71%, 73%) - Constructors
-    pub const CYAN_BRIGHT: Color = Color::Rgb { r: 137, g: 220, b: 235 };
+    pub const CYAN_BRIGHT: Color = Color::Rgb {
+        r: 137,
+        g: 220,
+        b: 235,
+    };
     /// #74c7ec - HSL(199°, 76%, 69%) - Info
-    pub const SKY: Color = Color::Rgb { r: 116, g: 199, b: 236 };
+    pub const SKY: Color = Color::Rgb {
+        r: 116,
+        g: 199,
+        b: 236,
+    };
     /// #2ac3de - HSL(189°, 71%, 52%) - Types (custom)
-    pub const AQUA: Color = Color::Rgb { r: 42, g: 195, b: 222 };
+    pub const AQUA: Color = Color::Rgb {
+        r: 42,
+        g: 195,
+        b: 222,
+    };
     /// #89ddff - HSL(191°, 100%, 77%) - Operators
-    pub const TURQUOISE: Color = Color::Rgb { r: 137, g: 221, b: 255 };
+    pub const TURQUOISE: Color = Color::Rgb {
+        r: 137,
+        g: 221,
+        b: 255,
+    };
     /// #7aa2f7 - HSL(220°, 89%, 72%) - Functions
-    pub const BLUE: Color = Color::Rgb { r: 122, g: 162, b: 247 };
+    pub const BLUE: Color = Color::Rgb {
+        r: 122,
+        g: 162,
+        b: 247,
+    };
     /// #89b4fa - HSL(217°, 92%, 76%) - Function definitions
-    pub const BLUE_BRIGHT: Color = Color::Rgb { r: 137, g: 180, b: 250 };
+    pub const BLUE_BRIGHT: Color = Color::Rgb {
+        r: 137,
+        g: 180,
+        b: 250,
+    };
     /// #3d59a1 - HSL(222°, 45%, 44%) - Modules, muted blue
-    pub const BLUE_DARK: Color = Color::Rgb { r: 61, g: 89, b: 161 };
+    pub const BLUE_DARK: Color = Color::Rgb {
+        r: 61,
+        g: 89,
+        b: 161,
+    };
     /// #6366f1 - HSL(239°, 84%, 67%) - Deep functions
-    pub const INDIGO: Color = Color::Rgb { r: 99, g: 102, b: 241 };
+    pub const INDIGO: Color = Color::Rgb {
+        r: 99,
+        g: 102,
+        b: 241,
+    };
 
     // -------------------------------------------------------------------------
     // PURPLE CLUSTER (260-320° Hue) - Keywords, control flow, macros
     // -------------------------------------------------------------------------
 
     /// #9d7cd8 - HSL(267°, 53%, 67%) - Keywords
-    pub const PURPLE: Color = Color::Rgb { r: 157, g: 124, b: 216 };
+    pub const PURPLE: Color = Color::Rgb {
+        r: 157,
+        g: 124,
+        b: 216,
+    };
     /// #bb9af7 - HSL(267°, 84%, 79%) - Control flow
-    pub const PURPLE_BRIGHT: Color = Color::Rgb { r: 187, g: 154, b: 247 };
+    pub const PURPLE_BRIGHT: Color = Color::Rgb {
+        r: 187,
+        g: 154,
+        b: 247,
+    };
     /// #c7b0fa - HSL(259°, 88%, 84%) - Type keywords
-    pub const LAVENDER: Color = Color::Rgb { r: 199, g: 176, b: 250 };
+    pub const LAVENDER: Color = Color::Rgb {
+        r: 199,
+        g: 176,
+        b: 250,
+    };
     /// #cba6f7 - HSL(267°, 84%, 81%) - Alt keywords
-    pub const MAUVE: Color = Color::Rgb { r: 203, g: 166, b: 247 };
+    pub const MAUVE: Color = Color::Rgb {
+        r: 203,
+        g: 166,
+        b: 247,
+    };
     /// #f5c2e7 - HSL(316°, 72%, 86%) - Macros
-    pub const MAGENTA: Color = Color::Rgb { r: 245, g: 194, b: 231 };
+    pub const MAGENTA: Color = Color::Rgb {
+        r: 245,
+        g: 194,
+        b: 231,
+    };
     /// #ff79c6 - HSL(326°, 100%, 74%) - Async/loops
-    pub const PINK: Color = Color::Rgb { r: 255, g: 121, b: 198 };
+    pub const PINK: Color = Color::Rgb {
+        r: 255,
+        g: 121,
+        b: 198,
+    };
     /// #f2cdcd - HSL(0°, 59%, 88%) - Decorators
-    pub const FLAMINGO: Color = Color::Rgb { r: 242, g: 205, b: 205 };
+    pub const FLAMINGO: Color = Color::Rgb {
+        r: 242,
+        g: 205,
+        b: 205,
+    };
     /// #f5e0dc - HSL(10°, 56%, 91%) - Special strings
-    pub const ROSEWATER: Color = Color::Rgb { r: 245, g: 224, b: 220 };
+    pub const ROSEWATER: Color = Color::Rgb {
+        r: 245,
+        g: 224,
+        b: 220,
+    };
 
     // -------------------------------------------------------------------------
     // NEUTRAL CLUSTER (Desaturated) - Text, backgrounds, UI
     // -------------------------------------------------------------------------
 
     /// #c0caf5 - HSL(227°, 70%, 85%) - Default text
-    pub const FG: Color = Color::Rgb { r: 192, g: 202, b: 245 };
+    pub const FG: Color = Color::Rgb {
+        r: 192,
+        g: 202,
+        b: 245,
+    };
     /// #a9b1d6 - HSL(227°, 36%, 75%) - Secondary text
-    pub const FG_DIM: Color = Color::Rgb { r: 169, g: 177, b: 214 };
+    pub const FG_DIM: Color = Color::Rgb {
+        r: 169,
+        g: 177,
+        b: 214,
+    };
     /// #9399b2 - HSL(227°, 20%, 65%) - Tertiary text
-    pub const FG_MUTED: Color = Color::Rgb { r: 147, g: 153, b: 178 };
+    pub const FG_MUTED: Color = Color::Rgb {
+        r: 147,
+        g: 153,
+        b: 178,
+    };
     /// #565f89 - HSL(225°, 23%, 44%) - Comments
-    pub const COMMENT: Color = Color::Rgb { r: 86, g: 95, b: 137 };
+    pub const COMMENT: Color = Color::Rgb {
+        r: 86,
+        g: 95,
+        b: 137,
+    };
     /// #6c7086 - HSL(227°, 12%, 47%) - Muted elements
-    pub const OVERLAY: Color = Color::Rgb { r: 108, g: 112, b: 134 };
+    pub const OVERLAY: Color = Color::Rgb {
+        r: 108,
+        g: 112,
+        b: 134,
+    };
     /// #3b4261 - HSL(224°, 25%, 30%) - Line numbers
-    pub const GUTTER: Color = Color::Rgb { r: 59, g: 66, b: 97 };
+    pub const GUTTER: Color = Color::Rgb {
+        r: 59,
+        g: 66,
+        b: 97,
+    };
     /// #45475a - HSL(225°, 13%, 31%) - Elevated surfaces
-    pub const SURFACE2: Color = Color::Rgb { r: 69, g: 71, b: 90 };
+    pub const SURFACE2: Color = Color::Rgb {
+        r: 69,
+        g: 71,
+        b: 90,
+    };
     /// #313244 - HSL(231°, 16%, 23%) - UI backgrounds
-    pub const SURFACE1: Color = Color::Rgb { r: 49, g: 50, b: 68 };
+    pub const SURFACE1: Color = Color::Rgb {
+        r: 49,
+        g: 50,
+        b: 68,
+    };
     /// #1e1e2e - HSL(240°, 23%, 15%) - Base background
-    pub const SURFACE0: Color = Color::Rgb { r: 30, g: 30, b: 46 };
+    pub const SURFACE0: Color = Color::Rgb {
+        r: 30,
+        g: 30,
+        b: 46,
+    };
     /// #181825 - HSL(240°, 21%, 12%) - Deepest background
-    pub const BLACK: Color = Color::Rgb { r: 24, g: 24, b: 37 };
+    pub const BLACK: Color = Color::Rgb {
+        r: 24,
+        g: 24,
+        b: 37,
+    };
 
     // -------------------------------------------------------------------------
     // SEMANTIC STATUS - Errors, warnings, diffs
@@ -535,8 +705,16 @@ mod tests {
         let theme = TreesitterTheme::reo();
 
         assert!(theme.style_for_capture("keyword").is_some());
-        assert!(theme.style_for_capture("keyword.control.conditional").is_some());
-        assert!(theme.style_for_capture("keyword.control.conditional.if").is_some());
+        assert!(
+            theme
+                .style_for_capture("keyword.control.conditional")
+                .is_some()
+        );
+        assert!(
+            theme
+                .style_for_capture("keyword.control.conditional.if")
+                .is_some()
+        );
     }
 
     #[test]
@@ -544,10 +722,38 @@ mod tests {
         use palette::*;
 
         // Verify key colors from each cluster
-        assert!(matches!(RED, Color::Rgb { r: 243, g: 139, b: 168 }));
-        assert!(matches!(GREEN, Color::Rgb { r: 152, g: 195, b: 121 }));
-        assert!(matches!(BLUE, Color::Rgb { r: 122, g: 162, b: 247 }));
-        assert!(matches!(PURPLE, Color::Rgb { r: 157, g: 124, b: 216 }));
+        assert!(matches!(
+            RED,
+            Color::Rgb {
+                r: 243,
+                g: 139,
+                b: 168
+            }
+        ));
+        assert!(matches!(
+            GREEN,
+            Color::Rgb {
+                r: 152,
+                g: 195,
+                b: 121
+            }
+        ));
+        assert!(matches!(
+            BLUE,
+            Color::Rgb {
+                r: 122,
+                g: 162,
+                b: 247
+            }
+        ));
+        assert!(matches!(
+            PURPLE,
+            Color::Rgb {
+                r: 157,
+                g: 124,
+                b: 216
+            }
+        ));
     }
 
     #[test]

--- a/plugins/languages/rust/src/lib.rs
+++ b/plugins/languages/rust/src/lib.rs
@@ -77,8 +77,7 @@ impl Plugin for RustPlugin {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use reovim_plugin_treesitter::LanguageSupport;
+    use {super::*, reovim_plugin_treesitter::LanguageSupport};
 
     #[test]
     fn test_highlights_query_compiles() {
@@ -88,11 +87,11 @@ mod tests {
 
         let query = tree_sitter::Query::new(&ts_lang, query_src);
         assert!(query.is_ok(), "Rust highlights query should compile: {:?}", query.err());
-        
+
         let q = query.unwrap();
         println!("Capture count: {}", q.capture_names().len());
         println!("Pattern count: {}", q.pattern_count());
-        
+
         // Print all captures
         for name in q.capture_names() {
             println!("Capture: {}", name);


### PR DESCRIPTION
Implements full jump list navigation with terminal compatibility and INSERT LEAVE recording. Fixed 5 bugs discovered through iterative user testing.

Features:
- Tab fallback for Ctrl+I (works in all terminals)
- Kitty keyboard enhancement protocol support
- Jump points recorded on INSERT LEAVE (where editing finished)
- Auto-skip current position (single keypress navigation)
- Insert mode jump navigation (Ctrl+O/Ctrl+I during editing)
- Marked as jumps: LSP gd/gr, leap s/S, buffer H/L

Closes #4 