### PR TITLE
feat(event_bus): add subscribe_targeted() API for component-specific events (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to Reovim will be documented in this file.
   - Migrated Range-Finder plugin: 5 subscription blocks (~30 lines saved)
   - Total: ~210 lines of boilerplate removed across 28 subscription blocks
 
+- **`subscribe_targeted()` API for EventBus** (Issue #45) - New method to automatically filter events by component ID
+  - `TargetedEvent` trait for events with a `target: ComponentId` field
+  - Implemented for `PluginTextInput`, `PluginBackspace`, and `RequestFocusChange`
+  - Eliminates boilerplate target-checking code in plugin event handlers
+  - Migrated 7 subscriptions across 4 plugins (Explorer, Microscope, Range-finder, Which-key)
+
 ### Fixed
 
 - **Light theme syntax highlighting** (Issue #43) - Light theme now uses proper One Light colors

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -1599,17 +1599,16 @@ fn build(&self, ctx: &mut PluginContext) {
 
 ### Plugin Input Handling
 
-Plugin input is handled via event subscriptions. When a plugin component has focus, the runtime emits `PluginTextInput` and `PluginBackspace` events that plugins can subscribe to:
+Plugin input is handled via event subscriptions. When a plugin component has focus, the runtime emits `PluginTextInput` and `PluginBackspace` events that plugins can subscribe to.
+
+Use `subscribe_targeted()` to automatically filter events by component ID:
 
 ```rust
 use reovim_core::event_bus::core_events::{PluginTextInput, PluginBackspace};
 
 fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
     let state_clone = Arc::clone(&state);
-    bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-        if event.target != COMPONENT_ID {
-            return EventResult::NotHandled;
-        }
+    bus.subscribe_targeted::<PluginTextInput, _>(COMPONENT_ID, 100, move |event, ctx| {
         state_clone.with_mut::<ExplorerState, _, _>(|s| {
             s.input_char(event.c);
         });
@@ -1618,10 +1617,7 @@ fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
     });
 
     let state_clone = Arc::clone(&state);
-    bus.subscribe::<PluginBackspace, _>(100, move |event, ctx| {
-        if event.target != COMPONENT_ID {
-            return EventResult::NotHandled;
-        }
+    bus.subscribe_targeted::<PluginBackspace, _>(COMPONENT_ID, 100, move |_event, ctx| {
         state_clone.with_mut::<ExplorerState, _, _>(|s| {
             s.input_backspace();
         });
@@ -1630,6 +1626,8 @@ fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
     });
 }
 ```
+
+The `subscribe_targeted()` method only calls your handler when `event.target()` matches the specified component ID, eliminating the need for manual target checks.
 
 **Built-in vs Plugin Components:**
 

--- a/lib/core/src/event_bus/bus.rs
+++ b/lib/core/src/event_bus/bus.rs
@@ -212,6 +212,44 @@ impl EventBus {
         entry.sort_by_key(|h| h.priority);
     }
 
+    /// Register a handler for a targeted event, filtering by component ID
+    ///
+    /// This is a convenience method for events that implement `TargetedEvent`.
+    /// The handler will only be called when `event.target() == target`.
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - The component ID to filter events for
+    /// * `priority` - Lower values are called first (0-50 for core, 100+ for plugins)
+    /// * `handler` - Function to call when matching event is received
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// pub const COMPONENT_ID: ComponentId = ComponentId("my_plugin");
+    ///
+    /// bus.subscribe_targeted::<PluginTextInput, _>(COMPONENT_ID, 100, |event, ctx| {
+    ///     // Only called when event.target == COMPONENT_ID
+    ///     println!("Received char: {}", event.c);
+    ///     EventResult::Handled
+    /// });
+    /// ```
+    pub fn subscribe_targeted<E: super::TargetedEvent, F>(
+        &self,
+        target: crate::modd::ComponentId,
+        priority: u32,
+        handler: F,
+    ) where
+        F: Fn(&E, &mut HandlerContext) -> EventResult + Send + Sync + 'static,
+    {
+        self.subscribe::<E, _>(priority, move |event, ctx| {
+            if event.target() != target {
+                return EventResult::NotHandled;
+            }
+            handler(event, ctx)
+        });
+    }
+
     /// Emit an event to the bus (non-blocking)
     pub fn emit<E: Event>(&self, event: E) {
         let _ = self.tx.try_send(DynEvent::new(event));
@@ -399,5 +437,58 @@ mod tests {
         let result = bus.dispatch(&event, &mut ctx);
 
         assert_eq!(result, EventResult::NotHandled);
+    }
+
+    #[test]
+    fn test_subscribe_targeted() {
+        use crate::{event_bus::TargetedEvent, modd::ComponentId};
+
+        #[derive(Debug)]
+        struct TargetedTestEvent {
+            target: ComponentId,
+            value: i32,
+        }
+
+        impl Event for TargetedTestEvent {}
+
+        impl TargetedEvent for TargetedTestEvent {
+            fn target(&self) -> ComponentId {
+                self.target
+            }
+        }
+
+        const MY_COMPONENT: ComponentId = ComponentId("my_component");
+        const OTHER_COMPONENT: ComponentId = ComponentId("other");
+
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicI32::new(0));
+        let counter_clone = counter.clone();
+
+        bus.subscribe_targeted::<TargetedTestEvent, _>(MY_COMPONENT, 100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        // Event targeting MY_COMPONENT - should be handled
+        let event1 = DynEvent::new(TargetedTestEvent {
+            target: MY_COMPONENT,
+            value: 10,
+        });
+        let mut ctx = HandlerContext::new(&sender);
+        let result = bus.dispatch(&event1, &mut ctx);
+        assert_eq!(result, EventResult::Handled);
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+
+        // Event targeting OTHER_COMPONENT - should NOT be handled
+        let event2 = DynEvent::new(TargetedTestEvent {
+            target: OTHER_COMPONENT,
+            value: 5,
+        });
+        let mut ctx = HandlerContext::new(&sender);
+        let result = bus.dispatch(&event2, &mut ctx);
+        assert_eq!(result, EventResult::NotHandled);
+        assert_eq!(counter.load(Ordering::SeqCst), 10); // Unchanged
     }
 }

--- a/lib/core/src/event_bus/core_events.rs
+++ b/lib/core/src/event_bus/core_events.rs
@@ -246,6 +246,12 @@ impl Event for RequestFocusChange {
     }
 }
 
+impl super::TargetedEvent for RequestFocusChange {
+    fn target(&self) -> crate::modd::ComponentId {
+        self.target
+    }
+}
+
 /// Request to change the editor mode
 ///
 /// Plugins emit this event to request a mode change (edit mode, sub-mode, etc.).
@@ -507,6 +513,12 @@ impl Event for PluginTextInput {
     }
 }
 
+impl super::TargetedEvent for PluginTextInput {
+    fn target(&self) -> crate::modd::ComponentId {
+        self.target
+    }
+}
+
 /// Backspace received by a plugin component
 ///
 /// Emitted when backspace is pressed while a plugin component has focus.
@@ -520,6 +532,12 @@ pub struct PluginBackspace {
 impl Event for PluginBackspace {
     fn priority(&self) -> u32 {
         priority::CORE
+    }
+}
+
+impl super::TargetedEvent for PluginBackspace {
+    fn target(&self) -> crate::modd::ComponentId {
+        self.target
     }
 }
 

--- a/lib/core/src/event_bus/mod.rs
+++ b/lib/core/src/event_bus/mod.rs
@@ -60,6 +60,16 @@ pub trait Event: Send + Sync + Debug + 'static {
     }
 }
 
+/// Marker trait for events that target a specific component
+///
+/// Events implementing this trait have a `target` field that specifies
+/// which component should handle the event. This enables `subscribe_targeted()`
+/// to automatically filter events by target.
+pub trait TargetedEvent: Event {
+    /// Get the target component ID for this event
+    fn target(&self) -> crate::modd::ComponentId;
+}
+
 /// A type-erased event that can carry any payload
 ///
 /// This allows different event types to be sent through the same channel

--- a/plugins/features/explorer/src/lib.rs
+++ b/plugins/features/explorer/src/lib.rs
@@ -174,12 +174,8 @@ impl Plugin for ExplorerPlugin {
         };
 
         // Handle text input from runtime (PluginTextInput event)
-        // Keep manual: target check with early return
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
+        bus.subscribe_targeted::<PluginTextInput, _>(COMPONENT_ID, 100, move |event, ctx| {
             state_clone.with_mut::<ExplorerState, _, _>(|s| {
                 s.input_char(event.c);
             });
@@ -188,12 +184,8 @@ impl Plugin for ExplorerPlugin {
         });
 
         // Handle backspace from runtime (PluginBackspace event)
-        // Keep manual: target check with early return
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginBackspace, _>(100, move |event, ctx| {
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
+        bus.subscribe_targeted::<PluginBackspace, _>(COMPONENT_ID, 100, move |_event, ctx| {
             state_clone.with_mut::<ExplorerState, _, _>(|s| {
                 s.input_backspace();
             });

--- a/plugins/features/microscope/src/lib.rs
+++ b/plugins/features/microscope/src/lib.rs
@@ -946,12 +946,7 @@ impl Plugin for MicroscopePlugin {
 
         // Handle text input from runtime (PluginTextInput event)
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-            // Only handle if target is microscope and microscope is active
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
-
+        bus.subscribe_targeted::<PluginTextInput, _>(COMPONENT_ID, 100, move |event, ctx| {
             let is_active = state_clone
                 .with::<MicroscopeState, _, _>(|s| s.active)
                 .unwrap_or(false);
@@ -969,12 +964,7 @@ impl Plugin for MicroscopePlugin {
 
         // Handle backspace from runtime (PluginBackspace event)
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginBackspace, _>(100, move |event, ctx| {
-            // Only handle if we're the target
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
-
+        bus.subscribe_targeted::<PluginBackspace, _>(COMPONENT_ID, 100, move |_event, ctx| {
             let is_active = state_clone
                 .with::<MicroscopeState, _, _>(|s| s.active)
                 .unwrap_or(false);

--- a/plugins/features/range-finder/src/lib.rs
+++ b/plugins/features/range-finder/src/lib.rs
@@ -319,12 +319,7 @@ impl Plugin for RangeFinderPlugin {
 
         // PluginTextInput - handle character input during jump mode
         let jump_state = Arc::clone(&self.jump_state);
-        bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-            // Only handle if we're the target
-            if event.target != JUMP_COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
-
+        bus.subscribe_targeted::<PluginTextInput, _>(JUMP_COMPONENT_ID, 100, move |event, ctx| {
             // Handle input through the state machine
             let result = jump_state.with_mut(|state| {
                 let buffer_id = state.buffer_id.unwrap_or(0);

--- a/plugins/features/which-key/src/lib.rs
+++ b/plugins/features/which-key/src/lib.rs
@@ -208,12 +208,7 @@ impl Plugin for WhichKeyPlugin {
 
         // Subscribe to PluginTextInput - handle keys typed while panel is visible
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginTextInput, _>(100, move |event, ctx| {
-            // Only handle if we're the target
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
-
+        bus.subscribe_targeted::<PluginTextInput, _>(COMPONENT_ID, 100, move |event, ctx| {
             tracing::info!("WhichKeyPlugin: received PluginTextInput c={}", event.c);
 
             // Convert char to keystroke and update filter
@@ -240,12 +235,7 @@ impl Plugin for WhichKeyPlugin {
 
         // Subscribe to PluginBackspace - same as WhichKeyBackspace
         let state_clone = Arc::clone(&state);
-        bus.subscribe::<PluginBackspace, _>(100, move |event, ctx| {
-            // Only handle if we're the target
-            if event.target != COMPONENT_ID {
-                return EventResult::NotHandled;
-            }
-
+        bus.subscribe_targeted::<PluginBackspace, _>(COMPONENT_ID, 100, move |_event, ctx| {
             tracing::info!("WhichKeyPlugin: received PluginBackspace");
 
             state_clone.with::<WhichKeyState, _, _>(|wk| {


### PR DESCRIPTION
Add a new `subscribe_targeted()` method to EventBus that automatically filters events by ComponentId, eliminating boilerplate target-checking code in plugin event handlers.

Changes:
- Add `TargetedEvent` trait for events with `target: ComponentId` field
- Implement trait for PluginTextInput, PluginBackspace, RequestFocusChange
- Add `subscribe_targeted()` method that wraps subscribe() with filtering
- Migrate 7 subscriptions across 4 plugins to use new API
- Add unit test for subscribe_targeted()
- Update plugin-system.md documentation

Closes #45