### PR TITLE
refactor(command): replace hardcoded mode_for_command() with declarative metadata (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Declarative mode metadata** (Issue #42) - Replace hardcoded `mode_for_command()` with `resulting_mode()` trait method
+  - Added `resulting_mode()` method to `CommandTrait` with default `None` return
+  - Implemented for 32 mode-changing commands (mode, window, operator, command-line)
+  - Replaced 60-line string matching function with 6-line trait-based lookup
+  - Provides compile-time safety: no more missing match arms causing flaky tests
+  - Fixed bug: `enter_visual_line_mode` was missing from old implementation
+
 ### Added
 
 - **Subscription helper macros** (Issue #41) - Reduce plugin boilerplate with three new macros

--- a/lib/core/src/command/builtin/command_line.rs
+++ b/lib/core/src/command/builtin/command_line.rs
@@ -1,8 +1,11 @@
 //! Command line mode commands
 
 use {
-    crate::command::traits::{
-        CommandLineAction, CommandResult, CommandTrait, DeferredAction, ExecutionContext,
+    crate::{
+        command::traits::{
+            CommandLineAction, CommandResult, CommandTrait, DeferredAction, ExecutionContext,
+        },
+        modd::ModeState,
     },
     std::any::Any,
 };
@@ -94,6 +97,10 @@ impl CommandTrait for CommandLineExecuteCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::normal())
+    }
 }
 
 /// Cancel command line
@@ -119,5 +126,9 @@ impl CommandTrait for CommandLineCancelCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::normal())
     }
 }

--- a/lib/core/src/command/builtin/mode.rs
+++ b/lib/core/src/command/builtin/mode.rs
@@ -37,6 +37,10 @@ impl CommandTrait for EnterNormalModeCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::normal())
+    }
 }
 
 /// Enter insert mode
@@ -62,6 +66,10 @@ impl CommandTrait for EnterInsertModeCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::insert())
     }
 }
 
@@ -95,6 +103,10 @@ impl CommandTrait for EnterInsertModeAfterCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::insert())
+    }
 }
 
 /// Enter insert mode at end of line (A)
@@ -125,6 +137,10 @@ impl CommandTrait for EnterInsertModeEolCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::insert())
     }
 }
 
@@ -161,6 +177,10 @@ impl CommandTrait for OpenLineBelowCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::insert())
+    }
 }
 
 /// Open line above (O)
@@ -195,6 +215,10 @@ impl CommandTrait for OpenLineAboveCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::insert())
+    }
 }
 
 /// Enter visual mode
@@ -221,6 +245,10 @@ impl CommandTrait for EnterVisualModeCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::visual())
     }
 }
 
@@ -249,6 +277,10 @@ impl CommandTrait for EnterVisualBlockModeCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::visual_block())
+    }
 }
 
 /// Enter visual line mode (V)
@@ -276,6 +308,10 @@ impl CommandTrait for EnterVisualLineModeCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::visual_line())
+    }
 }
 
 /// Enter command mode
@@ -301,5 +337,9 @@ impl CommandTrait for EnterCommandModeCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::command())
     }
 }

--- a/lib/core/src/command/builtin/operator.rs
+++ b/lib/core/src/command/builtin/operator.rs
@@ -32,6 +32,10 @@ impl CommandTrait for EnterDeleteOperatorCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::operator_pending(OperatorType::Delete, None))
+    }
 }
 
 /// Enter operator-pending mode for yank (y)
@@ -58,6 +62,10 @@ impl CommandTrait for EnterYankOperatorCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::operator_pending(OperatorType::Yank, None))
+    }
 }
 
 /// Enter operator-pending mode for change (c)
@@ -83,5 +91,9 @@ impl CommandTrait for EnterChangeOperatorCommand {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::operator_pending(OperatorType::Change, None))
     }
 }

--- a/lib/core/src/command/builtin/window.rs
+++ b/lib/core/src/command/builtin/window.rs
@@ -399,6 +399,10 @@ impl CommandTrait for EnterWindowModeCommand {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn resulting_mode(&self) -> Option<ModeState> {
+        Some(ModeState::new().with_sub(SubMode::Interactor(ComponentId::WINDOW)))
+    }
 }
 
 /// Helper to create window mode commands that exit to normal after execution
@@ -427,6 +431,10 @@ macro_rules! window_mode_command {
 
             fn as_any(&self) -> &dyn Any {
                 self
+            }
+
+            fn resulting_mode(&self) -> Option<ModeState> {
+                Some(ModeState::normal())
             }
         }
     };

--- a/lib/core/src/command/traits.rs
+++ b/lib/core/src/command/traits.rs
@@ -332,6 +332,15 @@ pub trait CommandTrait: Debug + Send + Sync {
     fn is_text_modifying(&self) -> bool {
         false
     }
+
+    /// The mode to transition to after this command executes, if any
+    ///
+    /// Commands that change modes should override this to return `Some(ModeState)`.
+    /// This is used by the command handler to update mode immediately before dispatch,
+    /// avoiding race conditions with the runtime's watch channel.
+    fn resulting_mode(&self) -> Option<ModeState> {
+        None
+    }
 }
 
 impl Clone for Box<dyn CommandTrait> {

--- a/lib/core/src/event/handler/command/dispatcher.rs
+++ b/lib/core/src/event/handler/command/dispatcher.rs
@@ -3,13 +3,14 @@
 use {
     crate::{
         bind::CommandRef,
-        command::{CommandContext, traits::OperatorMotionAction},
+        command::{CommandContext, CommandRegistry, traits::OperatorMotionAction},
         event::{
             InnerEvent,
             inner::{CommandEvent, VisualTextObjectAction},
         },
-        modd::{ComponentId, ModeState, OperatorType, SubMode},
+        modd::ModeState,
     },
+    std::sync::Arc,
     tokio::sync::mpsc::Sender,
 };
 
@@ -18,15 +19,22 @@ pub struct Dispatcher {
     inner_tx: Sender<InnerEvent>,
     current_buffer_id: usize,
     current_window_id: usize,
+    command_registry: Arc<CommandRegistry>,
 }
 
 impl Dispatcher {
     #[must_use]
-    pub const fn new(tx: Sender<InnerEvent>, buffer_id: usize, window_id: usize) -> Self {
+    pub const fn new(
+        tx: Sender<InnerEvent>,
+        buffer_id: usize,
+        window_id: usize,
+        command_registry: Arc<CommandRegistry>,
+    ) -> Self {
         Self {
             inner_tx: tx,
             current_buffer_id: buffer_id,
             current_window_id: window_id,
+            command_registry,
         }
     }
 
@@ -81,63 +89,15 @@ impl Dispatcher {
 
     /// Determine the new mode after a command, if any
     ///
-    /// Uses command names to detect mode-changing commands.
+    /// Queries the command's `resulting_mode()` method via the command registry.
     #[must_use]
-    pub fn mode_for_command(cmd: &CommandRef) -> Option<ModeState> {
-        let name = match cmd {
-            CommandRef::Registered(id) => id.as_str(),
-            CommandRef::Inline(cmd) => cmd.name(),
-        };
-
-        match name {
-            // Commands that return to Normal mode (Editor focus)
-            // NOTE: visual_delete and visual_yank are NOT here because they need
-            // to read the selection BEFORE mode changes to Normal (which clears selection).
-            // They handle mode transition via CommandResult::ClipboardWrite.
-            "enter_normal_mode" | "command_line_execute" | "command_line_cancel" => {
-                Some(ModeState::normal())
-            }
-            "enter_insert_mode"
-            | "enter_insert_mode_after"
-            | "enter_insert_mode_eol"
-            | "open_line_below"
-            | "open_line_above" => Some(ModeState::insert()),
-            "enter_visual_mode" => Some(ModeState::visual()),
-            "enter_visual_block_mode" => Some(ModeState::visual_block()),
-            "enter_command_mode" => Some(ModeState::command()),
-            // Operator-pending mode
-            "enter_delete_operator" => {
-                Some(ModeState::operator_pending(OperatorType::Delete, None))
-            }
-            "enter_yank_operator" => Some(ModeState::operator_pending(OperatorType::Yank, None)),
-            "enter_change_operator" => {
-                Some(ModeState::operator_pending(OperatorType::Change, None))
-            }
-            // Window mode (Ctrl-W)
-            "enter_window_mode" => {
-                Some(ModeState::new().with_sub(SubMode::Interactor(ComponentId::WINDOW)))
-            }
-            // Window mode actions -> Normal mode
-            "window_mode_focus_left"
-            | "window_mode_focus_down"
-            | "window_mode_focus_up"
-            | "window_mode_focus_right"
-            | "window_mode_move_left"
-            | "window_mode_move_down"
-            | "window_mode_move_up"
-            | "window_mode_move_right"
-            | "window_mode_swap_left"
-            | "window_mode_swap_down"
-            | "window_mode_swap_up"
-            | "window_mode_swap_right"
-            | "window_mode_split_h"
-            | "window_mode_split_v"
-            | "window_mode_close"
-            | "window_mode_only"
-            | "window_mode_equalize" => Some(ModeState::normal()),
-            // Plugin mode transitions (telescope, explorer) are handled via DeferredAction
-            // toggle_explorer, explorer_close, explorer_focus_editor etc.
-            _ => None,
+    pub fn mode_for_command(&self, cmd: &CommandRef) -> Option<ModeState> {
+        match cmd {
+            CommandRef::Registered(id) => self
+                .command_registry
+                .get(id)
+                .and_then(|c| c.resulting_mode()),
+            CommandRef::Inline(cmd) => cmd.resulting_mode(),
         }
     }
 

--- a/lib/core/src/event/handler/command/mod.rs
+++ b/lib/core/src/event/handler/command/mod.rs
@@ -9,7 +9,7 @@ pub use {count_parser::CountParser, dispatcher::Dispatcher, key_parser::key_to_s
 use {
     crate::{
         bind::{CommandRef, KeyMap, KeyMapInner},
-        command::traits::OperatorMotionAction,
+        command::{CommandRegistry, traits::OperatorMotionAction},
         event::{InnerEvent, KeyEvent, Subscribe, VisualTextObjectAction},
         keystroke::{KeyNotationFormat, KeySequence, Keystroke},
         modd::{ModeState, OperatorType, SubMode},
@@ -19,7 +19,7 @@ use {
             WordTextObject, WordType,
         },
     },
-    std::time::Duration,
+    std::{sync::Arc, time::Duration},
     tokio::sync::{broadcast::Receiver, mpsc::Sender, watch},
 };
 
@@ -50,6 +50,7 @@ impl CommandHandler {
         tx: Sender<InnerEvent>,
         mode_rx: watch::Receiver<ModeState>,
         keymap: KeyMap,
+        command_registry: Arc<CommandRegistry>,
     ) -> Self {
         let initial_mode = mode_rx.borrow().clone();
         Self {
@@ -59,7 +60,7 @@ impl CommandHandler {
             local_mode: initial_mode,
             pending_keys: KeySequence::new(),
             count_parser: CountParser::new(),
-            dispatcher: Dispatcher::new(tx, 0, 0),
+            dispatcher: Dispatcher::new(tx, 0, 0, command_registry),
             mode_locally_changed: false,
         }
     }
@@ -614,7 +615,7 @@ impl CommandHandler {
 
                                     // Check for mode change commands and update local mode immediately
                                     // This avoids race conditions with the Runtime's watch channel
-                                    if let Some(new_mode) = Dispatcher::mode_for_command(cmd) {
+                                    if let Some(new_mode) = self.dispatcher.mode_for_command(cmd) {
                                         tracing::debug!(
                                             "[MODE] Immediate mode update: {:?} -> {:?}",
                                             self.current_mode().sub_mode,

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -33,7 +33,12 @@ impl Runtime {
         // Command handler for key-to-command translation
         // Pass mode receiver so CommandHandler can read mode from Runtime (single source of truth)
         let mode_rx = self.subscribe_mode();
-        let mut command_hdr = CommandHandler::new(self.tx.clone(), mode_rx, self.keymap.clone());
+        let mut command_hdr = CommandHandler::new(
+            self.tx.clone(),
+            mode_rx,
+            self.keymap.clone(),
+            self.command_registry.clone(),
+        );
         let mut terminate_hdr = TerminateHandler::new(self.tx.clone());
 
         input_broker.key_broker.enlist(&mut command_hdr);
@@ -133,8 +138,12 @@ impl Runtime {
 
         // Command handler for key-to-command translation
         let mode_rx = self.subscribe_mode();
-        let mut command_hdr =
-            crate::event::CommandHandler::new(self.tx.clone(), mode_rx, self.keymap.clone());
+        let mut command_hdr = crate::event::CommandHandler::new(
+            self.tx.clone(),
+            mode_rx,
+            self.keymap.clone(),
+            self.command_registry.clone(),
+        );
         let mut terminate_hdr = crate::event::TerminateHandler::new(self.tx.clone());
 
         input_broker.key_broker.enlist(&mut command_hdr);


### PR DESCRIPTION
Replace the hardcoded string matching in mode_for_command() with a declarative resulting_mode() method on CommandTrait. This eliminates maintenance burden and prevents bugs from missing match arms.

Changes:
- Add resulting_mode() method to CommandTrait with default None return
- Implement for 32 mode-changing commands:
  - 10 mode commands (normal, insert, visual, visual-line, visual-block, command)
  - 18 window commands (enter + 17 window_mode_* via macro)
  - 3 operator commands (delete, yank, change)
  - 2 command-line commands (execute, cancel)
- Replace 60-line string matching with 6-line trait-based registry lookup
- Propagate CommandRegistry through Dispatcher -> CommandHandler -> Runtime

Bug fix: enter_visual_line_mode was missing from old implementation

Closes #42