### PR TITLE
feat(diagnostics): add sign column and virtual text configuration (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Sign column and virtual text configuration** (Issue #29) - Phase 3 of diagnostics system (#21)
+  - Sign column modes: `auto`, `yes`, `no`, `number`
+    - `auto`: Show sign column only when signs are present (width 2)
+    - `yes`: Always show sign column (default, width 2)
+    - `no`: Never show sign column
+    - `number`: Display signs as background color on line numbers
+  - Virtual text options: `:set virtual_text`, `virtual_text_prefix`, `virtual_text_max_length`, `virtual_text_show`
+    - `virtual_text` (bool): Enable/disable virtual text display
+    - `virtual_text_prefix` (string): Custom prefix (empty = use severity icons)
+    - `virtual_text_max_length` (number): Maximum length before truncation (default: 80)
+    - `virtual_text_show` (string): "first", "highest", or "all" mode
+  - Settings menu integration for all new options under "Diagnostics" section
+  - 14 new tests for sign column modes and virtual text configuration
+
 - **Virtual text system for inline diagnostics** (Issue #28) - Display diagnostic messages after line content
   - `VirtualTextEntry` type with text, style, and priority fields
   - `VirtualTextStyles` in theme for severity-based styling (error, warn, info, hint)

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     modd::{ComponentId, ModeState},
     plugin::PluginId,
     rpc::RpcResponse,
-    screen::{NavigateDirection, SplitDirection},
+    screen::{NavigateDirection, SplitDirection, window::SignColumnMode},
     syntax::SyntaxProvider,
     textobject::{SemanticTextObjectSpec, TextObject, WordTextObject},
 };
@@ -104,7 +104,7 @@ pub enum InnerEvent {
     },
     /// Set sign column configuration
     SetSignColumn {
-        width: Option<u16>,
+        mode: SignColumnMode,
     },
     /// Move cursor to specific position (from plugins like range-finder, LSP)
     MoveCursor {

--- a/lib/core/src/event_bus/core_events.rs
+++ b/lib/core/src/event_bus/core_events.rs
@@ -4,7 +4,7 @@
 //! need to react to. They use low priority numbers (0-50) to ensure core
 //! handlers run before plugin handlers.
 
-use super::Event;
+use {super::Event, crate::screen::window::SignColumnMode};
 
 /// Priority constants for core events
 pub mod priority {
@@ -474,8 +474,8 @@ impl Event for RequestSetIndentGuide {
 /// Emitted by plugins when the signcolumn option changes.
 #[derive(Debug, Clone, Copy)]
 pub struct RequestSetSignColumn {
-    /// Sign column width (None = disabled, Some(width) = enabled)
-    pub width: Option<u16>,
+    /// Sign column display mode
+    pub mode: SignColumnMode,
 }
 
 impl Event for RequestSetSignColumn {

--- a/lib/core/src/plugin/builtin/core.rs
+++ b/lib/core/src/plugin/builtin/core.rs
@@ -110,6 +110,7 @@ use crate::{
         OptionValue, RegisterOption, RegisterSettingSection,
     },
     plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
+    screen::window::SignColumnMode,
 };
 
 /// Core editor functionality plugin
@@ -206,15 +207,15 @@ impl CorePlugin {
                 }
                 "signcolumn" => {
                     if let OptionValue::String(value) = &event.new_value {
-                        // Parse signcolumn value: "no" or "yes:N"
-                        let width = if value == "no" {
-                            None
-                        } else if let Some(num_str) = value.strip_prefix("yes:") {
-                            num_str.parse::<u16>().ok()
-                        } else {
-                            Some(2) // Default width if invalid format
+                        // Parse signcolumn value: "auto", "yes", "no", "number"
+                        let mode = match value.as_str() {
+                            "yes" => SignColumnMode::Yes(2),
+                            "no" => SignColumnMode::No,
+                            "number" => SignColumnMode::Number,
+                            // "auto" and any invalid value default to Auto
+                            _ => SignColumnMode::Auto,
                         };
-                        ctx.emit(RequestSetSignColumn { width });
+                        ctx.emit(RequestSetSignColumn { mode });
                         needs_render = true;
                     }
                 }
@@ -795,8 +796,8 @@ impl CorePlugin {
         bus.emit(RegisterOption::new(
             OptionSpec::new(
                 "signcolumn",
-                "Sign column display ('no' or 'yes:N')",
-                OptionValue::String("yes:2".into()),
+                "Sign column display ('auto', 'yes', 'no', 'number')",
+                OptionValue::String("yes".into()),
             )
             .with_category(OptionCategory::Editor)
             .with_section("Editor")
@@ -912,6 +913,49 @@ impl CorePlugin {
             .with_category(OptionCategory::Window)
             .with_section("Window")
             .with_display_order(11),
+        ));
+
+        // Virtual text options (diagnostics)
+        bus.emit(RegisterOption::new(
+            OptionSpec::new("virtual_text", "Show inline diagnostics", OptionValue::Bool(true))
+                .with_short("vt")
+                .with_category(OptionCategory::Editor)
+                .with_section("Diagnostics")
+                .with_display_order(40),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "virtual_text_prefix",
+                "Prefix for virtual text",
+                OptionValue::String(String::new()),
+            )
+            .with_category(OptionCategory::Editor)
+            .with_section("Diagnostics")
+            .with_display_order(41),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "virtual_text_max_length",
+                "Maximum virtual text length",
+                OptionValue::Integer(80),
+            )
+            .with_category(OptionCategory::Editor)
+            .with_section("Diagnostics")
+            .with_constraint(OptionConstraint::range(10, 200))
+            .with_display_order(42),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "virtual_text_show",
+                "Which diagnostics to show ('first', 'highest', 'all')",
+                OptionValue::choice("first", vec!["first".into(), "highest".into(), "all".into()]),
+            )
+            .with_category(OptionCategory::Editor)
+            .with_section("Diagnostics")
+            .with_display_order(43),
         ));
     }
 }

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -595,7 +595,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetSignColumn, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetSignColumn { width: event.width });
+                    let _ = tx.try_send(InnerEvent::SetSignColumn { mode: event.mode });
                     EventResult::Handled
                 });
         }

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -633,9 +633,9 @@ impl Runtime {
                 tracing::info!("Runtime: Setting indent guide: {}", enabled);
                 self.indent_analyzer.set_enabled(enabled);
             }
-            InnerEvent::SetSignColumn { width } => {
-                tracing::info!("Runtime: Setting sign column: {:?}", width);
-                self.screen.set_sign_column_width(width);
+            InnerEvent::SetSignColumn { mode } => {
+                tracing::info!("Runtime: Setting sign column mode: {:?}", mode);
+                self.screen.set_sign_column_mode(mode);
             }
             InnerEvent::MoveCursor {
                 buffer_id,

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -62,11 +62,12 @@ use {
         content::WindowContentSource,
         decoration::DecorationStore,
         frame::{FrameBuffer, FrameRenderer},
-        highlight::{ColorMode, HighlightStore, Theme},
+        highlight::{ColorMode, HighlightStore, Style, Theme},
         indent::IndentAnalyzer,
         modd::{ComponentId, ModeState},
         modifier::{ModifierContext, ModifierRegistry},
         plugin::{SectionAlignment, StatuslineRenderContext},
+        sign::Sign,
         visibility::BufferVisibilitySource,
     },
     reovim_sys::{
@@ -79,7 +80,7 @@ use {
         collections::BTreeMap,
         io::{self, Write},
     },
-    window::{Anchor, LineNumber, Window},
+    window::{Anchor, LineNumber, SignColumnMode, Window},
 };
 
 pub use status_line::{StatusLineRenderer, render_command_line_to, render_status_line_to};
@@ -151,7 +152,7 @@ impl Default for Screen {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
-            sign_column_width: Some(2),
+            sign_column_mode: SignColumnMode::Yes(2),
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,
@@ -214,7 +215,7 @@ impl Screen {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
-            sign_column_width: Some(2),
+            sign_column_mode: SignColumnMode::Yes(2),
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,
@@ -510,6 +511,10 @@ impl Screen {
             1
         };
 
+        // Precompute whether any signs exist (for auto mode)
+        let has_signs = render_data.signs.iter().any(Option::is_some);
+        let sign_column_width = window.sign_column_mode.effective_width(has_signs);
+
         // Render each visible line, starting from scroll offset
         let mut display_row = 0u16;
         let start_line = scroll_offset as usize;
@@ -527,16 +532,18 @@ impl Screen {
                     let screen_y = window.anchor.y + display_row;
                     let mut gutter_width = 0u16;
 
+                    // Get sign for this line (used by both sign column and number mode)
+                    let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+
                     // Render sign column FIRST (if enabled) - leftmost gutter element
-                    if let Some(sign_width) = window.sign_column_width {
-                        let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+                    if sign_column_width > 0 {
                         let sign_x = window.anchor.x + gutter_width;
                         if line_idx == 0 {
                             tracing::info!(
                                 "SIGN_COLUMN: x={} y={} width={} sign_present={}",
                                 sign_x,
                                 screen_y,
-                                sign_width,
+                                sign_column_width,
                                 sign.is_some()
                             );
                         }
@@ -545,7 +552,7 @@ impl Screen {
                             sign_x,
                             screen_y,
                             sign,
-                            sign_width,
+                            sign_column_width,
                             theme,
                         );
                     }
@@ -564,6 +571,7 @@ impl Screen {
                         num_width,
                         theme,
                         window,
+                        sign,
                     );
 
                     // Render fold marker
@@ -608,16 +616,18 @@ impl Screen {
                     let screen_y = window.anchor.y + display_row;
                     let mut gutter_width = 0u16;
 
+                    // Get sign for this line (used by both sign column and number mode)
+                    let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+
                     // Render sign column FIRST (if enabled) - leftmost gutter element
-                    if let Some(sign_width) = window.sign_column_width {
-                        let sign = render_data.signs.get(line_idx).and_then(|s| s.as_ref());
+                    if sign_column_width > 0 {
                         let sign_x = window.anchor.x + gutter_width;
                         if line_idx == 0 {
                             tracing::info!(
                                 "SIGN_COLUMN: x={} y={} width={} sign_present={}",
                                 sign_x,
                                 screen_y,
-                                sign_width,
+                                sign_column_width,
                                 sign.is_some()
                             );
                         }
@@ -626,7 +636,7 @@ impl Screen {
                             sign_x,
                             screen_y,
                             sign,
-                            sign_width,
+                            sign_column_width,
                             theme,
                         );
                     }
@@ -645,6 +655,7 @@ impl Screen {
                         num_width,
                         theme,
                         window,
+                        sign,
                     );
 
                     // Render line content with syntax highlights and decorations
@@ -880,6 +891,7 @@ impl Screen {
         num_width: usize,
         theme: &Theme,
         window: &Window,
+        sign: Option<&Sign>,
     ) -> u16 {
         use crate::screen::window::LineNumberMode;
 
@@ -917,17 +929,32 @@ impl Screen {
         let line_num_str = format!("{num_str:>num_width$} ");
 
         // Render line number with style
-        let line_num_style = if !window.is_active {
-            &theme.gutter.inactive_line_number
+        // For Number mode: use sign's foreground as background color
+        let base_style = if !window.is_active {
+            theme.gutter.inactive_line_number.clone()
         } else if is_current_line {
-            &theme.gutter.current_line_number
+            theme.gutter.current_line_number.clone()
         } else {
-            &theme.gutter.line_number
+            theme.gutter.line_number.clone()
+        };
+
+        let line_num_style = if window.sign_column_mode == SignColumnMode::Number {
+            if let Some(sign) = sign {
+                // Use sign's foreground color as background for line number
+                Style {
+                    bg: sign.style.fg,
+                    ..base_style
+                }
+            } else {
+                base_style
+            }
+        } else {
+            base_style
         };
 
         let mut col = x;
         for ch in line_num_str.chars() {
-            buffer.put_char(col, y, ch, line_num_style);
+            buffer.put_char(col, y, ch, &line_num_style);
             col += 1;
         }
 
@@ -1025,7 +1052,8 @@ impl Screen {
                 let buffer_id = win.buffer_id()?;
                 let buf = buffers.get(&buffer_id)?;
                 let line_num_width = win.line_number_width(buf.contents.len());
-                let sign_width = win.sign_column_width.unwrap_or(0);
+                // Use max width for layout (assume signs present in auto mode)
+                let sign_width = win.sign_column_mode.effective_width(true);
                 let gutter_width = sign_width + line_num_width;
                 let scroll_y = win.buffer_anchor().map_or(0, |a| a.y);
                 Some((win.anchor.x, win.anchor.y, gutter_width, scroll_y, buf.cur.x, buf.cur.y))
@@ -1158,7 +1186,8 @@ impl Screen {
                 // Calculate cursor position only for the ACTIVE window (and if editor is focused)
                 if win.is_active {
                     let line_num_width = win.line_number_width(buf.contents.len());
-                    let sign_width = win.sign_column_width.unwrap_or(0);
+                    // Use max width for cursor position (assume signs present in auto mode)
+                    let sign_width = win.sign_column_mode.effective_width(true);
                     let cursor_x = win.anchor.x + sign_width + line_num_width + buf.cur.x;
                     let cursor_y = win.anchor.y
                         + buf
@@ -1233,9 +1262,9 @@ impl Screen {
         }
     }
 
-    pub fn set_sign_column_width(&mut self, width: Option<u16>) {
+    pub fn set_sign_column_mode(&mut self, mode: SignColumnMode) {
         for window in &mut self.windows {
-            window.sign_column_width = width;
+            window.sign_column_mode = mode;
         }
     }
 
@@ -1482,7 +1511,7 @@ impl Screen {
                     is_floating: false,
                     line_number: Some(LineNumber::default()),
                     scrollbar_enabled: false,
-                    sign_column_width: Some(2),
+                    sign_column_mode: SignColumnMode::Yes(2),
                     cursor,
                     desired_col,
                     border_config: None,

--- a/lib/core/src/screen/window.rs
+++ b/lib/core/src/screen/window.rs
@@ -70,9 +70,8 @@ pub struct Window {
     pub line_number: Option<LineNumber>,
     /// Whether to show scrollbar
     pub scrollbar_enabled: bool,
-    /// Sign column width (None = disabled, Some(width) = enabled)
-    /// Typical values: Some(1) or Some(2)
-    pub sign_column_width: Option<u16>,
+    /// Sign column display mode
+    pub sign_column_mode: SignColumnMode,
     /// Per-window cursor position
     pub cursor: Position,
     /// Track preferred column for vertical movement (j/k)
@@ -86,6 +85,38 @@ pub enum LineNumberMode {
     Absolute,
     Relative,
     Hybrid,
+}
+
+/// Sign column display mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SignColumnMode {
+    /// Show when signs present, hide otherwise (default)
+    #[default]
+    Auto,
+    /// Always show with specified width
+    Yes(u16),
+    /// Never show
+    No,
+    /// Display signs in line number column (as background color)
+    Number,
+}
+
+impl SignColumnMode {
+    /// Get the effective sign column width based on mode and whether signs exist
+    #[must_use]
+    pub const fn effective_width(&self, has_signs: bool) -> u16 {
+        match self {
+            Self::Auto => {
+                if has_signs {
+                    2
+                } else {
+                    0
+                }
+            }
+            Self::Yes(width) => *width,
+            Self::No | Self::Number => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1318,7 +1349,7 @@ pub mod tests {
             is_floating: false,
             line_number: Some(LineNumber::default()),
             scrollbar_enabled: false,
-            sign_column_width: None, // Disabled by default in tests to avoid position shifts
+            sign_column_mode: SignColumnMode::No, // Disabled by default in tests to avoid position shifts
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,

--- a/lib/core/tests/sign_column.rs
+++ b/lib/core/tests/sign_column.rs
@@ -1,24 +1,50 @@
 //! Integration tests for sign column rendering
 
-use reovim_core::{highlight::Style, render::RenderData, sign::Sign};
+use reovim_core::{
+    highlight::Style, render::RenderData, screen::window::SignColumnMode, sign::Sign,
+};
 
 #[test]
-fn test_sign_column_width_configuration() {
+fn test_sign_column_mode_configuration() {
     let mut window = common::create_test_window();
 
-    // Default should be enabled with width 2
-    assert_eq!(window.sign_column_width, Some(2));
+    // Default should be Yes(2) mode (always show with width 2)
+    assert_eq!(window.sign_column_mode, SignColumnMode::Yes(2));
+    assert_eq!(window.sign_column_mode.effective_width(true), 2);
+    assert_eq!(window.sign_column_mode.effective_width(false), 2);
 
-    // Can be disabled
-    window.sign_column_width = None;
-    assert!(window.sign_column_width.is_none());
+    // Can be set to No (disabled)
+    window.sign_column_mode = SignColumnMode::No;
+    assert_eq!(window.sign_column_mode, SignColumnMode::No);
+    assert_eq!(window.sign_column_mode.effective_width(true), 0);
+    assert_eq!(window.sign_column_mode.effective_width(false), 0);
 
-    // Can be set to different widths
-    window.sign_column_width = Some(1);
-    assert_eq!(window.sign_column_width, Some(1));
+    // Can be set to Yes with different widths
+    window.sign_column_mode = SignColumnMode::Yes(1);
+    assert_eq!(window.sign_column_mode.effective_width(true), 1);
 
-    window.sign_column_width = Some(3);
-    assert_eq!(window.sign_column_width, Some(3));
+    window.sign_column_mode = SignColumnMode::Yes(3);
+    assert_eq!(window.sign_column_mode.effective_width(true), 3);
+}
+
+#[test]
+fn test_sign_column_auto_mode() {
+    let mut window = common::create_test_window();
+
+    // Auto mode: width depends on whether signs exist
+    window.sign_column_mode = SignColumnMode::Auto;
+    assert_eq!(window.sign_column_mode.effective_width(false), 0);
+    assert_eq!(window.sign_column_mode.effective_width(true), 2);
+}
+
+#[test]
+fn test_sign_column_number_mode() {
+    let mut window = common::create_test_window();
+
+    // Number mode: signs displayed in line number column
+    window.sign_column_mode = SignColumnMode::Number;
+    assert_eq!(window.sign_column_mode.effective_width(true), 0);
+    assert_eq!(window.sign_column_mode.effective_width(false), 0);
 }
 
 #[test]
@@ -145,7 +171,7 @@ mod common {
         content::WindowContentSource,
         screen::{
             Position,
-            window::{Anchor, Window},
+            window::{Anchor, SignColumnMode, Window},
         },
     };
 
@@ -164,7 +190,7 @@ mod common {
             is_floating: false,
             line_number: None,
             scrollbar_enabled: false,
-            sign_column_width: Some(2),
+            sign_column_mode: SignColumnMode::Yes(2),
             cursor: Position { x: 0, y: 0 },
             desired_col: None,
             border_config: None,

--- a/lib/core/tests/sign_render_visual.rs
+++ b/lib/core/tests/sign_render_visual.rs
@@ -11,7 +11,7 @@ use reovim_core::{
     render::RenderData,
     screen::{
         Position,
-        window::{Anchor, LineNumber, Window},
+        window::{Anchor, LineNumber, SignColumnMode, Window},
     },
     sign::Sign,
 };
@@ -36,7 +36,7 @@ fn test_sign_visual_rendering() {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
-        sign_column_width: Some(2), // Enable 2-char sign column
+        sign_column_mode: SignColumnMode::Yes(2), // Enable 2-char sign column
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: 0 },
         desired_col: None,

--- a/lib/core/tests/virtual_text_render.rs
+++ b/lib/core/tests/virtual_text_render.rs
@@ -13,7 +13,7 @@ use reovim_core::{
     render::{RenderData, VirtualTextEntry},
     screen::{
         Position,
-        window::{Anchor, LineNumber, Window},
+        window::{Anchor, LineNumber, SignColumnMode, Window},
     },
     sign::Sign,
 };
@@ -32,7 +32,7 @@ fn create_test_window(width: u16, height: u16) -> Window {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
-        sign_column_width: Some(2),
+        sign_column_mode: SignColumnMode::Yes(2),
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: 0 },
         desired_col: None,

--- a/plugins/features/lsp/src/lib.rs
+++ b/plugins/features/lsp/src/lib.rs
@@ -673,6 +673,66 @@ impl Plugin for LspPlugin {
                 }
             });
         }
+
+        // Handle virtual text option changes
+        {
+            use reovim_core::option::{OptionChanged, OptionValue};
+
+            let state = Arc::clone(&state);
+            bus.subscribe::<OptionChanged, _>(100, move |event, _ctx| {
+                let name = event.name.as_str();
+
+                // Only handle virtual_text_* options
+                if !name.starts_with("virtual_text") {
+                    return EventResult::Handled;
+                }
+
+                state.with_mut::<Arc<SharedLspManager>, _, _>(|manager| {
+                    manager.with_mut(|m| {
+                        let config = &mut m.virtual_text_config;
+                        match name {
+                            "virtual_text" => {
+                                if let OptionValue::Bool(enabled) = &event.new_value {
+                                    config.enabled = *enabled;
+                                    debug!("LSP: virtual_text enabled = {}", enabled);
+                                }
+                            }
+                            "virtual_text_prefix" => {
+                                if let OptionValue::String(prefix) = &event.new_value {
+                                    config.prefix.clone_from(prefix);
+                                    debug!("LSP: virtual_text prefix = {:?}", prefix);
+                                }
+                            }
+                            "virtual_text_max_length" => {
+                                if let OptionValue::Integer(len) = &event.new_value {
+                                    #[allow(
+                                        clippy::cast_possible_truncation,
+                                        clippy::cast_sign_loss
+                                    )]
+                                    {
+                                        config.max_length = (*len).clamp(10, 200) as u16;
+                                    }
+                                    debug!("LSP: virtual_text max_length = {}", len);
+                                }
+                            }
+                            "virtual_text_show" => {
+                                if let OptionValue::String(mode) = &event.new_value {
+                                    config.show_mode = match mode.as_str() {
+                                        "highest" => manager::VirtualTextShowMode::Highest,
+                                        "all" => manager::VirtualTextShowMode::All,
+                                        _ => manager::VirtualTextShowMode::First,
+                                    };
+                                    debug!("LSP: virtual_text show_mode = {:?}", config.show_mode);
+                                }
+                            }
+                            _ => {}
+                        }
+                    });
+                });
+
+                EventResult::NeedsRender
+            });
+        }
     }
 
     #[allow(clippy::too_many_lines)]

--- a/plugins/features/lsp/src/manager.rs
+++ b/plugins/features/lsp/src/manager.rs
@@ -15,6 +15,42 @@ use {
 
 use crate::{document::DocumentManager, hover::HoverCache};
 
+/// Virtual text display mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VirtualTextShowMode {
+    /// Show first diagnostic only (default)
+    #[default]
+    First,
+    /// Show highest severity diagnostic
+    Highest,
+    /// Show all diagnostics concatenated with separator
+    All,
+}
+
+/// Configuration for virtual text display.
+#[derive(Debug, Clone)]
+pub struct VirtualTextConfig {
+    /// Whether virtual text is enabled
+    pub enabled: bool,
+    /// Custom prefix for virtual text (empty = use severity icon)
+    pub prefix: String,
+    /// Maximum length before truncation
+    pub max_length: u16,
+    /// Which diagnostics to show
+    pub show_mode: VirtualTextShowMode,
+}
+
+impl Default for VirtualTextConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            prefix: String::new(),
+            max_length: 80,
+            show_mode: VirtualTextShowMode::First,
+        }
+    }
+}
+
 /// Thread-safe wrapper for LSP state.
 ///
 /// Registered in `PluginStateRegistry` for cross-plugin access.
@@ -80,6 +116,8 @@ pub struct LspManager {
     pub running: bool,
     /// Last time a document was synced.
     pub last_sync: Option<Instant>,
+    /// Virtual text configuration.
+    pub virtual_text_config: VirtualTextConfig,
 }
 
 impl LspManager {
@@ -94,6 +132,7 @@ impl LspManager {
             event_tx: None,
             running: false,
             last_sync: None,
+            virtual_text_config: VirtualTextConfig::default(),
         }
     }
 

--- a/plugins/features/lsp/src/stage.rs
+++ b/plugins/features/lsp/src/stage.rs
@@ -249,7 +249,12 @@ impl LspRenderStage {
             }
 
             // Create virtual text for diagnostic message (inline display)
-            if start_line < input.virtual_texts.len() {
+            // Get virtual text config from manager
+            let vt_config = self.manager.with(|m| m.virtual_text_config.clone());
+
+            if vt_config.enabled && start_line < input.virtual_texts.len() {
+                use crate::manager::VirtualTextShowMode;
+
                 let vt_style = match diagnostic.severity {
                     Some(DiagnosticSeverity::ERROR) => ctx.theme.virtual_text.error.clone(),
                     Some(DiagnosticSeverity::WARNING) => ctx.theme.virtual_text.warn.clone(),
@@ -266,22 +271,62 @@ impl LspRenderStage {
                     Some(_) | None => 400,
                 };
 
-                // Only set if no existing higher-priority virtual text
-                let should_set = input.virtual_texts[start_line]
-                    .as_ref()
-                    .is_none_or(|existing| existing.priority < vt_priority);
+                // Determine if we should set virtual text based on show_mode
+                let should_set = match vt_config.show_mode {
+                    VirtualTextShowMode::First => {
+                        // First diagnostic wins
+                        input.virtual_texts[start_line].is_none()
+                    }
+                    VirtualTextShowMode::Highest => {
+                        // Higher priority wins
+                        input.virtual_texts[start_line]
+                            .as_ref()
+                            .is_none_or(|existing| existing.priority < vt_priority)
+                    }
+                    VirtualTextShowMode::All => {
+                        // Will concatenate in a separate pass - always set if higher priority
+                        true
+                    }
+                };
 
                 if should_set {
-                    // Format with severity icon prefix
-                    let icon = match diagnostic.severity {
-                        Some(DiagnosticSeverity::ERROR) => "●",
-                        Some(DiagnosticSeverity::WARNING) => "◐",
-                        Some(DiagnosticSeverity::HINT) => "·",
-                        Some(DiagnosticSeverity::INFORMATION | _) | None => "ⓘ",
+                    // Use custom prefix or default severity icon
+                    let prefix = if vt_config.prefix.is_empty() {
+                        match diagnostic.severity {
+                            Some(DiagnosticSeverity::ERROR) => "●",
+                            Some(DiagnosticSeverity::WARNING) => "◐",
+                            Some(DiagnosticSeverity::HINT) => "·",
+                            Some(DiagnosticSeverity::INFORMATION | _) | None => "ⓘ",
+                        }
+                    } else {
+                        &vt_config.prefix
                     };
 
+                    let mut text = format!("{prefix} {}", diagnostic.message);
+
+                    // Apply max_length truncation
+                    let max_len = vt_config.max_length as usize;
+                    if text.chars().count() > max_len {
+                        let truncated: String =
+                            text.chars().take(max_len.saturating_sub(3)).collect();
+                        text = format!("{truncated}...");
+                    }
+
+                    // For "all" mode, concatenate with existing
+                    if vt_config.show_mode == VirtualTextShowMode::All
+                        && let Some(existing) = &input.virtual_texts[start_line]
+                    {
+                        text = format!("{} | {text}", existing.text);
+                        // Re-truncate if needed
+                        if text.chars().count() > max_len {
+                            let truncated: String =
+                                text.chars().take(max_len.saturating_sub(3)).collect();
+                            text = format!("{truncated}...");
+                        }
+                    }
+
                     input.virtual_texts[start_line] = Some(VirtualTextEntry {
-                        text: format!("{} {}", icon, diagnostic.message),
+                        text,
                         style: vt_style,
                         priority: vt_priority,
                     });

--- a/tools/bench/benches/bench_modules/common.rs
+++ b/tools/bench/benches/bench_modules/common.rs
@@ -5,7 +5,7 @@ use reovim_core::{
     content::WindowContentSource,
     screen::{
         Position,
-        window::{Anchor, LineNumber, Window},
+        window::{Anchor, LineNumber, SignColumnMode, Window},
     },
 };
 
@@ -35,7 +35,7 @@ pub fn create_window(height: u16) -> Window {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
-        sign_column_width: None,
+        sign_column_mode: SignColumnMode::No,
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: 0 },
         desired_col: None,

--- a/tools/bench/benches/bench_modules/render_pipeline.rs
+++ b/tools/bench/benches/bench_modules/render_pipeline.rs
@@ -16,7 +16,7 @@ use {
         render::RenderData,
         screen::{
             Position,
-            window::{Anchor, LineNumber, Window},
+            window::{Anchor, LineNumber, SignColumnMode, Window},
         },
         syntax::SyntaxFactory,
     },
@@ -83,7 +83,7 @@ fn create_window_at_scroll(height: u16, scroll_y: u16) -> Window {
         is_active: true,
         is_floating: false,
         line_number: Some(LineNumber::default()),
-        sign_column_width: None,
+        sign_column_mode: SignColumnMode::No,
         scrollbar_enabled: false,
         cursor: Position { x: 0, y: scroll_y },
         desired_col: None,


### PR DESCRIPTION
Add configurable sign column modes and virtual text options for diagnostic display.

Sign column modes:
- `auto`: Show when signs present, hide otherwise (width: 2)
- `yes`: Always show (default, width: 2)
- `no`: Never show
- `number`: Display signs as background color on line numbers

Virtual text options:
- `virtual_text` (bool): Enable/disable virtual text display
- `virtual_text_prefix` (string): Custom prefix (empty = severity icons)
- `virtual_text_max_length` (number): Max length before truncation (default: 80)
- `virtual_text_show` (string): "first", "highest", or "all" mode

Implementation:
- Add SignColumnMode enum with effective_width() method
- Update RequestSetSignColumn to use mode instead of width
- Add VirtualTextConfig and VirtualTextShowMode to LSP manager
- LSP stage respects virtual text configuration
- Register options under "Diagnostics" settings section
- 14 new tests (6 sign column + 8 virtual text)

Closes #29