### PR TITLE
feat(sign): add sign column infrastructure for gutter markers

### DIFF
--- a/lib/core/src/animation/stage.rs
+++ b/lib/core/src/animation/stage.rs
@@ -146,6 +146,7 @@ mod tests {
             ],
             highlights: vec![vec![], vec![]],
             decorations: vec![vec![], vec![]],
+            signs: vec![None, None],
             buffer_id: 1,
             window_id: 1,
             window_bounds: Bounds {

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -102,6 +102,10 @@ pub enum InnerEvent {
     SetIndentGuide {
         enabled: bool,
     },
+    /// Set sign column configuration
+    SetSignColumn {
+        width: Option<u16>,
+    },
 }
 
 /// Input events routed to the active focus target

--- a/lib/core/src/event_bus/core_events.rs
+++ b/lib/core/src/event_bus/core_events.rs
@@ -418,6 +418,21 @@ impl Event for RequestSetIndentGuide {
     }
 }
 
+/// Request to set sign column configuration
+///
+/// Emitted by plugins when the signcolumn option changes.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestSetSignColumn {
+    /// Sign column width (None = disabled, Some(width) = enabled)
+    pub width: Option<u16>,
+}
+
+impl Event for RequestSetSignColumn {
+    fn priority(&self) -> u32 {
+        priority::CORE
+    }
+}
+
 // =============================================================================
 // Text Input Events
 // =============================================================================

--- a/lib/core/src/highlight/theme.rs
+++ b/lib/core/src/highlight/theme.rs
@@ -65,7 +65,8 @@ pub struct GutterStyles {
     pub line_number: Style,
     pub current_line_number: Style,
     pub inactive_line_number: Style,
-    pub sign_column: Style,
+    /// Background style for sign column
+    pub sign_column_bg: Style,
 }
 
 #[derive(Debug, Clone)]
@@ -387,7 +388,7 @@ impl Theme {
                 line_number: Style::new().fg(fg_dark).bg(bg_dark),
                 current_line_number: Style::new().fg(yellow).bg(bg_dark).bold(),
                 inactive_line_number: Style::new().fg(fg_dark).bg(bg_dark),
-                sign_column: Style::new().fg(fg_dark).bg(bg_dark),
+                sign_column_bg: Style::new().bg(bg_dark),
             },
             selection: SelectionStyles {
                 visual: Style::new().bg(bg_light),
@@ -550,7 +551,7 @@ impl Theme {
                 line_number: Style::new().fg(Color::Grey),
                 current_line_number: Style::new().fg(Color::DarkBlue).bold(),
                 inactive_line_number: Style::new().fg(Color::Grey),
-                sign_column: Style::new().fg(Color::Grey),
+                sign_column_bg: Style::new().bg(bg_medium),
             },
             selection: SelectionStyles {
                 visual: Style::new().bg(Color::AnsiValue(153)),
@@ -717,12 +718,6 @@ impl Theme {
             g: 95,
             b: 137,
         };
-        // TokyoNight fg_gutter color for active non-current line numbers (#3b4261)
-        let fg_gutter = Color::Rgb {
-            r: 59,
-            g: 66,
-            b: 97,
-        };
         // Much darker color for inactive windows (#292e42)
         let fg_inactive = Color::Rgb {
             r: 41,
@@ -785,7 +780,7 @@ impl Theme {
                 line_number: Style::new().fg(fg_dark),
                 current_line_number: Style::new().fg(orange_bright).bold(),
                 inactive_line_number: Style::new().fg(fg_inactive),
-                sign_column: Style::new().fg(fg_gutter),
+                sign_column_bg: Style::new().bg(bg_dark),
             },
             selection: SelectionStyles {
                 visual: Style::new().bg(bg_highlight),

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod render;
 pub mod runtime;
 pub mod screen;
 pub mod settings;
+pub mod sign;
 // settings_menu is now a standalone plugin: reovim-plugin-settings-menu
 pub mod style;
 pub mod syntax;

--- a/lib/core/src/plugin/builtin/core.rs
+++ b/lib/core/src/plugin/builtin/core.rs
@@ -100,7 +100,7 @@ use crate::{
         EventBus, EventResult,
         core_events::{
             RequestSetIndentGuide, RequestSetLineNumbers, RequestSetRelativeLineNumbers,
-            RequestSetScrollbar, RequestSetTheme,
+            RequestSetScrollbar, RequestSetSignColumn, RequestSetTheme,
         },
     },
     keys,
@@ -201,6 +201,20 @@ impl CorePlugin {
                 "scrollbar" => {
                     if let OptionValue::Bool(enabled) = &event.new_value {
                         ctx.emit(RequestSetScrollbar { enabled: *enabled });
+                        needs_render = true;
+                    }
+                }
+                "signcolumn" => {
+                    if let OptionValue::String(value) = &event.new_value {
+                        // Parse signcolumn value: "no" or "yes:N"
+                        let width = if value == "no" {
+                            None
+                        } else if let Some(num_str) = value.strip_prefix("yes:") {
+                            num_str.parse::<u16>().ok()
+                        } else {
+                            Some(2) // Default width if invalid format
+                        };
+                        ctx.emit(RequestSetSignColumn { width });
                         needs_render = true;
                     }
                 }
@@ -775,6 +789,19 @@ impl CorePlugin {
             .with_section("Editor")
             .with_scope(OptionScope::Window)
             .with_display_order(11),
+        ));
+
+        // Sign column
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "signcolumn",
+                "Sign column display ('no' or 'yes:N')",
+                OptionValue::String("yes:2".into()),
+            )
+            .with_category(OptionCategory::Editor)
+            .with_section("Editor")
+            .with_scope(OptionScope::Window)
+            .with_display_order(12),
         ));
 
         // Tab width

--- a/lib/core/src/render/mod.rs
+++ b/lib/core/src/render/mod.rs
@@ -14,7 +14,7 @@ pub use {
     registry::RenderStageRegistry, stage::RenderStage,
 };
 
-use crate::highlight::Style;
+use crate::{highlight::Style, sign::LineSign};
 
 /// Data flowing through the render pipeline
 #[derive(Debug, Clone)]
@@ -30,6 +30,10 @@ pub struct RenderData {
 
     /// Per-line decorations (conceals, backgrounds)
     pub decorations: Vec<Vec<Decoration>>,
+
+    /// Per-line signs for gutter (same length as lines)
+    /// Populated by plugins via `RenderStage` transforms
+    pub signs: Vec<LineSign>,
 
     /// Metadata
     pub buffer_id: usize,
@@ -93,6 +97,7 @@ impl RenderData {
             visibility: vec![LineVisibility::Visible; line_count],
             highlights,
             decorations,
+            signs: vec![None; line_count],
             buffer_id: buffer.id,
             window_id: window.id,
             window_bounds: Bounds {
@@ -162,4 +167,55 @@ pub struct Bounds {
     pub y: u16,
     pub width: u16,
     pub height: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_data_signs_initialization() {
+        // Create minimal test data
+        use crate::{buffer::Buffer, modd::ModeState};
+
+        let buffer = Buffer::empty(0);
+        let mode = ModeState::default();
+        let window = crate::screen::window::tests::create_test_window(10);
+
+        let render_data = RenderData::from_buffer(&window, &buffer, &mode);
+
+        // Signs should be initialized as empty vector with correct length
+        assert_eq!(render_data.signs.len(), buffer.contents.len());
+        assert!(render_data.signs.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn test_render_data_signs_can_be_modified() {
+        use crate::{
+            buffer::{Buffer, Line},
+            highlight::Style,
+            modd::ModeState,
+            sign::Sign,
+        };
+
+        let mut buffer = Buffer::empty(0);
+        // Add some lines to the buffer so we can test sign modification
+        buffer.contents.push(Line::from("line 1"));
+        buffer.contents.push(Line::from("line 2"));
+        buffer.contents.push(Line::from("line 3"));
+
+        let mode = ModeState::default();
+        let window = crate::screen::window::tests::create_test_window(10);
+
+        let mut render_data = RenderData::from_buffer(&window, &buffer, &mode);
+
+        // Add a sign to line 0
+        let sign = Sign::new("●".to_string(), Style::new(), 304);
+        render_data.signs[0] = Some(sign);
+
+        // Verify it was set
+        assert!(render_data.signs[0].is_some());
+        assert_eq!(render_data.signs[0].as_ref().unwrap().icon, "●");
+        assert_eq!(render_data.signs[0].as_ref().unwrap().priority, 304);
+    }
 }

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -508,6 +508,16 @@ impl Runtime {
                     EventResult::Handled
                 });
         }
+        {
+            use crate::event_bus::{EventResult, core_events::RequestSetSignColumn};
+            let tx = runtime.tx.clone();
+            runtime
+                .event_bus
+                .subscribe::<RequestSetSignColumn, _>(100, move |event, _ctx| {
+                    let _ = tx.try_send(InnerEvent::SetSignColumn { width: event.width });
+                    EventResult::Handled
+                });
+        }
 
         // Enable keyboard enhancement protocol if supported
         // This allows terminals (kitty, WezTerm, foot) to disambiguate Ctrl+I from Tab

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -629,6 +629,10 @@ impl Runtime {
                 tracing::info!("Runtime: Setting indent guide: {}", enabled);
                 self.indent_analyzer.set_enabled(enabled);
             }
+            InnerEvent::SetSignColumn { width } => {
+                tracing::info!("Runtime: Setting sign column: {:?}", width);
+                self.screen.set_sign_column_width(width);
+            }
         }
         false
     }

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -151,6 +151,7 @@ impl Default for Screen {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
+            sign_column_width: Some(2),
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,
@@ -213,6 +214,7 @@ impl Screen {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
+            sign_column_width: Some(2),
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,
@@ -523,9 +525,39 @@ impl Screen {
                 LineVisibility::Hidden => {}
                 LineVisibility::FoldMarker { preview, .. } => {
                     let screen_y = window.anchor.y + display_row;
-                    let gutter_width = self.render_line_number_to_buffer_simple(
+                    let mut gutter_width = 0u16;
+
+                    // Render sign column FIRST (if enabled) - leftmost gutter element
+                    if let Some(sign_width) = window.sign_column_width {
+                        let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+                        let sign_x = window.anchor.x + gutter_width;
+                        if line_idx == 0 {
+                            tracing::info!(
+                                "SIGN_COLUMN: x={} y={} width={} sign_present={}",
+                                sign_x,
+                                screen_y,
+                                sign_width,
+                                sign.is_some()
+                            );
+                        }
+                        gutter_width += Window::render_sign_to_buffer(
+                            frame_buffer,
+                            sign_x,
+                            screen_y,
+                            sign,
+                            sign_width,
+                            theme,
+                        );
+                    }
+
+                    // Render line numbers AFTER sign column
+                    let line_num_x = window.anchor.x + gutter_width;
+                    if line_idx == 0 {
+                        tracing::info!("LINE_NUM: x={} gutter_width={}", line_num_x, gutter_width);
+                    }
+                    gutter_width += self.render_line_number_to_buffer_simple(
                         frame_buffer,
-                        window.anchor.x,
+                        window.anchor.x + gutter_width,
                         screen_y,
                         line_idx as u16,
                         cursor_y,
@@ -574,9 +606,39 @@ impl Screen {
                     }
 
                     let screen_y = window.anchor.y + display_row;
-                    let gutter_width = self.render_line_number_to_buffer_simple(
+                    let mut gutter_width = 0u16;
+
+                    // Render sign column FIRST (if enabled) - leftmost gutter element
+                    if let Some(sign_width) = window.sign_column_width {
+                        let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+                        let sign_x = window.anchor.x + gutter_width;
+                        if line_idx == 0 {
+                            tracing::info!(
+                                "SIGN_COLUMN: x={} y={} width={} sign_present={}",
+                                sign_x,
+                                screen_y,
+                                sign_width,
+                                sign.is_some()
+                            );
+                        }
+                        gutter_width += Window::render_sign_to_buffer(
+                            frame_buffer,
+                            sign_x,
+                            screen_y,
+                            sign,
+                            sign_width,
+                            theme,
+                        );
+                    }
+
+                    // Render line numbers AFTER sign column
+                    let line_num_x = window.anchor.x + gutter_width;
+                    if line_idx == 0 {
+                        tracing::info!("LINE_NUM: x={} gutter_width={}", line_num_x, gutter_width);
+                    }
+                    gutter_width += self.render_line_number_to_buffer_simple(
                         frame_buffer,
-                        window.anchor.x,
+                        window.anchor.x + gutter_width,
                         screen_y,
                         line_idx as u16,
                         cursor_y,
@@ -914,7 +976,9 @@ impl Screen {
             .and_then(|win| {
                 let buffer_id = win.buffer_id()?;
                 let buf = buffers.get(&buffer_id)?;
-                let gutter_width = win.line_number_width(buf.contents.len());
+                let line_num_width = win.line_number_width(buf.contents.len());
+                let sign_width = win.sign_column_width.unwrap_or(0);
+                let gutter_width = sign_width + line_num_width;
                 let scroll_y = win.buffer_anchor().map_or(0, |a| a.y);
                 Some((win.anchor.x, win.anchor.y, gutter_width, scroll_y, buf.cur.x, buf.cur.y))
             })
@@ -1045,8 +1109,9 @@ impl Screen {
 
                 // Calculate cursor position only for the ACTIVE window (and if editor is focused)
                 if win.is_active {
-                    let gutter_width = win.line_number_width(buf.contents.len());
-                    let cursor_x = win.anchor.x + gutter_width + buf.cur.x;
+                    let line_num_width = win.line_number_width(buf.contents.len());
+                    let sign_width = win.sign_column_width.unwrap_or(0);
+                    let cursor_x = win.anchor.x + sign_width + line_num_width + buf.cur.x;
                     let cursor_y = win.anchor.y
                         + buf
                             .cur
@@ -1117,6 +1182,12 @@ impl Screen {
     pub fn set_relative_number(&mut self, enabled: bool) {
         for window in &mut self.windows {
             window.set_relative_number(enabled);
+        }
+    }
+
+    pub fn set_sign_column_width(&mut self, width: Option<u16>) {
+        for window in &mut self.windows {
+            window.sign_column_width = width;
         }
     }
 
@@ -1359,6 +1430,7 @@ impl Screen {
                     is_floating: false,
                     line_number: Some(LineNumber::default()),
                     scrollbar_enabled: false,
+                    sign_column_width: Some(2),
                     cursor,
                     desired_col,
                     border_config: None,

--- a/lib/core/src/screen/window.rs
+++ b/lib/core/src/screen/window.rs
@@ -70,6 +70,9 @@ pub struct Window {
     pub line_number: Option<LineNumber>,
     /// Whether to show scrollbar
     pub scrollbar_enabled: bool,
+    /// Sign column width (None = disabled, Some(width) = enabled)
+    /// Typical values: Some(1) or Some(2)
+    pub sign_column_width: Option<u16>,
     /// Per-window cursor position
     pub cursor: Position,
     /// Track preferred column for vertical movement (j/k)
@@ -729,6 +732,52 @@ impl Window {
         col.saturating_sub(x)
     }
 
+    /// Render sign column to frame buffer
+    ///
+    /// Displays sign icon if present, otherwise renders background padding.
+    /// Returns the width consumed (equal to `sign_column_width`).
+    pub(crate) fn render_sign_to_buffer(
+        buffer: &mut FrameBuffer,
+        x: u16,
+        y: u16,
+        sign: Option<&crate::sign::Sign>,
+        width: u16,
+        theme: &Theme,
+    ) -> u16 {
+        if sign.is_some() {
+            tracing::info!(
+                "SIGN_RENDER: Rendering sign at ({}, {}) width={} sign={:?}",
+                x,
+                y,
+                width,
+                sign
+            );
+        }
+        let bg_style = &theme.gutter.sign_column_bg;
+
+        if let Some(sign) = sign {
+            // Render sign icon (truncate if too long)
+            let mut col = x;
+            for ch in sign.icon.chars().take(width as usize) {
+                buffer.put_char(col, y, ch, &sign.style);
+                col += 1;
+            }
+
+            // Pad remaining width with background
+            while col < x + width {
+                buffer.put_char(col, y, ' ', bg_style);
+                col += 1;
+            }
+        } else {
+            // No sign - render background padding only
+            for col in x..(x + width) {
+                buffer.put_char(col, y, ' ', bg_style);
+            }
+        }
+
+        width
+    }
+
     /// Render a complete content line to frame buffer
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_arguments)]
@@ -1250,10 +1299,11 @@ impl Window {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
 
-    fn create_test_window(height: u16) -> Window {
+    #[must_use]
+    pub fn create_test_window(height: u16) -> Window {
         Window {
             id: 0,
             source: WindowContentSource::FileBuffer {
@@ -1268,6 +1318,7 @@ mod tests {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
+            sign_column_width: None, // Disabled by default in tests to avoid position shifts
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,

--- a/lib/core/src/sign.rs
+++ b/lib/core/src/sign.rs
@@ -1,0 +1,101 @@
+//! Generic sign column system for gutter markers (diagnostics, git, breakpoints)
+
+use crate::highlight::Style;
+
+/// A sign displayed in the gutter
+///
+/// Generic abstraction used by plugins to mark lines. Examples:
+/// - LSP diagnostics: "E", "W", "I", "H" with colors
+/// - Git changes: "+", "~", "-" for added/modified/deleted
+/// - Debugger: "●" for breakpoints
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sign {
+    /// Visual icon (1-2 characters typical)
+    pub icon: String,
+
+    /// Style for rendering the icon
+    pub style: Style,
+
+    /// Priority (higher = wins when multiple signs on same line)
+    ///
+    /// Suggested ranges:
+    /// - 0-99: Git signs (lowest priority)
+    /// - 100-199: Bookmarks/marks
+    /// - 200-299: Breakpoints
+    /// - 300-399: LSP diagnostics (highest priority)
+    pub priority: u32,
+}
+
+impl Sign {
+    /// Create a new sign
+    #[must_use]
+    pub const fn new(icon: String, style: Style, priority: u32) -> Self {
+        Self {
+            icon,
+            style,
+            priority,
+        }
+    }
+}
+
+/// Per-line sign (None = no sign on this line)
+pub type LineSign = Option<Sign>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sign_creation() {
+        let sign = Sign::new("●".to_string(), Style::new(), 100);
+        assert_eq!(sign.icon, "●");
+        assert_eq!(sign.priority, 100);
+    }
+
+    #[test]
+    fn test_sign_equality() {
+        let sign1 = Sign {
+            icon: "E".to_string(),
+            style: Style::new(),
+            priority: 304,
+        };
+        let sign2 = Sign {
+            icon: "E".to_string(),
+            style: Style::new(),
+            priority: 304,
+        };
+        assert_eq!(sign1, sign2);
+    }
+
+    #[test]
+    fn test_sign_priority_ordering() {
+        let error_sign = Sign {
+            icon: "●".to_string(),
+            style: Style::new(),
+            priority: 304,
+        };
+        let warning_sign = Sign {
+            icon: "◐".to_string(),
+            style: Style::new(),
+            priority: 303,
+        };
+        let git_sign = Sign {
+            icon: "+".to_string(),
+            style: Style::new(),
+            priority: 50,
+        };
+
+        // Higher priority should win
+        assert!(error_sign.priority > warning_sign.priority);
+        assert!(warning_sign.priority > git_sign.priority);
+    }
+
+    #[test]
+    fn test_line_sign_option() {
+        let sign: LineSign = Some(Sign::new("●".to_string(), Style::new(), 100));
+        assert!(sign.is_some());
+
+        let no_sign: LineSign = None;
+        assert!(no_sign.is_none());
+    }
+}

--- a/lib/core/tests/bracket_highlighting.rs
+++ b/lib/core/tests/bracket_highlighting.rs
@@ -7,18 +7,16 @@ mod common;
 
 use common::ServerTest;
 
-/// Helper: get cell at content position (accounting for line number gutter)
-/// Gutter format is "N " where N is line number (variable width) + 1 space
+/// Helper: get cell at content position (accounting for sign column + line number gutter)
+/// Gutter format is: `sign_column` (2 chars) + "N " where N is line number + 1 space
 fn get_content_cell(
     snap: &reovim_core::visual::VisualSnapshot,
     content_col: usize,
     row: usize,
 ) -> Option<&reovim_core::rpc::state::CellSnapshot> {
-    // Find gutter width by looking for first non-digit, non-space after digits
-    // For single-digit lines: "1 " = 2 chars
-    // For double-digit lines: "10 " = 3 chars
-    // Simpler: assume line numbers up to 99 = max 3 chars, but typically "N " = 2 for single digit
-    let gutter_width = 2; // "1 " format for single-digit line numbers
+    // Gutter = sign column (2) + line number (1 digit) + space (1) = 4 chars
+    // For single-digit lines with sign column: "  1 " = 4 chars
+    let gutter_width = 4; // sign_column (2) + "N " (2) for single-digit line numbers
     snap.cells
         .get(row)
         .and_then(|r| r.get(gutter_width + content_col))

--- a/lib/core/tests/sign_column.rs
+++ b/lib/core/tests/sign_column.rs
@@ -1,0 +1,173 @@
+//! Integration tests for sign column rendering
+
+use reovim_core::{highlight::Style, render::RenderData, sign::Sign};
+
+#[test]
+fn test_sign_column_width_configuration() {
+    let mut window = common::create_test_window();
+
+    // Default should be enabled with width 2
+    assert_eq!(window.sign_column_width, Some(2));
+
+    // Can be disabled
+    window.sign_column_width = None;
+    assert!(window.sign_column_width.is_none());
+
+    // Can be set to different widths
+    window.sign_column_width = Some(1);
+    assert_eq!(window.sign_column_width, Some(1));
+
+    window.sign_column_width = Some(3);
+    assert_eq!(window.sign_column_width, Some(3));
+}
+
+#[test]
+fn test_sign_priority_resolution() {
+    // Test that higher priority signs replace lower priority signs
+    let error_sign = Sign {
+        icon: "●".to_string(),
+        style: Style::new(),
+        priority: 304, // LSP error
+    };
+
+    let warning_sign = Sign {
+        icon: "◐".to_string(),
+        style: Style::new(),
+        priority: 303, // LSP warning
+    };
+
+    let git_sign = Sign {
+        icon: "+".to_string(),
+        style: Style::new(),
+        priority: 50, // Git addition
+    };
+
+    // Simulate priority-based replacement
+    let mut current_sign: Option<Sign> = Some(git_sign);
+
+    // Warning should replace git
+    if warning_sign.priority > current_sign.as_ref().unwrap().priority {
+        current_sign = Some(warning_sign);
+    }
+    assert_eq!(current_sign.as_ref().unwrap().icon, "◐");
+    assert_eq!(current_sign.as_ref().unwrap().priority, 303);
+
+    // Error should replace warning
+    if error_sign.priority > current_sign.as_ref().unwrap().priority {
+        current_sign = Some(error_sign);
+    }
+    assert_eq!(current_sign.as_ref().unwrap().icon, "●");
+    assert_eq!(current_sign.as_ref().unwrap().priority, 304);
+}
+
+#[test]
+fn test_render_data_contains_signs() {
+    use reovim_core::{
+        buffer::{Buffer, Line},
+        modd::ModeState,
+    };
+
+    let mut buffer = Buffer::empty(0);
+    // Add some lines to the buffer
+    buffer.contents.push(Line::from("line 1"));
+    buffer.contents.push(Line::from("line 2"));
+    buffer.contents.push(Line::from("line 3"));
+
+    let mode = ModeState::default();
+    let window = common::create_test_window();
+
+    let render_data = RenderData::from_buffer(&window, &buffer, &mode);
+
+    // RenderData should have signs field initialized
+    assert!(!render_data.signs.is_empty());
+    assert_eq!(render_data.signs.len(), buffer.contents.len());
+
+    // All signs should be None initially
+    for sign in &render_data.signs {
+        assert!(sign.is_none());
+    }
+}
+
+#[test]
+fn test_multiple_signs_on_different_lines() {
+    use reovim_core::{
+        buffer::{Buffer, Line},
+        modd::ModeState,
+    };
+
+    let mut buffer = Buffer::empty(0);
+    // Add enough lines to test signs on different lines
+    buffer.contents.push(Line::from("line 1"));
+    buffer.contents.push(Line::from("line 2"));
+    buffer.contents.push(Line::from("line 3"));
+    buffer.contents.push(Line::from("line 4"));
+    buffer.contents.push(Line::from("line 5"));
+
+    let mode = ModeState::default();
+    let window = common::create_test_window();
+
+    let mut render_data = RenderData::from_buffer(&window, &buffer, &mode);
+
+    // Add signs to different lines
+    render_data.signs[0] = Some(Sign {
+        icon: "●".to_string(),
+        style: Style::new(),
+        priority: 304,
+    });
+
+    render_data.signs[2] = Some(Sign {
+        icon: "◐".to_string(),
+        style: Style::new(),
+        priority: 303,
+    });
+
+    render_data.signs[4] = Some(Sign {
+        icon: "+".to_string(),
+        style: Style::new(),
+        priority: 50,
+    });
+
+    // Verify signs are on correct lines
+    assert!(render_data.signs[0].is_some());
+    assert!(render_data.signs[1].is_none());
+    assert!(render_data.signs[2].is_some());
+    assert!(render_data.signs[3].is_none());
+    assert!(render_data.signs[4].is_some());
+
+    // Verify icons
+    assert_eq!(render_data.signs[0].as_ref().unwrap().icon, "●");
+    assert_eq!(render_data.signs[2].as_ref().unwrap().icon, "◐");
+    assert_eq!(render_data.signs[4].as_ref().unwrap().icon, "+");
+}
+
+mod common {
+    use reovim_core::{
+        content::WindowContentSource,
+        screen::{
+            Position,
+            window::{Anchor, Window},
+        },
+    };
+
+    pub const fn create_test_window() -> Window {
+        Window {
+            id: 0,
+            source: WindowContentSource::FileBuffer {
+                buffer_id: 0,
+                buffer_anchor: Anchor { x: 0, y: 0 },
+            },
+            anchor: Anchor { x: 0, y: 0 },
+            width: 80,
+            height: 24,
+            z_order: 100,
+            is_active: true,
+            is_floating: false,
+            line_number: None,
+            scrollbar_enabled: false,
+            sign_column_width: Some(2),
+            cursor: Position { x: 0, y: 0 },
+            desired_col: None,
+            border_config: None,
+        }
+    }
+}

--- a/lib/core/tests/sign_render_visual.rs
+++ b/lib/core/tests/sign_render_visual.rs
@@ -1,0 +1,86 @@
+//! Visual test for sign rendering
+//!
+//! This test creates a mock scenario with signs and prints the visual output
+//! to help debug sign column rendering issues.
+
+use reovim_core::{
+    buffer::{Buffer, TextOps},
+    content::WindowContentSource,
+    highlight::Theme,
+    modd::ModeState,
+    render::RenderData,
+    screen::{
+        Position,
+        window::{Anchor, LineNumber, Window},
+    },
+    sign::Sign,
+};
+
+#[test]
+fn test_sign_visual_rendering() {
+    // Create buffer with content
+    let mut buffer = Buffer::empty(1);
+    buffer.set_content("Line 1\nLine 2 with error\nLine 3\nLine 4");
+
+    // Create window with sign column enabled
+    let window = Window {
+        id: 0,
+        source: WindowContentSource::FileBuffer {
+            buffer_id: 1,
+            buffer_anchor: Anchor { x: 0, y: 0 },
+        },
+        anchor: Anchor { x: 0, y: 0 },
+        width: 40,
+        height: 4,
+        z_order: 0,
+        is_active: true,
+        is_floating: false,
+        line_number: Some(LineNumber::default()),
+        sign_column_width: Some(2), // Enable 2-char sign column
+        scrollbar_enabled: false,
+        cursor: Position { x: 0, y: 0 },
+        desired_col: None,
+        border_config: None,
+    };
+
+    // Create render data with a sign on line 1 (index 1)
+    let mode = ModeState::normal();
+    let mut render_data = RenderData::from_buffer(&window, &buffer, &mode);
+
+    // Add an error sign on line 1 (the "Line 2 with error" line)
+    let theme = Theme::default();
+    let error_sign = Sign {
+        icon: "●".to_string(),         // Error icon
+        style: theme.diagnostic.error, // Use theme's error style
+        priority: 304,
+    };
+    render_data.signs[1] = Some(error_sign);
+
+    // Print test info
+    println!("\n=== Sign Column Visual Test ===");
+    println!("Buffer content:");
+    for (i, line) in buffer.contents.iter().enumerate() {
+        println!("  Line {}: {}", i, line.inner);
+    }
+    println!("\nSigns:");
+    for (i, sign) in render_data.signs.iter().enumerate() {
+        if let Some(s) = sign {
+            println!("  Line {}: icon='{}' priority={}", i, s.icon, s.priority);
+        }
+    }
+
+    // Verify sign data structure
+    assert!(render_data.signs.len() == 4, "Should have 4 sign slots");
+    assert!(render_data.signs[0].is_none(), "Line 0 should have no sign");
+    assert!(render_data.signs[1].is_some(), "Line 1 should have error sign");
+    assert_eq!(render_data.signs[1].as_ref().unwrap().icon, "●", "Line 1 sign should be ●");
+    assert_eq!(
+        render_data.signs[1].as_ref().unwrap().priority,
+        304,
+        "Line 1 sign should have priority 304"
+    );
+
+    println!("\n✓ Sign data structure correct");
+    println!("  - Line 1 has sign with icon '●' and priority 304");
+    println!("  - Signs array properly initialized");
+}

--- a/plugins/features/fold/src/tests/mod.rs
+++ b/plugins/features/fold/src/tests/mod.rs
@@ -150,6 +150,7 @@ fn test_fold_render_stage_no_folds() {
         visibility: vec![LineVisibility::Visible; 3],
         highlights: vec![Vec::new(); 3],
         decorations: vec![Vec::new(); 3],
+        signs: vec![None; 3],
         buffer_id: 1,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {
@@ -206,6 +207,7 @@ fn test_fold_render_stage_with_collapsed_fold() {
         visibility: vec![LineVisibility::Visible; 5],
         highlights: vec![Vec::new(); 5],
         decorations: vec![Vec::new(); 5],
+        signs: vec![None; 5],
         buffer_id: 1,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {
@@ -271,6 +273,7 @@ fn test_fold_render_stage_multiple_folds() {
         visibility: vec![LineVisibility::Visible; 9],
         highlights: vec![Vec::new(); 9],
         decorations: vec![Vec::new(); 9],
+        signs: vec![None; 9],
         buffer_id: 2,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {

--- a/plugins/features/lsp/src/stage.rs
+++ b/plugins/features/lsp/src/stage.rs
@@ -211,6 +211,39 @@ impl LspRenderStage {
             // Get style based on severity
             let style = severity_to_style(diagnostic.severity, diag_styles);
 
+            // Create sign for the diagnostic (only on start line)
+            if start_line < input.signs.len() {
+                tracing::debug!(
+                    "LSP: Creating sign for line {} (severity: {:?})",
+                    start_line,
+                    diagnostic.severity
+                );
+                let (icon, priority) = match diagnostic.severity {
+                    Some(DiagnosticSeverity::ERROR) => ("●", 304),
+                    Some(DiagnosticSeverity::WARNING) => ("◐", 303),
+                    Some(DiagnosticSeverity::INFORMATION) => ("ⓘ", 302),
+                    Some(DiagnosticSeverity::HINT) => ("·", 301),
+                    Some(_) | None => ("ⓘ", 300),
+                };
+
+                let sign = reovim_core::sign::Sign {
+                    icon: icon.to_string(),
+                    style: style.clone(),
+                    priority,
+                };
+
+                // Set sign only if none exists or we have higher priority
+                match &input.signs[start_line] {
+                    Some(existing) if existing.priority >= sign.priority => {
+                        // Keep existing higher-priority sign
+                    }
+                    _ => {
+                        // Replace with new sign
+                        input.signs[start_line] = Some(sign);
+                    }
+                }
+            }
+
             // Handle single-line and multi-line diagnostics
             if start_line == end_line {
                 // Single-line diagnostic
@@ -250,7 +283,13 @@ impl LspRenderStage {
             }
         }
 
-        debug!(buffer_id, count = diagnostics.len(), "LSP: applied diagnostic highlights");
+        let sign_count = input.signs.iter().filter(|s| s.is_some()).count();
+        debug!(
+            buffer_id,
+            count = diagnostics.len(),
+            signs_created = sign_count,
+            "LSP: applied diagnostic highlights and signs"
+        );
     }
 }
 

--- a/tools/bench/benches/bench_modules/common.rs
+++ b/tools/bench/benches/bench_modules/common.rs
@@ -35,6 +35,7 @@ pub fn create_window(height: u16) -> Window {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
+        sign_column_width: None,
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: 0 },
         desired_col: None,

--- a/tools/bench/benches/bench_modules/render_pipeline.rs
+++ b/tools/bench/benches/bench_modules/render_pipeline.rs
@@ -83,6 +83,7 @@ fn create_window_at_scroll(height: u16, scroll_y: u16) -> Window {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
+        sign_column_width: None,
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: scroll_y },
         desired_col: None,


### PR DESCRIPTION
Implement generic sign column system for displaying LSP diagnostics, breakpoints, bookmarks, and git hunks in the editor gutter.

Core components:
- Sign type with icon, style, and priority-based resolution
- RenderData.signs field populated by render stages
- Window.sign_column_width configuration (2 chars)
- render_sign_to_buffer() for gutter rendering

LSP integration:
- Diagnostic to sign conversion with severity icons
- Priority levels: ERROR(304) > WARNING(303) > INFO(302) > HINT(301)

Rendering fixes:
- Sign column renders BEFORE line numbers (correct order)
- Cursor position calculation includes sign column width

(Closes #21 Phase 1)