### PR TITLE
refactor(event_bus): add HandlerContext helpers for mode changes (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **HandlerContext mode change helpers** (Issue #44) - Reduce mode change boilerplate
+  - `enter_interactor_mode(component_id)` - Enter interactor sub-mode for text input
+  - `exit_to_normal()` - Return to normal editor mode
+  - `set_mode(mode)` - Set arbitrary mode state for edge cases
+  - Updated Range-Finder plugin: 5 mode changes simplified
+  - Updated Microscope plugin: 1 mode change simplified
+
 - **Subscription helper macros** (Issue #41) - Reduce plugin boilerplate with three new macros
   - `subscribe_state!` - Simple state mutation + render pattern (4 variants)
   - `subscribe_state_mode!` - State mutation + mode change + render (2 variants)

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -678,6 +678,47 @@ pub enum WindowEvent {
 
 Terminal key events from crossterm, broadcast to handlers.
 
+## HandlerContext Methods
+
+The `HandlerContext` passed to event handlers provides several utility methods:
+
+### Basic Methods
+
+```rust
+// Emit a new event
+ctx.emit(SomeEvent { ... });
+
+// Request a render after event processing
+ctx.request_render();
+
+// Request the editor to quit
+ctx.request_quit();
+```
+
+### Mode Change Helpers
+
+Common patterns for changing editor mode are simplified with helper methods:
+
+```rust
+// Enter interactor mode for a plugin component
+// Sets both interactor_id and SubMode::Interactor to the component
+ctx.enter_interactor_mode(COMPONENT_ID);
+
+// Return to normal editor mode
+ctx.exit_to_normal();
+
+// Set arbitrary mode state (for edge cases)
+ctx.set_mode(ModeState::with_interactor_id_and_mode(
+    COMPONENT_ID,
+    EditMode::Normal,
+));
+```
+
+**When to use:**
+- `enter_interactor_mode(id)` - Plugin needs to receive text input (like search, rename dialogs)
+- `exit_to_normal()` - Return to normal editing after plugin operation completes
+- `set_mode(mode)` - Custom mode transitions that don't fit the standard patterns
+
 ## Components
 
 ### InputEventBroker

--- a/lib/core/src/event_bus/bus.rs
+++ b/lib/core/src/event_bus/bus.rs
@@ -14,7 +14,8 @@ use std::{
 
 use tokio::sync::mpsc;
 
-use super::{DynEvent, Event, EventResult};
+use super::{core_events::RequestModeChange, DynEvent, Event, EventResult};
+use crate::modd::{ComponentId, EditMode, ModeState, SubMode};
 
 /// Handler function type - receives event and context, returns result
 type EventHandlerFn = Box<dyn Fn(&DynEvent, &mut HandlerContext) -> EventResult + Send + Sync>;
@@ -73,6 +74,38 @@ impl<'a> HandlerContext<'a> {
     #[must_use]
     pub fn quit_requested(&self) -> bool {
         self.quit_requested
+    }
+
+    // === Mode change helpers ===
+
+    /// Enter interactor mode: sets both focus and SubMode to component_id
+    ///
+    /// This is the common pattern for plugins that want to receive text input.
+    /// It sets the interactor_id to the component and also sets SubMode::Interactor
+    /// to route input events to the plugin.
+    pub fn enter_interactor_mode(&self, component_id: ComponentId) {
+        let mode = ModeState::with_interactor_id_sub_mode(
+            component_id,
+            EditMode::Normal,
+            SubMode::Interactor(component_id),
+        );
+        self.emit(RequestModeChange { mode });
+    }
+
+    /// Return to normal editor mode
+    ///
+    /// Resets to standard editor Normal mode with no sub-mode.
+    pub fn exit_to_normal(&self) {
+        self.emit(RequestModeChange {
+            mode: ModeState::normal(),
+        });
+    }
+
+    /// Set arbitrary mode state
+    ///
+    /// For edge cases that don't fit the standard patterns.
+    pub fn set_mode(&self, mode: ModeState) {
+        self.emit(RequestModeChange { mode });
     }
 }
 

--- a/plugins/features/microscope/src/lib.rs
+++ b/plugins/features/microscope/src/lib.rs
@@ -862,7 +862,7 @@ impl Plugin for MicroscopePlugin {
                     PluginBackspace, PluginTextInput, RequestFocusChange, RequestModeChange,
                 },
             },
-            modd::{EditMode, ModeState, SubMode},
+            modd::{EditMode, ModeState},
         };
 
         // Helper function to load preview for the currently selected item
@@ -1238,12 +1238,7 @@ impl Plugin for MicroscopePlugin {
             });
 
             // Enter Interactor sub-mode so characters route to PluginTextInput handler
-            let mode = ModeState::with_interactor_id_sub_mode(
-                COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
+            ctx.enter_interactor_mode(COMPONENT_ID);
 
             ctx.request_render();
             EventResult::Handled

--- a/plugins/features/range-finder/src/lib.rs
+++ b/plugins/features/range-finder/src/lib.rs
@@ -17,11 +17,11 @@ use {
         event_bus::{
             EventBus, EventResult,
             core_events::{
-                BufferClosed, MotionContext, PluginTextInput, RequestCursorMove, RequestModeChange,
+                BufferClosed, MotionContext, PluginTextInput, RequestCursorMove,
             },
         },
         keys,
-        modd::{ComponentId, EditMode, ModeState, SubMode},
+        modd::ComponentId,
         plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
         subscribe_state, subscribe_state_conditional,
     },
@@ -277,12 +277,7 @@ impl Plugin for RangeFinderPlugin {
             });
 
             // Enter Interactor mode to receive character input
-            let mode = ModeState::with_interactor_id_sub_mode(
-                JUMP_COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(JUMP_COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
+            ctx.enter_interactor_mode(JUMP_COMPONENT_ID);
             ctx.request_render();
 
             tracing::debug!(
@@ -311,12 +306,7 @@ impl Plugin for RangeFinderPlugin {
             });
 
             // Enter Interactor mode to receive character input
-            let mode = ModeState::with_interactor_id_sub_mode(
-                JUMP_COMPONENT_ID,
-                EditMode::Normal,
-                SubMode::Interactor(JUMP_COMPONENT_ID),
-            );
-            ctx.emit(RequestModeChange { mode });
+            ctx.enter_interactor_mode(JUMP_COMPONENT_ID);
             ctx.request_render();
 
             tracing::debug!(
@@ -385,8 +375,7 @@ impl Plugin for RangeFinderPlugin {
                     }
 
                     // Return to Normal mode after jump
-                    let mode = ModeState::normal();
-                    ctx.emit(RequestModeChange { mode });
+                    ctx.exit_to_normal();
 
                     // Reset jump state
                     jump_state.with_mut(jump::state::JumpState::reset);
@@ -399,8 +388,7 @@ impl Plugin for RangeFinderPlugin {
 
                     // Reset state and exit Interactor mode
                     jump_state.with_mut(jump::state::JumpState::reset);
-                    let mode = ModeState::normal();
-                    ctx.emit(RequestModeChange { mode });
+                    ctx.exit_to_normal();
                     ctx.request_render();
 
                     EventResult::Handled
@@ -415,8 +403,7 @@ impl Plugin for RangeFinderPlugin {
             jump_state.with_mut(jump::state::JumpState::reset);
 
             // Exit Interactor mode
-            let mode = ModeState::normal();
-            ctx.emit(RequestModeChange { mode });
+            ctx.exit_to_normal();
             ctx.request_render();
 
             tracing::debug!("Jump explicitly canceled");


### PR DESCRIPTION
Add helper methods to HandlerContext to reduce mode change boilerplate:
- enter_interactor_mode(component_id): Enter interactor sub-mode
- exit_to_normal(): Return to normal editor mode
- set_mode(mode): Set arbitrary mode state for edge cases

Updated Range-Finder plugin: 5 mode changes simplified
Updated Microscope plugin: 1 mode change simplified

Closes #44