### PR TITLE
feat(core): make accepts_char_input() metadata-driven (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Metadata-driven interactor input behavior** (Issue #46) - Refactored `accepts_char_input()` to use registry instead of hardcoded checks
+  - `InteractorConfig` struct for configuring input behavior per interactor
+  - `InteractorRegistry` for storing and querying interactor configurations
+  - `accepts_char_input_with(registry)` method on `ModeState` for registry-based lookup
+  - `PluginContext::register_interactor()` for plugins to register their input behavior
+  - Window mode registered via `InteractorConfig::using_keymap()` instead of hardcoded exclusion
+  - Default behavior: unregistered interactors accept character input (safe default)
+
 - **HandlerContext mode change helpers** (Issue #44) - Reduce mode change boilerplate
   - `enter_interactor_mode(component_id)` - Enter interactor sub-mode for text input
   - `exit_to_normal()` - Return to normal editor mode

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -558,7 +558,8 @@ impl ComponentId {
 - `is_command()`, `is_operator_pending()` - Sub-mode checks
 - `is_interactor(id)` - Check if current interactor matches given ID
 - `is_editor_focus()` - Check if focused on editor
-- `accepts_char_input()` - Check if mode accepts character input (excludes Window mode)
+- `accepts_char_input_with(registry)` - Check if mode accepts character input (queries `InteractorRegistry`)
+- `accepts_char_input()` - Deprecated: uses hardcoded fallbacks instead of registry
 
 **Hierarchical Display:**
 
@@ -1099,6 +1100,8 @@ Manages input-receiving components (UIComponents) that can receive focus and han
 - `UIComponent` trait - Interface for input-receiving components
 - `UIComponentRegistry` - Manages registered UI components and tracks active focus
 - `InputResult` - Result enum: `NotHandled`, `Handled`, `SendEvent(InnerEvent)`
+- `InteractorConfig` - Configuration for interactor input behavior (accepts char input vs keymap)
+- `InteractorRegistry` - Registry for interactor configurations, queried by `ModeState.accepts_char_input_with()`
 
 **Core ComponentIds:**
 | ComponentId | Component |
@@ -1132,9 +1135,26 @@ fn handle_focus_input(&mut self, input: InputEvent) {
 }
 ```
 
+**Input Behavior Configuration:**
+```rust
+// Plugins can configure how their interactor handles input
+// Default: accepts character input (like Explorer filter mode)
+// using_keymap(): uses keymap for commands (like Window mode)
+fn build(&self, ctx: &mut PluginContext) {
+    // Window mode doesn't accept char input - uses keymap for h/j/k/l
+    ctx.register_interactor(
+        ComponentId::WINDOW,
+        InteractorConfig::using_keymap()
+    );
+
+    // Most plugins default to accepting_input() - no registration needed
+}
+```
+
 **Benefits:**
 - Core has no knowledge of specific plugins
 - Plugins self-register their UIComponents
+- Input behavior is metadata-driven via `InteractorRegistry`
 - Runtime dispatch is fully generic via ComponentId lookup
 
 ### Modifier System (`lib/core/src/modifier/`)

--- a/lib/core/src/event/handler/command/mod.rs
+++ b/lib/core/src/event/handler/command/mod.rs
@@ -11,6 +11,7 @@ use {
         bind::{CommandRef, KeyMap, KeyMapInner},
         command::{CommandRegistry, traits::OperatorMotionAction},
         event::{InnerEvent, KeyEvent, Subscribe, VisualTextObjectAction},
+        interactor::InteractorRegistry,
         keystroke::{KeyNotationFormat, KeySequence, Keystroke},
         modd::{ModeState, OperatorType, SubMode},
         motion::Motion,
@@ -36,6 +37,8 @@ pub struct CommandHandler {
     dispatcher: Dispatcher,
     /// Track when mode was locally changed (avoids race condition with `mode_rx` sync)
     mode_locally_changed: bool,
+    /// Interactor registry for input behavior lookup
+    interactor_registry: Arc<InteractorRegistry>,
 }
 
 impl Subscribe<KeyEvent> for CommandHandler {
@@ -51,6 +54,7 @@ impl CommandHandler {
         mode_rx: watch::Receiver<ModeState>,
         keymap: KeyMap,
         command_registry: Arc<CommandRegistry>,
+        interactor_registry: Arc<InteractorRegistry>,
     ) -> Self {
         let initial_mode = mode_rx.borrow().clone();
         Self {
@@ -62,6 +66,7 @@ impl CommandHandler {
             count_parser: CountParser::new(),
             dispatcher: Dispatcher::new(tx, 0, 0, command_registry),
             mode_locally_changed: false,
+            interactor_registry,
         }
     }
 
@@ -575,7 +580,7 @@ impl CommandHandler {
                                 // Handle single-character input in modes that accept char input
                                 // Route via TextInputEvent instead of creating inline commands
                                 let mode = self.current_mode();
-                                if mode.accepts_char_input()
+                                if mode.accepts_char_input_with(&self.interactor_registry)
                                     && key_str.len() == 1
                                     && let Some(c) = key_str.chars().next()
                                 {
@@ -591,7 +596,8 @@ impl CommandHandler {
                                 // Handle Backspace in modes that accept char input
                                 // Route via TextInputEvent for text input handling
                                 let mode = self.current_mode();
-                                if mode.accepts_char_input() && key_str == "Backspace"
+                                if mode.accepts_char_input_with(&self.interactor_registry)
+                                    && key_str == "Backspace"
                                 {
                                     self.pending_keys.clear();
                                     self.dispatcher.send_focus_delete_backward().await;

--- a/lib/core/src/interactor/config.rs
+++ b/lib/core/src/interactor/config.rs
@@ -1,0 +1,153 @@
+//! Interactor configuration and registry
+//!
+//! This module provides metadata-driven configuration for interactor components,
+//! allowing them to declare their input handling behavior instead of relying on
+//! hardcoded checks in the mode system.
+
+use std::collections::HashMap;
+
+use crate::modd::ComponentId;
+
+/// Configuration for an interactor component
+///
+/// Defines how an interactor handles input. Components that accept character input
+/// (like Explorer's filter mode) will receive printable characters directly.
+/// Components that use keymap (like Window mode) will have characters looked up
+/// in the keymap instead.
+#[derive(Debug, Clone, Copy)]
+pub struct InteractorConfig {
+    /// Whether this interactor accepts character input (insert-mode style)
+    ///
+    /// When `true`, single printable characters are routed as text input via
+    /// `PluginTextInput` events. When `false`, characters are looked up in the
+    /// keymap and dispatched as commands.
+    pub accepts_char_input: bool,
+}
+
+impl InteractorConfig {
+    /// Create config that accepts character input (default for most plugins)
+    ///
+    /// Use this for interactors that need text input, like:
+    /// - Explorer's create/rename/filter modes
+    /// - Telescope's search input
+    /// - Leap/jump search modes
+    #[must_use]
+    pub const fn accepting_input() -> Self {
+        Self {
+            accepts_char_input: true,
+        }
+    }
+
+    /// Create config that uses keymap (like Window mode)
+    ///
+    /// Use this for interactors where keys trigger commands:
+    /// - Window mode (h/j/k/l for navigation)
+    /// - Any mode where characters map to actions
+    #[must_use]
+    pub const fn using_keymap() -> Self {
+        Self {
+            accepts_char_input: false,
+        }
+    }
+}
+
+impl Default for InteractorConfig {
+    fn default() -> Self {
+        // Default: accept char input (matches current behavior for most plugins)
+        Self::accepting_input()
+    }
+}
+
+/// Registry for interactor configurations
+///
+/// Stores metadata for interactor components, allowing the mode system to
+/// query behavior without hardcoding component-specific logic.
+#[derive(Debug, Default)]
+pub struct InteractorRegistry {
+    configs: HashMap<ComponentId, InteractorConfig>,
+}
+
+impl InteractorRegistry {
+    /// Create a new empty registry
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register configuration for an interactor
+    ///
+    /// If the interactor was already registered, the config is replaced.
+    pub fn register(&mut self, id: ComponentId, config: InteractorConfig) {
+        self.configs.insert(id, config);
+    }
+
+    /// Get configuration for an interactor
+    ///
+    /// Returns `None` if the interactor is not registered.
+    #[must_use]
+    pub fn get(&self, id: &ComponentId) -> Option<&InteractorConfig> {
+        self.configs.get(id)
+    }
+
+    /// Check if interactor accepts character input
+    ///
+    /// Returns `true` by default for unregistered interactors (safe default
+    /// that matches the behavior of most plugins).
+    #[must_use]
+    pub fn accepts_char_input(&self, id: &ComponentId) -> bool {
+        self.get(id).is_none_or(|config| config.accepts_char_input)
+    }
+
+    /// Register all built-in interactor configs
+    ///
+    /// This should be called during runtime initialization to set up
+    /// core component configurations.
+    pub fn register_builtins(&mut self) {
+        // Window mode does NOT accept char input - uses keymap for h/j/k/l
+        self.register(ComponentId::WINDOW, InteractorConfig::using_keymap());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interactor_config_defaults() {
+        let default = InteractorConfig::default();
+        assert!(default.accepts_char_input);
+
+        let accepting = InteractorConfig::accepting_input();
+        assert!(accepting.accepts_char_input);
+
+        let keymap = InteractorConfig::using_keymap();
+        assert!(!keymap.accepts_char_input);
+    }
+
+    #[test]
+    fn test_registry_accepts_char_input() {
+        let mut registry = InteractorRegistry::new();
+
+        // Unregistered interactor defaults to accepting input
+        let unknown = ComponentId("unknown");
+        assert!(registry.accepts_char_input(&unknown));
+
+        // Register WINDOW as not accepting input
+        registry.register_builtins();
+        assert!(!registry.accepts_char_input(&ComponentId::WINDOW));
+
+        // Register custom interactor
+        let explorer = ComponentId("explorer");
+        registry.register(explorer, InteractorConfig::accepting_input());
+        assert!(registry.accepts_char_input(&explorer));
+    }
+
+    #[test]
+    fn test_registry_get() {
+        let mut registry = InteractorRegistry::new();
+        registry.register_builtins();
+
+        assert!(registry.get(&ComponentId::WINDOW).is_some());
+        assert!(registry.get(&ComponentId("unknown")).is_none());
+    }
+}

--- a/lib/core/src/interactor/mod.rs
+++ b/lib/core/src/interactor/mod.rs
@@ -10,6 +10,17 @@
 //! the currently focused component. Built-in components (`Editor`, `CommandLine`)
 //! are handled directly by the runtime. Plugin components receive input via
 //! `PluginTextInput` and `PluginBackspace` events.
+//!
+//! ## Interactor Configuration
+//!
+//! Interactors can register their input behavior via [`InteractorConfig`] and
+//! [`InteractorRegistry`]. This allows the mode system to determine whether
+//! an interactor accepts character input without hardcoding component-specific
+//! logic.
+
+mod config;
+
+pub use config::{InteractorConfig, InteractorRegistry};
 
 #[cfg(test)]
 mod tests {

--- a/lib/core/src/modd/mod.rs
+++ b/lib/core/src/modd/mod.rs
@@ -278,10 +278,50 @@ impl ModeState {
         self.interactor_id.0 == "editor"
     }
 
+    /// Check if the mode accepts character input, using registry for interactor lookup
+    ///
+    /// This method queries the [`InteractorRegistry`] to determine whether an
+    /// interactor accepts character input, avoiding hardcoded component checks.
+    ///
+    /// # Arguments
+    ///
+    /// * `registry` - The interactor registry to query for input behavior
+    ///
+    /// # Returns
+    ///
+    /// * `true` if in Insert mode, Command mode, or an Interactor that accepts input
+    /// * `false` for Normal, Visual, `OperatorPending`, or Interactors using keymap
+    ///
+    /// [`InteractorRegistry`]: crate::interactor::InteractorRegistry
+    #[must_use]
+    pub fn accepts_char_input_with(
+        &self,
+        registry: &crate::interactor::InteractorRegistry,
+    ) -> bool {
+        // Insert mode or Command mode always accept char input
+        if self.is_insert() || self.is_command() {
+            return true;
+        }
+
+        // For Interactor sub-modes, check the registry
+        if let SubMode::Interactor(id) = &self.sub_mode {
+            return registry.accepts_char_input(id);
+        }
+
+        // Other sub-modes (None, OperatorPending) don't accept char input
+        false
+    }
+
     /// Check if the mode accepts character input (insert mode or command mode)
     ///
     /// Note: Window mode (`SubMode::Interactor(ComponentId::WINDOW)`) does NOT accept char input -
     /// it uses the keymap for commands like h/j/k/l to navigate windows.
+    ///
+    /// **Deprecated**: Use [`accepts_char_input_with()`] with an [`InteractorRegistry`]
+    /// for accurate results. This method uses hardcoded fallbacks for backwards compatibility.
+    ///
+    /// [`accepts_char_input_with()`]: ModeState::accepts_char_input_with
+    /// [`InteractorRegistry`]: crate::interactor::InteractorRegistry
     #[must_use]
     pub fn accepts_char_input(&self) -> bool {
         // Insert mode or Command mode accept char input

--- a/lib/core/src/plugin/context.rs
+++ b/lib/core/src/plugin/context.rs
@@ -6,6 +6,7 @@ use crate::{
     bind::{CommandRef, KeyMap, KeymapScope},
     command::{CommandRegistry, CommandTrait},
     display::{DisplayInfo, DisplayRegistry},
+    interactor::{InteractorConfig, InteractorRegistry},
     keystroke::KeySequence,
     modd::ComponentId,
     modifier::ModifierRegistry,
@@ -45,6 +46,9 @@ pub struct PluginContext {
 
     /// Current plugin ID for namespacing options
     pub(crate) current_plugin_id: Option<String>,
+
+    /// Interactor registry for input behavior configuration
+    pub(crate) interactor_registry: InteractorRegistry,
 }
 
 impl Default for PluginContext {
@@ -67,6 +71,7 @@ impl PluginContext {
             render_stages: RenderStageRegistry::new(),
             option_specs: Vec::new(),
             current_plugin_id: None,
+            interactor_registry: InteractorRegistry::new(),
         }
     }
 
@@ -203,6 +208,40 @@ impl PluginContext {
         crate::display::DisplayInfoBuilder::new(self, id)
     }
 
+    // === Interactor Registration ===
+
+    /// Register an interactor's input behavior configuration
+    ///
+    /// This configures how an interactor handles character input. By default,
+    /// interactors accept character input (like Explorer's filter mode).
+    /// Use [`InteractorConfig::using_keymap()`] for interactors that should
+    /// look up characters in the keymap (like Window mode).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Register an interactor that uses keymap for input
+    /// ctx.register_interactor(
+    ///     ComponentId("my_nav_mode"),
+    ///     InteractorConfig::using_keymap()
+    /// );
+    /// ```
+    pub fn register_interactor(&mut self, id: ComponentId, config: InteractorConfig) {
+        self.interactor_registry.register(id, config);
+    }
+
+    /// Get access to the interactor registry
+    #[must_use]
+    pub const fn interactor_registry(&self) -> &InteractorRegistry {
+        &self.interactor_registry
+    }
+
+    /// Get mutable access to the interactor registry
+    #[must_use]
+    pub const fn interactor_registry_mut(&mut self) -> &mut InteractorRegistry {
+        &mut self.interactor_registry
+    }
+
     // === Plugin Queries ===
 
     /// Check if a plugin has been loaded
@@ -328,6 +367,7 @@ impl PluginContext {
         DisplayRegistry,
         RenderStageRegistry,
         Vec<OptionSpec>,
+        InteractorRegistry,
     ) {
         (
             self.commands,
@@ -337,6 +377,7 @@ impl PluginContext {
             self.display_registry,
             self.render_stages,
             self.option_specs,
+            self.interactor_registry,
         )
     }
 }

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -23,6 +23,7 @@ use {
         },
         highlight::{ColorMode, HighlightStore, Theme},
         indent::IndentAnalyzer,
+        interactor::InteractorRegistry,
         jumplist::JumpList,
         modd::ModeState,
         modifier::{ModifierContext, ModifierRegistry},
@@ -104,6 +105,8 @@ pub struct Runtime {
     pub(crate) idle_shimmer_active: bool,
     /// Landing page animation state (when showing landing page)
     pub(crate) landing_state: Option<crate::landing::LandingState>,
+    /// Interactor registry for input behavior configuration
+    pub interactor_registry: Arc<InteractorRegistry>,
 }
 
 impl Default for Runtime {
@@ -192,7 +195,11 @@ impl Runtime {
             display_registry,
             render_stages,
             option_specs,
+            mut interactor_registry,
         ) = ctx.into_parts();
+
+        // Register built-in interactor configs (e.g., Window mode doesn't accept char input)
+        interactor_registry.register_builtins();
 
         // Register build-phase options (backward compatibility with ctx.option())
         for spec in option_specs {
@@ -264,6 +271,7 @@ impl Runtime {
             last_input_at: std::time::Instant::now(),
             idle_shimmer_active: false,
             landing_state: None,
+            interactor_registry: Arc::new(interactor_registry),
         };
 
         // Make keymap and command registry accessible to plugins (e.g., which-key)

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -37,7 +37,8 @@ impl Runtime {
             self.tx.clone(),
             mode_rx,
             self.keymap.clone(),
-            self.command_registry.clone(),
+            Arc::clone(&self.command_registry),
+            Arc::clone(&self.interactor_registry),
         );
         let mut terminate_hdr = TerminateHandler::new(self.tx.clone());
 
@@ -142,7 +143,8 @@ impl Runtime {
             self.tx.clone(),
             mode_rx,
             self.keymap.clone(),
-            self.command_registry.clone(),
+            Arc::clone(&self.command_registry),
+            Arc::clone(&self.interactor_registry),
         );
         let mut terminate_hdr = crate::event::TerminateHandler::new(self.tx.clone());
 


### PR DESCRIPTION
Refactor accepts_char_input() to use InteractorRegistry instead of hardcoded ComponentId checks. This decouples mode logic from specific components, making it easier to add new interactors with custom input behavior.

Changes:
- Add InteractorConfig struct for per-interactor input behavior
- Add InteractorRegistry for storing and querying configurations
- Add accepts_char_input_with(registry) method to ModeState
- Register Window mode as using_keymap() via registry
- Update CommandHandler to use new registry-based method
- Update architecture.md documentation

Default behavior: unregistered interactors accept character input (safe default matching existing plugin behavior).

Closes #46