### PR TITLE
feat(core): implement window resize, remove redundant MoveDirection (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,54 +4,13 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- **Remove dead status line code** (Issue #50) - Delete unused `StatusLineComponent` and consolidate duplicates
-  - Deleted `lib/core/src/component/status_line.rs` (303 lines) - `StatusLineComponent` was never instantiated
-  - Deleted `lib/core/src/screen/status_line.rs` (256 lines) - `StatusLineRenderer` trait was never called
-  - Removed `impl StatusLineRenderer for Screen` (31 lines) - Only consumer of deleted functions
-  - Active rendering uses `Screen::render_status_line_to_buffer()` which remains unchanged
-  - Fixes OperatorPending style bug (was in dead code path using wrong style)
-
-- **Remove unused cursor and animation theme features** (Issue #49) - Dead code cleanup
-  - Removed `CursorStyles` struct (line, column, glow, pulse fields never accessed)
-  - Removed `EffectConfig` struct (never instantiated)
-  - Removed `AnimationConfig` struct (actual animation system uses hardcoded frame rate)
-  - Removed `HighlightGroup::CursorEffect` enum variant (never applied)
-  - Updated docs/animation-system.md to remove future config section
-
-- **RAII-based cursor synchronization** (Issue #48) - Centralize cursor sync between windows and buffers
-  - Added `Screen::save_cursor_to_active_window()` for pre-split cursor save
-  - Added `Screen::switch_active_window()` for full cursor handoff during navigation
-  - Refactored `handle_window_split()` to use centralized API (15 lines → 1 call)
-  - Refactored `handle_window_navigate()` to use centralized API (50 lines → direction lookup + 1 call)
-  - Eliminates manual cursor sync scattered across handlers, reducing error risk
-
-- **Split large subscribe() methods** (Issue #52) - Improve plugin maintainability by splitting monolithic subscribe() methods
-  - Explorer plugin: Split 426-line method into 9 focused sub-methods (raw_input, navigation, tree_operations, clipboard, file_operations, input_handling, visual_mode, focus_visibility, popup)
-  - Range-Finder plugin: Split 191-line method into 5 focused sub-methods (jump_mode_handlers, jump_input_handler, fold_handlers, cleanup)
-  - Removed `#[allow(clippy::too_many_lines)]` pragmas from both plugins
-
-- **Decomposed window render_to_buffer() method** (Issue #51) - Extract focused helper methods for better testability
-  - `compute_line_number_width()` - Calculate line number column width
-  - `render_fold_marker_to_buffer()` - Render collapsed fold indicators
-  - `render_empty_lines_to_buffer()` - Fill viewport with tilde markers
-  - Main method reduced from ~106 to ~82 lines with clearer separation of concerns
-
-- **Declarative mode metadata** (Issue #42) - Replace hardcoded `mode_for_command()` with `resulting_mode()` trait method
-  - Added `resulting_mode()` method to `CommandTrait` with default `None` return
-  - Implemented for 32 mode-changing commands (mode, window, operator, command-line)
-  - Replaced 60-line string matching function with 6-line trait-based lookup
-  - Provides compile-time safety: no more missing match arms causing flaky tests
-  - Fixed bug: `enter_visual_line_mode` was missing from old implementation
-
-- **Unified active buffer tracking** (Issue #47) - Removed redundant `active_buffer_id` field from Runtime
-  - Screen is now the single source of truth for active buffer ID
-  - `Runtime::active_buffer_id()` method derives value from `Screen::active_buffer_id()`
-  - Eliminates dual tracking and manual synchronization between Runtime and Screen
-  - Simplifies buffer switching, file opening, and window navigation code
-
 ### Added
+
+- **Window resize operations** (Issue #54) - Implement direction-specific window resizing
+  - `SplitNode::adjust_ratio_in_direction()` - Find innermost split matching direction and adjust ratio
+  - `Screen::resize_window(direction, delta)` - Public API for resizing active window
+  - `WindowAction::Resize` handler now functional (5% ratio change per unit delta)
+  - Vertical direction adjusts width, Horizontal direction adjusts height
 
 - **Mouse click and scroll support** (Issue #59) - Basic mouse interaction for cursor positioning and scrolling
   - Left click: Move cursor to clicked position and focus window if different
@@ -101,6 +60,63 @@ All notable changes to Reovim will be documented in this file.
   - Implemented for `PluginTextInput`, `PluginBackspace`, and `RequestFocusChange`
   - Eliminates boilerplate target-checking code in plugin event handlers
   - Migrated 7 subscriptions across 4 plugins (Explorer, Microscope, Range-finder, Which-key)
+
+### Changed
+
+- **Remove dead status line code** (Issue #50) - Delete unused `StatusLineComponent` and consolidate duplicates
+  - Deleted `lib/core/src/component/status_line.rs` (303 lines) - `StatusLineComponent` was never instantiated
+  - Deleted `lib/core/src/screen/status_line.rs` (256 lines) - `StatusLineRenderer` trait was never called
+  - Removed `impl StatusLineRenderer for Screen` (31 lines) - Only consumer of deleted functions
+  - Active rendering uses `Screen::render_status_line_to_buffer()` which remains unchanged
+  - Fixes OperatorPending style bug (was in dead code path using wrong style)
+
+- **Remove unused cursor and animation theme features** (Issue #49) - Dead code cleanup
+  - Removed `CursorStyles` struct (line, column, glow, pulse fields never accessed)
+  - Removed `EffectConfig` struct (never instantiated)
+  - Removed `AnimationConfig` struct (actual animation system uses hardcoded frame rate)
+  - Removed `HighlightGroup::CursorEffect` enum variant (never applied)
+  - Updated docs/animation-system.md to remove future config section
+
+- **RAII-based cursor synchronization** (Issue #48) - Centralize cursor sync between windows and buffers
+  - Added `Screen::save_cursor_to_active_window()` for pre-split cursor save
+  - Added `Screen::switch_active_window()` for full cursor handoff during navigation
+  - Refactored `handle_window_split()` to use centralized API (15 lines → 1 call)
+  - Refactored `handle_window_navigate()` to use centralized API (50 lines → direction lookup + 1 call)
+  - Eliminates manual cursor sync scattered across handlers, reducing error risk
+
+- **Split large subscribe() methods** (Issue #52) - Improve plugin maintainability by splitting monolithic subscribe() methods
+  - Explorer plugin: Split 426-line method into 9 focused sub-methods (raw_input, navigation, tree_operations, clipboard, file_operations, input_handling, visual_mode, focus_visibility, popup)
+  - Range-Finder plugin: Split 191-line method into 5 focused sub-methods (jump_mode_handlers, jump_input_handler, fold_handlers, cleanup)
+  - Removed `#[allow(clippy::too_many_lines)]` pragmas from both plugins
+
+- **Decomposed window render_to_buffer() method** (Issue #51) - Extract focused helper methods for better testability
+  - `compute_line_number_width()` - Calculate line number column width
+  - `render_fold_marker_to_buffer()` - Render collapsed fold indicators
+  - `render_empty_lines_to_buffer()` - Fill viewport with tilde markers
+  - Main method reduced from ~106 to ~82 lines with clearer separation of concerns
+
+- **Declarative mode metadata** (Issue #42) - Replace hardcoded `mode_for_command()` with `resulting_mode()` trait method
+  - Added `resulting_mode()` method to `CommandTrait` with default `None` return
+  - Implemented for 32 mode-changing commands (mode, window, operator, command-line)
+  - Replaced 60-line string matching function with 6-line trait-based lookup
+  - Provides compile-time safety: no more missing match arms causing flaky tests
+  - Fixed bug: `enter_visual_line_mode` was missing from old implementation
+
+- **Unified active buffer tracking** (Issue #47) - Removed redundant `active_buffer_id` field from Runtime
+  - Screen is now the single source of truth for active buffer ID
+  - `Runtime::active_buffer_id()` method derives value from `Screen::active_buffer_id()`
+  - Eliminates dual tracking and manual synchronization between Runtime and Screen
+  - Simplifies buffer switching, file opening, and window navigation code
+
+- **Window move commands use SwapDirection** (Issue #54) - 8 move commands now use `SwapDirection` instead of `MoveDirection`
+  - `WindowMoveLeft/Down/Up/Right` commands and their window-mode variants now perform actual swaps
+  - Consistent behavior between move and swap operations
+
+### Removed
+
+- **`WindowAction::MoveDirection`** (Issue #54) - Removed redundant enum variant
+  - Was identical in purpose to existing `SwapDirection` but never implemented
+  - 8 commands updated to use `SwapDirection` directly
 
 ### Fixed
 

--- a/lib/core/src/command/builtin/window.rs
+++ b/lib/core/src/command/builtin/window.rs
@@ -137,7 +137,7 @@ impl CommandTrait for WindowMoveLeftCommand {
     }
 
     fn execute(&self, _ctx: &mut ExecutionContext) -> CommandResult {
-        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::MoveDirection {
+        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::SwapDirection {
             direction: NavigateDirection::Left,
         }))
     }
@@ -165,7 +165,7 @@ impl CommandTrait for WindowMoveDownCommand {
     }
 
     fn execute(&self, _ctx: &mut ExecutionContext) -> CommandResult {
-        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::MoveDirection {
+        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::SwapDirection {
             direction: NavigateDirection::Down,
         }))
     }
@@ -193,7 +193,7 @@ impl CommandTrait for WindowMoveUpCommand {
     }
 
     fn execute(&self, _ctx: &mut ExecutionContext) -> CommandResult {
-        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::MoveDirection {
+        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::SwapDirection {
             direction: NavigateDirection::Up,
         }))
     }
@@ -221,7 +221,7 @@ impl CommandTrait for WindowMoveRightCommand {
     }
 
     fn execute(&self, _ctx: &mut ExecutionContext) -> CommandResult {
-        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::MoveDirection {
+        CommandResult::DeferToRuntime(DeferredAction::Window(WindowAction::SwapDirection {
             direction: NavigateDirection::Right,
         }))
     }
@@ -482,7 +482,7 @@ window_mode_command!(
     WindowModeMoveLeftCommand,
     "window_mode_move_left",
     "Move window left (window mode)",
-    WindowAction::MoveDirection {
+    WindowAction::SwapDirection {
         direction: NavigateDirection::Left
     }
 );
@@ -491,7 +491,7 @@ window_mode_command!(
     WindowModeMoveDownCommand,
     "window_mode_move_down",
     "Move window down (window mode)",
-    WindowAction::MoveDirection {
+    WindowAction::SwapDirection {
         direction: NavigateDirection::Down
     }
 );
@@ -500,7 +500,7 @@ window_mode_command!(
     WindowModeMoveUpCommand,
     "window_mode_move_up",
     "Move window up (window mode)",
-    WindowAction::MoveDirection {
+    WindowAction::SwapDirection {
         direction: NavigateDirection::Up
     }
 );
@@ -509,7 +509,7 @@ window_mode_command!(
     WindowModeMoveRightCommand,
     "window_mode_move_right",
     "Move window right (window mode)",
-    WindowAction::MoveDirection {
+    WindowAction::SwapDirection {
         direction: NavigateDirection::Right
     }
 );

--- a/lib/core/src/command/traits.rs
+++ b/lib/core/src/command/traits.rs
@@ -146,9 +146,6 @@ pub enum WindowAction {
     FocusDirection {
         direction: NavigateDirection,
     },
-    MoveDirection {
-        direction: NavigateDirection,
-    },
     Resize {
         direction: SplitDirection,
         delta: i16,

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -991,12 +991,10 @@ impl Runtime {
             WindowAction::FocusDirection { direction } => {
                 self.handle_window_navigate(*direction);
             }
-            WindowAction::MoveDirection { direction } => {
-                // Window movement (swap windows) - not yet implemented
-                tracing::info!(direction = ?direction, "Window move direction (not yet implemented)");
-            }
             WindowAction::Resize { direction, delta } => {
-                tracing::info!(direction = ?direction, delta = %delta, "Window resize (not yet implemented)");
+                // Each unit represents 5% of the split ratio
+                let ratio_delta = f32::from(*delta) * 0.05;
+                self.screen.resize_window(*direction, ratio_delta);
             }
             WindowAction::Equalize => {
                 self.handle_window_equalize();

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -1773,6 +1773,19 @@ impl Screen {
         }
     }
 
+    /// Resize the active window in the specified direction
+    ///
+    /// - `Vertical` direction adjusts the width of vertical splits (left/right)
+    /// - `Horizontal` direction adjusts the height of horizontal splits (top/bottom)
+    /// - Positive delta increases size in that direction
+    /// - Negative delta decreases size
+    pub fn resize_window(&mut self, direction: SplitDirection, delta: f32) {
+        if let Some(tab) = self.tab_manager.active_tab_mut() {
+            tab.adjust_ratio_in_direction(direction, delta);
+            self.update_window_layouts();
+        }
+    }
+
     /// Swap the active window with the window in the given direction
     ///
     /// Returns true if a swap occurred
@@ -2483,4 +2496,3 @@ impl StyleExt for crate::highlight::Style {
         self
     }
 }
-

--- a/lib/core/src/screen/split.rs
+++ b/lib/core/src/screen/split.rs
@@ -233,6 +233,59 @@ impl SplitNode {
         }
     }
 
+    /// Adjust ratio of splits matching a specific direction
+    ///
+    /// Finds the innermost split that:
+    /// 1. Contains the window
+    /// 2. Matches the specified split direction
+    ///
+    /// Returns true if a matching split was found and adjusted.
+    pub fn adjust_ratio_in_direction(
+        &mut self,
+        window_id: usize,
+        target_direction: SplitDirection,
+        delta: f32,
+    ) -> bool {
+        match self {
+            Self::Leaf { .. } => false,
+            Self::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
+                let in_first = first.contains_window(window_id);
+                let in_second = second.contains_window(window_id);
+
+                if !in_first && !in_second {
+                    // Window not in this subtree, search children
+                    return first.adjust_ratio_in_direction(window_id, target_direction, delta)
+                        || second.adjust_ratio_in_direction(window_id, target_direction, delta);
+                }
+
+                // Window is in this split - try children first (innermost matching split)
+                let found_in_child = if in_first {
+                    first.adjust_ratio_in_direction(window_id, target_direction, delta)
+                } else {
+                    second.adjust_ratio_in_direction(window_id, target_direction, delta)
+                };
+
+                if found_in_child {
+                    return true;
+                }
+
+                // No matching split in children, check if this split matches
+                if *direction == target_direction {
+                    let adjustment = if in_first { delta } else { -delta };
+                    *ratio = (*ratio + adjustment).clamp(0.1, 0.9);
+                    return true;
+                }
+
+                false
+            }
+        }
+    }
+
     pub fn equalize(&mut self) {
         if let Self::Split {
             ratio,

--- a/lib/core/src/screen/tab.rs
+++ b/lib/core/src/screen/tab.rs
@@ -86,6 +86,12 @@ impl TabPage {
     pub fn adjust_ratio(&mut self, delta: f32) {
         self.root.adjust_ratio(self.active_window_id, delta);
     }
+
+    /// Adjust ratio of splits matching a specific direction for the active window
+    pub fn adjust_ratio_in_direction(&mut self, target_direction: SplitDirection, delta: f32) {
+        self.root
+            .adjust_ratio_in_direction(self.active_window_id, target_direction, delta);
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Implement direction-specific window resizing and clean up redundant WindowAction::MoveDirection variant.

Window Resize:
- Add SplitNode::adjust_ratio_in_direction() to find innermost split matching the specified direction and adjust its ratio
- Add TabPage::adjust_ratio_in_direction() delegate method
- Add Screen::resize_window(direction, delta) public API
- Implement WindowAction::Resize handler (5% ratio per delta unit)
- Vertical direction adjusts width, Horizontal adjusts height

MoveDirection Removal:
- Remove WindowAction::MoveDirection enum variant (was unimplemented)
- Update 8 move commands to use SwapDirection instead:
  - WindowMoveLeft/Down/Up/Right commands
  - WindowModeMoveLeft/Down/Up/Right commands
- Move and swap operations now have consistent behavior

Closes #54