### PR TITLE
refactor(highlight): remove unused cursor and animation theme feature…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to Reovim will be documented in this file.
   - Active rendering uses `Screen::render_status_line_to_buffer()` which remains unchanged
   - Fixes OperatorPending style bug (was in dead code path using wrong style)
 
+- **Remove unused cursor and animation theme features** (Issue #49) - Dead code cleanup
+  - Removed `CursorStyles` struct (line, column, glow, pulse fields never accessed)
+  - Removed `EffectConfig` struct (never instantiated)
+  - Removed `AnimationConfig` struct (actual animation system uses hardcoded frame rate)
+  - Removed `HighlightGroup::CursorEffect` enum variant (never applied)
+  - Updated docs/animation-system.md to remove future config section
+
 - **RAII-based cursor synchronization** (Issue #48) - Centralize cursor sync between windows and buffers
   - Added `Screen::save_cursor_to_active_window()` for pre-split cursor save
   - Added `Screen::switch_active_window()` for full cursor handoff during navigation

--- a/docs/animation-system.md
+++ b/docs/animation-system.md
@@ -354,19 +354,6 @@ impl Effect for MyCustomEffect {
 }
 ```
 
-## Configuration (Future)
-
-Planned configuration options:
-
-```toml
-[animation]
-enabled = true
-frame_rate = 30
-yank_effect = "fade"       # or "pulse", "none"
-paste_effect = "pulse"     # or "fade", "none"
-cursor_trail = false       # Experimental
-```
-
 ## Source Files
 
 - `lib/core/src/animation/mod.rs` - Core types and exports

--- a/lib/core/src/highlight/mod.rs
+++ b/lib/core/src/highlight/mod.rs
@@ -11,8 +11,8 @@ pub use {
     store::{BufferHighlights, HighlightStore, LineHighlight},
     style::{Attributes, Style},
     theme::{
-        AnimationConfig, BracketStyles, CursorStyles, DiagnosticStyles, EffectConfig, LeapStyles,
-        SemanticStyles, StatusLineModeStyles, Theme, ThemeName,
+        BracketStyles, DiagnosticStyles, LeapStyles, SemanticStyles, StatusLineModeStyles, Theme,
+        ThemeName,
     },
     theme_override::{StyleOverride, ThemeOverrideError, ThemeOverrides},
 };
@@ -72,8 +72,6 @@ pub enum HighlightGroup {
     CursorColumn = 41,
     /// Matched bracket pair (high priority, visible over cursor line)
     MatchedBracket = 45,
-    /// Cursor effects (glow, pulse) - highest cursor layer
-    CursorEffect = 50,
 
     // === Mode Indicator Layer (60-69) ===
     /// Mode-specific styling for UI elements
@@ -164,7 +162,7 @@ impl HighlightGroup {
     /// Check if this is a cursor-related group
     #[must_use]
     pub const fn is_cursor_related(self) -> bool {
-        matches!(self, Self::CursorLine | Self::CursorColumn | Self::CursorEffect)
+        matches!(self, Self::CursorLine | Self::CursorColumn)
     }
 }
 

--- a/lib/core/src/highlight/theme.rs
+++ b/lib/core/src/highlight/theme.rs
@@ -15,10 +15,8 @@
 //! - `tab`: Tab line styles
 //! - `window`: Window separator styles
 //! - `diagnostic`: Enhanced diagnostic styles with underline colors
-//! - `cursor`: Cursor effects (glow, pulse)
 //! - `semantic`: Language-specific semantic token styles
 //! - `leap`: Leap navigation label styles
-//! - `animation`: Animation configuration
 
 use {
     crate::highlight::{
@@ -204,30 +202,6 @@ pub struct DiagnosticStyles {
     pub unnecessary: Style,
 }
 
-/// Cursor-related styles and effect configurations
-#[derive(Debug, Clone)]
-pub struct CursorStyles {
-    /// Cursor line background
-    pub line: Style,
-    /// Cursor column background (if enabled)
-    pub column: Style,
-    /// Cursor glow effect configuration
-    pub glow: Option<EffectConfig>,
-    /// Cursor pulse effect configuration
-    pub pulse: Option<EffectConfig>,
-}
-
-/// Configuration for visual effects
-#[derive(Debug, Clone)]
-pub struct EffectConfig {
-    /// Base style for the effect
-    pub style: Style,
-    /// Effect radius in cells (for glow)
-    pub radius: u8,
-    /// Animation speed in ms per frame (0 = no animation)
-    pub animation_ms: u16,
-}
-
 /// Semantic token styles for language-specific highlighting
 #[derive(Debug, Clone)]
 pub struct SemanticStyles {
@@ -279,24 +253,6 @@ pub struct VirtualTextStyles {
     pub hint: Style,
 }
 
-/// Animation configuration
-#[derive(Debug, Clone)]
-pub struct AnimationConfig {
-    /// Enable animations globally
-    pub enabled: bool,
-    /// Animation frame rate (fps, default 30)
-    pub frame_rate: u8,
-}
-
-impl Default for AnimationConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            frame_rate: 30,
-        }
-    }
-}
-
 // ============================================================================
 // Main Theme Struct
 // ============================================================================
@@ -318,11 +274,9 @@ pub struct Theme {
     pub brackets: BracketStyles,
     // Extended style categories
     pub diagnostic: DiagnosticStyles,
-    pub cursor: CursorStyles,
     pub semantic: SemanticStyles,
     pub leap: LeapStyles,
     pub virtual_text: VirtualTextStyles,
-    pub animation: AnimationConfig,
 }
 
 impl Default for Theme {
@@ -516,12 +470,6 @@ impl Theme {
                 deprecated: Style::new().strikethrough().dim(),
                 unnecessary: Style::new().dim(),
             },
-            cursor: CursorStyles {
-                line: Style::new().bg(bg_light),
-                column: Style::new().bg(bg_light),
-                glow: None, // No animation by default
-                pulse: None,
-            },
             semantic: SemanticStyles {
                 lifetime: Style::new().fg(magenta).italic(),
                 trait_bound: Style::new().fg(yellow).italic(),
@@ -546,7 +494,6 @@ impl Theme {
                 info: Style::new().fg(blue).italic(),
                 hint: Style::new().fg(fg_dark).italic(),
             },
-            animation: AnimationConfig::default(),
         }
     }
 
@@ -692,12 +639,6 @@ impl Theme {
                 deprecated: Style::new().strikethrough().dim(),
                 unnecessary: Style::new().dim(),
             },
-            cursor: CursorStyles {
-                line: Style::new().bg(bg_highlight),
-                column: Style::new().bg(bg_highlight),
-                glow: None,
-                pulse: None,
-            },
             semantic: SemanticStyles {
                 lifetime: Style::new().fg(Color::DarkMagenta).italic(),
                 trait_bound: Style::new().fg(Color::DarkYellow).italic(),
@@ -722,7 +663,6 @@ impl Theme {
                 info: Style::new().fg(Color::DarkBlue).italic(),
                 hint: Style::new().fg(Color::Grey).italic(),
             },
-            animation: AnimationConfig::default(),
         }
     }
 
@@ -930,12 +870,6 @@ impl Theme {
                 deprecated: Style::new().strikethrough().dim(),
                 unnecessary: Style::new().dim(),
             },
-            cursor: CursorStyles {
-                line: Style::new().bg(bg_highlight),
-                column: Style::new().bg(bg_highlight),
-                glow: None,
-                pulse: None,
-            },
             semantic: SemanticStyles {
                 lifetime: Style::new().fg(magenta).italic(),
                 trait_bound: Style::new().fg(yellow).italic(),
@@ -960,7 +894,6 @@ impl Theme {
                 info: Style::new().fg(blue).italic(),
                 hint: Style::new().fg(fg_dark).italic(),
             },
-            animation: AnimationConfig::default(),
         }
     }
 
@@ -1018,7 +951,6 @@ impl Theme {
     /// - `window.separator`
     /// - `brackets.{rainbow.0-5,matched,unmatched}`
     /// - `diagnostic.{hint,info,warn,error,deprecated,unnecessary}`
-    /// - `cursor.{line,column}`
     /// - `semantic.{lifetime,trait_bound,async_keyword,await_keyword,unsafe_keyword,macro_invocation,attribute,mutable,constant,static_var}`
     /// - `leap.{label_primary,label_secondary,dimmed}`
     /// - `virtual_text.{default,error,warn,info,hint}`
@@ -1126,10 +1058,6 @@ impl Theme {
             ["diagnostic", "error"] => Ok(&mut self.diagnostic.error),
             ["diagnostic", "deprecated"] => Ok(&mut self.diagnostic.deprecated),
             ["diagnostic", "unnecessary"] => Ok(&mut self.diagnostic.unnecessary),
-
-            // cursor.*
-            ["cursor", "line"] => Ok(&mut self.cursor.line),
-            ["cursor", "column"] => Ok(&mut self.cursor.column),
 
             // semantic.*
             ["semantic", "lifetime"] => Ok(&mut self.semantic.lifetime),


### PR DESCRIPTION
Remove dead code related to cursor effects and animation theme configuration that was planned but never implemented. The actual animation system uses hardcoded frame rate passed to AnimationSystem::spawn(), completely independent of theme config.

Removed:
- CursorStyles struct (line, column, glow, pulse fields never accessed)
- EffectConfig struct (never instantiated)
- AnimationConfig struct and Default impl (never read)
- HighlightGroup::CursorEffect enum variant (never applied)
- cursor.* paths from theme override system (referenced removed struct)

Also updated docs/animation-system.md to remove future config section.

Closes #49