### PR TITLE
git commit -m "feat(server): add multi-instance support with port fallback and discovery (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Multi-instance server support** (Issue #19) - Multiple reovim servers can now run concurrently
+  - Port fallback: When default port (12521) is in use, server automatically tries 12522, 12523, etc.
+  - Port files: Each server writes `~/.local/share/reovim/servers/<pid>.port` for discovery
+  - `reo-cli list` command: Lists all running reovim server instances with PID and port
+  - Auto-discovery: `reo-cli` auto-connects to single server, prompts when multiple servers running
+  - Clean shutdown: Port files automatically removed when server exits
+
 - **Ex-command registry system** - Plugins can now register custom ex-commands dynamically
   - `ExCommandRegistry` for thread-safe command registration and dispatch
   - `RegisterExCommand` event for plugin-based command registration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,20 @@ Use `REOVIM_LOG=debug` to enable debug logging in spawned server processes.
 - Use generic APIs: `ComposableId::Custom("my_plugin")`
 - Extend core APIs only when multiple plugins would benefit
 
+### Process Safety Policy
+
+**NEVER kill other reovim instances.** Multiple reovim servers can run concurrently for debugging.
+
+**Forbidden commands:**
+- `pkill reovim` or `pkill -f reovim`
+- `killall reovim`
+- Any command that terminates reovim processes you didn't start
+
+**Safe alternatives:**
+- Use `reo-cli list` to see running servers
+- Use `reo-cli --tcp 127.0.0.1:<PORT> kill` to kill a specific server
+- Only kill servers you started in the current session
+
 ## Build Commands
 
 ```bash
@@ -84,8 +98,9 @@ cargo bench -p reovim-bench
 # Generate report from existing benchmark data
 cargo run -p perf-report -- update -v X.Y.Z
 
-# Run in server mode (TCP on 127.0.0.1:12521)
+# Run in server mode (TCP on 127.0.0.1:12521, or next available port)
 cargo run -- --server
+# Server prints "Listening on 127.0.0.1:<PORT>" to stderr
 
 # Run server with stdio transport
 cargo run -- --stdio
@@ -97,10 +112,10 @@ cargo run -- --listen-socket /tmp/reovim.sock
 cargo run -- --listen-tcp 9000
 
 # Run reo-cli client
-cargo run -p reo-cli -- mode
-cargo run -p reo-cli -- keys 'iHello<Esc>'
-# screen capture
-cargo run -p reo-cli -- capture
+cargo run -p reo-cli -- list              # List running servers
+cargo run -p reo-cli -- keys 'iHello<Esc>'  # Inject keys, show status (screen + mode + cursor)
+cargo run -p reo-cli -- --tcp 127.0.0.1:12522 keys 'j'  # Connect to specific server
+cargo run -p reo-cli -- -i                # Interactive REPL mode
 
 # View logs (timestamped files)
 tail -f ~/.local/share/reovim/reovim-*.log
@@ -250,6 +265,14 @@ Reovim is a Rust-based neovim-like text editor built with async tokio runtime an
 - `FrameBufferHandle` - Unified capture for all RPC formats (RawAnsi, PlainText, CellGrid)
 - Default port: 12521 ('r'×100 + 'e'×10 + 'o')
 - Server modes: `--server` (persistent, runs forever), `--server --test` (exit when all clients disconnect), `--stdio` (always one-shot)
+
+**Multi-Instance Support** (`runner/src/dirs.rs`, `runner/src/server.rs`):
+- Port fallback: If default port (12521) is in use, tries 12522, 12523, ... up to 12530
+- Port files: `~/.local/share/reovim/servers/<pid>.port` stores the bound port for discovery
+- Server prints `Listening on <host>:<port>` to stderr on startup
+- `reo-cli list` discovers running servers by scanning port files
+- Auto-discovery: `reo-cli` auto-connects to single server, prompts when multiple running
+- Clean shutdown removes port file automatically
 
 ### Event Flow
 

--- a/README.md
+++ b/README.md
@@ -119,14 +119,15 @@ reovim --server --terminal
 A CLI client tool is available for interacting with the server:
 
 ```bash
-# Connect to default server (127.0.0.1:12521)
-reo-cli mode                    # Get current mode
-reo-cli keys 'iHello<Esc>'      # Inject key sequence
-reo-cli cursor                  # Get cursor position
+# List running servers
+reo-cli list
+
+# Inject keys and show status (screen + mode + cursor)
+reo-cli keys 'iHello<Esc>'
 
 # Connect to custom address
-reo-cli --tcp localhost:9000 mode
-reo-cli --socket /tmp/reovim.sock mode
+reo-cli --tcp localhost:9000 keys 'j'
+reo-cli --socket /tmp/reovim.sock keys 'j'
 
 # Interactive REPL
 reo-cli --interactive

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,8 +36,8 @@ cargo run -p reovim -- --stdio
 cargo run -p reovim -- --listen-socket /tmp/reovim.sock
 
 # Run reo-cli client
-cargo run -p reo-cli -- mode
-cargo run -p reo-cli -- keys 'iHello<Esc>'
+cargo run -p reo-cli -- list              # List running servers
+cargo run -p reo-cli -- keys 'iHello<Esc>'  # Inject keys, show status
 
 # Check code without building
 cargo check

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -172,7 +172,7 @@ lib/core/tests/
 Spawns and manages a reovim server process:
 
 ```rust
-// Automatically spawns server on unique port (12600-12699)
+// Automatically spawns server on unique port (17000-17099)
 let harness = ServerTestHarness::spawn().await?;
 
 // Get a connected client
@@ -431,7 +431,19 @@ lib/core/tests/
 2. **Keep key sequences short** - Long sequences are harder to debug
 3. **Test one behavior per test** - Makes failures easier to diagnose
 4. **Use `with_content()` for cursor tests** - Need text to move through
-5. **Tests run in parallel** - Each spawns its own server on a unique port
+5. **Tests run in parallel** - Each spawns its own server on a unique port (17000-17099)
+
+### Port Allocation
+
+Integration tests use a **separate port range** (17000-17099) from regular server mode (12521+):
+
+- **Test servers**: Ports 17000-17099 (atomic allocation, wraps around)
+- **Regular servers**: Port 12521 by default, auto-increments to 12522, 12523, ... if in use
+
+This separation ensures:
+- Tests don't interfere with manually started debug servers
+- Multiple test runs can execute in parallel
+- `reo-cli list` only shows regular servers (not test instances)
 
 ### How It Works
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1188,6 +1188,14 @@ TransportListener::bind()
 
 **Default Port:** 12521 (derived from ASCII: 'r'×100 + 'e'×10 + 'o' = 11400 + 1010 + 111)
 
+**Multi-Instance Support** (`runner/src/dirs.rs`, `runner/src/server.rs`):
+- **Port fallback**: If default port (12521) is in use, tries 12522, 12523, ... up to 12530
+- **Port files**: Each server writes `~/.local/share/reovim/servers/<pid>.port` for discovery
+- **Startup output**: Server prints `Listening on <host>:<port>` to stderr
+- **Discovery**: `reo-cli list` scans port files to find running servers
+- **Auto-connect**: `reo-cli` auto-connects to single server, prompts when multiple running
+- **Clean shutdown**: Port files removed automatically when server exits
+
 **Edge Cases:**
 | Case | Behavior |
 |------|----------|
@@ -1195,6 +1203,9 @@ TransportListener::bind()
 | New client while old connected | Old connection orphaned, new one takes over |
 | No client connected | Requests process, responses dropped |
 | `--test` all clients disconnect | Server exits cleanly |
+| Default port in use | Tries next port (12522, 12523, ...) |
+| All ports 12521-12530 in use | Server fails with clear error |
+| Server crashes | Stale port file cleaned up on next `reo-cli list` |
 
 ## Architecture Patterns
 

--- a/docs/issues/lsp-commands-not-working.md
+++ b/docs/issues/lsp-commands-not-working.md
@@ -160,7 +160,7 @@ Questions to answer:
 3. Wait for rust-analyzer to initialize (check log for "Language server ready")
 4. Send keys: `cargo run -p reo-cli -- keys 'gg49jwK'`
 5. Wait for response: `sleep 5`
-6. Capture screen: `cargo run -p reo-cli -- capture`
+6. Check screen: `cargo run -p reo-cli -- keys ''`  # Empty keys to just show status
 7. Check logs: `grep -E "(hover|didOpen|definition|references)" /tmp/lsp.log`
 
 ## Related Files

--- a/lib/core/src/display/mod.rs
+++ b/lib/core/src/display/mod.rs
@@ -127,10 +127,8 @@ mod tests {
         let style = crate::highlight::Style::new();
 
         // Register a component
-        registry.register_interactor(
-            ComponentId::EDITOR,
-            DisplayInfo::new(" EDITOR ", "󰈸 ", style),
-        );
+        registry
+            .register_interactor(ComponentId::EDITOR, DisplayInfo::new(" EDITOR ", "󰈸 ", style));
 
         // Check that we can retrieve it
         let mode = ModeState::normal();

--- a/lib/core/src/rpc/transport.rs
+++ b/lib/core/src/rpc/transport.rs
@@ -176,6 +176,48 @@ pub enum TransportListener {
 }
 
 impl TransportListener {
+    /// Bind to TCP with port fallback
+    ///
+    /// Tries ports starting from `start_port` up to `start_port + max_attempts - 1`.
+    /// Returns the listener and the actual port that was bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if all ports in the range are unavailable or if binding fails
+    /// for a reason other than "address in use".
+    pub async fn bind_tcp_with_fallback(
+        host: &str,
+        start_port: u16,
+        max_attempts: u16,
+    ) -> io::Result<(Self, u16)> {
+        for offset in 0..max_attempts {
+            let port = start_port.saturating_add(offset);
+            let addr = format!("{host}:{port}");
+            match TcpListener::bind(&addr).await {
+                Ok(listener) => {
+                    if offset > 0 {
+                        tracing::info!("Port {} in use, bound to {} instead", start_port, port);
+                    } else {
+                        tracing::info!("Listening on TCP: {}", addr);
+                    }
+                    return Ok((Self::Tcp { listener }, port));
+                }
+                Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
+                    tracing::debug!("Port {} in use, trying next", port);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            format!(
+                "No available port in range {}-{}",
+                start_port,
+                start_port.saturating_add(max_attempts - 1)
+            ),
+        ))
+    }
+
     /// Bind to the given transport configuration
     ///
     /// Returns `None` for stdio (no listener needed).

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -1776,17 +1776,13 @@ impl Screen {
                     // Fallback for unregistered components
                     (
                         format!(" {} ", mode.interactor_id.0),
-                        "",  // No icon fallback
-                        interactor_style,  // theme.statusline.interactor
+                        "",               // No icon fallback
+                        interactor_style, // theme.statusline.interactor
                     )
                 },
                 |info| {
                     // Use plugin-provided info
-                    (
-                        info.display_string.to_string(),
-                        info.icon,
-                        &info.style,
-                    )
+                    (info.display_string.to_string(), info.icon, &info.style)
                 },
             );
 

--- a/runner/src/dirs.rs
+++ b/runner/src/dirs.rs
@@ -1,0 +1,71 @@
+//! XDG directory helpers for reovim
+//!
+//! Centralizes path logic for data and config directories following
+//! the XDG Base Directory specification.
+
+use std::path::PathBuf;
+
+/// Get the XDG data directory for reovim (~/.local/share/reovim)
+#[must_use]
+pub fn data_dir() -> PathBuf {
+    // Follow XDG Base Directory spec
+    // $XDG_DATA_HOME defaults to $HOME/.local/share
+    std::env::var("XDG_DATA_HOME")
+        .map_or_else(
+            |_| {
+                let home = std::env::var("HOME").expect("HOME environment variable not set");
+                PathBuf::from(home).join(".local").join("share")
+            },
+            PathBuf::from,
+        )
+        .join("reovim")
+}
+
+/// Get the servers directory for port files (~/.local/share/reovim/servers)
+#[must_use]
+pub fn servers_dir() -> PathBuf {
+    data_dir().join("servers")
+}
+
+/// Write a port file for the current process
+///
+/// Creates `~/.local/share/reovim/servers/<pid>.port` containing the port number.
+///
+/// # Errors
+///
+/// Returns an error if directory creation or file writing fails.
+pub fn write_port_file(port: u16) -> std::io::Result<PathBuf> {
+    let servers_dir = servers_dir();
+    std::fs::create_dir_all(&servers_dir)?;
+
+    let port_file = servers_dir.join(format!("{}.port", std::process::id()));
+    std::fs::write(&port_file, port.to_string())?;
+    tracing::info!("Port file written: {}", port_file.display());
+    Ok(port_file)
+}
+
+/// Remove a port file
+pub fn remove_port_file(path: &std::path::Path) {
+    if let Err(e) = std::fs::remove_file(path) {
+        tracing::warn!("Failed to remove port file: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_data_dir_contains_reovim() {
+        let dir = data_dir();
+        assert!(dir.ends_with("reovim"));
+    }
+
+    #[test]
+    fn test_servers_dir_is_subdir() {
+        let data = data_dir();
+        let servers = servers_dir();
+        assert!(servers.starts_with(&data));
+        assert!(servers.ends_with("servers"));
+    }
+}

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -7,6 +7,7 @@ use {
     std::io::{self, IsTerminal},
 };
 
+mod dirs;
 mod logging;
 mod plugins;
 mod server;

--- a/runner/src/server.rs
+++ b/runner/src/server.rs
@@ -7,6 +7,7 @@
 
 use std::{
     io,
+    path::PathBuf,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -123,6 +124,9 @@ pub async fn run_server(
     // Create RPC server with frame buffer handle for all capture formats
     let server = Arc::new(RpcServer::new(event_tx, key_tx, frame_handle, notification_tx));
 
+    // Track port file for cleanup on shutdown
+    let mut port_file_path: Option<PathBuf> = None;
+
     // Set up transport based on configuration
     match &transport_config {
         TransportConfig::Stdio => {
@@ -135,69 +139,48 @@ pub async fn run_server(
             let server_clone = Arc::clone(&server);
             tokio::spawn(run_server_loop(server_clone, request_rx, response_tx));
         }
-        TransportConfig::UnixSocket { .. } | TransportConfig::Tcp { .. } => {
-            // Listener mode: persistent server
+        TransportConfig::UnixSocket { path } => {
+            // Unix socket mode: bind directly (no port fallback needed)
             let listener = TransportListener::bind(&transport_config)
                 .await?
-                .expect("listener should be Some for non-stdio transport");
+                .expect("listener should be Some for unix socket transport");
 
-            let conn_state = Arc::new(ConnectionState {
-                response_tx: Mutex::new(None),
-                notification_tx: Mutex::new(None),
-                connection_count: AtomicUsize::new(0),
-            });
+            // Print the socket path to stderr
+            eprintln!("Listening on {}", path.display());
 
-            // Spawn persistent server loop (uses shared state for responses)
-            let server_clone = Arc::clone(&server);
-            let conn_state_clone = Arc::clone(&conn_state);
-            tokio::spawn(run_server_loop_persistent(server_clone, request_rx, conn_state_clone));
+            spawn_persistent_server(
+                listener,
+                server,
+                request_tx,
+                request_rx,
+                event_tx_for_shutdown,
+                test_mode,
+            );
+        }
+        TransportConfig::Tcp { host, port } => {
+            // TCP mode: use port fallback for multi-instance support
+            const MAX_PORT_ATTEMPTS: u16 = 10;
 
-            // Accept loop (runs in background)
-            let conn_state_accept = Arc::clone(&conn_state);
-            tokio::spawn(async move {
-                loop {
-                    tracing::info!("Waiting for client connection...");
-                    match listener.accept().await {
-                        Ok(conn) => {
-                            conn_state_accept
-                                .connection_count
-                                .fetch_add(1, Ordering::SeqCst);
-                            let count = conn_state_accept.connection_count.load(Ordering::SeqCst);
-                            tracing::info!("Client connected (active connections: {count})");
+            let (listener, actual_port) =
+                TransportListener::bind_tcp_with_fallback(host, *port, MAX_PORT_ATTEMPTS).await?;
 
-                            // Fresh channels for this connection
-                            let (resp_tx, resp_rx) = mpsc::channel::<RpcResponse>(256);
-                            let (notif_tx, notif_rx) = mpsc::channel::<RpcNotification>(256);
+            // Print the actual port to stderr for scripts/users to capture
+            eprintln!("Listening on {host}:{actual_port}");
 
-                            // Update shared state with new connection's channels
-                            *conn_state_accept.response_tx.lock().unwrap() = Some(resp_tx);
-                            *conn_state_accept.notification_tx.lock().unwrap() = Some(notif_tx);
-
-                            // Spawn connection handler that tracks disconnect
-                            let state = Arc::clone(&conn_state_accept);
-                            tokio::spawn(handle_connection(
-                                conn,
-                                request_tx.clone(),
-                                resp_rx,
-                                notif_rx,
-                                state,
-                            ));
-                        }
-                        Err(e) => {
-                            tracing::error!("Accept error: {e}");
-                        }
-                    }
-                }
-            });
-
-            // In test mode: run for 3 minutes then shutdown
-            if test_mode {
-                tokio::spawn(async move {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(180)).await;
-                    tracing::info!("Test mode: 3 minutes elapsed, shutting down");
-                    let _ = event_tx_for_shutdown.send(InnerEvent::KillSignal).await;
-                });
+            // Write port file for discovery (only for TCP)
+            match crate::dirs::write_port_file(actual_port) {
+                Ok(path) => port_file_path = Some(path),
+                Err(e) => tracing::warn!("Failed to write port file: {}", e),
             }
+
+            spawn_persistent_server(
+                listener,
+                server,
+                request_tx,
+                request_rx,
+                event_tx_for_shutdown,
+                test_mode,
+            );
         }
     }
 
@@ -210,8 +193,80 @@ pub async fn run_server(
         reovim_core::command::terminal::disable_raw_mode()?;
     }
 
+    // Remove port file on shutdown
+    if let Some(path) = port_file_path {
+        crate::dirs::remove_port_file(&path);
+    }
+
     tracing::info!("Server mode shutting down");
     Ok(())
+}
+
+/// Spawn the persistent server accept loop and related tasks
+fn spawn_persistent_server(
+    listener: TransportListener,
+    server: Arc<RpcServer>,
+    request_tx: mpsc::Sender<RpcRequest>,
+    request_rx: mpsc::Receiver<RpcRequest>,
+    event_tx_for_shutdown: mpsc::Sender<InnerEvent>,
+    test_mode: bool,
+) {
+    let conn_state = Arc::new(ConnectionState {
+        response_tx: Mutex::new(None),
+        notification_tx: Mutex::new(None),
+        connection_count: AtomicUsize::new(0),
+    });
+
+    // Spawn persistent server loop (uses shared state for responses)
+    let conn_state_clone = Arc::clone(&conn_state);
+    tokio::spawn(run_server_loop_persistent(server, request_rx, conn_state_clone));
+
+    // Accept loop (runs in background)
+    let conn_state_accept = Arc::clone(&conn_state);
+    tokio::spawn(async move {
+        loop {
+            tracing::info!("Waiting for client connection...");
+            match listener.accept().await {
+                Ok(conn) => {
+                    conn_state_accept
+                        .connection_count
+                        .fetch_add(1, Ordering::SeqCst);
+                    let count = conn_state_accept.connection_count.load(Ordering::SeqCst);
+                    tracing::info!("Client connected (active connections: {count})");
+
+                    // Fresh channels for this connection
+                    let (resp_tx, resp_rx) = mpsc::channel::<RpcResponse>(256);
+                    let (notif_tx, notif_rx) = mpsc::channel::<RpcNotification>(256);
+
+                    // Update shared state with new connection's channels
+                    *conn_state_accept.response_tx.lock().unwrap() = Some(resp_tx);
+                    *conn_state_accept.notification_tx.lock().unwrap() = Some(notif_tx);
+
+                    // Spawn connection handler that tracks disconnect
+                    let state = Arc::clone(&conn_state_accept);
+                    tokio::spawn(handle_connection(
+                        conn,
+                        request_tx.clone(),
+                        resp_rx,
+                        notif_rx,
+                        state,
+                    ));
+                }
+                Err(e) => {
+                    tracing::error!("Accept error: {e}");
+                }
+            }
+        }
+    });
+
+    // In test mode: run for 3 minutes then shutdown
+    if test_mode {
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(180)).await;
+            tracing::info!("Test mode: 3 minutes elapsed, shutting down");
+            let _ = event_tx_for_shutdown.send(InnerEvent::KillSignal).await;
+        });
+    }
 }
 
 /// Handle a single client connection, tracking its lifecycle

--- a/tools/reo-cli/src/discovery.rs
+++ b/tools/reo-cli/src/discovery.rs
@@ -1,0 +1,75 @@
+//! Server discovery for reo-cli
+//!
+//! Scans port files to find running reovim server instances.
+
+use std::path::PathBuf;
+
+/// Information about a running reovim server instance
+#[derive(Debug, Clone)]
+pub struct ServerInfo {
+    /// Process ID of the server
+    pub pid: u32,
+    /// TCP port the server is listening on
+    pub port: u16,
+}
+
+/// Get the XDG data directory for reovim
+fn data_dir() -> PathBuf {
+    std::env::var("XDG_DATA_HOME")
+        .map_or_else(
+            |_| {
+                let home = std::env::var("HOME").expect("HOME environment variable not set");
+                PathBuf::from(home).join(".local").join("share")
+            },
+            PathBuf::from,
+        )
+        .join("reovim")
+}
+
+/// Get the servers directory for port files
+fn servers_dir() -> PathBuf {
+    data_dir().join("servers")
+}
+
+/// Check if a process with the given PID exists
+fn process_exists(pid: u32) -> bool {
+    // Check if /proc/<pid> directory exists (Linux-specific but safe)
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// List running reovim server instances by scanning port files
+///
+/// Validates that the PID is still running and cleans up stale files.
+pub fn list_servers() -> Vec<ServerInfo> {
+    let servers_dir = servers_dir();
+    let Ok(entries) = servers_dir.read_dir() else {
+        return vec![];
+    };
+
+    entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let filename = entry.file_name();
+            let name = filename.to_str()?;
+
+            // Parse PID from filename (e.g., "12345.port")
+            let pid: u32 = name.strip_suffix(".port")?.parse().ok()?;
+
+            // Check if process is still running
+            if !process_exists(pid) {
+                // Cleanup stale file
+                let _ = std::fs::remove_file(entry.path());
+                return None;
+            }
+
+            // Read port from file
+            let port: u16 = std::fs::read_to_string(entry.path())
+                .ok()?
+                .trim()
+                .parse()
+                .ok()?;
+
+            Some(ServerInfo { pid, port })
+        })
+        .collect()
+}

--- a/tools/reo-cli/src/main.rs
+++ b/tools/reo-cli/src/main.rs
@@ -10,6 +10,7 @@ use {
 
 mod client;
 mod commands;
+mod discovery;
 mod repl;
 
 use client::ConnectionConfig;
@@ -20,7 +21,7 @@ const DEFAULT_PORT: u16 = 12521; // 'r'×100 + 'e'×10 + 'o' = 11400 + 1010 + 11
 /// CLI client for reovim server mode
 #[derive(Parser)]
 #[command(name = "reo-cli")]
-#[command(about = "Control reovim via JSON-RPC")]
+#[command(about = "Control reovim via JSON-RPC. Shows screen/mode/cursor by default.")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -44,20 +45,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// List running reovim server instances
+    List,
+
     /// Inject key sequence (vim notation)
     Keys {
         /// Key sequence (e.g., "iHello<Esc>")
         keys: String,
-    },
-
-    /// Get current mode
-    Mode,
-
-    /// Get cursor position
-    Cursor {
-        /// Buffer ID (default: active buffer)
-        #[arg(long)]
-        buffer_id: Option<u64>,
     },
 
     /// Get selection state
@@ -69,13 +63,6 @@ enum Commands {
 
     /// Get screen dimensions
     ScreenSize,
-
-    /// Get rendered screen capture
-    Capture {
-        /// Output format: `plain_text`, `raw_ansi`
-        #[arg(long, default_value = "plain_text")]
-        format: String,
-    },
 
     /// Buffer operations
     Buffer {
@@ -152,11 +139,35 @@ fn get_connection_config(cli: &Cli) -> Result<ConnectionConfig, String> {
             Ok(ConnectionConfig::Tcp { host, port })
         }
         (Some(_), Some(_)) => Err("Cannot specify both --socket and --tcp".to_string()),
-        // Default to TCP on DEFAULT_HOST:DEFAULT_PORT
-        (None, None) => Ok(ConnectionConfig::Tcp {
-            host: DEFAULT_HOST.to_string(),
-            port: DEFAULT_PORT,
-        }),
+        // Auto-discover running servers
+        (None, None) => {
+            let servers = discovery::list_servers();
+            match servers.len() {
+                0 => {
+                    // No servers found - fall back to default port (will fail with clear error)
+                    Ok(ConnectionConfig::Tcp {
+                        host: DEFAULT_HOST.to_string(),
+                        port: DEFAULT_PORT,
+                    })
+                }
+                1 => {
+                    // Single server - auto-connect
+                    Ok(ConnectionConfig::Tcp {
+                        host: DEFAULT_HOST.to_string(),
+                        port: servers[0].port,
+                    })
+                }
+                _ => {
+                    // Multiple servers - require explicit selection
+                    let server_list = servers
+                        .iter()
+                        .map(|s| format!("  --tcp {DEFAULT_HOST}:{} (PID {})", s.port, s.pid))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    Err(format!("Multiple servers running. Use --tcp to specify:\n{server_list}"))
+                }
+            }
+        }
     }
 }
 
@@ -164,42 +175,41 @@ fn get_connection_config(cli: &Cli) -> Result<ConnectionConfig, String> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    // Get connection config
-    let config = get_connection_config(&cli)?;
-
-    // Interactive mode
-    if cli.interactive || cli.command.is_none() {
-        return repl::run_repl(&config).await;
-    }
-
-    // One-shot mode
-    let mut client = client::ReoClient::connect(&config).await?;
-
-    let command = cli.command.unwrap();
-
-    // Handle screen-capture specially - print content directly, not as JSON
-    if let Commands::Capture { ref format } = command {
-        let result = commands::cmd_screen_content(&mut client, format).await?;
-
-        // Extract and print just the content field
-        if let Some(content) = result.get("content").and_then(Value::as_str) {
-            println!("{content}");
+    // Handle List command specially (doesn't need a connection)
+    if matches!(cli.command, Some(Commands::List)) {
+        let servers = discovery::list_servers();
+        if servers.is_empty() {
+            println!("No running reovim servers found");
         } else {
-            // Fallback to JSON if content field is missing
-            if cli.json {
-                println!("{}", serde_json::to_string(&result)?);
-            } else {
-                println!("{}", serde_json::to_string_pretty(&result)?);
+            println!("{:<10} {:<8}", "PID", "PORT");
+            for server in servers {
+                println!("{:<10} {:<8}", server.pid, server.port);
             }
         }
         return Ok(());
     }
 
+    // Get connection config
+    let config = get_connection_config(&cli)?;
+
+    // Interactive mode (explicit -i flag or no command)
+    if cli.interactive || cli.command.is_none() {
+        return repl::run_repl(&config).await;
+    }
+
+    // Connect to server
+    let mut client = client::ReoClient::connect(&config).await?;
+
+    let command = cli.command.unwrap();
+
+    // Keys command: inject keys then show status
+    if let Commands::Keys { ref keys } = command {
+        commands::cmd_keys(&mut client, keys).await?;
+        return show_status(&mut client).await;
+    }
+
     // All other commands - return JSON
     let result = match command {
-        Commands::Keys { keys } => commands::cmd_keys(&mut client, &keys).await?,
-        Commands::Mode => commands::cmd_mode(&mut client).await?,
-        Commands::Cursor { buffer_id } => commands::cmd_cursor(&mut client, buffer_id).await?,
         Commands::Selection { buffer_id } => {
             commands::cmd_selection(&mut client, buffer_id).await?
         }
@@ -220,7 +230,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Quit => commands::cmd_quit(&mut client).await?,
         Commands::Kill => commands::cmd_kill(&mut client).await?,
         Commands::Raw { json } => commands::cmd_raw(&mut client, &json).await?,
-        Commands::Capture { .. } => unreachable!("handled above"),
+        Commands::Keys { .. } | Commands::List => {
+            unreachable!("handled above")
+        }
     };
 
     // Output result
@@ -228,6 +240,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", serde_json::to_string(&result)?);
     } else {
         println!("{}", serde_json::to_string_pretty(&result)?);
+    }
+
+    Ok(())
+}
+
+/// Show default status: screen capture, mode, and cursor
+async fn show_status(client: &mut client::ReoClient) -> Result<(), Box<dyn std::error::Error>> {
+    // Get screen capture
+    let capture = commands::cmd_screen_content(client, "plain_text").await?;
+    if let Some(content) = capture.get("content").and_then(Value::as_str) {
+        println!("{content}");
+    }
+
+    // Get mode and cursor
+    let mode = commands::cmd_mode(client).await?;
+    let cursor = commands::cmd_cursor(client, None).await?;
+
+    // Print status line
+    println!("---");
+    if let Some(display) = mode.get("display").and_then(Value::as_str) {
+        println!("Mode: {display}");
+    }
+    if let (Some(x), Some(y)) =
+        (cursor.get("x").and_then(Value::as_u64), cursor.get("y").and_then(Value::as_u64))
+    {
+        println!("Cursor: ({x}, {y})");
     }
 
     Ok(())


### PR DESCRIPTION
- Add port fallback: servers try ports 12521-12530 if default is in use
- Add port file discovery: ~/.local/share/reovim/servers/<pid>.port
- Add `reo-cli list` command to show running servers
- Auto-discover single server, prompt when multiple found
- Simplify reo-cli: remove capture/mode/cursor commands, use unified status
- Add Process Safety Policy to CLAUDE.md (never kill other instances)