### PR TITLE
refactor(runtime): unify active buffer tracking (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to Reovim will be documented in this file.
   - Provides compile-time safety: no more missing match arms causing flaky tests
   - Fixed bug: `enter_visual_line_mode` was missing from old implementation
 
+- **Unified active buffer tracking** (Issue #47) - Removed redundant `active_buffer_id` field from Runtime
+  - Screen is now the single source of truth for active buffer ID
+  - `Runtime::active_buffer_id()` method derives value from `Screen::active_buffer_id()`
+  - Eliminates dual tracking and manual synchronization between Runtime and Screen
+  - Simplifies buffer switching, file opening, and window navigation code
+
 ### Added
 
 - **Metadata-driven interactor input behavior** (Issue #46) - Refactored `accepts_char_input()` to use registry instead of hardcoded checks

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,8 +213,8 @@ The central event loop that owns all editor state:
 pub struct Runtime {
     // Buffer management
     pub buffers: BTreeMap<usize, Buffer>,
-    pub active_buffer_id: usize,
-    pub next_buffer_id: usize,
+    next_buffer_id: usize,
+    // Note: active_buffer_id is derived from screen.active_buffer_id()
 
     // Display
     pub screen: Screen,

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -61,8 +61,6 @@ pub struct Runtime {
     pub command_registry: Arc<CommandRegistry>,
     /// Keymap with all registered keybindings (built-in + plugins)
     pub keymap: KeyMap,
-    /// Currently active buffer ID
-    pub active_buffer_id: usize,
     /// Next buffer ID to assign
     next_buffer_id: usize,
     /// Jump list for Ctrl-O/Ctrl-I navigation
@@ -249,7 +247,6 @@ impl Runtime {
             mode_rx,
             command_registry: Arc::new(command_registry),
             keymap,
-            active_buffer_id: 0,
             next_buffer_id: 0,
             jump_list: JumpList::new(),
             indent_analyzer: IndentAnalyzer::default(),
@@ -694,19 +691,20 @@ impl Runtime {
         let to_mode = format!("{:?}", mode_state.edit_mode);
 
         // Handle undo batching on insert mode transitions
+        let active_buf_id = self.active_buffer_id();
         if !was_insert && is_insert {
             // Entering insert mode: begin batching
-            if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
+            if let Some(buf) = self.buffers.get_mut(&active_buf_id) {
                 buf.begin_batch();
             }
         } else if was_insert && !is_insert {
             // Leaving insert mode: flush batch and record jump position
-            if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
+            if let Some(buf) = self.buffers.get_mut(&active_buf_id) {
                 buf.flush_batch();
                 // Record current position as a jump point when leaving insert mode
                 // This allows navigating back to where editing was completed
                 // Use push_current() which doesn't truncate (preserves jump history)
-                self.jump_list.push_current(self.active_buffer_id, buf.cur);
+                self.jump_list.push_current(active_buf_id, buf.cur);
             }
         }
 
@@ -957,7 +955,7 @@ impl Runtime {
     /// Switch to a different buffer by ID
     pub fn switch_buffer(&mut self, buffer_id: usize) {
         if self.buffers.contains_key(&buffer_id) {
-            self.active_buffer_id = buffer_id;
+            self.screen.set_editor_buffer(buffer_id);
         }
     }
 
@@ -977,10 +975,10 @@ impl Runtime {
             self.event_bus.emit(BufferClosed { buffer_id });
 
             // If we closed the active buffer, switch to another one
-            if self.active_buffer_id == buffer_id
+            if self.active_buffer_id() == buffer_id
                 && let Some(&new_id) = self.buffers.keys().next()
             {
-                self.active_buffer_id = new_id;
+                self.screen.set_editor_buffer(new_id);
             }
             true
         } else {
@@ -995,7 +993,7 @@ impl Runtime {
         if ids.len() <= 1 {
             return None;
         }
-        let current_pos = ids.iter().position(|&id| id == self.active_buffer_id)?;
+        let current_pos = ids.iter().position(|&id| id == self.active_buffer_id())?;
         let prev_pos = if current_pos == 0 {
             ids.len() - 1
         } else {
@@ -1011,20 +1009,29 @@ impl Runtime {
         if ids.len() <= 1 {
             return None;
         }
-        let current_pos = ids.iter().position(|&id| id == self.active_buffer_id)?;
+        let current_pos = ids.iter().position(|&id| id == self.active_buffer_id())?;
         let next_pos = (current_pos + 1) % ids.len();
         Some(ids[next_pos])
+    }
+
+    /// Get the currently active buffer ID (derived from active window)
+    ///
+    /// This is the single source of truth for the active buffer, derived from
+    /// the screen's active window. Returns 0 if no active window exists.
+    #[must_use]
+    pub fn active_buffer_id(&self) -> usize {
+        self.screen.active_buffer_id().unwrap_or(0)
     }
 
     /// Get the currently active buffer
     #[must_use]
     pub fn active_buffer(&self) -> Option<&Buffer> {
-        self.buffers.get(&self.active_buffer_id)
+        self.buffers.get(&self.active_buffer_id())
     }
 
     /// Get the currently active buffer mutably
     pub fn active_buffer_mut(&mut self) -> Option<&mut Buffer> {
-        self.buffers.get_mut(&self.active_buffer_id)
+        self.buffers.get_mut(&self.active_buffer_id())
     }
 
     /// Open a file, creating a new buffer or switching to existing one
@@ -1035,7 +1042,7 @@ impl Runtime {
         for (id, buf) in &self.buffers {
             if buf.file_path.as_deref() == Some(path) {
                 debug!(id, path, "open_file: file already open, switching buffer");
-                self.active_buffer_id = *id;
+                self.screen.set_editor_buffer(*id);
                 return;
             }
         }
@@ -1043,7 +1050,7 @@ impl Runtime {
         // Create new buffer from file
         if let Some(id) = self.create_buffer_from_file(path) {
             debug!(id, path, "open_file: created new buffer");
-            self.active_buffer_id = id;
+            self.screen.set_editor_buffer(id);
             self.showing_landing_page = false;
             self.landing_state = None;
         } else {
@@ -1251,7 +1258,7 @@ impl Runtime {
         crate::rpc::ScreenSnapshot {
             width: self.screen.width(),
             height: self.screen.height(),
-            active_buffer_id: self.active_buffer_id,
+            active_buffer_id: self.active_buffer_id(),
             active_window_id: self.screen.active_window_id(),
             window_count: self.screen.window_count(),
         }
@@ -1309,7 +1316,7 @@ impl Runtime {
         // Get cursor info
         let cursor =
             self.buffers
-                .get(&self.active_buffer_id)
+                .get(&self.active_buffer_id())
                 .map(|buf| crate::visual::CursorInfo {
                     x: buf.cur.x,
                     y: buf.cur.y,
@@ -1370,7 +1377,7 @@ impl super::RuntimeContext for Runtime {
     }
 
     fn active_buffer_id(&self) -> usize {
-        self.active_buffer_id
+        Self::active_buffer_id(self)
     }
 
     fn mode(&self) -> &ModeState {
@@ -1383,19 +1390,20 @@ impl super::RuntimeContext for Runtime {
         let is_insert = mode.is_insert();
 
         // Handle undo batching on insert mode transitions
+        let active_buf_id = self.active_buffer_id();
         if !was_insert && is_insert {
             // Entering insert mode: begin batching
-            if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
+            if let Some(buf) = self.buffers.get_mut(&active_buf_id) {
                 buf.begin_batch();
             }
         } else if was_insert && !is_insert {
             // Leaving insert mode: flush batch and record jump position
-            if let Some(buf) = self.buffers.get_mut(&self.active_buffer_id) {
+            if let Some(buf) = self.buffers.get_mut(&active_buf_id) {
                 buf.flush_batch();
                 // Record current position as a jump point when leaving insert mode
                 // This allows navigating back to where editing was completed
                 // Use push_current() which doesn't truncate (preserves jump history)
-                self.jump_list.push_current(self.active_buffer_id, buf.cur);
+                self.jump_list.push_current(active_buf_id, buf.cur);
             }
         }
 

--- a/lib/core/src/runtime/enlist.rs
+++ b/lib/core/src/runtime/enlist.rs
@@ -45,7 +45,7 @@ pub fn handle_editor_input(
         }
     } else if rt.mode_state.is_insert() {
         // Buffer input
-        let buffer_id = rt.active_buffer_id;
+        let buffer_id = rt.active_buffer_id();
         if let Some(buffer) = rt.buffers.get_mut(&buffer_id) {
             if let Some(c) = char {
                 // Get position before insertion for event

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -89,7 +89,7 @@ impl Runtime {
             // Use create_buffer_from_file which handles treesitter parsing and decorations
             if let Some(buffer_id) = self.create_buffer_from_file(&path) {
                 // Update active buffer to the newly created one
-                self.active_buffer_id = buffer_id;
+                self.screen.set_editor_buffer(buffer_id);
             } else {
                 // File failed to load, create empty buffer
                 let mut buffer = Buffer::empty(0);
@@ -195,7 +195,7 @@ impl Runtime {
             // Use create_buffer_from_file which handles treesitter parsing and decorations
             if let Some(buffer_id) = self.create_buffer_from_file(&path) {
                 // Update active buffer to the newly created one
-                self.active_buffer_id = buffer_id;
+                self.screen.set_editor_buffer(buffer_id);
             } else {
                 // File failed to load, create empty buffer with path
                 let mut buffer = Buffer::empty(0);
@@ -310,7 +310,7 @@ impl Runtime {
                                 self.screen.width(),
                                 self.screen.height().saturating_sub(1),
                             );
-                            if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id) {
+                            if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id()) {
                                 buffer.set_content(&content);
                             }
                             self.request_render();
@@ -568,7 +568,7 @@ impl Runtime {
                 // Convert PathBuf to &str for open_file
                 if let Some(path_str) = path.to_str() {
                     self.open_file(path_str);
-                    self.screen.set_editor_buffer(self.active_buffer_id);
+                    self.screen.set_editor_buffer(self.active_buffer_id());
                     self.request_render();
                 } else {
                     tracing::error!("Runtime: Invalid UTF-8 in file path: {:?}", path);
@@ -579,9 +579,9 @@ impl Runtime {
                 tracing::info!("Runtime: Opening file at position: {:?}:{}:{}", path, line, column);
                 if let Some(path_str) = path.to_str() {
                     self.open_file(path_str);
-                    self.screen.set_editor_buffer(self.active_buffer_id);
+                    self.screen.set_editor_buffer(self.active_buffer_id());
                     // Set cursor position in the opened buffer
-                    if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id) {
+                    if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id()) {
                         // Ensure line is within bounds
                         let max_line = buffer.contents.len().saturating_sub(1);
                         let target_line = line.min(max_line);
@@ -709,7 +709,7 @@ impl Runtime {
         let rpc_ctx = crate::rpc::RpcHandlerContext::new(
             &self.plugin_state,
             &self.mode_state,
-            self.active_buffer_id,
+            self.active_buffer_id(),
         );
         if let Some(result) = self.rpc_handler_registry.dispatch(method, params, &rpc_ctx) {
             return match result {
@@ -727,14 +727,14 @@ impl Runtime {
                 RpcResponse::success(id, serde_json::to_value(snapshot).unwrap())
             }
             methods::STATE_CURSOR => {
-                let buffer_id = get_buffer_id(params, self.active_buffer_id);
+                let buffer_id = get_buffer_id(params, self.active_buffer_id());
                 self.cursor_snapshot(buffer_id).map_or_else(
                     || RpcResponse::error(id, RpcError::buffer_not_found(buffer_id)),
                     |snapshot| RpcResponse::success(id, serde_json::to_value(snapshot).unwrap()),
                 )
             }
             methods::STATE_SELECTION => {
-                let buffer_id = get_buffer_id(params, self.active_buffer_id);
+                let buffer_id = get_buffer_id(params, self.active_buffer_id());
                 self.selection_snapshot(buffer_id).map_or_else(
                     || RpcResponse::error(id, RpcError::buffer_not_found(buffer_id)),
                     |snapshot| RpcResponse::success(id, serde_json::to_value(snapshot).unwrap()),
@@ -809,7 +809,7 @@ impl Runtime {
 
                 let cursor_pos = self
                     .buffers
-                    .get(&self.active_buffer_id)
+                    .get(&self.active_buffer_id())
                     .map(|b| (b.cur.x, b.cur.y));
 
                 let content = if annotated {
@@ -893,14 +893,14 @@ impl Runtime {
                 RpcResponse::success(id, serde_json::to_value(snapshots).unwrap())
             }
             methods::BUFFER_GET_CONTENT => {
-                let buffer_id = get_buffer_id(params, self.active_buffer_id);
+                let buffer_id = get_buffer_id(params, self.active_buffer_id());
                 self.buffer_content(buffer_id).map_or_else(
                     || RpcResponse::error(id, RpcError::buffer_not_found(buffer_id)),
                     |content| RpcResponse::success(id, serde_json::json!({ "content": content })),
                 )
             }
             methods::BUFFER_SET_CONTENT => {
-                let buffer_id = get_buffer_id(params, self.active_buffer_id);
+                let buffer_id = get_buffer_id(params, self.active_buffer_id());
                 let content = params.get("content").and_then(serde_json::Value::as_str);
 
                 match (self.buffers.get_mut(&buffer_id), content) {
@@ -927,7 +927,7 @@ impl Runtime {
                         self.request_render();
                         RpcResponse::success(
                             id,
-                            serde_json::json!({ "buffer_id": self.active_buffer_id }),
+                            serde_json::json!({ "buffer_id": self.active_buffer_id() }),
                         )
                     },
                 )
@@ -989,7 +989,7 @@ impl Runtime {
         // Handle normal mode
         if new_mode.is_normal() && matches!(new_mode.sub_mode, SubMode::None) {
             // Clear selection when returning to normal mode
-            if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id) {
+            if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id()) {
                 buffer.clear_selection();
             }
             // Note: command line is cleared in handle_command_line_command

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -249,7 +249,7 @@ impl Runtime {
                         }
                         ExCommand::Edit { filename } => {
                             self.open_file(&filename);
-                            self.screen.set_editor_buffer(self.active_buffer_id);
+                            self.screen.set_editor_buffer(self.active_buffer_id());
                         }
                         // Window management
                         ExCommand::Split { filename } => {
@@ -366,7 +366,7 @@ impl Runtime {
         // Use active_buffer_id instead of context.buffer_id since the dispatcher
         // doesn't track buffer changes. In a single-window editor, active_buffer_id
         // is the correct buffer to operate on.
-        let buffer_id = self.active_buffer_id;
+        let buffer_id = self.active_buffer_id();
 
         // Get the buffer and execute the command
         if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
@@ -488,7 +488,7 @@ impl Runtime {
 
                             // Handle paste from specified register
                             // Use active_buffer_id, not context.buffer_id (which is hardcoded to 0 in dispatcher)
-                            let paste_buffer_id = self.active_buffer_id;
+                            let paste_buffer_id = self.active_buffer_id();
                             if let Some(content) = self.registers.get_by_name(register)
                                 && let Some(buf) = self.buffers.get_mut(&paste_buffer_id)
                             {
@@ -572,7 +572,7 @@ impl Runtime {
                             );
 
                             // Get current position to skip if jump returns the same position
-                            let current_buf_id = self.active_buffer_id;
+                            let current_buf_id = self.active_buffer_id();
                             let current_pos = self.buffers.get(&current_buf_id).map(|b| b.cur);
 
                             // Try to jump older, skipping current position if needed
@@ -610,7 +610,7 @@ impl Runtime {
                         }
                         DeferredAction::JumpNewer => {
                             // Get current position to skip if jump returns the same position
-                            let current_buf_id = self.active_buffer_id;
+                            let current_buf_id = self.active_buffer_id();
                             let current_pos = self.buffers.get(&current_buf_id).map(|b| b.cur);
 
                             // Try to jump newer, skipping current position if needed
@@ -717,7 +717,7 @@ impl Runtime {
     /// Handle operator + motion action (d/y/c + motion)
     #[allow(clippy::too_many_lines)]
     pub(crate) fn handle_operator_motion(&mut self, action: &OperatorMotionAction) {
-        let buffer_id = self.active_buffer_id;
+        let buffer_id = self.active_buffer_id();
         let mut text_modified = false;
 
         if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
@@ -1066,8 +1066,8 @@ impl Runtime {
         }
 
         // Get the current buffer ID (either the newly opened file or existing buffer)
-        // Use self.active_buffer_id directly since open_file updates it
-        let buffer_id = self.active_buffer_id;
+        // Use self.active_buffer_id() since open_file updates it via screen
+        let buffer_id = self.active_buffer_id();
 
         // CRITICAL: Save the buffer's live cursor to the current window BEFORE splitting.
         // split_window() reads window.cursor to copy to the new window, so we must
@@ -1161,9 +1161,6 @@ impl Runtime {
                 start.elapsed()
             );
 
-            // Update active_buffer_id to match the new window's buffer
-            self.active_buffer_id = new_buffer_id;
-
             // Load window's cursor into buffer
             if let Some(buffer) = self.buffers.get_mut(&new_buffer_id) {
                 buffer.cur = window_cursor;
@@ -1188,8 +1185,8 @@ impl Runtime {
         }
 
         // Get the current buffer ID
-        // Use self.active_buffer_id directly since open_file updates it
-        let buffer_id = self.active_buffer_id;
+        // Use self.active_buffer_id() since open_file updates it via screen
+        let buffer_id = self.active_buffer_id();
 
         let tab_id = self.screen.new_tab(buffer_id);
         tracing::info!(tab_id = tab_id, buffer_id = buffer_id, "New tab created");
@@ -1234,12 +1231,12 @@ impl Runtime {
             }
             BufferAction::Delete { force: _ } => {
                 // TODO: Check modified state if !force
-                let buffer_id = self.active_buffer_id;
+                let buffer_id = self.active_buffer_id();
                 self.close_buffer(buffer_id);
                 // Update window to show the new active buffer
                 if let Some(window_id) = self.screen.active_window_id() {
                     self.screen
-                        .set_window_buffer(window_id, self.active_buffer_id);
+                        .set_window_buffer(window_id, self.active_buffer_id());
                 }
             }
         }
@@ -1258,7 +1255,7 @@ impl Runtime {
         match action {
             FileAction::Open { path } => {
                 self.open_file(path);
-                self.screen.set_editor_buffer(self.active_buffer_id);
+                self.screen.set_editor_buffer(self.active_buffer_id());
                 // Switch focus to editor if a plugin has focus
                 if self.screen.has_plugin_focus() {
                     self.screen.focus_editor();


### PR DESCRIPTION
Remove redundant `active_buffer_id` field from Runtime struct and derive it from Screen's active window instead.

- Add `Runtime::active_buffer_id()` method that delegates to `Screen::active_buffer_id().unwrap_or(0)`
- Remove field declaration and initialization
- Replace direct field assignments with `screen.set_editor_buffer()`
- Remove manual sync in `handle_window_navigate()` (now automatic)
- Fix borrow checker issues by getting buffer_id before mutable borrows

Screen is now the single source of truth for active buffer ID, eliminating dual tracking and manual synchronization.

Closes #47