### PR TITLE
feat(lsp): add debugging tools for LSP communication (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ All notable changes to Reovim will be documented in this file.
   - Visual identity: Explorer (orange), Microscope (blue), Settings (gray), Leap (green), Health (teal)
   - Status line shows `[INTERACTOR][MODE]` as separate colored sections
   - `Color` type exported from `reovim_core::highlight` for plugin use
+- **LSP debugging tools** (Issue #26) - Tools for debugging LSP communication
+  - LSP health check: Shows server status, document count, and diagnostic stats in `:health` modal
+  - Dedicated LSP log: `--lsp-log` flag for capturing JSON-RPC messages to separate file
+    - `--lsp-log=default` creates timestamped `lsp-<timestamp>.log` in data directory
+    - `--lsp-log=/path/to/file.log` for custom path
+    - Logs show `->` for outgoing and `<-` for incoming messages at TRACE level
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,11 @@ cargo run -- --server --log=-
 
 # Server mode with custom log file
 cargo run -- --server --log=/tmp/reovim-server.log
+
+# LSP JSON-RPC message logging (for debugging LSP issues)
+reovim --lsp-log=default myfile.rs           # Timestamped lsp-*.log in data dir
+reovim --lsp-log=/tmp/lsp.log myfile.rs      # Custom path
+cargo run -- --server --log=/tmp/main.log --lsp-log=/tmp/lsp.log  # Both logs
 ```
 
 ### Log Level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "reovim-core",
  "reovim-lang-markdown",
  "reovim-lsp",
+ "reovim-plugin-health-check",
  "reovim-plugin-microscope",
  "reovim-plugin-notification",
  "reovim-plugin-statusline",

--- a/lib/lsp/src/transport.rs
+++ b/lib/lsp/src/transport.rs
@@ -125,10 +125,10 @@ impl Transport {
         reader.read_exact(&mut buffer).await?;
 
         let json_str = String::from_utf8_lossy(&buffer);
-        trace!(len = content_length, "<- {}", json_str);
+        trace!(target: "reovim_lsp", len = content_length, "<- {}", json_str);
 
         let message: Message = serde_json::from_slice(&buffer)?;
-        debug!("<- {:?}", message);
+        debug!(target: "reovim_lsp", "<- {:?}", message);
 
         Ok(message)
     }
@@ -149,8 +149,8 @@ impl Transport {
         let json = serde_json::to_string(message)?;
         let content_length = json.len();
 
-        debug!("-> {:?}", message);
-        trace!(len = content_length, "-> {}", json);
+        debug!(target: "reovim_lsp", "-> {:?}", message);
+        trace!(target: "reovim_lsp", len = content_length, "-> {}", json);
 
         // Write header
         let header = format!("Content-Length: {content_length}\r\n\r\n");

--- a/plugins/features/lsp/Cargo.toml
+++ b/plugins/features/lsp/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 reovim-core.workspace = true
 reovim-lsp.workspace = true
 reovim-lang-markdown.workspace = true
+reovim-plugin-health-check.workspace = true
 reovim-plugin-microscope.workspace = true
 reovim-plugin-notification.workspace = true
 reovim-plugin-statusline.workspace = true

--- a/plugins/features/lsp/src/health.rs
+++ b/plugins/features/lsp/src/health.rs
@@ -1,0 +1,79 @@
+//! LSP health check for the health-check plugin.
+//!
+//! Provides status information about the LSP server connection and diagnostics.
+
+use std::{fmt, sync::Arc};
+
+use reovim_plugin_health_check::{HealthCheck, HealthCheckResult};
+
+use crate::SharedLspManager;
+
+/// Health check for LSP server status.
+///
+/// Reports:
+/// - Server running status
+/// - Number of open documents
+/// - Diagnostic cache summary
+pub struct LspHealthCheck {
+    manager: Arc<SharedLspManager>,
+}
+
+impl fmt::Debug for LspHealthCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LspHealthCheck").finish_non_exhaustive()
+    }
+}
+
+impl LspHealthCheck {
+    /// Create a new LSP health check.
+    #[must_use]
+    pub const fn new(manager: Arc<SharedLspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+impl HealthCheck for LspHealthCheck {
+    fn name(&self) -> &'static str {
+        "Language Server"
+    }
+
+    fn category(&self) -> &'static str {
+        "Plugin"
+    }
+
+    fn run(&self) -> HealthCheckResult {
+        self.manager.with(|m| {
+            if !m.running {
+                return HealthCheckResult::warning("Server not running").with_details(
+                    "LSP server is not active. Open a supported file (.rs) to start.",
+                );
+            }
+
+            // Gather statistics
+            let doc_count = m.documents.buffer_ids().len();
+            let pending_syncs = m.documents.has_pending_syncs();
+
+            // Diagnostic cache stats
+            let (cache_entries, total_diagnostics) = m.cache.as_ref().map_or((0, 0), |c| {
+                let all = c.get_all();
+                let total: usize = all.values().map(|bd| bd.diagnostics.len()).sum();
+                (all.len(), total)
+            });
+
+            // Build details string
+            let mut details = Vec::new();
+            details.push("Server: rust-analyzer (running)".to_string());
+            details.push(format!("Open documents: {doc_count}"));
+            details.push(format!("Documents with diagnostics: {cache_entries}"));
+            details.push(format!("Total diagnostics: {total_diagnostics}"));
+            if pending_syncs {
+                details.push("Pending syncs: yes (debouncing)".to_string());
+            }
+
+            HealthCheckResult::ok(format!(
+                "Running - {doc_count} docs, {total_diagnostics} diagnostics"
+            ))
+            .with_details(details.join("\n"))
+        })
+    }
+}

--- a/plugins/features/lsp/src/lib.rs
+++ b/plugins/features/lsp/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod command;
 mod document;
+mod health;
 mod hover;
 mod manager;
 mod picker;
@@ -179,6 +180,14 @@ impl Plugin for LspPlugin {
 
     #[allow(clippy::too_many_lines)]
     fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
+        // Register LSP health check with health-check plugin
+        {
+            use reovim_plugin_health_check::RegisterHealthCheck;
+
+            let manager = Arc::clone(&self.manager);
+            bus.emit(RegisterHealthCheck::new(Arc::new(health::LspHealthCheck::new(manager))));
+        }
+
         // Handle file open - register document and schedule sync for render stage
         // Note: We don't send didOpen here directly. The render stage handles it
         // via schedule_immediate_sync() to avoid version synchronization bugs.

--- a/runner/src/logging.rs
+++ b/runner/src/logging.rs
@@ -8,13 +8,20 @@
 //! - **Custom file**: `--log=/path/to/file.log`
 //! - **Stderr**: `--log=-` or `--log=stderr`
 //! - **Disabled**: `--log=none` or `--log=off`
+//!
+//! ## LSP Log
+//!
+//! Dedicated LSP JSON-RPC message logging:
+//! - `--lsp-log=default` - Timestamped file `lsp-<timestamp>.log`
+//! - `--lsp-log=/path/to/lsp.log` - Custom file path
+//! - Filter: Only logs with target `reovim_lsp` are captured
 
 use std::{io, path::PathBuf};
 
 use {
     tracing_appender::non_blocking::WorkerGuard,
     tracing_subscriber::{
-        EnvFilter,
+        EnvFilter, Layer,
         fmt::{self, time::UtcTime},
         layer::SubscriberExt,
         util::SubscriberInitExt,
@@ -32,6 +39,29 @@ pub enum LogTarget {
     Stderr,
     /// Logging disabled
     Disabled,
+}
+
+/// Target for LSP-specific log output
+#[derive(Debug, Clone)]
+pub enum LspLogTarget {
+    /// LSP logging disabled (default)
+    Disabled,
+    /// Default: timestamped file `lsp-<timestamp>.log` in XDG data directory
+    Default,
+    /// Custom file path
+    File(PathBuf),
+}
+
+/// Container for log guards (must be held for duration of program)
+///
+/// These guards are intentionally held but never read - dropping them would
+/// cause the non-blocking writers to flush and shut down.
+#[allow(dead_code)]
+pub struct LogGuards {
+    /// Main log guard
+    main: Option<WorkerGuard>,
+    /// LSP log guard
+    lsp: Option<WorkerGuard>,
 }
 
 /// Parse a log target from a CLI argument
@@ -58,6 +88,34 @@ pub fn parse_log_target(arg: Option<&str>) -> LogTarget {
                 )
             } else {
                 LogTarget::File(path)
+            }
+        }
+    }
+}
+
+/// Parse an LSP log target from a CLI argument
+///
+/// # Special values
+/// - `None` -> Disabled (no LSP logging)
+/// - `"default"` -> Default (timestamped file in ~/.local/share/reovim/)
+/// - `"none"` or `"off"` -> Disabled
+/// - Any other string -> File path
+#[must_use]
+pub fn parse_lsp_log_target(arg: Option<&str>) -> LspLogTarget {
+    match arg {
+        None | Some("none" | "off") => LspLogTarget::Disabled,
+        Some("default") => LspLogTarget::Default,
+        Some(path) => {
+            let path = PathBuf::from(path);
+            // Resolve relative paths against CWD
+            if path.is_relative() {
+                LspLogTarget::File(
+                    std::env::current_dir()
+                        .map(|cwd| cwd.join(&path))
+                        .unwrap_or(path),
+                )
+            } else {
+                LspLogTarget::File(path)
             }
         }
     }
@@ -90,7 +148,13 @@ fn generate_log_filename() -> String {
     format!("reovim-{}.log", now.format("%Y-%m-%d-%H-%M-%S"))
 }
 
-/// Initialize the logging system
+/// Generate a timestamped LSP log filename
+fn generate_lsp_log_filename() -> String {
+    let now = chrono::Local::now();
+    format!("lsp-{}.log", now.format("%Y-%m-%d-%H-%M-%S"))
+}
+
+/// Initialize the logging system (without LSP logging)
 ///
 /// Returns a guard that must be held for the duration of the program
 /// to ensure logs are flushed before exit.
@@ -110,97 +174,307 @@ fn generate_log_filename() -> String {
 /// REOVIM_LOG=debug reovim myfile.txt
 /// REOVIM_LOG=trace reovim --log=- myfile.txt  # Debug to stderr
 /// ```
+/// Convenience function for initializing without LSP logging.
 #[must_use]
-pub fn init(target: &LogTarget) -> Option<WorkerGuard> {
+#[allow(dead_code)]
+pub fn init(target: &LogTarget) -> LogGuards {
+    init_with_lsp(target, &LspLogTarget::Disabled)
+}
+
+/// Initialize the logging system with optional LSP logging
+///
+/// Returns guards that must be held for the duration of the program
+/// to ensure logs are flushed before exit.
+#[must_use]
+pub fn init_with_lsp(target: &LogTarget, lsp_target: &LspLogTarget) -> LogGuards {
+    let main_filter = EnvFilter::try_from_env(LOG_LEVEL_ENV)
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
+
+    // Handle each combination of main + LSP logging
+    match (target, lsp_target) {
+        (LogTarget::Disabled, LspLogTarget::Disabled) => {
+            // No logging at all
+            tracing_subscriber::registry().init();
+            LogGuards {
+                main: None,
+                lsp: None,
+            }
+        }
+        (LogTarget::Disabled, lsp) => {
+            // Only LSP logging
+            let lsp_guard = init_lsp_only(lsp);
+            LogGuards {
+                main: None,
+                lsp: lsp_guard,
+            }
+        }
+        (main, LspLogTarget::Disabled) => {
+            // Only main logging (original behavior)
+            let main_guard = init_main_only(main, main_filter);
+            LogGuards {
+                main: main_guard,
+                lsp: None,
+            }
+        }
+        (main, lsp) => {
+            // Both main and LSP logging
+            init_both_layers(main, lsp, main_filter)
+        }
+    }
+}
+
+/// Initialize main logging only (original single-layer behavior)
+fn init_main_only(target: &LogTarget, filter: EnvFilter) -> Option<WorkerGuard> {
     match target {
         LogTarget::Disabled => None,
-        LogTarget::Stderr => Some(init_stderr()),
-        LogTarget::Default => init_default_file(),
-        LogTarget::File(path) => init_custom_file(path),
+        LogTarget::Stderr => {
+            let (non_blocking, guard) = tracing_appender::non_blocking(io::stderr());
+            let layer = fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(true)
+                .with_timer(UtcTime::rfc_3339())
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true);
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(layer)
+                .init();
+            Some(guard)
+        }
+        LogTarget::Default => {
+            let log_dir = get_log_directory();
+            if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                eprintln!("Warning: Failed to create log directory: {e}");
+                return None;
+            }
+            let log_filename = generate_log_filename();
+            Some(init_file_layer(&log_dir, &log_filename, filter))
+        }
+        LogTarget::File(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("Warning: Failed to create log directory {}: {e}", parent.display());
+                return None;
+            }
+            let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let log_filename = path
+                .file_name()
+                .map_or_else(|| "reovim.log".to_string(), |s| s.to_string_lossy().to_string());
+            Some(init_file_layer(log_dir, &log_filename, filter))
+        }
     }
 }
 
-/// Initialize logging to stderr
-fn init_stderr() -> WorkerGuard {
-    let filter = EnvFilter::try_from_env(LOG_LEVEL_ENV)
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
-
-    // Use non_blocking for consistency with file-based logging
-    let (non_blocking, guard) = tracing_appender::non_blocking(io::stderr());
-
-    let fmt_layer = fmt::layer()
-        .with_writer(non_blocking)
-        .with_ansi(true) // Enable ANSI colors for stderr
-        .with_timer(UtcTime::rfc_3339())
-        .with_target(true)
-        .with_file(true)
-        .with_line_number(true);
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(fmt_layer)
-        .init();
-
-    guard
-}
-
-/// Initialize logging to default timestamped file
-fn init_default_file() -> Option<WorkerGuard> {
-    let log_dir = get_log_directory();
-
-    // Create log directory if it doesn't exist
-    if let Err(e) = std::fs::create_dir_all(&log_dir) {
-        eprintln!("Warning: Failed to create log directory: {e}");
-        return None;
-    }
-
-    let log_filename = generate_log_filename();
-    Some(init_file_internal(&log_dir, &log_filename))
-}
-
-/// Initialize logging to custom file path
-fn init_custom_file(path: &std::path::Path) -> Option<WorkerGuard> {
-    // Ensure parent directory exists
-    if let Some(parent) = path.parent()
-        && !parent.as_os_str().is_empty()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        eprintln!("Warning: Failed to create log directory {}: {e}", parent.display());
-        return None;
-    }
-
-    // Extract directory and filename
-    let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let log_filename = path
-        .file_name()
-        .map_or_else(|| "reovim.log".to_string(), |s| s.to_string_lossy().to_string());
-
-    Some(init_file_internal(log_dir, &log_filename))
-}
-
-/// Internal helper for file-based logging
-fn init_file_internal(log_dir: &std::path::Path, log_filename: &str) -> WorkerGuard {
-    // Create file appender (non-blocking for async compatibility)
+/// Initialize a file-based log layer
+fn init_file_layer(
+    log_dir: &std::path::Path,
+    log_filename: &str,
+    filter: EnvFilter,
+) -> WorkerGuard {
     let file_appender = tracing_appender::rolling::never(log_dir, log_filename);
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-
-    // Build env filter from REOVIM_LOG or default
-    let filter = EnvFilter::try_from_env(LOG_LEVEL_ENV)
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL));
-
-    // Configure subscriber with file output
-    let fmt_layer = fmt::layer()
+    let layer = fmt::layer()
         .with_writer(non_blocking)
-        .with_ansi(false) // No ANSI colors in log file
+        .with_ansi(false)
         .with_timer(UtcTime::rfc_3339())
         .with_target(true)
         .with_file(true)
         .with_line_number(true);
-
     tracing_subscriber::registry()
         .with(filter)
-        .with(fmt_layer)
+        .with(layer)
         .init();
-
     guard
+}
+
+/// Initialize LSP-only logging (when main logging is disabled)
+fn init_lsp_only(target: &LspLogTarget) -> Option<WorkerGuard> {
+    let (log_dir, log_filename) = match target {
+        LspLogTarget::Disabled => return None,
+        LspLogTarget::Default => {
+            let log_dir = get_log_directory();
+            if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                eprintln!("Warning: Failed to create LSP log directory: {e}");
+                return None;
+            }
+            (log_dir, generate_lsp_log_filename())
+        }
+        LspLogTarget::File(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("Warning: Failed to create LSP log directory {}: {e}", parent.display());
+                return None;
+            }
+            let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let log_filename = path
+                .file_name()
+                .map_or_else(|| "lsp.log".to_string(), |s| s.to_string_lossy().to_string());
+            (log_dir.to_path_buf(), log_filename)
+        }
+    };
+
+    let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    // Filter to only include reovim_lsp target at trace level
+    let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+
+    let layer = fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_timer(UtcTime::rfc_3339())
+        .with_target(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_filter(lsp_filter);
+
+    tracing_subscriber::registry().with(layer).init();
+    Some(guard)
+}
+
+/// Initialize both main and LSP logging layers
+#[allow(clippy::too_many_lines)]
+fn init_both_layers(
+    main_target: &LogTarget,
+    lsp_target: &LspLogTarget,
+    main_filter: EnvFilter,
+) -> LogGuards {
+    // Get main layer components
+    let (main_guard, main_nb) = match main_target {
+        LogTarget::Disabled => (None, None),
+        LogTarget::Stderr => {
+            let (nb, guard) = tracing_appender::non_blocking(io::stderr());
+            (Some(guard), Some((nb, true))) // true = ansi
+        }
+        LogTarget::Default => {
+            let log_dir = get_log_directory();
+            if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                eprintln!("Warning: Failed to create log directory: {e}");
+                (None, None)
+            } else {
+                let log_filename = generate_log_filename();
+                let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
+                let (nb, guard) = tracing_appender::non_blocking(file_appender);
+                (Some(guard), Some((nb, false))) // false = no ansi
+            }
+        }
+        LogTarget::File(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("Warning: Failed to create log directory {}: {e}", parent.display());
+                (None, None)
+            } else {
+                let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+                let log_filename = path
+                    .file_name()
+                    .map_or_else(|| "reovim.log".to_string(), |s| s.to_string_lossy().to_string());
+                let file_appender = tracing_appender::rolling::never(log_dir, &log_filename);
+                let (nb, guard) = tracing_appender::non_blocking(file_appender);
+                (Some(guard), Some((nb, false)))
+            }
+        }
+    };
+
+    // Get LSP layer components
+    let (lsp_guard, lsp_nb) = match lsp_target {
+        LspLogTarget::Disabled => (None, None),
+        LspLogTarget::Default => {
+            let log_dir = get_log_directory();
+            if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                eprintln!("Warning: Failed to create LSP log directory: {e}");
+                (None, None)
+            } else {
+                let log_filename = generate_lsp_log_filename();
+                let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
+                let (nb, guard) = tracing_appender::non_blocking(file_appender);
+                (Some(guard), Some(nb))
+            }
+        }
+        LspLogTarget::File(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!("Warning: Failed to create LSP log directory {}: {e}", parent.display());
+                (None, None)
+            } else {
+                let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+                let log_filename = path
+                    .file_name()
+                    .map_or_else(|| "lsp.log".to_string(), |s| s.to_string_lossy().to_string());
+                let file_appender = tracing_appender::rolling::never(log_dir, &log_filename);
+                let (nb, guard) = tracing_appender::non_blocking(file_appender);
+                (Some(guard), Some(nb))
+            }
+        }
+    };
+
+    // Build the subscriber with both layers
+    let registry = tracing_subscriber::registry();
+
+    match (main_nb, lsp_nb) {
+        (Some((main_nb, ansi)), Some(lsp_nb)) => {
+            // Apply main_filter to main_layer only (not at registry level)
+            // so LSP trace events can reach the lsp_layer
+            let main_layer = fmt::layer()
+                .with_writer(main_nb)
+                .with_ansi(ansi)
+                .with_timer(UtcTime::rfc_3339())
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_filter(main_filter);
+
+            let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+            let lsp_layer = fmt::layer()
+                .with_writer(lsp_nb)
+                .with_ansi(false)
+                .with_timer(UtcTime::rfc_3339())
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_filter(lsp_filter);
+
+            registry.with(main_layer).with(lsp_layer).init();
+        }
+        (Some((main_nb, ansi)), None) => {
+            let main_layer = fmt::layer()
+                .with_writer(main_nb)
+                .with_ansi(ansi)
+                .with_timer(UtcTime::rfc_3339())
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true);
+
+            registry.with(main_filter).with(main_layer).init();
+        }
+        (None, Some(lsp_nb)) => {
+            let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+            let lsp_layer = fmt::layer()
+                .with_writer(lsp_nb)
+                .with_ansi(false)
+                .with_timer(UtcTime::rfc_3339())
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_filter(lsp_filter);
+
+            registry.with(lsp_layer).init();
+        }
+        (None, None) => {
+            registry.init();
+        }
+    }
+
+    LogGuards {
+        main: main_guard,
+        lsp: lsp_guard,
+    }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -61,6 +61,11 @@ struct Cli {
     /// Special values: '-' or 'stderr' for stderr, 'none' or 'off' to disable
     #[arg(long, value_name = "PATH")]
     log: Option<String>,
+
+    /// Enable LSP JSON-RPC message logging for debugging
+    /// Values: 'default' for timestamped file, or custom path
+    #[arg(long, value_name = "PATH")]
+    lsp_log: Option<String>,
 }
 
 #[tokio::main]
@@ -70,7 +75,8 @@ async fn main() -> Result<(), io::Error> {
 
     // Initialize logging BEFORE any terminal manipulation
     let log_target = logging::parse_log_target(cli.log.as_deref());
-    let _log_guard = logging::init(&log_target);
+    let lsp_log_target = logging::parse_lsp_log_target(cli.lsp_log.as_deref());
+    let _log_guards = logging::init_with_lsp(&log_target, &lsp_log_target);
 
     tracing::info!("reovim {} starting", env!("CARGO_PKG_VERSION"));
 


### PR DESCRIPTION
Add two debugging tools to help diagnose LSP issues:

1. LSP Health Check - Shows server status in :health modal
- Server running state
- Open document count
- Diagnostic cache statistics

2. Dedicated LSP Log - Separate log file for JSON-RPC messages
- --lsp-log=default for timestamped file
- --lsp-log=/path for custom path
- Captures -> outgoing and <- incoming messages at TRACE level

The LSP log uses per-layer filtering so TRACE-level LSP messages are captured even when main log level is INFO.