### PR TITLE
feat(lsp): add debugging tools and fix pull diagnostics (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,14 @@ All notable changes to Reovim will be documented in this file.
   - Status line shows `[INTERACTOR][MODE]` as separate colored sections
   - `Color` type exported from `reovim_core::highlight` for plugin use
 - **LSP debugging tools** (Issue #26) - Tools for debugging LSP communication
-  - LSP health check: Shows server status, document count, and diagnostic stats in `:health` modal
+  - LSP health check: Shows server status, document count, diagnostic stats, and timestamps in `:health` modal
+  - `:LspLog` command to open the latest LSP log file directly in the editor
   - Dedicated LSP log: `--lsp-log` flag for capturing JSON-RPC messages to separate file
     - `--lsp-log=default` creates timestamped `lsp-<timestamp>.log` in data directory
     - `--lsp-log=/path/to/file.log` for custom path
-    - Logs show `->` for outgoing and `<-` for incoming messages at TRACE level
+    - `--lsp-log=default:LEVEL` or `--lsp-log=/path:LEVEL` for configurable verbosity
+    - Supported levels: error, warn, info, debug, trace (default: trace)
+    - Logs show `->` for outgoing and `<-` for incoming messages
 - **Request-driven cursor movement with operator support** - Plugin-to-runtime communication for cursor positioning
   - `RequestCursorMove` event allows plugins to request cursor movement
   - `Motion::JumpTo { line, column }` variant for absolute positioning
@@ -60,6 +63,13 @@ All notable changes to Reovim will be documented in this file.
   - Automatic operator integration: `d`/`y`/`c` + jump creates `OperatorMotionAction`
   - Runtime detects `OperatorPending` mode and applies operators to jump targets
   - Enables jump navigation, LSP goto-definition, and other plugin-driven navigation with full vim operator semantics
+
+### Fixed
+
+- **LSP diagnostics not received after opening files** (Issue #26)
+  - rust-analyzer uses LSP 3.17 "pull diagnostics" instead of push notifications
+  - Now request diagnostics immediately after `textDocument/didOpen`
+  - Handle `workspace/diagnostic/refresh` requests from server
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,11 @@ cargo run -- --server --log=-
 cargo run -- --server --log=/tmp/reovim-server.log
 
 # LSP JSON-RPC message logging (for debugging LSP issues)
-reovim --lsp-log=default myfile.rs           # Timestamped lsp-*.log in data dir
-reovim --lsp-log=/tmp/lsp.log myfile.rs      # Custom path
+reovim --lsp-log=default myfile.rs              # Timestamped lsp-*.log in data dir (trace level)
+reovim --lsp-log=/tmp/lsp.log myfile.rs         # Custom path (trace level)
+reovim --lsp-log=default:debug myfile.rs        # Default path with debug level
+reovim --lsp-log=/tmp/lsp.log:info myfile.rs    # Custom path with info level
+# LSP log levels: error, warn, info, debug, trace (default: trace)
 cargo run -- --server --log=/tmp/main.log --lsp-log=/tmp/lsp.log  # Both logs
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +733,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -981,6 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1473,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1679,6 +1738,7 @@ name = "reovim-plugin-lsp"
 version = "0.7.9"
 dependencies = [
  "arc-swap",
+ "dirs",
  "reovim-core",
  "reovim-lang-markdown",
  "reovim-lsp",
@@ -2060,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/lib/lsp/src/cache.rs
+++ b/lib/lsp/src/cache.rs
@@ -6,7 +6,7 @@
 //!
 //! This ensures the render thread never blocks on diagnostic updates.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use {
     arc_swap::ArcSwap,
@@ -29,6 +29,8 @@ pub struct BufferDiagnostics {
 struct CacheData {
     /// Map from document URI string to diagnostics.
     entries: HashMap<String, BufferDiagnostics>,
+    /// When the cache was last updated.
+    last_updated: Option<Instant>,
 }
 
 /// Lock-free diagnostic cache.
@@ -80,6 +82,7 @@ impl DiagnosticCache {
         // Atomic swap
         self.current.store(Arc::new(CacheData {
             entries: new_entries,
+            last_updated: Some(Instant::now()),
         }));
     }
 
@@ -113,6 +116,7 @@ impl DiagnosticCache {
 
         self.current.store(Arc::new(CacheData {
             entries: new_entries,
+            last_updated: old.last_updated,
         }));
     }
 
@@ -141,6 +145,12 @@ impl DiagnosticCache {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Get when the cache was last updated.
+    #[must_use]
+    pub fn last_updated(&self) -> Option<Instant> {
+        self.current.load().last_updated
     }
 }
 

--- a/lib/lsp/src/saturator.rs
+++ b/lib/lsp/src/saturator.rs
@@ -410,7 +410,27 @@ impl LspSaturator {
                 Some(request) = request_rx.recv() => {
                     match request {
                         LspRequest::DidOpen { uri, language_id, version, content } => {
-                            Self::handle_did_open(&client, &open_docs, uri, language_id, version, content);
+                            Self::handle_did_open(&client, &open_docs, uri.clone(), language_id, version, content);
+
+                            // Request diagnostics for the opened document (pull diagnostics - LSP 3.17)
+                            // rust-analyzer uses pull diagnostics, so we must request them after didOpen
+                            // Note: Only store non-empty results from immediate request since rust-analyzer
+                            // may not have finished analyzing yet. Empty results will be filled by
+                            // subsequent workspace/diagnostic/refresh requests.
+                            let client = Arc::clone(&client);
+                            let cache = Arc::clone(&cache);
+                            let render_signal = render_signal.clone();
+                            tokio::spawn(async move {
+                                debug!(uri = %uri.as_str(), "Requesting diagnostics after didOpen");
+                                match client.request_diagnostics(uri.clone(), None, None).await {
+                                    Ok(report) => {
+                                        Self::handle_diagnostic_report_if_non_empty(&cache, render_signal.as_ref(), &uri, report);
+                                    }
+                                    Err(e) => {
+                                        debug!(uri = %uri.as_str(), error = %e, "Failed to request diagnostics after didOpen");
+                                    }
+                                }
+                            });
                         }
                         LspRequest::DidChange { uri, version, content } => {
                             Self::handle_did_change(&client, uri, version, content);
@@ -726,6 +746,43 @@ impl LspSaturator {
                     "Diagnostics unchanged"
                 );
                 // No update needed - diagnostics haven't changed
+            }
+        }
+    }
+
+    /// Handle a diagnostic report, but only store if non-empty.
+    ///
+    /// Used for immediate post-didOpen requests where rust-analyzer may not have
+    /// finished analyzing the file yet. Empty results are ignored to avoid
+    /// polluting the cache before actual diagnostics are available.
+    fn handle_diagnostic_report_if_non_empty(
+        cache: &Arc<DiagnosticCache>,
+        render_signal: Option<&mpsc::Sender<()>>,
+        uri: &Uri,
+        report: DocumentDiagnosticReport,
+    ) {
+        match report {
+            DocumentDiagnosticReport::Full(full_report) => {
+                let diagnostics = full_report.full_document_diagnostic_report.items;
+                let count = diagnostics.len();
+
+                if count > 0 {
+                    debug!(uri = ?uri, count = count, "Received full diagnostic report (immediate)");
+                    cache.store(uri, None, diagnostics);
+
+                    if let Some(tx) = render_signal {
+                        let _ = tx.try_send(());
+                    }
+                } else {
+                    debug!(uri = ?uri, "Skipping empty diagnostic report (waiting for refresh)");
+                }
+            }
+            DocumentDiagnosticReport::Unchanged(unchanged_report) => {
+                debug!(
+                    uri = ?uri,
+                    result_id = ?unchanged_report.unchanged_document_diagnostic_report.result_id,
+                    "Diagnostics unchanged (immediate)"
+                );
             }
         }
     }

--- a/plugins/features/lsp/Cargo.toml
+++ b/plugins/features/lsp/Cargo.toml
@@ -18,6 +18,7 @@ reovim-plugin-microscope.workspace = true
 reovim-plugin-notification.workspace = true
 reovim-plugin-statusline.workspace = true
 arc-swap = "1.8"
+dirs = "6"
 tracing.workspace = true
 tokio.workspace = true
 

--- a/plugins/features/lsp/src/command.rs
+++ b/plugins/features/lsp/src/command.rs
@@ -70,6 +70,16 @@ impl Event for LspHoverDismiss {
     }
 }
 
+/// Event emitted to open the LSP log file
+#[derive(Debug, Clone, Copy)]
+pub struct LspLogOpen;
+
+impl Event for LspLogOpen {
+    fn priority(&self) -> u32 {
+        100
+    }
+}
+
 // =============================================================================
 // Commands (extract context from ExecutionContext, emit events)
 // =============================================================================

--- a/plugins/features/lsp/src/health.rs
+++ b/plugins/features/lsp/src/health.rs
@@ -2,11 +2,23 @@
 //!
 //! Provides status information about the LSP server connection and diagnostics.
 
-use std::{fmt, sync::Arc};
+use std::{fmt, sync::Arc, time::Instant};
 
 use reovim_plugin_health_check::{HealthCheck, HealthCheckResult};
 
 use crate::SharedLspManager;
+
+/// Format an instant as "Xs ago" or "Xm ago".
+fn format_elapsed(instant: Instant) -> String {
+    let elapsed = instant.elapsed();
+    if elapsed.as_secs() < 60 {
+        format!("{}s ago", elapsed.as_secs())
+    } else if elapsed.as_secs() < 3600 {
+        format!("{}m ago", elapsed.as_secs() / 60)
+    } else {
+        format!("{}h ago", elapsed.as_secs() / 3600)
+    }
+}
 
 /// Health check for LSP server status.
 ///
@@ -68,6 +80,16 @@ impl HealthCheck for LspHealthCheck {
             details.push(format!("Total diagnostics: {total_diagnostics}"));
             if pending_syncs {
                 details.push("Pending syncs: yes (debouncing)".to_string());
+            }
+
+            // Timestamps
+            if let Some(ref cache) = m.cache
+                && let Some(last_diag) = cache.last_updated()
+            {
+                details.push(format!("Last diagnostics: {}", format_elapsed(last_diag)));
+            }
+            if let Some(last_sync) = m.last_sync {
+                details.push(format!("Last sync: {}", format_elapsed(last_sync)));
             }
 
             HealthCheckResult::ok(format!(

--- a/plugins/features/lsp/src/lib.rs
+++ b/plugins/features/lsp/src/lib.rs
@@ -59,7 +59,7 @@ pub use {
 // Re-export events and commands for external use
 pub use command::{
     LspGotoDefinition, LspGotoDefinitionCommand, LspGotoReferences, LspGotoReferencesCommand,
-    LspHoverDismiss, LspShowHover, LspShowHoverCommand,
+    LspHoverDismiss, LspLogOpen, LspShowHover, LspShowHoverCommand,
 };
 
 /// LSP integration plugin.
@@ -187,6 +187,67 @@ impl Plugin for LspPlugin {
             let manager = Arc::clone(&self.manager);
             bus.emit(RegisterHealthCheck::new(Arc::new(health::LspHealthCheck::new(manager))));
         }
+
+        // Register :LspLog ex-command
+        {
+            use reovim_core::{
+                command_line::ExCommandHandler,
+                event_bus::{DynEvent, core_events::RegisterExCommand},
+            };
+
+            bus.emit(RegisterExCommand::new(
+                "LspLog",
+                ExCommandHandler::ZeroArg {
+                    event_constructor: || DynEvent::new(command::LspLogOpen),
+                    description: "Open the LSP log file",
+                },
+            ));
+        }
+
+        // Handle LspLogOpen - find and open the LSP log file
+        bus.subscribe::<command::LspLogOpen, _>(100, move |_event, ctx| {
+            use reovim_core::event_bus::core_events::RequestOpenFile;
+
+            // Find the latest LSP log file in the data directory
+            let data_dir = dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("reovim");
+
+            // Find latest lsp-*.log file
+            if let Ok(entries) = std::fs::read_dir(&data_dir) {
+                let mut lsp_logs: Vec<_> = entries
+                    .filter_map(std::result::Result::ok)
+                    .filter(|e| {
+                        e.file_name().to_string_lossy().starts_with("lsp-")
+                            && e.file_name().to_string_lossy().ends_with(".log")
+                    })
+                    .collect();
+
+                // Sort by modification time (newest first)
+                lsp_logs.sort_by(|a, b| {
+                    b.metadata()
+                        .and_then(|m| m.modified())
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+                        .cmp(
+                            &a.metadata()
+                                .and_then(|m| m.modified())
+                                .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+                        )
+                });
+
+                if let Some(latest) = lsp_logs.first() {
+                    let log_path = latest.path();
+                    info!("Opening LSP log: {}", log_path.display());
+                    ctx.emit(RequestOpenFile { path: log_path });
+                } else {
+                    warn!("No LSP log files found in {}", data_dir.display());
+                }
+            } else {
+                warn!("Could not read data directory: {}", data_dir.display());
+            }
+
+            EventResult::Handled
+        });
 
         // Handle file open - register document and schedule sync for render stage
         // Note: We don't send didOpen here directly. The render stage handles it

--- a/plugins/features/lsp/src/manager.rs
+++ b/plugins/features/lsp/src/manager.rs
@@ -2,7 +2,10 @@
 //!
 //! Manages the LSP client connection and document synchronization state.
 
-use std::sync::{Arc, RwLock};
+use std::{
+    sync::{Arc, RwLock},
+    time::Instant,
+};
 
 use {
     reovim_core::event::InnerEvent,
@@ -75,6 +78,8 @@ pub struct LspManager {
     pub event_tx: Option<mpsc::Sender<InnerEvent>>,
     /// Whether the LSP server is running.
     pub running: bool,
+    /// Last time a document was synced.
+    pub last_sync: Option<Instant>,
 }
 
 impl LspManager {
@@ -88,7 +93,13 @@ impl LspManager {
             hover_cache: HoverCache::new(),
             event_tx: None,
             running: false,
+            last_sync: None,
         }
+    }
+
+    /// Update the last document sync timestamp.
+    pub fn mark_sync_sent(&mut self) {
+        self.last_sync = Some(Instant::now());
     }
 
     /// Set the event sender for triggering re-renders.

--- a/plugins/features/lsp/src/stage.rs
+++ b/plugins/features/lsp/src/stage.rs
@@ -166,6 +166,9 @@ impl LspRenderStage {
                 // Mark as opened only after successfully sending didOpen
                 m.documents.mark_opened(buffer_id);
             }
+
+            // Update last sync timestamp
+            m.mark_sync_sent();
         });
     }
 

--- a/runner/src/logging.rs
+++ b/runner/src/logging.rs
@@ -41,15 +41,44 @@ pub enum LogTarget {
     Disabled,
 }
 
+/// Log verbosity level for LSP logging
+#[derive(Debug, Clone, Copy, Default)]
+pub enum LspLogLevel {
+    /// Error level only
+    Error,
+    /// Warn and above
+    Warn,
+    /// Info and above
+    Info,
+    /// Debug and above
+    Debug,
+    /// All messages (default for LSP logging)
+    #[default]
+    Trace,
+}
+
+impl LspLogLevel {
+    /// Convert to tracing filter directive
+    const fn as_filter_directive(self) -> &'static str {
+        match self {
+            Self::Error => "reovim_lsp=error",
+            Self::Warn => "reovim_lsp=warn",
+            Self::Info => "reovim_lsp=info",
+            Self::Debug => "reovim_lsp=debug",
+            Self::Trace => "reovim_lsp=trace",
+        }
+    }
+}
+
 /// Target for LSP-specific log output
 #[derive(Debug, Clone)]
 pub enum LspLogTarget {
     /// LSP logging disabled (default)
     Disabled,
     /// Default: timestamped file `lsp-<timestamp>.log` in XDG data directory
-    Default,
+    Default(LspLogLevel),
     /// Custom file path
-    File(PathBuf),
+    File(PathBuf, LspLogLevel),
 }
 
 /// Container for log guards (must be held for duration of program)
@@ -93,29 +122,67 @@ pub fn parse_log_target(arg: Option<&str>) -> LogTarget {
     }
 }
 
+/// Parse a log level from a string
+fn parse_lsp_level(s: &str) -> LspLogLevel {
+    match s.to_lowercase().as_str() {
+        "error" => LspLogLevel::Error,
+        "warn" | "warning" => LspLogLevel::Warn,
+        "info" => LspLogLevel::Info,
+        "debug" => LspLogLevel::Debug,
+        // trace or any invalid value defaults to trace
+        _ => LspLogLevel::Trace,
+    }
+}
+
 /// Parse an LSP log target from a CLI argument
 ///
 /// # Special values
 /// - `None` -> Disabled (no LSP logging)
-/// - `"default"` -> Default (timestamped file in ~/.local/share/reovim/)
+/// - `"default"` -> Default path with trace level
+/// - `"default:LEVEL"` -> Default path with specified level
 /// - `"none"` or `"off"` -> Disabled
-/// - Any other string -> File path
+/// - `"/path"` -> File path with trace level
+/// - `"/path:LEVEL"` -> File path with specified level
+///
+/// # Levels
+/// - `error`, `warn`, `info`, `debug`, `trace`
 #[must_use]
 pub fn parse_lsp_log_target(arg: Option<&str>) -> LspLogTarget {
     match arg {
         None | Some("none" | "off") => LspLogTarget::Disabled,
-        Some("default") => LspLogTarget::Default,
-        Some(path) => {
-            let path = PathBuf::from(path);
-            // Resolve relative paths against CWD
-            if path.is_relative() {
-                LspLogTarget::File(
+        Some(s) => {
+            // Check for level suffix (e.g., "default:debug" or "/path:trace")
+            let (target, level) = s.rfind(':').map_or_else(
+                || (s, LspLogLevel::default()),
+                |pos| {
+                    let (t, l) = s.split_at(pos);
+                    // Check if the part after ':' looks like a level
+                    let potential_level = &l[1..];
+                    if matches!(
+                        potential_level.to_lowercase().as_str(),
+                        "error" | "warn" | "warning" | "info" | "debug" | "trace"
+                    ) {
+                        (t, parse_lsp_level(potential_level))
+                    } else {
+                        // Not a level suffix, treat whole string as path (could be C:\path on Windows)
+                        (s, LspLogLevel::default())
+                    }
+                },
+            );
+
+            if target == "default" {
+                LspLogTarget::Default(level)
+            } else {
+                let path = PathBuf::from(target);
+                // Resolve relative paths against CWD
+                let resolved = if path.is_relative() {
                     std::env::current_dir()
                         .map(|cwd| cwd.join(&path))
-                        .unwrap_or(path),
-                )
-            } else {
-                LspLogTarget::File(path)
+                        .unwrap_or(path)
+                } else {
+                    path
+                };
+                LspLogTarget::File(resolved, level)
             }
         }
     }
@@ -292,17 +359,17 @@ fn init_file_layer(
 
 /// Initialize LSP-only logging (when main logging is disabled)
 fn init_lsp_only(target: &LspLogTarget) -> Option<WorkerGuard> {
-    let (log_dir, log_filename) = match target {
+    let (log_dir, log_filename, level) = match target {
         LspLogTarget::Disabled => return None,
-        LspLogTarget::Default => {
+        LspLogTarget::Default(level) => {
             let log_dir = get_log_directory();
             if let Err(e) = std::fs::create_dir_all(&log_dir) {
                 eprintln!("Warning: Failed to create LSP log directory: {e}");
                 return None;
             }
-            (log_dir, generate_lsp_log_filename())
+            (log_dir, generate_lsp_log_filename(), *level)
         }
-        LspLogTarget::File(path) => {
+        LspLogTarget::File(path, level) => {
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
                 && let Err(e) = std::fs::create_dir_all(parent)
@@ -314,15 +381,15 @@ fn init_lsp_only(target: &LspLogTarget) -> Option<WorkerGuard> {
             let log_filename = path
                 .file_name()
                 .map_or_else(|| "lsp.log".to_string(), |s| s.to_string_lossy().to_string());
-            (log_dir.to_path_buf(), log_filename)
+            (log_dir.to_path_buf(), log_filename, *level)
         }
     };
 
     let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-    // Filter to only include reovim_lsp target at trace level
-    let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+    // Filter to only include reovim_lsp target at configured level
+    let lsp_filter = EnvFilter::new(level.as_filter_directive());
 
     let layer = fmt::layer()
         .with_writer(non_blocking)
@@ -382,28 +449,28 @@ fn init_both_layers(
         }
     };
 
-    // Get LSP layer components
-    let (lsp_guard, lsp_nb) = match lsp_target {
-        LspLogTarget::Disabled => (None, None),
-        LspLogTarget::Default => {
+    // Get LSP layer components and level
+    let (lsp_guard, lsp_nb, lsp_level) = match lsp_target {
+        LspLogTarget::Disabled => (None, None, LspLogLevel::default()),
+        LspLogTarget::Default(level) => {
             let log_dir = get_log_directory();
             if let Err(e) = std::fs::create_dir_all(&log_dir) {
                 eprintln!("Warning: Failed to create LSP log directory: {e}");
-                (None, None)
+                (None, None, *level)
             } else {
                 let log_filename = generate_lsp_log_filename();
                 let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
                 let (nb, guard) = tracing_appender::non_blocking(file_appender);
-                (Some(guard), Some(nb))
+                (Some(guard), Some(nb), *level)
             }
         }
-        LspLogTarget::File(path) => {
+        LspLogTarget::File(path, level) => {
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
                 && let Err(e) = std::fs::create_dir_all(parent)
             {
                 eprintln!("Warning: Failed to create LSP log directory {}: {e}", parent.display());
-                (None, None)
+                (None, None, *level)
             } else {
                 let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
                 let log_filename = path
@@ -411,7 +478,7 @@ fn init_both_layers(
                     .map_or_else(|| "lsp.log".to_string(), |s| s.to_string_lossy().to_string());
                 let file_appender = tracing_appender::rolling::never(log_dir, &log_filename);
                 let (nb, guard) = tracing_appender::non_blocking(file_appender);
-                (Some(guard), Some(nb))
+                (Some(guard), Some(nb), *level)
             }
         }
     };
@@ -432,7 +499,7 @@ fn init_both_layers(
                 .with_line_number(true)
                 .with_filter(main_filter);
 
-            let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+            let lsp_filter = EnvFilter::new(lsp_level.as_filter_directive());
             let lsp_layer = fmt::layer()
                 .with_writer(lsp_nb)
                 .with_ansi(false)
@@ -456,7 +523,7 @@ fn init_both_layers(
             registry.with(main_filter).with(main_layer).init();
         }
         (None, Some(lsp_nb)) => {
-            let lsp_filter = EnvFilter::new("reovim_lsp=trace");
+            let lsp_filter = EnvFilter::new(lsp_level.as_filter_directive());
             let lsp_layer = fmt::layer()
                 .with_writer(lsp_nb)
                 .with_ansi(false)


### PR DESCRIPTION
Add debugging tools to help diagnose LSP issues:

1. LSP Health Check - Shows server status in :health modal
   - Server running state, document count, diagnostic stats
   - Last diagnostics received and last sync timestamps

2. Dedicated LSP Log - Separate log file for JSON-RPC messages
   - --lsp-log=default for timestamped file
   - --lsp-log=/path for custom path
   - --lsp-log=default:LEVEL for configurable verbosity (error/warn/info/debug/trace)
   - Captures -> outgoing and <- incoming messages

3. :LspLog command - Open the latest LSP log file in the editor

Fix LSP diagnostics not received after opening files:
- rust-analyzer uses LSP 3.17 "pull diagnostics" instead of push
- Now request diagnostics immediately after textDocument/didOpen
- Only store non-empty results from immediate request to avoid polluting cache before analysis completes
- Handle workspace/diagnostic/refresh for subsequent updates

Closes #26