### PR TITLE
feat(plugin): add subscription helper macros to reduce boilerplate (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Subscription helper macros** (Issue #41) - Reduce plugin boilerplate with three new macros
+  - `subscribe_state!` - Simple state mutation + render pattern (4 variants)
+  - `subscribe_state_mode!` - State mutation + mode change + render (2 variants)
+  - `subscribe_state_conditional!` - Conditional render based on return value (4 variants)
+  - Migrated Explorer plugin: 23 subscription blocks (~180 lines saved)
+  - Migrated Range-Finder plugin: 5 subscription blocks (~30 lines saved)
+  - Total: ~210 lines of boilerplate removed across 28 subscription blocks
+
 ### Fixed
 
 - **RegisterOption events not processed** (Issue #39) - Options registered via `bus.emit(RegisterOption)` are now properly added to the option registry

--- a/lib/core/src/plugin/macros.rs
+++ b/lib/core/src/plugin/macros.rs
@@ -1,0 +1,259 @@
+//! Subscription helper macros for reducing plugin boilerplate
+//!
+//! These macros reduce repetitive code when subscribing to events in plugins.
+//! They handle the common patterns of state mutation, rendering, and mode changes.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_core::subscribe_state;
+//!
+//! // Registry-based state with event access
+//! subscribe_state!(bus, state, MyCursorDown, MyState, |s, e| {
+//!     s.move_cursor(e.count as isize);
+//! });
+//!
+//! // Registry-based state without event access
+//! subscribe_state!(bus, state, MyRefresh, MyState, |s| {
+//!     s.refresh();
+//! });
+//!
+//! // Arc-based state (plugin-owned)
+//! subscribe_state!(bus, self.my_state, MyEvent, |s| {
+//!     s.update();
+//! });
+//! ```
+
+/// Subscribe to an event with automatic state mutation and render
+///
+/// This macro handles the common pattern of:
+/// 1. Cloning the state Arc
+/// 2. Subscribing to an event with plugin priority
+/// 3. Mutating state via `with_mut`
+/// 4. Requesting render
+/// 5. Returning `EventResult::Handled`
+///
+/// # Variants
+///
+/// ## Registry-based state (`PluginStateRegistry`)
+///
+/// Without event access:
+/// ```ignore
+/// subscribe_state!(bus, state, EventType, StateType, |s| {
+///     s.method();
+/// });
+/// ```
+///
+/// With event access:
+/// ```ignore
+/// subscribe_state!(bus, state, EventType, StateType, |s, e| {
+///     s.method(e.count);
+/// });
+/// ```
+///
+/// ## Arc-based state (plugin-owned)
+///
+/// Without event access:
+/// ```ignore
+/// subscribe_state!(bus, arc_state, EventType, |s| {
+///     s.method();
+/// });
+/// ```
+///
+/// With event access:
+/// ```ignore
+/// subscribe_state!(bus, arc_state, EventType, |s, e| {
+///     s.method(e.field);
+/// });
+/// ```
+#[macro_export]
+macro_rules! subscribe_state {
+    // Registry-based, no event access
+    ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident| $body:block) => {{
+        let state_clone = std::sync::Arc::clone(&$state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Registry-based, with event access
+    ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident, $e:ident| $body:block) => {{
+        let state_clone = std::sync::Arc::clone(&$state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |$e, ctx| {
+                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Arc-based (plugin-owned state), no event access
+    ($bus:expr, $arc_state:expr, $event:ty, |$s:ident| $body:block) => {{
+        let state_clone = std::sync::Arc::clone(&$arc_state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                state_clone.with_mut(|$s| $body);
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Arc-based (plugin-owned state), with event access
+    ($bus:expr, $arc_state:expr, $event:ty, |$s:ident, $e:ident| $body:block) => {{
+        let state_clone = std::sync::Arc::clone(&$arc_state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |$e, ctx| {
+                state_clone.with_mut(|$s| $body);
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+}
+
+/// Subscribe to an event with state mutation, mode change, and render
+///
+/// This macro handles the pattern of:
+/// 1. Cloning the state Arc
+/// 2. Subscribing to an event with plugin priority
+/// 3. Mutating state via `with_mut`
+/// 4. Emitting `RequestModeChange` with the provided mode
+/// 5. Requesting render
+/// 6. Returning `EventResult::Handled`
+///
+/// # Example
+///
+/// ```ignore
+/// subscribe_state_mode!(
+///     bus, state, ExplorerCreateFile, ExplorerState,
+///     |s| { s.start_create_file(); },
+///     ModeState::with_interactor_id_sub_mode(
+///         COMPONENT_ID,
+///         EditMode::Normal,
+///         SubMode::Interactor(COMPONENT_ID),
+///     )
+/// );
+/// ```
+#[macro_export]
+macro_rules! subscribe_state_mode {
+    // Registry-based
+    ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident| $body:block, $mode:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$state);
+        // Evaluate mode expression before closure to avoid move issues
+        let mode = $mode;
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+                ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Arc-based
+    ($bus:expr, $arc_state:expr, $event:ty, |$s:ident| $body:block, $mode:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$arc_state);
+        // Evaluate mode expression before closure to avoid move issues
+        let mode = $mode;
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                state_clone.with_mut(|$s| $body);
+                ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
+                ctx.request_render();
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+}
+
+/// Subscribe with conditional render based on return value
+///
+/// This macro handles the pattern where rendering should only occur
+/// if the state mutation returns `true` (indicating a change occurred).
+///
+/// # Example
+///
+/// ```ignore
+/// subscribe_state_conditional!(bus, self.fold_manager, FoldToggle, |m, e| {
+///     m.toggle(e.buffer_id, e.line)
+/// });
+/// ```
+#[macro_export]
+macro_rules! subscribe_state_conditional {
+    // Arc-based with event access (most common for fold operations)
+    ($bus:expr, $arc_state:expr, $event:ty, |$s:ident, $e:ident| $body:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$arc_state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |$e, ctx| {
+                let changed = state_clone.with_mut(|$s| $body);
+                if changed {
+                    ctx.request_render();
+                }
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Arc-based without event access
+    ($bus:expr, $arc_state:expr, $event:ty, |$s:ident| $body:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$arc_state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                let changed = state_clone.with_mut(|$s| $body);
+                if changed {
+                    ctx.request_render();
+                }
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Registry-based with event access
+    ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident, $e:ident| $body:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |$e, ctx| {
+                let changed = state_clone
+                    .with_mut::<$state_type, _, _>(|$s| $body)
+                    .unwrap_or(false);
+                if changed {
+                    ctx.request_render();
+                }
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+
+    // Registry-based without event access
+    ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident| $body:expr) => {{
+        let state_clone = std::sync::Arc::clone(&$state);
+        $bus.subscribe::<$event, _>(
+            $crate::event_bus::priority::PLUGIN,
+            move |_event, ctx| {
+                let changed = state_clone
+                    .with_mut::<$state_type, _, _>(|$s| $body)
+                    .unwrap_or(false);
+                if changed {
+                    ctx.request_render();
+                }
+                $crate::event_bus::EventResult::Handled
+            },
+        );
+    }};
+}

--- a/lib/core/src/plugin/mod.rs
+++ b/lib/core/src/plugin/mod.rs
@@ -31,6 +31,7 @@
 mod context;
 mod editor_context;
 mod loader;
+pub mod macros;
 mod runtime_context;
 mod state;
 mod statusline;

--- a/plugins/features/explorer/src/lib.rs
+++ b/plugins/features/explorer/src/lib.rs
@@ -22,6 +22,7 @@ use reovim_core::{
     keys,
     modd::ComponentId,
     plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
+    subscribe_state, subscribe_state_mode,
 };
 
 mod command;
@@ -173,13 +174,12 @@ impl Plugin for ExplorerPlugin {
         };
 
         // Handle text input from runtime (PluginTextInput event)
+        // Keep manual: target check with early return
         let state_clone = Arc::clone(&state);
         bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-            // Only handle if we're the target
             if event.target != COMPONENT_ID {
                 return EventResult::NotHandled;
             }
-
             state_clone.with_mut::<ExplorerState, _, _>(|s| {
                 s.input_char(event.c);
             });
@@ -188,13 +188,12 @@ impl Plugin for ExplorerPlugin {
         });
 
         // Handle backspace from runtime (PluginBackspace event)
+        // Keep manual: target check with early return
         let state_clone = Arc::clone(&state);
         bus.subscribe::<PluginBackspace, _>(100, move |event, ctx| {
-            // Only handle if we're the target
             if event.target != COMPONENT_ID {
                 return EventResult::NotHandled;
             }
-
             state_clone.with_mut::<ExplorerState, _, _>(|s| {
                 s.input_backspace();
             });
@@ -203,81 +202,46 @@ impl Plugin for ExplorerPlugin {
         });
 
         // Navigation events (sync popup with cursor if visible)
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCursorUp, _>(100, move |event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_cursor(-(event.count as isize));
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerCursorUp, ExplorerState, |s, e| {
+            s.move_cursor(-(e.count as isize));
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCursorDown, _>(100, move |event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_cursor(event.count as isize);
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerCursorDown, ExplorerState, |s, e| {
+            s.move_cursor(e.count as isize);
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerPageUp, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_page(s.visible_height, false);
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerPageUp, ExplorerState, |s| {
+            s.move_page(s.visible_height, false);
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerPageDown, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_page(s.visible_height, true);
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerPageDown, ExplorerState, |s| {
+            s.move_page(s.visible_height, true);
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerGotoFirst, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_to_first();
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerGotoFirst, ExplorerState, |s| {
+            s.move_to_first();
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerGotoLast, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.move_to_last();
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerGotoLast, ExplorerState, |s| {
+            s.move_to_last();
+            s.update_scroll();
+            s.sync_popup();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerGoToParent, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.go_to_parent();
-                s.update_scroll();
-                s.sync_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerGoToParent, ExplorerState, |s| {
+            s.go_to_parent();
+            s.update_scroll();
+            s.sync_popup();
         });
 
         // Open file or toggle directory
@@ -322,183 +286,86 @@ impl Plugin for ExplorerPlugin {
         });
 
         // Tree manipulation events
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerToggleNode, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                let _ = s.toggle_current();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerToggleNode, ExplorerState, |s| {
+            let _ = s.toggle_current();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCloseParent, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.collapse_current();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerCloseParent, ExplorerState, |s| {
+            s.collapse_current();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerRefresh, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                let _ = s.refresh();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerRefresh, ExplorerState, |s| {
+            let _ = s.refresh();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerToggleHidden, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.toggle_hidden();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerToggleHidden, ExplorerState, |s| {
+            s.toggle_hidden();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerToggleSizes, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.toggle_sizes();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerToggleSizes, ExplorerState, |s| {
+            s.toggle_sizes();
         });
 
         // Clipboard events
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerYank, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.yank_current();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerYank, ExplorerState, |s| {
+            s.yank_current();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCut, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.cut_current();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerCut, ExplorerState, |s| {
+            s.cut_current();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerPaste, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                let _ = s.paste();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerPaste, ExplorerState, |s| {
+            let _ = s.paste();
         });
 
-        // File operation events
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCreateFile, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.start_create_file();
-            });
+        // File operation events (enter Interactor sub-mode for input)
+        subscribe_state_mode!(
+            bus, state, ExplorerCreateFile, ExplorerState,
+            |s| { s.start_create_file(); },
+            ModeState::with_interactor_id_sub_mode(
+                COMPONENT_ID, EditMode::Normal, SubMode::Interactor(COMPONENT_ID)
+            )
+        );
 
-            // Enter Interactor sub-mode so characters route to focus handler
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
+        subscribe_state_mode!(
+            bus, state, ExplorerCreateDir, ExplorerState,
+            |s| { s.start_create_dir(); },
+            ModeState::with_interactor_id_sub_mode(
+                COMPONENT_ID, EditMode::Normal, SubMode::Interactor(COMPONENT_ID)
+            )
+        );
 
-            ctx.request_render();
-            EventResult::Handled
-        });
+        subscribe_state_mode!(
+            bus, state, ExplorerRename, ExplorerState,
+            |s| { s.start_rename(); },
+            ModeState::with_interactor_id_sub_mode(
+                COMPONENT_ID, EditMode::Normal, SubMode::Interactor(COMPONENT_ID)
+            )
+        );
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerCreateDir, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.start_create_dir();
-            });
+        subscribe_state_mode!(
+            bus, state, ExplorerDelete, ExplorerState,
+            |s| { s.start_delete(); },
+            ModeState::with_interactor_id_sub_mode(
+                COMPONENT_ID, EditMode::Normal, SubMode::Interactor(COMPONENT_ID)
+            )
+        );
 
-            // Enter Interactor sub-mode so characters route to focus handler
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
+        subscribe_state_mode!(
+            bus, state, ExplorerStartFilter, ExplorerState,
+            |s| { s.start_filter(); },
+            ModeState::with_interactor_id_sub_mode(
+                COMPONENT_ID, EditMode::Normal, SubMode::Interactor(COMPONENT_ID)
+            )
+        );
 
-            ctx.request_render();
-            EventResult::Handled
-        });
-
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerRename, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.start_rename();
-            });
-
-            // Enter Interactor sub-mode so characters route to focus handler
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
-
-            ctx.request_render();
-            EventResult::Handled
-        });
-
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerDelete, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.start_delete();
-            });
-
-            // Enter Interactor sub-mode for confirmation input
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
-
-            ctx.request_render();
-            EventResult::Handled
-        });
-
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerStartFilter, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.start_filter();
-            });
-
-            // Enter Interactor sub-mode so characters route to focus handler
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
-
-            ctx.request_render();
-            EventResult::Handled
-        });
-
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerClearFilter, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.clear_filter();
-            });
-
-            // Exit Interactor sub-mode back to normal explorer mode
-            let mode = ModeState::with_interactor_id_and_mode(COMPONENT_ID, EditMode::Normal);
-            ctx.emit(RequestModeChange { mode });
-
-            ctx.request_render();
-            EventResult::Handled
-        });
+        // Exit Interactor sub-mode back to normal explorer mode
+        subscribe_state_mode!(
+            bus, state, ExplorerClearFilter, ExplorerState,
+            |s| { s.clear_filter(); },
+            ModeState::with_interactor_id_and_mode(COMPONENT_ID, EditMode::Normal)
+        );
 
         // Input events
         let state_clone = Arc::clone(&state);
@@ -583,59 +450,29 @@ impl Plugin for ExplorerPlugin {
             EventResult::Handled
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerInputChar, _>(100, move |event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.input_char(event.c);
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerInputChar, ExplorerState, |s, e| {
+            s.input_char(e.c);
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerInputBackspace, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.input_backspace();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerInputBackspace, ExplorerState, |s| {
+            s.input_backspace();
         });
 
         // Visual selection events
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerVisualMode, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.enter_visual_mode();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerVisualMode, ExplorerState, |s| {
+            s.enter_visual_mode();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerToggleSelect, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.toggle_select_current();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerToggleSelect, ExplorerState, |s| {
+            s.toggle_select_current();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerSelectAll, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.select_all();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerSelectAll, ExplorerState, |s| {
+            s.select_all();
         });
 
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerExitVisual, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.exit_visual_mode();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerExitVisual, ExplorerState, |s| {
+            s.exit_visual_mode();
         });
 
         // Toggle explorer visibility
@@ -720,23 +557,13 @@ impl Plugin for ExplorerPlugin {
         });
 
         // Show file details popup
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerShowInfo, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.show_file_details();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerShowInfo, ExplorerState, |s| {
+            s.show_file_details();
         });
 
         // Close file details popup
-        let state_clone = Arc::clone(&state);
-        bus.subscribe::<ExplorerClosePopup, _>(100, move |_event, ctx| {
-            state_clone.with_mut::<ExplorerState, _, _>(|s| {
-                s.close_popup();
-            });
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, state, ExplorerClosePopup, ExplorerState, |s| {
+            s.close_popup();
         });
 
         // Copy path to clipboard

--- a/plugins/features/range-finder/src/lib.rs
+++ b/plugins/features/range-finder/src/lib.rs
@@ -23,6 +23,7 @@ use {
         keys,
         modd::{ComponentId, EditMode, ModeState, SubMode},
         plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
+        subscribe_state, subscribe_state_conditional,
     },
 };
 
@@ -424,53 +425,29 @@ impl Plugin for RangeFinderPlugin {
 
         // === Fold Event Subscriptions ===
 
-        // FoldToggle
-        let fold_manager = Arc::clone(&self.fold_manager);
-        bus.subscribe::<FoldToggle, _>(100, move |event, ctx| {
-            let changed = fold_manager.with_mut(|m| m.toggle(event.buffer_id, event.line));
-            if changed {
-                ctx.request_render();
-            }
-            EventResult::Handled
+        // Conditional render subscriptions (render only if state changed)
+        subscribe_state_conditional!(bus, self.fold_manager, FoldToggle, |m, e| {
+            m.toggle(e.buffer_id, e.line)
         });
 
-        // FoldOpen
-        let fold_manager = Arc::clone(&self.fold_manager);
-        bus.subscribe::<FoldOpen, _>(100, move |event, ctx| {
-            let changed = fold_manager.with_mut(|m| m.open(event.buffer_id, event.line));
-            if changed {
-                ctx.request_render();
-            }
-            EventResult::Handled
+        subscribe_state_conditional!(bus, self.fold_manager, FoldOpen, |m, e| {
+            m.open(e.buffer_id, e.line)
         });
 
-        // FoldClose
-        let fold_manager = Arc::clone(&self.fold_manager);
-        bus.subscribe::<FoldClose, _>(100, move |event, ctx| {
-            let changed = fold_manager.with_mut(|m| m.close(event.buffer_id, event.line));
-            if changed {
-                ctx.request_render();
-            }
-            EventResult::Handled
+        subscribe_state_conditional!(bus, self.fold_manager, FoldClose, |m, e| {
+            m.close(e.buffer_id, e.line)
         });
 
-        // FoldOpenAll
-        let fold_manager = Arc::clone(&self.fold_manager);
-        bus.subscribe::<FoldOpenAll, _>(100, move |event, ctx| {
-            fold_manager.with_mut(|m| m.open_all(event.buffer_id));
-            ctx.request_render();
-            EventResult::Handled
+        // Simple mutation + render subscriptions
+        subscribe_state!(bus, self.fold_manager, FoldOpenAll, |m, e| {
+            m.open_all(e.buffer_id);
         });
 
-        // FoldCloseAll
-        let fold_manager = Arc::clone(&self.fold_manager);
-        bus.subscribe::<FoldCloseAll, _>(100, move |event, ctx| {
-            fold_manager.with_mut(|m| m.close_all(event.buffer_id));
-            ctx.request_render();
-            EventResult::Handled
+        subscribe_state!(bus, self.fold_manager, FoldCloseAll, |m, e| {
+            m.close_all(e.buffer_id);
         });
 
-        // FoldRangesUpdated (from treesitter)
+        // FoldRangesUpdated (from treesitter) - uses priority 50, keep manual
         let fold_manager = Arc::clone(&self.fold_manager);
         bus.subscribe::<FoldRangesUpdated, _>(50, move |event, ctx| {
             fold_manager.with_mut(|m| m.set_ranges(event.buffer_id, event.ranges.clone()));


### PR DESCRIPTION
Add three new macros to reduce repetitive event subscription code in plugins:

- `subscribe_state!` - Simple state mutation + render (4 variants)
- `subscribe_state_mode!` - State mutation + mode change + render (2 variants)
- `subscribe_state_conditional!` - Conditional render based on return value (4 variants)

Migrate Explorer and Range-Finder plugins to use the new macros:
- Explorer: 23 subscription blocks migrated (~180 lines saved)
- Range-Finder: 5 fold subscription blocks migrated (~30 lines saved)
- Total: 28 blocks migrated, ~210 lines of boilerplate removed

The macros encapsulate the common pattern of:
1. Arc cloning state
2. Subscribing with plugin priority (100)
3. Mutating state via with_mut()
4. Requesting render
5. Returning EventResult::Handled

Closes #41