### PR TITLE
refactor(runtime): centralize cursor synchronization for window navigation (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Reovim will be documented in this file.
 
 ### Changed
 
+- **RAII-based cursor synchronization** (Issue #48) - Centralize cursor sync between windows and buffers
+  - Added `Screen::save_cursor_to_active_window()` for pre-split cursor save
+  - Added `Screen::switch_active_window()` for full cursor handoff during navigation
+  - Refactored `handle_window_split()` to use centralized API (15 lines → 1 call)
+  - Refactored `handle_window_navigate()` to use centralized API (50 lines → direction lookup + 1 call)
+  - Eliminates manual cursor sync scattered across handlers, reducing error risk
+
 - **Split large subscribe() methods** (Issue #52) - Improve plugin maintainability by splitting monolithic subscribe() methods
   - Explorer plugin: Split 426-line method into 9 focused sub-methods (raw_input, navigation, tree_operations, clipboard, file_operations, input_handling, visual_mode, focus_visibility, popup)
   - Range-Finder plugin: Split 191-line method into 5 focused sub-methods (jump_mode_handlers, jump_input_handler, fold_handlers, cleanup)

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -1069,23 +1069,10 @@ impl Runtime {
         // Use self.active_buffer_id() since open_file updates it via screen
         let buffer_id = self.active_buffer_id();
 
-        // CRITICAL: Save the buffer's live cursor to the current window BEFORE splitting.
-        // split_window() reads window.cursor to copy to the new window, so we must
-        // ensure it reflects the current buffer cursor, not a stale saved value.
-        if let Some(window) = self.screen.active_window_mut()
-            && let Some(buffer) = self.buffers.get(&buffer_id)
-        {
-            tracing::debug!(
-                "[SPLIT] SAVE cursor: win={} buffer.cur=({},{}) -> window.cursor at {:?}",
-                window.id,
-                buffer.cur.x,
-                buffer.cur.y,
-                start.elapsed()
-            );
-            window.cursor = buffer.cur;
-            window.desired_col = buffer.desired_col;
-        } else {
-            tracing::warn!("[SPLIT] failed to get active window or buffer!");
+        // CENTRALIZED: Save buffer cursor to window before split.
+        // split_window() reads window.cursor to copy to new window.
+        if self.screen.save_cursor_to_active_window(&self.buffers).is_none() {
+            tracing::warn!("[SPLIT] failed to save cursor to active window");
         }
 
         // Split the window
@@ -1116,58 +1103,50 @@ impl Runtime {
     /// Handle window navigation (focus direction)
     pub(crate) fn handle_window_navigate(&mut self, direction: NavigateDirection) {
         let start = std::time::Instant::now();
-        let before_window_id = self.screen.active_window_id();
 
-        // Before navigation: save current buffer cursor to current window
-        if let Some(window) = self.screen.active_window_mut()
-            && let Some(buffer_id) = window.buffer_id()
-            && let Some(buffer) = self.buffers.get(&buffer_id)
-        {
-            tracing::debug!(
-                "[NAV] SAVE cursor: win={} buffer.cur=({},{}) -> window.cursor at {:?}",
-                window.id,
-                buffer.cur.x,
-                buffer.cur.y,
-                start.elapsed()
-            );
-            window.cursor = buffer.cur;
-            window.desired_col = buffer.desired_col;
+        // Handle plugin focus case: unfocus plugin and return
+        if self.screen.has_plugin_focus() {
+            self.screen.focus_editor();
+            self.screen.update_window_active_state();
+            tracing::debug!("[NAV] Unfocused plugin, focused editor at {:?}", start.elapsed());
+            return;
         }
 
-        // Navigate to new window
-        self.screen.navigate_window(direction);
+        // Find target window via direction lookup
+        let target_id = {
+            let Some(tab) = self.screen.tab_manager().active_tab() else {
+                return;
+            };
+            let editor_layout = self.screen.layout().editor_layout();
+            let editor_rect = crate::screen::WindowRect::new(
+                editor_layout.anchor.x,
+                editor_layout.anchor.y,
+                editor_layout.width,
+                editor_layout.height,
+            );
+            let layouts = tab.calculate_layouts(editor_rect);
 
-        let after_window_id = self.screen.active_window_id();
+            let Some(id) = crate::screen::split::find_adjacent_window(
+                tab.active_window_id,
+                direction,
+                &layouts,
+            ) else {
+                tracing::debug!("[NAV] No adjacent window in direction {:?}", direction);
+                return;
+            };
+            id
+        };
+
+        // CENTRALIZED: Full cursor sync (save to old, load from new)
+        let prev = self.screen.switch_active_window(target_id, &mut self.buffers);
+
         tracing::debug!(
-            "[NAV] navigate {:?}: win {} -> win {:?} at {:?}",
+            "[NAV] {:?}: win {:?} -> {} at {:?}",
             direction,
-            before_window_id.unwrap_or(999),
-            after_window_id,
+            prev,
+            target_id,
             start.elapsed()
         );
-
-        // After navigation: load new window's cursor into buffer and update active_buffer_id
-        if let Some(window) = self.screen.active_window()
-            && let Some(new_buffer_id) = window.buffer_id()
-        {
-            let window_cursor = window.cursor;
-            let window_desired_col = window.desired_col;
-
-            tracing::debug!(
-                "[NAV] LOAD cursor: win={} window.cursor=({},{}) -> buffer.cur at {:?}",
-                window.id,
-                window_cursor.x,
-                window_cursor.y,
-                start.elapsed()
-            );
-
-            // Load window's cursor into buffer
-            if let Some(buffer) = self.buffers.get_mut(&new_buffer_id) {
-                buffer.cur = window_cursor;
-                buffer.desired_col = window_desired_col;
-            }
-        }
-        tracing::debug!("[NAV] handle_window_navigate DONE at {:?}", start.elapsed());
     }
 
     /// Handle window equalize

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -1414,6 +1414,90 @@ impl Screen {
         self.windows.iter_mut().find(|w| w.id == active_id)
     }
 
+    /// Save cursor from buffer to active window.
+    ///
+    /// Used before split to ensure new window inherits current cursor.
+    /// Returns the active window ID if save was performed.
+    pub fn save_cursor_to_active_window(
+        &mut self,
+        buffers: &BTreeMap<usize, Buffer>,
+    ) -> Option<usize> {
+        let active_id = self.active_window_id()?;
+        let window = self.active_window_mut()?;
+        let buffer_id = window.buffer_id()?;
+        let buffer = buffers.get(&buffer_id)?;
+
+        window.cursor = buffer.cur;
+        window.desired_col = buffer.desired_col;
+
+        tracing::debug!(
+            "[CURSOR_SYNC] SAVE: win={} buffer.cur=({},{}) -> window.cursor",
+            active_id,
+            buffer.cur.x,
+            buffer.cur.y,
+        );
+
+        Some(active_id)
+    }
+
+    /// Switch active window with full cursor synchronization.
+    ///
+    /// Use this for keyboard-driven window navigation (Ctrl-W h/j/k/l).
+    /// For mouse clicks, use `set_active_window()` instead since the mouse
+    /// directly sets cursor position.
+    ///
+    /// Performs the complete cursor handoff:
+    /// 1. Saves current buffer cursor to old active window
+    /// 2. Changes active window (updates `is_active` flags)
+    /// 3. Loads new window's cursor into buffer
+    ///
+    /// Returns the previous active window ID, or `None` if same window (no-op).
+    pub fn switch_active_window(
+        &mut self,
+        window_id: usize,
+        buffers: &mut BTreeMap<usize, Buffer>,
+    ) -> Option<usize> {
+        let current_active = self.active_window_id();
+
+        // Early return if same window (no-op)
+        if current_active == Some(window_id) {
+            return None;
+        }
+
+        // Step 1: Save cursor to old window
+        self.save_cursor_to_active_window(buffers);
+
+        // Step 2: Update is_active flags
+        for window in &mut self.windows {
+            window.is_active = window.id == window_id;
+        }
+        if let Some(tab) = self.tab_manager.active_tab_mut() {
+            tab.active_window_id = window_id;
+        }
+
+        // Step 3: Load cursor from new window into buffer
+        let new_window_data = self
+            .windows
+            .iter()
+            .find(|w| w.id == window_id)
+            .map(|w| (w.buffer_id(), w.cursor, w.desired_col));
+
+        if let Some((Some(buffer_id), cursor, desired_col)) = new_window_data
+            && let Some(buffer) = buffers.get_mut(&buffer_id)
+        {
+            buffer.cur = cursor;
+            buffer.desired_col = desired_col;
+            tracing::debug!(
+                "[CURSOR_SYNC] LOAD: win={} window.cursor=({},{}) -> buffer.cur",
+                window_id,
+                cursor.x,
+                cursor.y,
+            );
+        }
+
+        current_active
+    }
+
     /// Get the number of windows in the active tab
     #[must_use]
     pub fn window_count(&self) -> usize {
@@ -1640,7 +1724,7 @@ impl Screen {
     }
 
     /// Update `is_active` flag on all windows based on active window ID
-    fn update_window_active_state(&mut self) {
+    pub fn update_window_active_state(&mut self) {
         if let Some(active_id) = self.tab_manager.active_window_id() {
             for window in &mut self.windows {
                 window.is_active = window.id == active_id;


### PR DESCRIPTION
Replace manual cursor sync scattered in handlers with two centralized Screen methods:
- save_cursor_to_active_window() - save-only for split operations
- switch_active_window() - full cursor handoff for navigation

This eliminates error-prone manual sync code and follows DRY principles.

Changes:
- Add Screen::save_cursor_to_active_window() for pre-split cursor save
- Add Screen::switch_active_window() for full navigation cursor handoff
- Refactor handle_window_split() to use save_cursor_to_active_window()
- Refactor handle_window_navigate() to use switch_active_window()
- Make update_window_active_state() public for plugin focus handling

Closes #48