### PR TITLE
feat(display): add plugin-specific status line styling API (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,21 @@ All notable changes to Reovim will be documented in this file.
   - `RegisterHealthCheck` event for plugins to register custom health checks
   - Built-in checks for runtime, plugin system, event bus, terminal, and keybindings
   - Plugin-decoupled architecture - zero core modifications using v0.7.9+ ex-command registry
+- **Plugin-specific status line styling** - Plugins can now provide custom colors for status line
+  - Each plugin defines its own `Style` with custom fg/bg colors
+  - Visual identity: Explorer (orange), Microscope (blue), Settings (gray), Leap (green), Health (teal)
+  - Status line shows `[INTERACTOR][MODE]` as separate colored sections
+  - `Color` type exported from `reovim_core::highlight` for plugin use
 
 ### Changed
+
+- **DisplayInfo API (BREAKING)** - Simplified and made styling mandatory
+  - `DisplayInfo::new()` now requires `style: Style` parameter
+  - Removed `EditModeKey`, `SubModeKey` enums (mode-specific displays removed)
+  - Removed `DisplayInfoBuilder::when_mode()` and `when_sub_mode()` methods
+  - `DisplayRegistry` simplified to single HashMap lookup
+  - `register_builtins()` now requires `theme` parameter
+  - Plugins must update to provide styles when registering display info
 
 - **Ex-command architecture refactored** - Full decoupling of core from plugin-specific commands (Issue #13)
   - Removed `Settings`, `ProfileLoad`, `ProfileSave`, `ProfileList` variants from `ExCommand` enum

--- a/lib/core/src/component/display.rs
+++ b/lib/core/src/component/display.rs
@@ -54,6 +54,8 @@ pub struct RenderState<'a> {
     pub renderer_registry: Option<&'a LanguageRendererRegistry>,
     /// Render stage registry for pipeline transformations
     pub render_stages: &'a std::sync::Arc<std::sync::RwLock<crate::render::RenderStageRegistry>>,
+    /// Display registry for plugin-provided display information
+    pub display_registry: &'a crate::display::DisplayRegistry,
 }
 
 impl std::fmt::Debug for RenderState<'_> {

--- a/lib/core/src/display/builder.rs
+++ b/lib/core/src/display/builder.rs
@@ -2,29 +2,24 @@
 //!
 //! Provides a fluent API for registering display info across multiple scopes.
 
-use crate::{
-    display::{DisplayInfo, EditModeKey, SubModeKey},
-    modd::{ComponentId, EditMode, SubMode},
-    plugin::PluginContext,
-};
+use crate::{display::DisplayInfo, modd::ComponentId, plugin::PluginContext};
 
 /// Builder for registering display information with a fluent API
 ///
 /// # Examples
 ///
 /// ```ignore
-/// // Register default and mode-specific displays
+/// // Register display info with custom color
+/// use reovim_core::highlight::{Style, Color};
+/// let style = Style::new().fg(fg_color).bg(bg_color).bold();
 /// ctx.display_info(COMPONENT_ID)
-///     .default(" EXPLORER ", "󰙅 ")
-///     .when_mode(EditMode::Insert(InsertVariant::Standard), " EXPLORER | INSERT ", "󰙅 ")
+///     .default(" EXPLORER ", "󰙅 ", style)
 ///     .register();
 /// ```
 pub struct DisplayInfoBuilder<'a> {
     ctx: &'a mut PluginContext,
     component_id: ComponentId,
     default_info: Option<DisplayInfo>,
-    mode_info: Vec<(EditModeKey, DisplayInfo)>,
-    sub_mode_info: Vec<(SubModeKey, DisplayInfo)>,
 }
 
 impl<'a> DisplayInfoBuilder<'a> {
@@ -35,63 +30,31 @@ impl<'a> DisplayInfoBuilder<'a> {
             ctx,
             component_id,
             default_info: None,
-            mode_info: Vec::new(),
-            sub_mode_info: Vec::new(),
         }
     }
 
     /// Set the default display info for this component
     ///
-    /// This is shown when the component is focused but no specific mode display is registered.
+    /// This is shown when the component is focused.
+    /// The MODE section will separately show the edit mode (Normal/Insert/Visual).
     #[must_use]
-    pub const fn default(mut self, name: &'static str, icon: &'static str) -> Self {
-        self.default_info = Some(DisplayInfo::new(name, icon));
-        self
-    }
-
-    /// Add display info for a specific edit mode
-    ///
-    /// For example, showing " EXPLORER | INSERT " when in insert mode within Explorer.
-    #[must_use]
-    pub fn when_mode(mut self, mode: &EditMode, name: &'static str, icon: &'static str) -> Self {
-        self.mode_info
-            .push((EditModeKey::from(mode), DisplayInfo::new(name, icon)));
-        self
-    }
-
-    /// Add display info for a sub-mode
-    ///
-    /// Sub-modes take priority over component/edit mode displays.
-    #[must_use]
-    pub fn when_sub_mode(
+    pub const fn default(
         mut self,
-        sub_mode: &SubMode,
         name: &'static str,
         icon: &'static str,
+        style: crate::highlight::Style,
     ) -> Self {
-        self.sub_mode_info
-            .push((SubModeKey::from(sub_mode), DisplayInfo::new(name, icon)));
+        self.default_info = Some(DisplayInfo::new(name, icon, style));
         self
     }
 
-    /// Register all configured display information
+    /// Register the display information
     ///
-    /// Consumes the builder and registers all display info with the plugin context.
+    /// Consumes the builder and registers the display info with the plugin context.
     pub fn register(self) {
         // Register default display for component
         if let Some(info) = self.default_info {
             self.ctx.register_display(self.component_id, info);
-        }
-
-        // Register component + mode combinations
-        for (mode_key, info) in self.mode_info {
-            self.ctx
-                .register_component_mode_display(self.component_id, mode_key, info);
-        }
-
-        // Register sub-modes
-        for (sub_mode_key, info) in self.sub_mode_info {
-            self.ctx.register_sub_mode_display(sub_mode_key, info);
         }
     }
 }

--- a/lib/core/src/display/mod.rs
+++ b/lib/core/src/display/mod.rs
@@ -10,7 +10,7 @@ pub use builder::DisplayInfoBuilder;
 
 use std::collections::HashMap;
 
-use crate::modd::{ComponentId, EditMode, InsertVariant, ModeState, SubMode, VisualVariant};
+use crate::modd::{ComponentId, ModeState};
 
 /// Display information for a mode/component
 #[derive(Debug, Clone)]
@@ -19,90 +19,40 @@ pub struct DisplayInfo {
     pub display_string: &'static str,
     /// Icon for compact display (e.g., "󰆾 ", "󰙅 ")
     pub icon: &'static str,
+    /// Style for this component's status line appearance
+    pub style: crate::highlight::Style,
 }
 
 impl DisplayInfo {
-    /// Create new display info with both display string and icon
+    /// Create new display info with display string, icon, and style
     #[must_use]
-    pub const fn new(display_string: &'static str, icon: &'static str) -> Self {
+    pub const fn new(
+        display_string: &'static str,
+        icon: &'static str,
+        style: crate::highlight::Style,
+    ) -> Self {
         Self {
             display_string,
             icon,
+            style,
         }
     }
 }
 
-/// Key for edit mode display lookup
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum EditModeKey {
-    Normal,
-    Insert,
-    InsertReplace,
-    VisualChar,
-    VisualLine,
-    VisualBlock,
-}
+// Removed EditModeKey and SubModeKey enums - no longer needed
+// since status line shows [INTERACTOR][MODE] as separate sections
 
-impl From<&EditMode> for EditModeKey {
-    fn from(mode: &EditMode) -> Self {
-        match mode {
-            EditMode::Normal => Self::Normal,
-            EditMode::Insert(InsertVariant::Standard) => Self::Insert,
-            EditMode::Insert(InsertVariant::Replace) => Self::InsertReplace,
-            EditMode::Visual(VisualVariant::Char) => Self::VisualChar,
-            EditMode::Visual(VisualVariant::Line) => Self::VisualLine,
-            EditMode::Visual(VisualVariant::Block) => Self::VisualBlock,
-        }
-    }
-}
-
-/// Key for sub-mode display lookup
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SubModeKey {
-    /// No sub-mode active
-    None,
-    /// Command line mode
-    Command,
-    /// Operator pending mode (d, y, c waiting for motion)
-    OperatorPending,
-    /// Plugin-provided interactor (identified by `ComponentId`)
-    Interactor(ComponentId),
-}
-
-impl From<&SubMode> for SubModeKey {
-    fn from(mode: &SubMode) -> Self {
-        match mode {
-            SubMode::None => Self::None,
-            SubMode::Command => Self::Command,
-            SubMode::OperatorPending { .. } => Self::OperatorPending,
-            SubMode::Interactor(id) => Self::Interactor(*id),
-        }
-    }
-}
-
-/// Registry for plugin-provided display strings and icons
+/// Registry for plugin-provided display information
 ///
-/// This registry allows plugins to register custom display information for:
-/// - Component focus (e.g., Explorer shows " EXPLORER ")
-/// - Edit modes within a component (e.g., Editor + Normal shows " NORMAL ")
-/// - Sub-modes (e.g., Command shows " COMMAND ")
+/// This registry allows plugins to register custom display information
+/// for their components (e.g., Explorer shows " EXPLORER " with orange color).
 ///
-/// Lookups are prioritized:
-/// 1. Sub-mode (if not None) - highest priority
-/// 2. Component + `EditMode` combination
-/// 3. Component only (default for that focus)
-/// 4. Fallback to hardcoded defaults
+/// The status line displays: [INTERACTOR][MODE] as two separate sections,
+/// so each component only needs one display registration.
 #[derive(Debug, Default)]
 pub struct DisplayRegistry {
-    /// Display info for component focus (`ComponentId` -> `DisplayInfo`)
+    /// Display info for each component (`ComponentId` -> `DisplayInfo`)
     interactors: HashMap<ComponentId, DisplayInfo>,
-
-    /// Display info for component + edit mode combination
-    /// Key: (`ComponentId`, `EditModeKey`)
-    component_modes: HashMap<(ComponentId, EditModeKey), DisplayInfo>,
-
-    /// Display info for sub-modes
-    sub_modes: HashMap<SubModeKey, DisplayInfo>,
 }
 
 impl DisplayRegistry {
@@ -112,57 +62,19 @@ impl DisplayRegistry {
         Self::default()
     }
 
-    /// Register display info for a component focus
+    /// Register display info for a component
     ///
-    /// This is used when the component is focused but no specific edit mode
-    /// display is registered.
+    /// This is shown in the INTERACTOR section of the status line.
+    /// The MODE section will separately show the edit mode (Normal/Insert/Visual).
     pub fn register_interactor(&mut self, id: ComponentId, info: DisplayInfo) {
         self.interactors.insert(id, info);
     }
 
-    /// Register display info for a component + edit mode combination
+    /// Get display info for a component
     ///
-    /// For example, Editor + Normal = " NORMAL ", Editor + Insert = " INSERT "
-    pub fn register_component_mode(
-        &mut self,
-        id: ComponentId,
-        mode: EditModeKey,
-        info: DisplayInfo,
-    ) {
-        self.component_modes.insert((id, mode), info);
-    }
-
-    /// Register display info for a sub-mode
-    ///
-    /// Sub-modes take priority over component/edit mode displays
-    pub fn register_sub_mode(&mut self, key: SubModeKey, info: DisplayInfo) {
-        self.sub_modes.insert(key, info);
-    }
-
-    /// Get display info for a mode state
-    ///
-    /// Returns the most specific display info available:
-    /// 1. Sub-mode (if not None)
-    /// 2. Component + edit mode
-    /// 3. Component only
-    /// 4. None (use fallback)
+    /// Simply looks up the component in the interactors map.
     #[must_use]
     pub fn get_display(&self, mode: &ModeState) -> Option<&DisplayInfo> {
-        // Priority 1: Sub-mode
-        let sub_key = SubModeKey::from(&mode.sub_mode);
-        if sub_key != SubModeKey::None
-            && let Some(info) = self.sub_modes.get(&sub_key)
-        {
-            return Some(info);
-        }
-
-        // Priority 2: Component + edit mode
-        let edit_key = EditModeKey::from(&mode.edit_mode);
-        if let Some(info) = self.component_modes.get(&(mode.interactor_id, edit_key)) {
-            return Some(info);
-        }
-
-        // Priority 3: Component only
         self.interactors.get(&mode.interactor_id)
     }
 
@@ -181,131 +93,86 @@ impl DisplayRegistry {
 
     /// Register all built-in display info
     ///
-    /// This registers the default display strings and icons for core components.
+    /// This registers the default display info for the core editor component.
     /// Plugins should register their own display info via `PluginContext`.
-    pub fn register_builtins(&mut self) {
-        // === Editor modes (core) ===
-        self.register_component_mode(
+    ///
+    /// Note: Editor modes (Normal/Insert/Visual) are shown in the MODE section
+    /// of the status line, not in the interactor section, so they don't need
+    /// to be registered here.
+    pub fn register_builtins(&mut self, theme: &crate::highlight::Theme) {
+        // Editor component
+        // Mode (Normal/Insert/Visual) will be shown separately in MODE section
+        self.register_interactor(
             ComponentId::EDITOR,
-            EditModeKey::Normal,
-            DisplayInfo::new(" NORMAL ", "󰆾 "),
+            DisplayInfo::new(" EDITOR ", "󰈸 ", theme.statusline.interactor.clone()),
         );
-        self.register_component_mode(
-            ComponentId::EDITOR,
-            EditModeKey::Insert,
-            DisplayInfo::new(" INSERT ", "󰏫 "),
-        );
-        self.register_component_mode(
-            ComponentId::EDITOR,
-            EditModeKey::InsertReplace,
-            DisplayInfo::new(" REPLACE ", "󰏫 "),
-        );
-        self.register_component_mode(
-            ComponentId::EDITOR,
-            EditModeKey::VisualChar,
-            DisplayInfo::new(" VISUAL ", "󰒉 "),
-        );
-        self.register_component_mode(
-            ComponentId::EDITOR,
-            EditModeKey::VisualLine,
-            DisplayInfo::new(" V-LINE ", "󰒉 "),
-        );
-        self.register_component_mode(
-            ComponentId::EDITOR,
-            EditModeKey::VisualBlock,
-            DisplayInfo::new(" V-BLOCK ", "󰒉 "),
-        );
-
-        // === Core sub-modes ===
-        self.register_sub_mode(SubModeKey::Command, DisplayInfo::new(" COMMAND ", " "));
-        self.register_sub_mode(SubModeKey::OperatorPending, DisplayInfo::new(" OPERATOR ", "󰆾 "));
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::modd::OperatorType};
+    use super::*;
 
     #[test]
     fn test_display_info_new() {
-        let info = DisplayInfo::new(" TEST ", "󰆾 ");
+        let style = crate::highlight::Style::new();
+        let info = DisplayInfo::new(" TEST ", "󰆾 ", style);
         assert_eq!(info.display_string, " TEST ");
         assert_eq!(info.icon, "󰆾 ");
     }
 
     #[test]
-    fn test_edit_mode_key_conversion() {
-        assert_eq!(EditModeKey::from(&EditMode::Normal), EditModeKey::Normal);
-        assert_eq!(
-            EditModeKey::from(&EditMode::Insert(InsertVariant::Standard)),
-            EditModeKey::Insert
-        );
-        assert_eq!(
-            EditModeKey::from(&EditMode::Insert(InsertVariant::Replace)),
-            EditModeKey::InsertReplace
-        );
-        assert_eq!(
-            EditModeKey::from(&EditMode::Visual(VisualVariant::Char)),
-            EditModeKey::VisualChar
-        );
-    }
-
-    #[test]
-    fn test_sub_mode_key_conversion() {
-        assert_eq!(SubModeKey::from(&SubMode::None), SubModeKey::None);
-        assert_eq!(SubModeKey::from(&SubMode::Command), SubModeKey::Command);
-        assert_eq!(
-            SubModeKey::from(&SubMode::OperatorPending {
-                operator: OperatorType::Delete,
-                count: None
-            }),
-            SubModeKey::OperatorPending
-        );
-        assert_eq!(
-            SubModeKey::from(&SubMode::Interactor(ComponentId("leap"))),
-            SubModeKey::Interactor(ComponentId("leap"))
-        );
-    }
-
-    #[test]
-    fn test_registry_lookup_priority() {
+    fn test_registry_lookup() {
         let mut registry = DisplayRegistry::new();
+        let style = crate::highlight::Style::new();
 
-        // Register component, component+mode, and sub-mode
-        registry
-            .register_interactor(ComponentId::EDITOR, DisplayInfo::new(" EDITOR DEFAULT ", "E"));
-        registry.register_component_mode(
+        // Register a component
+        registry.register_interactor(
             ComponentId::EDITOR,
-            EditModeKey::Normal,
-            DisplayInfo::new(" NORMAL ", "N"),
+            DisplayInfo::new(" EDITOR ", "󰈸 ", style),
         );
-        registry.register_sub_mode(SubModeKey::Command, DisplayInfo::new(" COMMAND ", "C"));
 
-        // Sub-mode takes priority
-        let command_mode = ModeState::command();
-        assert_eq!(registry.display_string(&command_mode).as_str(), " COMMAND ");
-
-        // Component + mode is second priority
-        let normal_mode = ModeState::normal();
-        assert_eq!(registry.display_string(&normal_mode).as_str(), " NORMAL ");
+        // Check that we can retrieve it
+        let mode = ModeState::normal();
+        let display = registry.get_display(&mode);
+        assert!(display.is_some());
+        assert_eq!(display.unwrap().display_string, " EDITOR ");
+        assert_eq!(display.unwrap().icon, "󰈸 ");
     }
 
     #[test]
     fn test_builtins_registration() {
         let mut registry = DisplayRegistry::new();
-        registry.register_builtins();
+        let theme = crate::highlight::Theme::default();
+        registry.register_builtins(&theme);
 
-        // Check editor normal mode
+        // Check that editor component is registered
         let normal = ModeState::normal();
-        assert_eq!(registry.display_string(&normal).as_str(), " NORMAL ");
-        assert_eq!(registry.icon(&normal), "󰆾 ");
+        let display = registry.get_display(&normal);
+        assert!(display.is_some());
+        assert_eq!(display.unwrap().display_string, " EDITOR ");
+        assert_eq!(display.unwrap().icon, "󰈸 ");
 
-        // Check command mode
-        let command = ModeState::command();
-        assert_eq!(registry.display_string(&command).as_str(), " COMMAND ");
+        // Display string should use plugin-provided text
+        assert_eq!(registry.display_string(&normal).as_str(), " EDITOR ");
+        assert_eq!(registry.icon(&normal), "󰈸 ");
+    }
 
-        // Check operator pending mode
-        let op = ModeState::operator_pending(crate::modd::OperatorType::Delete, None);
-        assert_eq!(registry.display_string(&op).as_str(), " OPERATOR ");
+    #[test]
+    fn test_fallback_for_unregistered() {
+        let registry = DisplayRegistry::new();
+
+        // Unregistered component should return None
+        let mode = ModeState::normal();
+        assert!(registry.get_display(&mode).is_none());
+
+        // display_string should fall back to hierarchical display
+        let display_str = registry.display_string(&mode);
+        // hierarchical_display() format is "component" or "component.submode"
+        assert!(!display_str.is_empty());
+        assert!(display_str.to_lowercase().contains("editor") || display_str.contains("editor"));
+
+        // icon should return default
+        assert_eq!(registry.icon(&mode), " ");
     }
 }

--- a/lib/core/src/highlight/mod.rs
+++ b/lib/core/src/highlight/mod.rs
@@ -15,6 +15,9 @@ pub use {
     },
 };
 
+// Re-export Color from reovim_sys for plugin use
+pub use reovim_sys::style::Color;
+
 /// Identifies the source/type of highlight for layering and management
 /// Lower values have lower priority (get overridden by higher values)
 ///

--- a/lib/core/src/plugin/builtin/core.rs
+++ b/lib/core/src/plugin/builtin/core.rs
@@ -96,7 +96,6 @@ use crate::{
         },
         id::CommandId,
     },
-    display::{DisplayInfo, EditModeKey, SubModeKey},
     event_bus::{
         EventBus, EventResult,
         core_events::{
@@ -153,7 +152,6 @@ impl Plugin for CorePlugin {
         self.register_buffer_commands(ctx);
         self.register_system_commands(ctx);
         self.register_window_mode_commands(ctx);
-        self.register_builtin_displays(ctx);
         self.register_default_keybindings(ctx);
     }
 
@@ -337,49 +335,6 @@ impl CorePlugin {
         let _ = ctx.register_command(WindowModeCloseCommand);
         let _ = ctx.register_command(WindowModeOnlyCommand);
         let _ = ctx.register_command(WindowModeEqualizeCommand);
-    }
-
-    /// Register built-in display strings and icons for core modes
-    fn register_builtin_displays(&self, ctx: &mut PluginContext) {
-        // === Editor modes ===
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::Normal,
-            DisplayInfo::new(" NORMAL ", "󰆾 "),
-        );
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::Insert,
-            DisplayInfo::new(" INSERT ", "󰏫 "),
-        );
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::InsertReplace,
-            DisplayInfo::new(" REPLACE ", "󰏫 "),
-        );
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::VisualChar,
-            DisplayInfo::new(" VISUAL ", "󰒉 "),
-        );
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::VisualLine,
-            DisplayInfo::new(" V-LINE ", "󰒉 "),
-        );
-        ctx.register_component_mode_display(
-            ComponentId::EDITOR,
-            EditModeKey::VisualBlock,
-            DisplayInfo::new(" V-BLOCK ", "󰒉 "),
-        );
-
-        // === Sub-modes (core only) ===
-        ctx.register_sub_mode_display(SubModeKey::Command, DisplayInfo::new(" COMMAND ", " "));
-        ctx.register_sub_mode_display(
-            SubModeKey::OperatorPending,
-            DisplayInfo::new(" OPERATOR ", "󰆾 "),
-        );
-        // Note: Plugin sub-modes (Leap, etc.) are registered by their respective plugins
     }
 
     /// Register default vim-style keybindings for the editor

--- a/lib/core/src/plugin/context.rs
+++ b/lib/core/src/plugin/context.rs
@@ -5,7 +5,7 @@ use std::{any::TypeId, borrow::Cow, sync::Arc};
 use crate::{
     bind::{CommandRef, KeyMap, KeymapScope},
     command::{CommandRegistry, CommandTrait},
-    display::{DisplayInfo, DisplayRegistry, EditModeKey, SubModeKey},
+    display::{DisplayInfo, DisplayRegistry},
     keystroke::KeySequence,
     modd::ComponentId,
     modifier::ModifierRegistry,
@@ -171,44 +171,6 @@ impl PluginContext {
     /// ```
     pub fn register_display(&mut self, id: ComponentId, info: DisplayInfo) {
         self.display_registry.register_interactor(id, info);
-    }
-
-    /// Register display info for a component + edit mode combination
-    ///
-    /// This allows different display strings for the same component
-    /// depending on the edit mode (Normal, Insert, Visual, etc.).
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// ctx.register_component_mode_display(
-    ///     ComponentId::EDITOR,
-    ///     EditModeKey::Normal,
-    ///     DisplayInfo::new(" NORMAL ", "󰆾 "),
-    /// );
-    /// ```
-    pub fn register_component_mode_display(
-        &mut self,
-        id: ComponentId,
-        mode: EditModeKey,
-        info: DisplayInfo,
-    ) {
-        self.display_registry
-            .register_component_mode(id, mode, info);
-    }
-
-    /// Register display info for a sub-mode
-    ///
-    /// Sub-modes (Command, `OperatorPending`, Leap, etc.) take priority
-    /// over component/edit mode displays.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// ctx.register_sub_mode_display(SubModeKey::Command, DisplayInfo::new(" COMMAND ", " "));
-    /// ```
-    pub fn register_sub_mode_display(&mut self, key: SubModeKey, info: DisplayInfo) {
-        self.display_registry.register_sub_mode(key, info);
     }
 
     /// Get access to the display registry

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -208,7 +208,7 @@ impl Runtime {
             .unwrap()
             .register(std::sync::Arc::new(animation_system.render_stage()));
 
-        let runtime = Self {
+        let mut runtime = Self {
             buffers: BTreeMap::new(),
             screen,
             highlight_store: HighlightStore::new(),
@@ -258,6 +258,9 @@ impl Runtime {
         runtime
             .plugin_state
             .set_command_registry(Arc::clone(&runtime.command_registry));
+
+        // Register built-in display info for status line
+        runtime.display_registry.register_builtins(&runtime.theme);
 
         // Subscribe to focus change requests from plugins
         {
@@ -660,6 +663,7 @@ impl Runtime {
             decoration_store: Some(&self.decoration_store),
             renderer_registry: Some(&self.renderer_registry),
             render_stages: &self.render_stages,
+            display_registry: &self.display_registry,
         };
         let pre_render = render_start.elapsed();
         self.screen

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -381,6 +381,7 @@ impl Screen {
             state.decoration_store,
             state.render_stages,
             state.plugin_state,
+            state.display_registry,
         )
     }
 
@@ -843,6 +844,7 @@ impl Screen {
         decoration_store: Option<&DecorationStore>,
         render_stages: &std::sync::Arc<std::sync::RwLock<crate::render::RenderStageRegistry>>,
         plugin_state: &std::sync::Arc<crate::plugin::PluginStateRegistry>,
+        display_registry: &crate::display::DisplayRegistry,
     ) -> std::result::Result<(), std::io::Error> {
         let rw_start = std::time::Instant::now();
         // Take frame renderer out (borrow checker workaround)
@@ -1075,6 +1077,7 @@ impl Screen {
                 theme,
                 color_mode,
                 plugin_state,
+                display_registry,
             );
         }
 
@@ -1736,6 +1739,7 @@ impl Screen {
         theme: &Theme,
         _color_mode: ColorMode,
         plugin_state: &std::sync::Arc<crate::plugin::PluginStateRegistry>,
+        display_registry: &crate::display::DisplayRegistry,
     ) {
         let y = self.size.height.saturating_sub(1);
         let mut x = 0u16;
@@ -1765,17 +1769,47 @@ impl Screen {
             };
 
         // === Section 1: Interactor (e.g., "Editor", "Explorer") ===
-        let interactor_text = format!(" {} ", mode.interactor_id.0);
+        // Query DisplayRegistry for plugin-provided display info
+        let (interactor_text, interactor_icon, actual_interactor_style) =
+            display_registry.get_display(mode).map_or_else(
+                || {
+                    // Fallback for unregistered components
+                    (
+                        format!(" {} ", mode.interactor_id.0),
+                        "",  // No icon fallback
+                        interactor_style,  // theme.statusline.interactor
+                    )
+                },
+                |info| {
+                    // Use plugin-provided info
+                    (
+                        info.display_string.to_string(),
+                        info.icon,
+                        &info.style,
+                    )
+                },
+            );
+
+        // Render icon if present
+        for ch in interactor_icon.chars() {
+            if x < buffer.width() {
+                let style = apply_sweep(actual_interactor_style, x);
+                buffer.put_char(x, y, ch, &style);
+                x += 1;
+            }
+        }
+
+        // Render text
         for ch in interactor_text.chars() {
             if x < buffer.width() {
-                let style = apply_sweep(interactor_style, x);
+                let style = apply_sweep(actual_interactor_style, x);
                 buffer.put_char(x, y, ch, &style);
                 x += 1;
             }
         }
 
         // Powerline separator: interactor -> mode
-        let sep_style = Self::create_separator_style(interactor_style, mode_style);
+        let sep_style = Self::create_separator_style(actual_interactor_style, mode_style);
         for ch in separator.left.chars() {
             if x < buffer.width() {
                 let style = apply_sweep(&sep_style, x);

--- a/plugins/features/explorer/src/lib.rs
+++ b/plugins/features/explorer/src/lib.rs
@@ -20,7 +20,7 @@ use reovim_core::{
     bind::{CommandRef, EditModeKind, KeymapScope},
     event_bus::{EventBus, EventResult},
     keys,
-    modd::{ComponentId, EditMode, InsertVariant, VisualVariant},
+    modd::ComponentId,
     plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
 };
 
@@ -780,10 +780,23 @@ pub const COMPONENT_ID: ComponentId = ComponentId("explorer");
 #[allow(clippy::unused_self)]
 impl ExplorerPlugin {
     fn register_display_info(&self, ctx: &mut PluginContext) {
+        use reovim_core::highlight::{Color, Style};
+
+        // Orange background for file explorer
+        let orange = Color::Rgb {
+            r: 255,
+            g: 153,
+            b: 51,
+        };
+        let fg = Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        };
+        let style = Style::new().fg(fg).bg(orange).bold();
+
         ctx.display_info(COMPONENT_ID)
-            .default(" EXPLORER ", "󰙅 ")
-            .when_mode(&EditMode::Insert(InsertVariant::Standard), " EXPLORER | INSERT ", "󰙅 ")
-            .when_mode(&EditMode::Visual(VisualVariant::Char), " EXPLORER | VISUAL ", "󰙅 ")
+            .default(" EXPLORER ", "󰙅 ", style)
             .register();
     }
 

--- a/plugins/features/health-check/src/lib.rs
+++ b/plugins/features/health-check/src/lib.rs
@@ -89,7 +89,22 @@ impl Plugin for HealthCheckPlugin {
 
     fn build(&self, ctx: &mut PluginContext) {
         // Register display info for status line
-        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" HEALTH ", " "));
+        use reovim_core::highlight::{Color, Style};
+
+        // Teal/cyan for health diagnostics (medical theme)
+        let teal = Color::Rgb {
+            r: 38,
+            g: 198,
+            b: 218,
+        };
+        let fg = Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        };
+        let style = Style::new().fg(fg).bg(teal).bold();
+
+        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" HEALTH ", " ", style));
 
         // Register commands
         let _ = ctx.register_command(HealthCheckOpen);

--- a/plugins/features/leap/src/lib.rs
+++ b/plugins/features/leap/src/lib.rs
@@ -16,7 +16,7 @@ use std::{any::TypeId, sync::Arc};
 
 use reovim_core::{
     bind::{CommandRef, KeymapScope},
-    display::{DisplayInfo, SubModeKey},
+    display::DisplayInfo,
     event_bus::{EventBus, EventResult},
     frame::FrameBuffer,
     highlight::{Style, Theme},
@@ -147,11 +147,23 @@ impl Plugin for LeapPlugin {
     }
 
     fn build(&self, ctx: &mut PluginContext) {
-        // Register sub-mode display info
-        ctx.register_sub_mode_display(
-            SubModeKey::Interactor(COMPONENT_ID),
-            DisplayInfo::new(" LEAP ", "\u{f0168} "),
-        );
+        // Register display info
+        use reovim_core::highlight::{Color, Style};
+
+        // Bright green for leap mode (like a "jump" or "go")
+        let green = Color::Rgb {
+            r: 76,
+            g: 175,
+            b: 80,
+        };
+        let fg = Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        };
+        let style = Style::new().fg(fg).bg(green).bold();
+
+        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" LEAP ", "\u{f0168} ", style));
 
         // Register commands
         let _ = ctx.register_command(LeapForwardCommand);

--- a/plugins/features/microscope/src/lib.rs
+++ b/plugins/features/microscope/src/lib.rs
@@ -22,7 +22,7 @@ use std::{any::TypeId, sync::Arc};
 
 use reovim_core::{
     bind::{CommandRef, EditModeKind, KeyMapInner, KeymapScope, SubModeKind},
-    display::{DisplayInfo, EditModeKey},
+    display::DisplayInfo,
     frame::FrameBuffer,
     highlight::Theme,
     keys,
@@ -534,17 +534,22 @@ impl Plugin for MicroscopePlugin {
 
     fn build(&self, ctx: &mut PluginContext) {
         // Register display info for status line
-        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" MICROSCOPE ", "󰍉 "));
-        ctx.register_component_mode_display(
-            COMPONENT_ID,
-            EditModeKey::Normal,
-            DisplayInfo::new(" MICROSCOPE ", "󰍉 "),
-        );
-        ctx.register_component_mode_display(
-            COMPONENT_ID,
-            EditModeKey::Insert,
-            DisplayInfo::new(" MICROSCOPE | INSERT ", "󰍉 "),
-        );
+        use reovim_core::highlight::{Color, Style};
+
+        // Blue background for search/picker
+        let blue = Color::Rgb {
+            r: 97,
+            g: 175,
+            b: 239,
+        };
+        let fg = Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        };
+        let style = Style::new().fg(fg).bg(blue).bold();
+
+        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" MICROSCOPE ", "󰍉 ", style));
 
         // Register picker opening commands
         let _ = ctx.register_command(MicroscopeFindFiles);

--- a/plugins/features/settings-menu/src/lib.rs
+++ b/plugins/features/settings-menu/src/lib.rs
@@ -34,7 +34,7 @@ use reovim_core::{
     bind::{CommandRef, EditModeKind, KeymapScope},
     command::id::CommandId,
     config::ProfileConfig,
-    display::{DisplayInfo, EditModeKey},
+    display::DisplayInfo,
     event_bus::{EventBus, EventResult, core_events::RequestFocusChange},
     frame::FrameBuffer,
     highlight::Theme,
@@ -246,12 +246,22 @@ impl Plugin for SettingsMenuPlugin {
 
     fn build(&self, ctx: &mut PluginContext) {
         // Register display info for status line
-        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" SETTINGS ", " "));
-        ctx.register_component_mode_display(
-            COMPONENT_ID,
-            EditModeKey::Insert,
-            DisplayInfo::new(" SETTINGS | INSERT ", " "),
-        );
+        use reovim_core::highlight::{Color, Style};
+
+        // Gray background for settings/configuration
+        let gray = Color::Rgb {
+            r: 92,
+            g: 99,
+            b: 112,
+        };
+        let fg = Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        };
+        let style = Style::new().fg(fg).bg(gray).bold();
+
+        ctx.register_display(COMPONENT_ID, DisplayInfo::new(" SETTINGS ", " ", style));
 
         // Register navigation commands (unified types)
         let _ = ctx.register_command(SettingsMenuOpen);


### PR DESCRIPTION
Extend the interactor API to allow each plugin to provide its own status line color/style. Previously, all interactors used a generic purple color.

**BREAKING CHANGE**: DisplayInfo API simplified with mandatory styling

Changes:
- DisplayInfo now requires style: Style parameter (BREAKING)
- Removed EditModeKey/SubModeKey enums (redundant with two-section design)
- Removed when_mode()/when_sub_mode() builder methods
- DisplayRegistry simplified to single HashMap lookup (~80 lines removed)
- display_registry threaded through RenderState and render pipeline
- Status line now queries DisplayRegistry for plugin-provided styles
- Color type exported from reovim_core::highlight for plugin use

Plugin colors:
- Explorer: Orange (255,153,51) - file operations, warm/active
- Microscope: Blue (97,175,239) - search/analysis, cool/focused
- Settings: Gray (92,99,112) - configuration, neutral
- Leap: Green (76,175,80) - jump navigation, energetic
- Health: Teal (38,198,218) - diagnostics, medical theme

Architecture: Status line shows [INTERACTOR][MODE] as separate colored sections, eliminating need for mode-specific displays like "EXPLORER | INSERT".

Closes #17