### PR TITLE
feat(mouse): add click and scroll event support (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Mouse click and scroll support** (Issue #59) - Basic mouse interaction for cursor positioning and scrolling
+  - Left click: Move cursor to clicked position and focus window if different
+  - Scroll wheel: Move viewport up/down by 3 lines, cursor adjusts to stay visible
+  - Coordinate translation: Screen position to buffer position with gutter and scrollbar awareness
+  - Server mode support: Mouse events forwarded in dual-output mode
+
 - **Metadata-driven interactor input behavior** (Issue #46) - Refactored `accepts_char_input()` to use registry instead of hardcoded checks
   - `InteractorConfig` struct for configuring input behavior per interactor
   - `InteractorRegistry` for storing and querying interactor configurations

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use reovim_sys::event::KeyModifiers;
 use tokio::sync::oneshot;
 
 use crate::{
@@ -117,6 +118,8 @@ pub enum InnerEvent {
         text: String,
         replace_start: usize,
     },
+    /// Mouse event from terminal
+    MouseEvent(MouseEvent),
 }
 
 /// Input events routed to the active focus target
@@ -232,4 +235,91 @@ pub enum VisualTextObjectAction {
     SelectWord { text_object: WordTextObject },
     /// Select semantic text object (vif, vac, etc.) - uses treesitter
     SelectSemantic { text_object: SemanticTextObjectSpec },
+}
+
+// =============================================================================
+// Mouse Events
+// =============================================================================
+
+/// Mouse event from terminal input
+#[derive(Debug, Clone, Copy)]
+pub struct MouseEvent {
+    /// Type of mouse action
+    pub kind: MouseEventKind,
+    /// Column (x) position in terminal coordinates
+    pub column: u16,
+    /// Row (y) position in terminal coordinates
+    pub row: u16,
+    /// Modifier keys held during the event
+    pub modifiers: KeyModifiers,
+}
+
+/// Type of mouse action
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseEventKind {
+    /// Mouse button pressed down
+    Down(MouseButton),
+    /// Mouse button released
+    Up(MouseButton),
+    /// Mouse dragged while button held
+    Drag(MouseButton),
+    /// Scroll wheel up
+    ScrollUp,
+    /// Scroll wheel down
+    ScrollDown,
+    /// Scroll wheel left (horizontal)
+    ScrollLeft,
+    /// Scroll wheel right (horizontal)
+    ScrollRight,
+    /// Mouse moved (without button pressed)
+    Moved,
+}
+
+/// Mouse button identifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton {
+    /// Left mouse button
+    Left,
+    /// Right mouse button
+    Right,
+    /// Middle mouse button (scroll wheel click)
+    Middle,
+}
+
+impl From<reovim_sys::event::MouseEvent> for MouseEvent {
+    fn from(event: reovim_sys::event::MouseEvent) -> Self {
+        Self {
+            kind: event.kind.into(),
+            column: event.column,
+            row: event.row,
+            modifiers: event.modifiers,
+        }
+    }
+}
+
+impl From<reovim_sys::event::MouseEventKind> for MouseEventKind {
+    fn from(kind: reovim_sys::event::MouseEventKind) -> Self {
+        use reovim_sys::event::MouseEventKind as CT;
+        match kind {
+            CT::Down(btn) => Self::Down(btn.into()),
+            CT::Up(btn) => Self::Up(btn.into()),
+            CT::Drag(btn) => Self::Drag(btn.into()),
+            CT::Moved => Self::Moved,
+            CT::ScrollUp => Self::ScrollUp,
+            CT::ScrollDown => Self::ScrollDown,
+            CT::ScrollLeft => Self::ScrollLeft,
+            CT::ScrollRight => Self::ScrollRight,
+        }
+    }
+}
+
+impl From<reovim_sys::event::MouseButton> for MouseButton {
+    fn from(button: reovim_sys::event::MouseButton) -> Self {
+        use reovim_sys::event::MouseButton as CT;
+        match button {
+            CT::Left => Self::Left,
+            CT::Right => Self::Right,
+            CT::Middle => Self::Middle,
+        }
+    }
 }

--- a/lib/core/src/event/mod.rs
+++ b/lib/core/src/event/mod.rs
@@ -9,8 +9,8 @@ mod input;
 pub use {
     handler::{CommandHandler, PrintEventHandler, TerminateHandler},
     inner::{
-        BufferEvent, CommandEvent, HighlightEvent, InnerEvent, SyntaxEvent, TextInputEvent,
-        VisualTextObjectAction, WindowEvent,
+        BufferEvent, CommandEvent, HighlightEvent, InnerEvent, MouseButton, MouseEvent,
+        MouseEventKind, SyntaxEvent, TextInputEvent, VisualTextObjectAction, WindowEvent,
     },
     input::*,
 };

--- a/lib/core/src/io/input.rs
+++ b/lib/core/src/io/input.rs
@@ -190,8 +190,15 @@ impl KeySource for EventStreamKeySource {
                     }
                     // Continue polling for key events
                 }
+                Poll::Ready(Some(Ok(Event::Mouse(mouse_event)))) => {
+                    // Forward mouse events to runtime
+                    if let Some(ref sender) = self.event_sender {
+                        let _ = sender.try_send(InnerEvent::MouseEvent(mouse_event.into()));
+                    }
+                    // Continue polling for key events
+                }
                 Poll::Ready(Some(Ok(_))) => {
-                    // Skip other non-key events (Mouse, Focus, Paste)
+                    // Skip other non-key events (Focus, Paste)
                     // Fall through to loop
                 }
                 Poll::Ready(Some(Err(e))) => {

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -535,6 +535,9 @@ impl Runtime {
                 self.screen.resize(width, height);
                 self.request_render();
             }
+            InnerEvent::MouseEvent(mouse_event) => {
+                self.handle_mouse_event(mouse_event);
+            }
             InnerEvent::RpcRequest {
                 id,
                 method,

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -13,11 +13,11 @@ use crate::{
         },
     },
     command_line::{ExCommand, SetOption},
-    event::{CommandEvent, VisualTextObjectAction},
+    event::{CommandEvent, MouseButton, MouseEvent, MouseEventKind, VisualTextObjectAction},
     event_bus::BufferModification,
     highlight::Theme,
     modd::{ComponentId, ModeState, SubMode},
-    screen::{NavigateDirection, Position, SplitDirection},
+    screen::{NavigateDirection, Position, SplitDirection, window::Anchor},
     textobject::SemanticTextObjectSpec,
 };
 
@@ -1477,5 +1477,190 @@ impl Runtime {
                 tracing::warn!(option = %name, error = %e, "Failed to reset option");
             }
         }
+    }
+
+    // =========================================================================
+    // Mouse Event Handling
+    // =========================================================================
+
+    /// Handle mouse events from terminal input
+    ///
+    /// Processes click and scroll events:
+    /// - Left click: Move cursor to clicked position, focus window if different
+    /// - Scroll: Move viewport by 3 lines, adjust cursor to stay visible
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn handle_mouse_event(&mut self, event: MouseEvent) {
+        tracing::debug!(
+            "Mouse event: {:?} at ({}, {})",
+            event.kind,
+            event.column,
+            event.row
+        );
+
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.handle_mouse_click(event.column, event.row);
+            }
+            MouseEventKind::ScrollUp => {
+                self.handle_mouse_scroll(-3); // Scroll up = move viewport up
+            }
+            MouseEventKind::ScrollDown => {
+                self.handle_mouse_scroll(3); // Scroll down = move viewport down
+            }
+            // Ignore other mouse events for now (drag, right-click, etc.)
+            _ => {}
+        }
+    }
+
+    /// Handle mouse click at screen position
+    ///
+    /// - Finds the window under the click
+    /// - Focuses the window if different from current
+    /// - Moves cursor to clicked buffer position
+    fn handle_mouse_click(&mut self, screen_x: u16, screen_y: u16) {
+        // Find which window was clicked
+        let Some(window_id) = self.screen.window_at_position(screen_x, screen_y) else {
+            tracing::debug!("Click outside any window at ({}, {})", screen_x, screen_y);
+            return;
+        };
+
+        // Get window info before mutating
+        let (buffer_id, buffer_line_count) = {
+            let Some(window) = self.screen.window(window_id) else {
+                return;
+            };
+            let Some(buffer_id) = window.buffer_id() else {
+                return; // Window doesn't have a buffer
+            };
+            let buffer_line_count = self
+                .buffers
+                .get(&buffer_id)
+                .map_or(0, |b| b.contents.len());
+            (buffer_id, buffer_line_count)
+        };
+
+        // Note: has_signs is false for now since sign data isn't readily accessible
+        // This may cause slight positioning inaccuracy when signs are present
+        let has_signs = false;
+
+        // Translate screen position to buffer position
+        let buffer_pos = {
+            let Some(window) = self.screen.window(window_id) else {
+                return;
+            };
+            window.screen_to_buffer_position(screen_x, screen_y, buffer_line_count, has_signs)
+        };
+
+        let Some(buffer_pos) = buffer_pos else {
+            tracing::debug!("Click on scrollbar or invalid position");
+            return;
+        };
+
+        // Focus window if different from current active window
+        let current_active = self.screen.active_window_id();
+        if current_active != Some(window_id) {
+            tracing::debug!("Focusing window {} (was {:?})", window_id, current_active);
+            self.screen.set_active_window(window_id);
+            // Screen is now the source of truth for active buffer
+            // set_active_window already updates which window is active
+        }
+
+        // Move cursor to clicked position
+        if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
+            // Clamp x to line length
+            let line_len = buffer
+                .contents
+                .get(buffer_pos.y as usize)
+                .map_or(0, |l| l.inner.len());
+            #[allow(clippy::cast_possible_truncation)]
+            let clamped_x = if line_len == 0 {
+                0
+            } else {
+                buffer_pos.x.min((line_len.saturating_sub(1)) as u16)
+            };
+
+            buffer.cur.x = clamped_x;
+            buffer.cur.y = buffer_pos.y;
+
+            tracing::debug!(
+                "Cursor moved to ({}, {}) in buffer {}",
+                buffer.cur.x,
+                buffer.cur.y,
+                buffer_id
+            );
+        }
+
+        self.request_render();
+    }
+
+    /// Handle mouse scroll by delta lines
+    ///
+    /// Positive delta = scroll down (content moves up)
+    /// Negative delta = scroll up (content moves down)
+    fn handle_mouse_scroll(&mut self, delta: i16) {
+        let Some(active_window_id) = self.screen.active_window_id() else {
+            return;
+        };
+
+        let Some(window) = self.screen.window_mut(active_window_id) else {
+            return;
+        };
+
+        let Some(buffer_id) = window.buffer_id() else {
+            return;
+        };
+
+        let buffer_line_count = self
+            .buffers
+            .get(&buffer_id)
+            .map_or(0, |b| b.contents.len());
+
+        // Get current buffer anchor (scroll position)
+        let current_anchor = window.buffer_anchor().unwrap_or(Anchor { x: 0, y: 0 });
+
+        // Calculate new scroll position
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let new_y = if delta > 0 {
+            // Scroll down: increase anchor.y
+            let max_scroll = buffer_line_count.saturating_sub(window.height as usize);
+            (current_anchor.y as usize + delta as usize).min(max_scroll) as u16
+        } else {
+            // Scroll up: decrease anchor.y
+            current_anchor.y.saturating_sub((-delta) as u16)
+        };
+
+        // Update buffer anchor
+        window.set_buffer_anchor(Anchor {
+            x: current_anchor.x,
+            y: new_y,
+        });
+
+        // Adjust cursor if it goes off-screen
+        if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
+            let viewport_top = new_y;
+            let viewport_bottom = new_y + window.height.saturating_sub(1);
+
+            if buffer.cur.y < viewport_top {
+                // Cursor above viewport - move to top
+                buffer.cur.y = viewport_top;
+            } else if buffer.cur.y > viewport_bottom {
+                // Cursor below viewport - move to bottom
+                buffer.cur.y = viewport_bottom;
+            }
+
+            // Ensure cursor x is still valid for the new line
+            let line_len = buffer
+                .contents
+                .get(buffer.cur.y as usize)
+                .map_or(0, |l| l.inner.len());
+            #[allow(clippy::cast_possible_truncation)]
+            if line_len == 0 {
+                buffer.cur.x = 0;
+            } else {
+                buffer.cur.x = buffer.cur.x.min((line_len.saturating_sub(1)) as u16);
+            }
+        }
+
+        self.request_render();
     }
 }

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -313,6 +313,47 @@ impl Screen {
         }
     }
 
+    /// Find the window at a given screen position
+    ///
+    /// Returns the window ID if a window exists at the position, or None if the
+    /// position is outside all windows (e.g., on the status line).
+    ///
+    /// When multiple windows overlap (floating windows), returns the topmost
+    /// window (highest z-order).
+    #[must_use]
+    pub fn window_at_position(&self, x: u16, y: u16) -> Option<usize> {
+        // Find all windows containing this position, sorted by z-order (highest first)
+        self.windows
+            .iter()
+            .filter(|w| w.contains_screen_position(x, y))
+            .max_by_key(|w| w.z_order)
+            .map(|w| w.id)
+    }
+
+    /// Get a reference to a window by ID
+    #[must_use]
+    pub fn window(&self, window_id: usize) -> Option<&Window> {
+        self.windows.iter().find(|w| w.id == window_id)
+    }
+
+    /// Get a mutable reference to a window by ID
+    pub fn window_mut(&mut self, window_id: usize) -> Option<&mut Window> {
+        self.windows.iter_mut().find(|w| w.id == window_id)
+    }
+
+    /// Set the active window by ID
+    ///
+    /// Returns true if the window was found and activated, false otherwise.
+    pub fn set_active_window(&mut self, window_id: usize) -> bool {
+        let found = self.windows.iter().any(|w| w.id == window_id);
+        if found {
+            for w in &mut self.windows {
+                w.is_active = w.id == window_id;
+            }
+        }
+        found
+    }
+
     /// Enable frame buffer capture and return a handle for external readers
     ///
     /// This enables capture on the frame renderer and returns a handle that

--- a/lib/core/src/screen/window.rs
+++ b/lib/core/src/screen/window.rs
@@ -1265,6 +1265,78 @@ impl Window {
         self.scrollbar_enabled = enabled;
     }
 
+    /// Check if a screen position is within this window's bounds
+    #[must_use]
+    pub const fn contains_screen_position(&self, x: u16, y: u16) -> bool {
+        x >= self.anchor.x
+            && x < self.anchor.x + self.width
+            && y >= self.anchor.y
+            && y < self.anchor.y + self.height
+    }
+
+    /// Translate screen coordinates to buffer position
+    ///
+    /// Returns `Some(Position)` if the click is in the content area,
+    /// `None` if the click is outside the window or in the gutter/scrollbar.
+    ///
+    /// # Arguments
+    /// * `screen_x` - Screen column coordinate
+    /// * `screen_y` - Screen row coordinate
+    /// * `buffer_line_count` - Total number of lines in the buffer
+    /// * `has_signs` - Whether the buffer has any signs to display
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn screen_to_buffer_position(
+        &self,
+        screen_x: u16,
+        screen_y: u16,
+        buffer_line_count: usize,
+        has_signs: bool,
+    ) -> Option<Position> {
+        // Check if position is within window bounds
+        if !self.contains_screen_position(screen_x, screen_y) {
+            return None;
+        }
+
+        // Calculate window-relative position
+        let window_x = screen_x - self.anchor.x;
+        let window_y = screen_y - self.anchor.y;
+
+        // Calculate gutter width (line numbers + sign column)
+        let line_num_width = self.line_number_width(buffer_line_count);
+        let sign_width = self.sign_column_mode.effective_width(has_signs);
+        let gutter_width = line_num_width + sign_width;
+
+        // Check if click is in gutter area
+        if window_x < gutter_width {
+            // Click in gutter - treat as first column of that line
+            let buffer_y = self.buffer_anchor().map_or(0, |a| a.y) + window_y;
+            return Some(Position { x: 0, y: buffer_y });
+        }
+
+        // Calculate content position (accounting for scrollbar on right)
+        let scrollbar_width = u16::from(self.scrollbar_enabled);
+        let content_width = self.width.saturating_sub(gutter_width + scrollbar_width);
+
+        // Check if click is in scrollbar area
+        if window_x >= gutter_width + content_width {
+            return None; // Click on scrollbar - don't move cursor
+        }
+
+        // Calculate buffer position
+        let content_x = window_x - gutter_width;
+        let buffer_y = self.buffer_anchor().map_or(0, |a| a.y) + window_y;
+
+        // Clamp to valid buffer bounds
+        let max_y = buffer_line_count.saturating_sub(1) as u16;
+        let clamped_y = buffer_y.min(max_y);
+
+        Some(Position {
+            x: content_x,
+            y: clamped_y,
+        })
+    }
+
     /// Compute scrollbar state based on buffer content and viewport
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]

--- a/runner/src/server.rs
+++ b/runner/src/server.rs
@@ -109,7 +109,12 @@ pub async fn run_server(
                             })
                             .await;
                     }
-                    Ok(_) => {} // Ignore other events (Mouse, Focus, Paste)
+                    Ok(Event::Mouse(mouse_event)) => {
+                        let _ = event_tx_resize
+                            .send(InnerEvent::MouseEvent(mouse_event.into()))
+                            .await;
+                    }
+                    Ok(_) => {} // Ignore other events (Focus, Paste)
                     Err(_) => break,
                 }
             }


### PR DESCRIPTION
- Add MouseEvent types to InnerEvent for terminal mouse events
- Forward mouse events in EventStreamKeySource and server mode
- Implement coordinate translation (screen → buffer position)
- Handle left-click: move cursor, focus window if different
- Handle scroll: move viewport 3 lines, adjust cursor to stay visible
- Add window_at_position() and screen_to_buffer_position() helpers

Closes #59