### PR TITLE
refactor(screen): decompose render_to_buffer() method (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to Reovim will be documented in this file.
   - Range-Finder plugin: Split 191-line method into 5 focused sub-methods (jump_mode_handlers, jump_input_handler, fold_handlers, cleanup)
   - Removed `#[allow(clippy::too_many_lines)]` pragmas from both plugins
 
+- **Decomposed window render_to_buffer() method** (Issue #51) - Extract focused helper methods for better testability
+  - `compute_line_number_width()` - Calculate line number column width
+  - `render_fold_marker_to_buffer()` - Render collapsed fold indicators
+  - `render_empty_lines_to_buffer()` - Fill viewport with tilde markers
+  - Main method reduced from ~106 to ~82 lines with clearer separation of concerns
+
 - **Declarative mode metadata** (Issue #42) - Replace hardcoded `mode_for_command()` with `resulting_mode()` trait method
   - Added `resulting_mode()` method to `CommandTrait` with default `None` return
   - Implemented for 32 mode-changing commands (mode, window, operator, command-line)

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
-use reovim_sys::event::KeyModifiers;
-use tokio::sync::oneshot;
+use {reovim_sys::event::KeyModifiers, tokio::sync::oneshot};
 
 use crate::{
     bind::CommandRef,

--- a/lib/core/src/event_bus/bus.rs
+++ b/lib/core/src/event_bus/bus.rs
@@ -14,8 +14,10 @@ use std::{
 
 use tokio::sync::mpsc;
 
-use super::{core_events::RequestModeChange, DynEvent, Event, EventResult};
-use crate::modd::{ComponentId, EditMode, ModeState, SubMode};
+use {
+    super::{DynEvent, Event, EventResult, core_events::RequestModeChange},
+    crate::modd::{ComponentId, EditMode, ModeState, SubMode},
+};
 
 /// Handler function type - receives event and context, returns result
 type EventHandlerFn = Box<dyn Fn(&DynEvent, &mut HandlerContext) -> EventResult + Send + Sync>;

--- a/lib/core/src/highlight/color.rs
+++ b/lib/core/src/highlight/color.rs
@@ -442,14 +442,8 @@ mod tests {
 
     #[test]
     fn test_parse_color_hex_6digit() {
-        assert_eq!(
-            parse_color("#ff0000"),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
-        assert_eq!(
-            parse_color("#00ff00"),
-            Some(Color::Rgb { r: 0, g: 255, b: 0 })
-        );
+        assert_eq!(parse_color("#ff0000"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+        assert_eq!(parse_color("#00ff00"), Some(Color::Rgb { r: 0, g: 255, b: 0 }));
         assert_eq!(
             parse_color("#1a1b26"),
             Some(Color::Rgb {
@@ -463,10 +457,7 @@ mod tests {
     #[test]
     fn test_parse_color_hex_3digit() {
         // #f00 -> #ff0000
-        assert_eq!(
-            parse_color("#f00"),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
+        assert_eq!(parse_color("#f00"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
         // #abc -> #aabbcc
         assert_eq!(
             parse_color("#abc"),
@@ -481,22 +472,13 @@ mod tests {
     #[test]
     fn test_parse_color_hex_8digit() {
         // Alpha is ignored
-        assert_eq!(
-            parse_color("#ff0000ff"),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
+        assert_eq!(parse_color("#ff0000ff"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
     }
 
     #[test]
     fn test_parse_color_rgb_function() {
-        assert_eq!(
-            parse_color("rgb(255, 0, 0)"),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
-        assert_eq!(
-            parse_color("rgb(255,0,0)"),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
+        assert_eq!(parse_color("rgb(255, 0, 0)"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+        assert_eq!(parse_color("rgb(255,0,0)"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
         assert_eq!(
             parse_color("rgb( 128 , 64 , 32 )"),
             Some(Color::Rgb {
@@ -539,10 +521,7 @@ mod tests {
 
     #[test]
     fn test_parse_color_whitespace() {
-        assert_eq!(
-            parse_color("  #ff0000  "),
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
+        assert_eq!(parse_color("  #ff0000  "), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
         assert_eq!(parse_color("  red  "), Some(Color::Red));
     }
 }

--- a/lib/core/src/highlight/theme.rs
+++ b/lib/core/src/highlight/theme.rs
@@ -20,11 +20,13 @@
 //! - `leap`: Leap navigation label styles
 //! - `animation`: Animation configuration
 
-use crate::highlight::{
-    theme_override::{ThemeOverrideError, ThemeOverrides},
-    Style,
+use {
+    crate::highlight::{
+        Style,
+        theme_override::{ThemeOverrideError, ThemeOverrides},
+    },
+    reovim_sys::style::Color,
 };
-use reovim_sys::style::Color;
 
 // ============================================================================
 // Theme Name Enum
@@ -990,7 +992,9 @@ impl Theme {
         for (path, style_override) in &overrides.overrides {
             match self.get_style_mut(path) {
                 Ok(style) => style_override.apply_to(style),
-                Err(e) => tracing::warn!(path = %path, error = %e, "Failed to apply theme override"),
+                Err(e) => {
+                    tracing::warn!(path = %path, error = %e, "Failed to apply theme override");
+                }
             }
         }
     }
@@ -1258,8 +1262,10 @@ mod tests {
 
     #[test]
     fn test_apply_overrides() {
-        use crate::highlight::theme_override::{StyleOverride, ThemeOverrides};
-        use std::collections::HashMap;
+        use {
+            crate::highlight::theme_override::{StyleOverride, ThemeOverrides},
+            std::collections::HashMap,
+        };
 
         let mut overrides_map = HashMap::new();
         overrides_map.insert(
@@ -1277,16 +1283,15 @@ mod tests {
         let mut theme = Theme::dark();
         theme.apply_overrides(&overrides);
 
-        assert_eq!(
-            theme.gutter.line_number.fg,
-            Some(Color::Rgb { r: 255, g: 0, b: 0 })
-        );
+        assert_eq!(theme.gutter.line_number.fg, Some(Color::Rgb { r: 255, g: 0, b: 0 }));
     }
 
     #[test]
     fn test_from_name_with_overrides() {
-        use crate::highlight::theme_override::{StyleOverride, ThemeOverrides};
-        use std::collections::HashMap;
+        use {
+            crate::highlight::theme_override::{StyleOverride, ThemeOverrides},
+            std::collections::HashMap,
+        };
 
         let mut overrides_map = HashMap::new();
         overrides_map.insert(

--- a/lib/core/src/highlight/theme_override.rs
+++ b/lib/core/src/highlight/theme_override.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use {
-    crate::highlight::{color::parse_color, Attributes, Style},
+    crate::highlight::{Attributes, Style, color::parse_color},
     serde::{Deserialize, Serialize},
     std::collections::HashMap,
 };
@@ -229,7 +229,14 @@ mod tests {
 
         override_.apply_to(&mut style);
 
-        assert_eq!(style.bg, Some(Color::Rgb { r: 26, g: 27, b: 38 }));
+        assert_eq!(
+            style.bg,
+            Some(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38
+            })
+        );
         assert_eq!(style.fg, None);
     }
 
@@ -261,11 +268,7 @@ mod tests {
 
     #[test]
     fn test_style_override_preserves_unset() {
-        let mut style = Style::new()
-            .fg(Color::Red)
-            .bg(Color::Blue)
-            .bold()
-            .italic();
+        let mut style = Style::new().fg(Color::Red).bg(Color::Blue).bold().italic();
 
         let override_ = StyleOverride {
             fg: Some("green".to_string()),

--- a/lib/core/src/plugin/macros.rs
+++ b/lib/core/src/plugin/macros.rs
@@ -71,53 +71,41 @@ macro_rules! subscribe_state {
     // Registry-based, no event access
     ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident| $body:block) => {{
         let state_clone = std::sync::Arc::clone(&$state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Registry-based, with event access
     ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident, $e:ident| $body:block) => {{
         let state_clone = std::sync::Arc::clone(&$state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |$e, ctx| {
-                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |$e, ctx| {
+            state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Arc-based (plugin-owned state), no event access
     ($bus:expr, $arc_state:expr, $event:ty, |$s:ident| $body:block) => {{
         let state_clone = std::sync::Arc::clone(&$arc_state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                state_clone.with_mut(|$s| $body);
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            state_clone.with_mut(|$s| $body);
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Arc-based (plugin-owned state), with event access
     ($bus:expr, $arc_state:expr, $event:ty, |$s:ident, $e:ident| $body:block) => {{
         let state_clone = std::sync::Arc::clone(&$arc_state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |$e, ctx| {
-                state_clone.with_mut(|$s| $body);
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |$e, ctx| {
+            state_clone.with_mut(|$s| $body);
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 }
 
@@ -151,15 +139,12 @@ macro_rules! subscribe_state_mode {
         let state_clone = std::sync::Arc::clone(&$state);
         // Evaluate mode expression before closure to avoid move issues
         let mode = $mode;
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                state_clone.with_mut::<$state_type, _, _>(|$s| $body);
-                ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            state_clone.with_mut::<$state_type, _, _>(|$s| $body);
+            ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Arc-based
@@ -167,15 +152,12 @@ macro_rules! subscribe_state_mode {
         let state_clone = std::sync::Arc::clone(&$arc_state);
         // Evaluate mode expression before closure to avoid move issues
         let mode = $mode;
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                state_clone.with_mut(|$s| $body);
-                ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
-                ctx.request_render();
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            state_clone.with_mut(|$s| $body);
+            ctx.emit($crate::event_bus::RequestModeChange { mode: mode.clone() });
+            ctx.request_render();
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 }
 
@@ -196,64 +178,52 @@ macro_rules! subscribe_state_conditional {
     // Arc-based with event access (most common for fold operations)
     ($bus:expr, $arc_state:expr, $event:ty, |$s:ident, $e:ident| $body:expr) => {{
         let state_clone = std::sync::Arc::clone(&$arc_state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |$e, ctx| {
-                let changed = state_clone.with_mut(|$s| $body);
-                if changed {
-                    ctx.request_render();
-                }
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |$e, ctx| {
+            let changed = state_clone.with_mut(|$s| $body);
+            if changed {
+                ctx.request_render();
+            }
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Arc-based without event access
     ($bus:expr, $arc_state:expr, $event:ty, |$s:ident| $body:expr) => {{
         let state_clone = std::sync::Arc::clone(&$arc_state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                let changed = state_clone.with_mut(|$s| $body);
-                if changed {
-                    ctx.request_render();
-                }
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            let changed = state_clone.with_mut(|$s| $body);
+            if changed {
+                ctx.request_render();
+            }
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Registry-based with event access
     ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident, $e:ident| $body:expr) => {{
         let state_clone = std::sync::Arc::clone(&$state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |$e, ctx| {
-                let changed = state_clone
-                    .with_mut::<$state_type, _, _>(|$s| $body)
-                    .unwrap_or(false);
-                if changed {
-                    ctx.request_render();
-                }
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |$e, ctx| {
+            let changed = state_clone
+                .with_mut::<$state_type, _, _>(|$s| $body)
+                .unwrap_or(false);
+            if changed {
+                ctx.request_render();
+            }
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 
     // Registry-based without event access
     ($bus:expr, $state:expr, $event:ty, $state_type:ty, |$s:ident| $body:expr) => {{
         let state_clone = std::sync::Arc::clone(&$state);
-        $bus.subscribe::<$event, _>(
-            $crate::event_bus::priority::PLUGIN,
-            move |_event, ctx| {
-                let changed = state_clone
-                    .with_mut::<$state_type, _, _>(|$s| $body)
-                    .unwrap_or(false);
-                if changed {
-                    ctx.request_render();
-                }
-                $crate::event_bus::EventResult::Handled
-            },
-        );
+        $bus.subscribe::<$event, _>($crate::event_bus::priority::PLUGIN, move |_event, ctx| {
+            let changed = state_clone
+                .with_mut::<$state_type, _, _>(|$s| $body)
+                .unwrap_or(false);
+            if changed {
+                ctx.request_render();
+            }
+            $crate::event_bus::EventResult::Handled
+        });
     }};
 }

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -1071,7 +1071,11 @@ impl Runtime {
 
         // CENTRALIZED: Save buffer cursor to window before split.
         // split_window() reads window.cursor to copy to new window.
-        if self.screen.save_cursor_to_active_window(&self.buffers).is_none() {
+        if self
+            .screen
+            .save_cursor_to_active_window(&self.buffers)
+            .is_none()
+        {
             tracing::warn!("[SPLIT] failed to save cursor to active window");
         }
 
@@ -1138,7 +1142,9 @@ impl Runtime {
         };
 
         // CENTRALIZED: Full cursor sync (save to old, load from new)
-        let prev = self.screen.switch_active_window(target_id, &mut self.buffers);
+        let prev = self
+            .screen
+            .switch_active_window(target_id, &mut self.buffers);
 
         tracing::debug!(
             "[NAV] {:?}: win {:?} -> {} at {:?}",
@@ -1469,12 +1475,7 @@ impl Runtime {
     /// - Scroll: Move viewport by 3 lines, adjust cursor to stay visible
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn handle_mouse_event(&mut self, event: MouseEvent) {
-        tracing::debug!(
-            "Mouse event: {:?} at ({}, {})",
-            event.kind,
-            event.column,
-            event.row
-        );
+        tracing::debug!("Mouse event: {:?} at ({}, {})", event.kind, event.column, event.row);
 
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
@@ -1511,10 +1512,7 @@ impl Runtime {
             let Some(buffer_id) = window.buffer_id() else {
                 return; // Window doesn't have a buffer
             };
-            let buffer_line_count = self
-                .buffers
-                .get(&buffer_id)
-                .map_or(0, |b| b.contents.len());
+            let buffer_line_count = self.buffers.get(&buffer_id).map_or(0, |b| b.contents.len());
             (buffer_id, buffer_line_count)
         };
 
@@ -1589,10 +1587,7 @@ impl Runtime {
             return;
         };
 
-        let buffer_line_count = self
-            .buffers
-            .get(&buffer_id)
-            .map_or(0, |b| b.contents.len());
+        let buffer_line_count = self.buffers.get(&buffer_id).map_or(0, |b| b.contents.len());
 
         // Get current buffer anchor (scroll position)
         let current_anchor = window.buffer_anchor().unwrap_or(Anchor { x: 0, y: 0 });

--- a/lib/core/src/screen/window.rs
+++ b/lib/core/src/screen/window.rs
@@ -809,6 +809,70 @@ impl Window {
         width
     }
 
+    /// Calculate the width needed for line numbers based on total line count.
+    ///
+    /// Returns the number of character columns required to display the largest line number.
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    #[allow(clippy::cast_precision_loss)]
+    fn compute_line_number_width(&self, total_lines: usize) -> usize {
+        if self.line_number.as_ref().is_some_and(LineNumber::is_shown) && total_lines > 0 {
+            (total_lines as f64).log10().floor() as usize + 1
+        } else {
+            1
+        }
+    }
+
+    /// Render a fold marker line (collapsed fold indicator) to frame buffer.
+    ///
+    /// Displays line number followed by fold indicator text "+-- folded ---".
+    fn render_fold_marker_to_buffer(
+        &self,
+        buffer: &mut FrameBuffer,
+        screen_y: u16,
+        row: u16,
+        cursor_y: u16,
+        num_width: usize,
+        theme: &Theme,
+    ) {
+        let gutter_width = self.render_line_number_to_buffer(
+            buffer,
+            self.anchor.x,
+            screen_y,
+            row,
+            cursor_y,
+            num_width,
+            theme,
+        );
+        let fold_style = &theme.fold.marker;
+        let fold_text = "+-- folded ---";
+        let mut col = self.anchor.x + gutter_width;
+        for ch in fold_text.chars() {
+            if col < buffer.width() {
+                buffer.put_char(col, screen_y, ch, fold_style);
+                col += 1;
+            }
+        }
+    }
+
+    /// Fill remaining viewport rows with empty line markers (~).
+    ///
+    /// Renders tilde characters in the gutter for lines beyond the buffer content.
+    fn render_empty_lines_to_buffer(
+        &self,
+        buffer: &mut FrameBuffer,
+        start_display_row: u16,
+        theme: &Theme,
+    ) {
+        let tilde_style = &theme.gutter.line_number;
+        let mut display_row = start_display_row;
+        while display_row < self.height {
+            let screen_y = self.anchor.y + display_row;
+            buffer.put_char(self.anchor.x, screen_y, '~', tilde_style);
+            display_row += 1;
+        }
+    }
+
     /// Render a complete content line to frame buffer
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_arguments)]
@@ -1073,9 +1137,6 @@ impl Window {
     }
 
     /// Render the entire window content to frame buffer
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::too_many_arguments)]
     pub fn render_to_buffer(
         &self,
@@ -1089,13 +1150,7 @@ impl Window {
         edit_mode: &EditMode,
     ) {
         // Calculate line number width for alignment
-        let total_lines = buf.contents.len();
-        let num_width =
-            if self.line_number.as_ref().is_some_and(LineNumber::is_shown) && total_lines > 0 {
-                (total_lines as f64).log10().floor() as usize + 1
-            } else {
-                1
-            };
+        let num_width = self.compute_line_number_width(buf.contents.len());
 
         // Build visual selection highlight
         let visual_highlight = Self::build_visual_highlight(buf, theme);
@@ -1124,25 +1179,10 @@ impl Window {
             let screen_y = self.anchor.y + display_row;
 
             if visibility_marker.is_some() {
-                // Render fold marker (simplified - just show fold indicator)
-                let gutter_width = self.render_line_number_to_buffer(
-                    buffer,
-                    self.anchor.x,
-                    screen_y,
-                    row,
-                    cursor_y,
-                    num_width,
-                    theme,
+                // Render fold marker
+                self.render_fold_marker_to_buffer(
+                    buffer, screen_y, row, cursor_y, num_width, theme,
                 );
-                let fold_style = &theme.fold.marker;
-                let fold_text = "+-- folded ---";
-                let mut col = self.anchor.x + gutter_width;
-                for ch in fold_text.chars() {
-                    if col < buffer.width() {
-                        buffer.put_char(col, screen_y, ch, fold_style);
-                        col += 1;
-                    }
-                }
             } else {
                 // Render normal content line
                 if screen_y == self.anchor.y {
@@ -1176,13 +1216,8 @@ impl Window {
             display_row += 1;
         }
 
-        // Fill remaining rows with empty cells (tilde markers for empty lines)
-        let tilde_style = &theme.gutter.line_number;
-        while display_row < self.height {
-            let screen_y = self.anchor.y + display_row;
-            buffer.put_char(self.anchor.x, screen_y, '~', tilde_style);
-            display_row += 1;
-        }
+        // Fill remaining rows with empty line markers
+        self.render_empty_lines_to_buffer(buffer, display_row, theme);
     }
 
     pub fn set_number(&mut self, enabled: bool) {


### PR DESCRIPTION
Extract focused helper methods from Window::render_to_buffer() for better separation of concerns and testability:

- compute_line_number_width(): Calculate line number column width
- render_fold_marker_to_buffer(): Render collapsed fold indicators
- render_empty_lines_to_buffer(): Fill viewport with tilde markers

Main method reduced from ~106 to ~82 lines. Pure refactoring with no functional changes.

Also fixes pre-existing clippy warning in theme.rs (missing semicolon).

Closes #51