### PR TITLE
feat(core): add theme customization/override system (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ All notable changes to Reovim will be documented in this file.
   - Coordinate translation: Screen position to buffer position with gutter and scrollbar awareness
   - Server mode support: Mouse events forwarded in dual-output mode
 
+- **Theme customization/override system** (Issue #55) - Allow users to override individual colors/styles in TOML config
+  - `ThemeOverrides` struct for storing style path -> override mappings
+  - `StyleOverride` struct with fg, bg, underline_color, and attribute options
+  - `parse_color()` function supporting hex, rgb(), ansi:N, and named color formats
+  - `Theme::from_name_with_overrides()` and `Theme::apply_overrides()` methods
+  - `editor.theme_overrides` field in profile config schema
+  - Example config:
+    ```toml
+    [editor.theme_overrides]
+    "statusline.background" = { bg = "#1a1b26" }
+    "gutter.line_number" = { fg = "#565f89" }
+    "statusline.mode.normal" = { fg = "#1a1b26", bg = "#7aa2f7", bold = true }
+    ```
+
 - **Metadata-driven interactor input behavior** (Issue #46) - Refactored `accepts_char_input()` to use registry instead of hardcoded checks
   - `InteractorConfig` struct for configuring input behavior per interactor
   - `InteractorRegistry` for storing and querying interactor configurations

--- a/lib/core/src/config/schema.rs
+++ b/lib/core/src/config/schema.rs
@@ -1,6 +1,7 @@
 //! TOML schema definitions for configuration profiles
 
 use {
+    crate::highlight::ThemeOverrides,
     serde::{Deserialize, Serialize},
     std::collections::HashMap,
 };
@@ -103,6 +104,20 @@ pub struct EditorConfig {
     #[serde(default = "default_theme")]
     pub theme: String,
 
+    /// Theme style overrides
+    ///
+    /// Override individual colors/styles in the selected theme.
+    ///
+    /// # Example TOML
+    /// ```toml
+    /// [editor.theme_overrides]
+    /// "statusline.background" = { bg = "#1a1b26" }
+    /// "gutter.line_number" = { fg = "#565f89" }
+    /// "statusline.mode.normal" = { fg = "#1a1b26", bg = "#7aa2f7", bold = true }
+    /// ```
+    #[serde(default)]
+    pub theme_overrides: ThemeOverrides,
+
     /// Color mode: ansi, 256, truecolor
     #[serde(default = "default_colormode")]
     pub colormode: String,
@@ -144,6 +159,7 @@ impl Default for EditorConfig {
     fn default() -> Self {
         Self {
             theme: default_theme(),
+            theme_overrides: ThemeOverrides::default(),
             colormode: default_colormode(),
             number: true,
             relativenumber: true,
@@ -329,5 +345,41 @@ tabwidth = 2
         let toml = toml::to_string_pretty(&config).unwrap();
         assert!(toml.contains("[profile]"));
         assert!(toml.contains("[editor]"));
+    }
+
+    #[test]
+    fn test_parse_profile_with_theme_overrides() {
+        let toml = r##"
+[profile]
+name = "custom_theme"
+
+[editor]
+theme = "dark"
+
+[editor.theme_overrides]
+"statusline.background" = { bg = "#1a1b26" }
+"gutter.line_number" = { fg = "#565f89" }
+"statusline.mode.normal" = { fg = "#000000", bg = "#7aa2f7", bold = true }
+"##;
+        let config: ProfileConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.profile.name, "custom_theme");
+        assert_eq!(config.editor.theme, "dark");
+        assert_eq!(config.editor.theme_overrides.len(), 3);
+
+        let statusline_bg = config
+            .editor
+            .theme_overrides
+            .overrides
+            .get("statusline.background")
+            .unwrap();
+        assert_eq!(statusline_bg.bg, Some("#1a1b26".to_string()));
+
+        let mode_normal = config
+            .editor
+            .theme_overrides
+            .overrides
+            .get("statusline.mode.normal")
+            .unwrap();
+        assert_eq!(mode_normal.bold, Some(true));
     }
 }

--- a/lib/core/src/highlight/color.rs
+++ b/lib/core/src/highlight/color.rs
@@ -1,4 +1,9 @@
 //! Terminal color capability detection and conversion
+//!
+//! This module provides:
+//! - Color mode detection (ANSI 16, 256, `TrueColor`)
+//! - Color conversion between modes
+//! - Color string parsing for theme overrides
 
 use std::sync::LazyLock;
 
@@ -210,6 +215,109 @@ pub fn downgrade_color(color: Color, mode: ColorMode) -> Color {
     }
 }
 
+// ============================================================================
+// Color String Parsing
+// ============================================================================
+
+/// Parse a color string to Color
+///
+/// Supported formats:
+/// - Hex: `#ff0000`, `#f00` (shorthand), `#ff0000ff` (with alpha, alpha ignored)
+/// - RGB function: `rgb(255, 0, 0)` or `rgb(255,0,0)`
+/// - ANSI 256: `ansi:196` or `256:196`
+/// - Named colors: `red`, `darkblue`, `black`, etc.
+///
+/// # Examples
+/// ```
+/// use reovim_core::highlight::parse_color;
+/// use reovim_sys::style::Color;
+///
+/// assert_eq!(parse_color("#ff0000"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+/// assert_eq!(parse_color("rgb(255, 0, 0)"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+/// assert_eq!(parse_color("ansi:196"), Some(Color::AnsiValue(196)));
+/// assert_eq!(parse_color("red"), Some(Color::Red));
+/// ```
+#[must_use]
+pub fn parse_color(s: &str) -> Option<Color> {
+    let s = s.trim();
+
+    // Hex format: #rgb, #rrggbb, #rrggbbaa
+    if let Some(hex) = s.strip_prefix('#') {
+        return parse_hex_color(hex);
+    }
+
+    // RGB function: rgb(r, g, b)
+    if let Some(inner) = s.strip_prefix("rgb(").and_then(|s| s.strip_suffix(')')) {
+        return parse_rgb_function(inner);
+    }
+
+    // ANSI 256: ansi:N or 256:N
+    if let Some(n) = s.strip_prefix("ansi:").or_else(|| s.strip_prefix("256:")) {
+        return n.trim().parse::<u8>().ok().map(Color::AnsiValue);
+    }
+
+    // Named colors
+    parse_named_color(s)
+}
+
+/// Parse hex color string (without # prefix)
+fn parse_hex_color(hex: &str) -> Option<Color> {
+    match hex.len() {
+        3 => {
+            // #rgb -> expand each digit to double
+            let r = u8::from_str_radix(&hex[0..1], 16).ok()? * 17;
+            let g = u8::from_str_radix(&hex[1..2], 16).ok()? * 17;
+            let b = u8::from_str_radix(&hex[2..3], 16).ok()? * 17;
+            Some(Color::Rgb { r, g, b })
+        }
+        6 | 8 => {
+            // #rrggbb or #rrggbbaa (ignore alpha)
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            Some(Color::Rgb { r, g, b })
+        }
+        _ => None,
+    }
+}
+
+/// Parse rgb(r, g, b) function content
+fn parse_rgb_function(inner: &str) -> Option<Color> {
+    let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let r = parts[0].parse::<u8>().ok()?;
+    let g = parts[1].parse::<u8>().ok()?;
+    let b = parts[2].parse::<u8>().ok()?;
+    Some(Color::Rgb { r, g, b })
+}
+
+/// Parse named color string
+fn parse_named_color(s: &str) -> Option<Color> {
+    match s.to_lowercase().replace(['-', '_'], "").as_str() {
+        "black" => Some(Color::Black),
+        "red" => Some(Color::Red),
+        "darkred" => Some(Color::DarkRed),
+        "green" => Some(Color::Green),
+        "darkgreen" => Some(Color::DarkGreen),
+        "yellow" => Some(Color::Yellow),
+        "darkyellow" => Some(Color::DarkYellow),
+        "blue" => Some(Color::Blue),
+        "darkblue" => Some(Color::DarkBlue),
+        "magenta" => Some(Color::Magenta),
+        "darkmagenta" => Some(Color::DarkMagenta),
+        "cyan" => Some(Color::Cyan),
+        "darkcyan" => Some(Color::DarkCyan),
+        "white" => Some(Color::White),
+        "grey" | "gray" => Some(Color::Grey),
+        "darkgrey" | "darkgray" => Some(Color::DarkGrey),
+        "reset" | "none" | "default" => Some(Color::Reset),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,5 +436,113 @@ mod tests {
         // Access the lookup table to ensure it initializes without panic
         let _ = ANSI256_TO_16[0];
         let _ = ANSI256_TO_16[255];
+    }
+
+    // ========== parse_color tests ==========
+
+    #[test]
+    fn test_parse_color_hex_6digit() {
+        assert_eq!(
+            parse_color("#ff0000"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+        assert_eq!(
+            parse_color("#00ff00"),
+            Some(Color::Rgb { r: 0, g: 255, b: 0 })
+        );
+        assert_eq!(
+            parse_color("#1a1b26"),
+            Some(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_color_hex_3digit() {
+        // #f00 -> #ff0000
+        assert_eq!(
+            parse_color("#f00"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+        // #abc -> #aabbcc
+        assert_eq!(
+            parse_color("#abc"),
+            Some(Color::Rgb {
+                r: 170,
+                g: 187,
+                b: 204
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_color_hex_8digit() {
+        // Alpha is ignored
+        assert_eq!(
+            parse_color("#ff0000ff"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn test_parse_color_rgb_function() {
+        assert_eq!(
+            parse_color("rgb(255, 0, 0)"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+        assert_eq!(
+            parse_color("rgb(255,0,0)"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+        assert_eq!(
+            parse_color("rgb( 128 , 64 , 32 )"),
+            Some(Color::Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_color_ansi() {
+        assert_eq!(parse_color("ansi:196"), Some(Color::AnsiValue(196)));
+        assert_eq!(parse_color("256:42"), Some(Color::AnsiValue(42)));
+        assert_eq!(parse_color("ansi: 100"), Some(Color::AnsiValue(100)));
+    }
+
+    #[test]
+    fn test_parse_color_named() {
+        assert_eq!(parse_color("red"), Some(Color::Red));
+        assert_eq!(parse_color("RED"), Some(Color::Red));
+        assert_eq!(parse_color("darkblue"), Some(Color::DarkBlue));
+        assert_eq!(parse_color("dark-blue"), Some(Color::DarkBlue));
+        assert_eq!(parse_color("dark_blue"), Some(Color::DarkBlue));
+        assert_eq!(parse_color("DarkBlue"), Some(Color::DarkBlue));
+        assert_eq!(parse_color("grey"), Some(Color::Grey));
+        assert_eq!(parse_color("gray"), Some(Color::Grey));
+        assert_eq!(parse_color("reset"), Some(Color::Reset));
+        assert_eq!(parse_color("none"), Some(Color::Reset));
+    }
+
+    #[test]
+    fn test_parse_color_invalid() {
+        assert_eq!(parse_color("invalid"), None);
+        assert_eq!(parse_color("#gg0000"), None);
+        assert_eq!(parse_color("#12345"), None); // Wrong length
+        assert_eq!(parse_color("rgb(256, 0, 0)"), None); // Out of range
+        assert_eq!(parse_color("ansi:abc"), None); // Not a number
+    }
+
+    #[test]
+    fn test_parse_color_whitespace() {
+        assert_eq!(
+            parse_color("  #ff0000  "),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+        assert_eq!(parse_color("  red  "), Some(Color::Red));
     }
 }

--- a/lib/core/src/highlight/mod.rs
+++ b/lib/core/src/highlight/mod.rs
@@ -3,9 +3,10 @@ mod span;
 pub mod store;
 mod style;
 mod theme;
+mod theme_override;
 
 pub use {
-    color::{ColorMode, downgrade_color, rgb_to_ansi256},
+    color::{ColorMode, downgrade_color, parse_color, rgb_to_ansi256},
     span::Span,
     store::{BufferHighlights, HighlightStore, LineHighlight},
     style::{Attributes, Style},
@@ -13,6 +14,7 @@ pub use {
         AnimationConfig, BracketStyles, CursorStyles, DiagnosticStyles, EffectConfig, LeapStyles,
         SemanticStyles, StatusLineModeStyles, Theme, ThemeName,
     },
+    theme_override::{StyleOverride, ThemeOverrideError, ThemeOverrides},
 };
 
 // Re-export Color from reovim_sys for plugin use

--- a/lib/core/src/highlight/theme.rs
+++ b/lib/core/src/highlight/theme.rs
@@ -20,7 +20,11 @@
 //! - `leap`: Leap navigation label styles
 //! - `animation`: Animation configuration
 
-use {crate::highlight::Style, reovim_sys::style::Color};
+use crate::highlight::{
+    theme_override::{ThemeOverrideError, ThemeOverrides},
+    Style,
+};
+use reovim_sys::style::Color;
 
 // ============================================================================
 // Theme Name Enum
@@ -957,6 +961,199 @@ impl Theme {
             animation: AnimationConfig::default(),
         }
     }
+
+    // ========================================================================
+    // Theme Override Methods
+    // ========================================================================
+
+    /// Create a theme from name with custom overrides applied
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_core::highlight::{Theme, ThemeName, ThemeOverrides};
+    ///
+    /// let overrides = ThemeOverrides::default();
+    /// let theme = Theme::from_name_with_overrides(ThemeName::Dark, &overrides);
+    /// ```
+    #[must_use]
+    pub fn from_name_with_overrides(name: ThemeName, overrides: &ThemeOverrides) -> Self {
+        let mut theme = Self::from_name(name);
+        theme.apply_overrides(overrides);
+        theme
+    }
+
+    /// Apply overrides to this theme
+    ///
+    /// Invalid paths are logged as warnings and skipped.
+    pub fn apply_overrides(&mut self, overrides: &ThemeOverrides) {
+        for (path, style_override) in &overrides.overrides {
+            match self.get_style_mut(path) {
+                Ok(style) => style_override.apply_to(style),
+                Err(e) => tracing::warn!(path = %path, error = %e, "Failed to apply theme override"),
+            }
+        }
+    }
+
+    /// Get mutable reference to a style by dot-notation path
+    ///
+    /// # Valid Paths
+    ///
+    /// - `base.{default,cursor_line,command_line}`
+    /// - `gutter.{line_number,current_line_number,inactive_line_number,sign_column_bg}`
+    /// - `selection.{visual,block}`
+    /// - `statusline.{background,interactor,filename,modified,position,filetype}`
+    /// - `statusline.mode.{normal,insert,visual,command,replace,operator_pending}`
+    /// - `popup.{normal,selected,border,match_fg}`
+    /// - `whichkey.{background,key,description,prefix,border}`
+    /// - `fold.{marker,folded_line}`
+    /// - `indent.{guide,active}`
+    /// - `scrollbar.{track,thumb,search_mark,error_mark,warn_mark,info_mark,hint_mark}`
+    /// - `search.{match_highlight,current_match,inc_search}`
+    /// - `tab.{active,inactive,fill}`
+    /// - `window.separator`
+    /// - `brackets.{rainbow.0-5,matched,unmatched}`
+    /// - `diagnostic.{hint,info,warn,error,deprecated,unnecessary}`
+    /// - `cursor.{line,column}`
+    /// - `semantic.{lifetime,trait_bound,async_keyword,await_keyword,unsafe_keyword,macro_invocation,attribute,mutable,constant,static_var}`
+    /// - `leap.{label_primary,label_secondary,dimmed}`
+    /// - `virtual_text.{default,error,warn,info,hint}`
+    ///
+    /// # Errors
+    ///
+    /// Returns `ThemeOverrideError::InvalidPath` if the path does not match any valid theme style.
+    #[allow(clippy::too_many_lines)]
+    pub fn get_style_mut(&mut self, path: &str) -> Result<&mut Style, ThemeOverrideError> {
+        let parts: Vec<&str> = path.split('.').collect();
+        match parts.as_slice() {
+            // base.*
+            ["base", "default"] => Ok(&mut self.base.default),
+            ["base", "cursor_line"] => Ok(&mut self.base.cursor_line),
+            ["base", "command_line"] => Ok(&mut self.base.command_line),
+
+            // gutter.*
+            ["gutter", "line_number"] => Ok(&mut self.gutter.line_number),
+            ["gutter", "current_line_number"] => Ok(&mut self.gutter.current_line_number),
+            ["gutter", "inactive_line_number"] => Ok(&mut self.gutter.inactive_line_number),
+            ["gutter", "sign_column_bg"] => Ok(&mut self.gutter.sign_column_bg),
+
+            // selection.*
+            ["selection", "visual"] => Ok(&mut self.selection.visual),
+            ["selection", "block"] => Ok(&mut self.selection.block),
+
+            // statusline.*
+            ["statusline", "background"] => Ok(&mut self.statusline.background),
+            ["statusline", "interactor"] => Ok(&mut self.statusline.interactor),
+            ["statusline", "filename"] => Ok(&mut self.statusline.filename),
+            ["statusline", "modified"] => Ok(&mut self.statusline.modified),
+            ["statusline", "position"] => Ok(&mut self.statusline.position),
+            ["statusline", "filetype"] => Ok(&mut self.statusline.filetype),
+
+            // statusline.mode.*
+            ["statusline", "mode", "normal"] => Ok(&mut self.statusline.mode.normal),
+            ["statusline", "mode", "insert"] => Ok(&mut self.statusline.mode.insert),
+            ["statusline", "mode", "visual"] => Ok(&mut self.statusline.mode.visual),
+            ["statusline", "mode", "command"] => Ok(&mut self.statusline.mode.command),
+            ["statusline", "mode", "replace"] => Ok(&mut self.statusline.mode.replace),
+            ["statusline", "mode", "operator_pending"] => {
+                Ok(&mut self.statusline.mode.operator_pending)
+            }
+
+            // popup.*
+            ["popup", "normal"] => Ok(&mut self.popup.normal),
+            ["popup", "selected"] => Ok(&mut self.popup.selected),
+            ["popup", "border"] => Ok(&mut self.popup.border),
+            ["popup", "match_fg"] => Ok(&mut self.popup.match_fg),
+
+            // whichkey.*
+            ["whichkey", "background"] => Ok(&mut self.whichkey.background),
+            ["whichkey", "key"] => Ok(&mut self.whichkey.key),
+            ["whichkey", "description"] => Ok(&mut self.whichkey.description),
+            ["whichkey", "prefix"] => Ok(&mut self.whichkey.prefix),
+            ["whichkey", "border"] => Ok(&mut self.whichkey.border),
+
+            // fold.*
+            ["fold", "marker"] => Ok(&mut self.fold.marker),
+            ["fold", "folded_line"] => Ok(&mut self.fold.folded_line),
+
+            // indent.*
+            ["indent", "guide"] => Ok(&mut self.indent.guide),
+            ["indent", "active"] => Ok(&mut self.indent.active),
+
+            // scrollbar.*
+            ["scrollbar", "track"] => Ok(&mut self.scrollbar.track),
+            ["scrollbar", "thumb"] => Ok(&mut self.scrollbar.thumb),
+            ["scrollbar", "search_mark"] => Ok(&mut self.scrollbar.search_mark),
+            ["scrollbar", "error_mark"] => Ok(&mut self.scrollbar.error_mark),
+            ["scrollbar", "warn_mark"] => Ok(&mut self.scrollbar.warn_mark),
+            ["scrollbar", "info_mark"] => Ok(&mut self.scrollbar.info_mark),
+            ["scrollbar", "hint_mark"] => Ok(&mut self.scrollbar.hint_mark),
+
+            // search.*
+            ["search", "match_highlight"] => Ok(&mut self.search.match_highlight),
+            ["search", "current_match"] => Ok(&mut self.search.current_match),
+            ["search", "inc_search"] => Ok(&mut self.search.inc_search),
+
+            // tab.*
+            ["tab", "active"] => Ok(&mut self.tab.active),
+            ["tab", "inactive"] => Ok(&mut self.tab.inactive),
+            ["tab", "fill"] => Ok(&mut self.tab.fill),
+
+            // window.*
+            ["window", "separator"] => Ok(&mut self.window.separator),
+
+            // brackets.*
+            ["brackets", "matched"] => Ok(&mut self.brackets.matched),
+            ["brackets", "unmatched"] => Ok(&mut self.brackets.unmatched),
+            ["brackets", "rainbow", idx] => {
+                let i: usize = idx.parse().map_err(|_| {
+                    ThemeOverrideError::InvalidPath(format!("brackets.rainbow.{idx}"))
+                })?;
+                self.brackets
+                    .rainbow
+                    .get_mut(i)
+                    .ok_or_else(|| ThemeOverrideError::InvalidPath(path.to_string()))
+            }
+
+            // diagnostic.*
+            ["diagnostic", "hint"] => Ok(&mut self.diagnostic.hint),
+            ["diagnostic", "info"] => Ok(&mut self.diagnostic.info),
+            ["diagnostic", "warn"] => Ok(&mut self.diagnostic.warn),
+            ["diagnostic", "error"] => Ok(&mut self.diagnostic.error),
+            ["diagnostic", "deprecated"] => Ok(&mut self.diagnostic.deprecated),
+            ["diagnostic", "unnecessary"] => Ok(&mut self.diagnostic.unnecessary),
+
+            // cursor.*
+            ["cursor", "line"] => Ok(&mut self.cursor.line),
+            ["cursor", "column"] => Ok(&mut self.cursor.column),
+
+            // semantic.*
+            ["semantic", "lifetime"] => Ok(&mut self.semantic.lifetime),
+            ["semantic", "trait_bound"] => Ok(&mut self.semantic.trait_bound),
+            ["semantic", "async_keyword"] => Ok(&mut self.semantic.async_keyword),
+            ["semantic", "await_keyword"] => Ok(&mut self.semantic.await_keyword),
+            ["semantic", "unsafe_keyword"] => Ok(&mut self.semantic.unsafe_keyword),
+            ["semantic", "macro_invocation"] => Ok(&mut self.semantic.macro_invocation),
+            ["semantic", "attribute"] => Ok(&mut self.semantic.attribute),
+            ["semantic", "mutable"] => Ok(&mut self.semantic.mutable),
+            ["semantic", "constant"] => Ok(&mut self.semantic.constant),
+            ["semantic", "static_var"] => Ok(&mut self.semantic.static_var),
+
+            // leap.*
+            ["leap", "label_primary"] => Ok(&mut self.leap.label_primary),
+            ["leap", "label_secondary"] => Ok(&mut self.leap.label_secondary),
+            ["leap", "dimmed"] => Ok(&mut self.leap.dimmed),
+
+            // virtual_text.*
+            ["virtual_text", "default"] => Ok(&mut self.virtual_text.default),
+            ["virtual_text", "error"] => Ok(&mut self.virtual_text.error),
+            ["virtual_text", "warn"] => Ok(&mut self.virtual_text.warn),
+            ["virtual_text", "info"] => Ok(&mut self.virtual_text.info),
+            ["virtual_text", "hint"] => Ok(&mut self.virtual_text.hint),
+
+            _ => Err(ThemeOverrideError::InvalidPath(path.to_string())),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1022,5 +1219,97 @@ mod tests {
         assert_eq!(ThemeName::parse("dark"), Some(ThemeName::Dark));
         assert_eq!(ThemeName::parse("tokyonight"), Some(ThemeName::TokyoNightOrange));
         assert_eq!(ThemeName::parse("invalid"), None);
+    }
+
+    // ========== Theme override tests ==========
+
+    #[test]
+    fn test_get_style_mut_base() {
+        let mut theme = Theme::dark();
+        let style = theme.get_style_mut("base.default").unwrap();
+        assert!(style.fg.is_some());
+    }
+
+    #[test]
+    fn test_get_style_mut_nested() {
+        let mut theme = Theme::dark();
+        let style = theme.get_style_mut("statusline.mode.normal").unwrap();
+        assert!(style.bg.is_some());
+    }
+
+    #[test]
+    fn test_get_style_mut_brackets_rainbow() {
+        let mut theme = Theme::dark();
+        for i in 0..6 {
+            let path = format!("brackets.rainbow.{i}");
+            assert!(theme.get_style_mut(&path).is_ok());
+        }
+        // Out of bounds
+        assert!(theme.get_style_mut("brackets.rainbow.6").is_err());
+    }
+
+    #[test]
+    fn test_get_style_mut_invalid_path() {
+        let mut theme = Theme::dark();
+        assert!(theme.get_style_mut("invalid.path").is_err());
+        assert!(theme.get_style_mut("base.nonexistent").is_err());
+        assert!(theme.get_style_mut("").is_err());
+    }
+
+    #[test]
+    fn test_apply_overrides() {
+        use crate::highlight::theme_override::{StyleOverride, ThemeOverrides};
+        use std::collections::HashMap;
+
+        let mut overrides_map = HashMap::new();
+        overrides_map.insert(
+            "gutter.line_number".to_string(),
+            StyleOverride {
+                fg: Some("#ff0000".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let overrides = ThemeOverrides {
+            overrides: overrides_map,
+        };
+
+        let mut theme = Theme::dark();
+        theme.apply_overrides(&overrides);
+
+        assert_eq!(
+            theme.gutter.line_number.fg,
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn test_from_name_with_overrides() {
+        use crate::highlight::theme_override::{StyleOverride, ThemeOverrides};
+        use std::collections::HashMap;
+
+        let mut overrides_map = HashMap::new();
+        overrides_map.insert(
+            "selection.visual".to_string(),
+            StyleOverride {
+                bg: Some("#3d3d5c".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let overrides = ThemeOverrides {
+            overrides: overrides_map,
+        };
+
+        let theme = Theme::from_name_with_overrides(ThemeName::Dark, &overrides);
+
+        assert_eq!(
+            theme.selection.visual.bg,
+            Some(Color::Rgb {
+                r: 61,
+                g: 61,
+                b: 92
+            })
+        );
     }
 }

--- a/lib/core/src/highlight/theme_override.rs
+++ b/lib/core/src/highlight/theme_override.rs
@@ -1,0 +1,326 @@
+//! Theme override system for customizing individual colors/styles
+//!
+//! Allows users to override specific theme styles via TOML configuration
+//! without modifying the base theme.
+//!
+//! # Example Configuration
+//!
+//! ```toml
+//! [editor.theme_overrides]
+//! "statusline.background" = { bg = "#1a1b26" }
+//! "gutter.line_number" = { fg = "#565f89" }
+//! "statusline.mode.normal" = { fg = "#1a1b26", bg = "#7aa2f7", bold = true }
+//! ```
+
+use {
+    crate::highlight::{color::parse_color, Attributes, Style},
+    serde::{Deserialize, Serialize},
+    std::collections::HashMap,
+};
+
+/// Error when applying a theme override
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThemeOverrideError {
+    /// The path does not match any valid theme style
+    InvalidPath(String),
+}
+
+impl std::fmt::Display for ThemeOverrideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPath(path) => write!(f, "Invalid theme override path: {path}"),
+        }
+    }
+}
+
+impl std::error::Error for ThemeOverrideError {}
+
+/// Override for a single style field
+///
+/// All fields are optional - only specified fields will be applied.
+/// Colors are specified as strings and parsed using `parse_color()`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StyleOverride {
+    /// Foreground color (e.g., "#ff0000", "rgb(255,0,0)", "red")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fg: Option<String>,
+
+    /// Background color
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bg: Option<String>,
+
+    /// Underline color (only applies when underline is active)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub underline_color: Option<String>,
+
+    // === Attributes ===
+    /// Bold text
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bold: Option<bool>,
+
+    /// Italic text
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub italic: Option<bool>,
+
+    /// Standard underline
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub underline: Option<bool>,
+
+    /// Strikethrough text
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strikethrough: Option<bool>,
+
+    /// Dimmed text
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dim: Option<bool>,
+
+    /// Reverse video (swap fg/bg)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+
+    /// Blinking text
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blink: Option<bool>,
+
+    // === Extended underline styles ===
+    /// Curly/wavy underline (for diagnostics)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub curly_underline: Option<bool>,
+
+    /// Dotted underline
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dotted_underline: Option<bool>,
+
+    /// Dashed underline
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dashed_underline: Option<bool>,
+
+    /// Double underline
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub double_underline: Option<bool>,
+}
+
+impl StyleOverride {
+    /// Apply this override to a style
+    ///
+    /// Only fields that are `Some` will be applied.
+    /// Invalid color strings are logged as warnings and skipped.
+    pub fn apply_to(&self, style: &mut Style) {
+        // Colors
+        if let Some(fg) = &self.fg {
+            if let Some(color) = parse_color(fg) {
+                style.fg = Some(color);
+            } else {
+                tracing::warn!(color = %fg, "Invalid foreground color in theme override");
+            }
+        }
+
+        if let Some(bg) = &self.bg {
+            if let Some(color) = parse_color(bg) {
+                style.bg = Some(color);
+            } else {
+                tracing::warn!(color = %bg, "Invalid background color in theme override");
+            }
+        }
+
+        if let Some(ul) = &self.underline_color {
+            if let Some(color) = parse_color(ul) {
+                style.underline_color = Some(color);
+            } else {
+                tracing::warn!(color = %ul, "Invalid underline color in theme override");
+            }
+        }
+
+        // Standard attributes (only set if true, don't clear if false)
+        if self.bold == Some(true) {
+            style.attributes.set(Attributes::BOLD);
+        }
+        if self.italic == Some(true) {
+            style.attributes.set(Attributes::ITALIC);
+        }
+        if self.underline == Some(true) {
+            style.attributes.set(Attributes::UNDERLINE);
+        }
+        if self.strikethrough == Some(true) {
+            style.attributes.set(Attributes::STRIKETHROUGH);
+        }
+        if self.dim == Some(true) {
+            style.attributes.set(Attributes::DIM);
+        }
+        if self.reverse == Some(true) {
+            style.attributes.set(Attributes::REVERSE);
+        }
+        if self.blink == Some(true) {
+            style.attributes.set(Attributes::BLINK);
+        }
+
+        // Extended underline styles
+        if self.curly_underline == Some(true) {
+            style.attributes.set(Attributes::CURLY_UNDERLINE);
+        }
+        if self.dotted_underline == Some(true) {
+            style.attributes.set(Attributes::DOTTED_UNDERLINE);
+        }
+        if self.dashed_underline == Some(true) {
+            style.attributes.set(Attributes::DASHED_UNDERLINE);
+        }
+        if self.double_underline == Some(true) {
+            style.attributes.set(Attributes::DOUBLE_UNDERLINE);
+        }
+    }
+}
+
+/// Theme overrides configuration
+///
+/// Maps style paths to their overrides.
+/// Paths use dot notation: `"statusline.mode.normal"` or `"gutter.line_number"`
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ThemeOverrides {
+    /// Map of style paths to overrides
+    #[serde(flatten)]
+    pub overrides: HashMap<String, StyleOverride>,
+}
+
+impl ThemeOverrides {
+    /// Create empty overrides
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check if there are any overrides
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.overrides.is_empty()
+    }
+
+    /// Get the number of overrides
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.overrides.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, reovim_sys::style::Color};
+
+    #[test]
+    fn test_style_override_apply_fg_only() {
+        let mut style = Style::new();
+        let override_ = StyleOverride {
+            fg: Some("#ff0000".to_string()),
+            ..Default::default()
+        };
+
+        override_.apply_to(&mut style);
+
+        assert_eq!(style.fg, Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+        assert_eq!(style.bg, None);
+    }
+
+    #[test]
+    fn test_style_override_apply_bg_only() {
+        let mut style = Style::new();
+        let override_ = StyleOverride {
+            bg: Some("#1a1b26".to_string()),
+            ..Default::default()
+        };
+
+        override_.apply_to(&mut style);
+
+        assert_eq!(style.bg, Some(Color::Rgb { r: 26, g: 27, b: 38 }));
+        assert_eq!(style.fg, None);
+    }
+
+    #[test]
+    fn test_style_override_apply_full() {
+        let mut style = Style::new();
+        let override_ = StyleOverride {
+            fg: Some("white".to_string()),
+            bg: Some("#7aa2f7".to_string()),
+            bold: Some(true),
+            italic: Some(true),
+            ..Default::default()
+        };
+
+        override_.apply_to(&mut style);
+
+        assert_eq!(style.fg, Some(Color::White));
+        assert_eq!(
+            style.bg,
+            Some(Color::Rgb {
+                r: 122,
+                g: 162,
+                b: 247
+            })
+        );
+        assert!(style.attributes.contains(Attributes::BOLD));
+        assert!(style.attributes.contains(Attributes::ITALIC));
+    }
+
+    #[test]
+    fn test_style_override_preserves_unset() {
+        let mut style = Style::new()
+            .fg(Color::Red)
+            .bg(Color::Blue)
+            .bold()
+            .italic();
+
+        let override_ = StyleOverride {
+            fg: Some("green".to_string()),
+            ..Default::default()
+        };
+
+        override_.apply_to(&mut style);
+
+        // fg changed
+        assert_eq!(style.fg, Some(Color::Green));
+        // bg preserved
+        assert_eq!(style.bg, Some(Color::Blue));
+        // attributes preserved
+        assert!(style.attributes.contains(Attributes::BOLD));
+        assert!(style.attributes.contains(Attributes::ITALIC));
+    }
+
+    #[test]
+    fn test_style_override_invalid_color_skipped() {
+        let mut style = Style::new().fg(Color::Red);
+        let override_ = StyleOverride {
+            fg: Some("invalid_color".to_string()),
+            ..Default::default()
+        };
+
+        override_.apply_to(&mut style);
+
+        // Original color preserved (invalid was skipped)
+        assert_eq!(style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_theme_overrides_serde() {
+        let toml = r##"
+"statusline.background" = { bg = "#1a1b26" }
+"gutter.line_number" = { fg = "#565f89" }
+"##;
+
+        let overrides: ThemeOverrides = toml::from_str(toml).unwrap();
+        assert_eq!(overrides.len(), 2);
+        assert!(overrides.overrides.contains_key("statusline.background"));
+        assert!(overrides.overrides.contains_key("gutter.line_number"));
+    }
+
+    #[test]
+    fn test_theme_overrides_serde_with_attributes() {
+        let toml = r##"
+"statusline.mode.normal" = { fg = "#1a1b26", bg = "#7aa2f7", bold = true }
+"##;
+
+        let overrides: ThemeOverrides = toml::from_str(toml).unwrap();
+        let normal_override = overrides.overrides.get("statusline.mode.normal").unwrap();
+
+        assert_eq!(normal_override.fg, Some("#1a1b26".to_string()));
+        assert_eq!(normal_override.bg, Some("#7aa2f7".to_string()));
+        assert_eq!(normal_override.bold, Some(true));
+    }
+}

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -1114,12 +1114,17 @@ impl Runtime {
     pub fn apply_profile(&mut self, config: &ProfileConfig) {
         use crate::highlight::ThemeName;
 
-        // Apply theme
+        // Apply theme with overrides
         if let Some(theme_name) = ThemeName::parse(&config.editor.theme) {
-            self.theme = Theme::from_name(theme_name);
+            self.theme =
+                Theme::from_name_with_overrides(theme_name, &config.editor.theme_overrides);
             // Theme change will trigger rehighlighting via event bus
             self.rehighlight_all_buffers();
-            debug!(theme = %config.editor.theme, "Applied theme from profile");
+            debug!(
+                theme = %config.editor.theme,
+                overrides = config.editor.theme_overrides.len(),
+                "Applied theme with overrides from profile"
+            );
         }
 
         // Apply color mode


### PR DESCRIPTION
Allow users to override individual colors/styles in their TOML profile configuration without modifying base themes.

Changes:
- Add parse_color() supporting hex, rgb(), ansi:N, and named formats
- Add StyleOverride and ThemeOverrides types for config-based overrides
- Add Theme::from_name_with_overrides() and Theme::apply_overrides()
- Add theme_overrides field to EditorConfig schema
- Integrate overrides into apply_profile() runtime flow

Example config:
  [editor.theme_overrides] "statusline.background" = { bg = "#1a1b26" } "gutter.line_number" = { fg = "#565f89" }

Closes #55