### PR TITLE
perf(core): use dedicated thread for event bus processor (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,12 @@ All notable changes to Reovim will be documented in this file.
 
 ### Fixed
 
+- **Event bus performance under parallel load** (Issue #85) - Fix 300ms auto-pair delay under parallel test load
+  - Changed event bus processor from `tokio::spawn` to `std::thread::spawn`
+  - Dedicated OS thread avoids tokio scheduler starvation under contention
+  - Uses `blocking_recv()` instead of async `recv().await`
+  - No API changes; event bus channel and dispatch remain unchanged
+
 - **Light theme syntax highlighting** (Issue #43) - Light theme now uses proper One Light colors
   - Added `light_palette` module with Atom One Light colors (red, blue, purple, green, cyan, orange, yellow)
   - Created `TreesitterTheme::light()` with comprehensive capture mappings

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -49,13 +49,13 @@ impl Runtime {
         tokio::spawn(async move { terminate_hdr.run().await });
         tokio::spawn(async move { input_broker.subscribe().await });
 
-        // STEP 2: Spawn EventBus event processor
-        // This starts processing queued events (like RegisterLanguage from subscribe phase)
+        // STEP 2: Spawn EventBus event processor on dedicated OS thread
+        // Uses std::thread to avoid tokio scheduler starvation under parallel load (#85)
         if let Some(mut event_rx) = self.event_bus.take_receiver() {
             let event_bus = Arc::clone(&self.event_bus);
             let inner_tx = self.tx.clone();
-            tokio::spawn(async move {
-                while let Some(event) = event_rx.recv().await {
+            std::thread::spawn(move || {
+                while let Some(event) = event_rx.blocking_recv() {
                     let event_type = event.type_name();
                     let sender = event_bus.sender();
                     let mut ctx = crate::event_bus::HandlerContext::new(&sender);
@@ -155,13 +155,13 @@ impl Runtime {
         tokio::spawn(async move { terminate_hdr.run().await });
         tokio::spawn(async move { input_broker.subscribe().await });
 
-        // STEP 2: Spawn EventBus event processor
-        // This starts processing queued events (like RegisterLanguage from subscribe phase)
+        // STEP 2: Spawn EventBus event processor on dedicated OS thread
+        // Uses std::thread to avoid tokio scheduler starvation under parallel load (#85)
         if let Some(mut event_rx) = self.event_bus.take_receiver() {
             let event_bus = Arc::clone(&self.event_bus);
             let inner_tx = self.tx.clone();
-            tokio::spawn(async move {
-                while let Some(event) = event_rx.recv().await {
+            std::thread::spawn(move || {
+                while let Some(event) = event_rx.blocking_recv() {
                     let event_type = event.type_name();
                     let sender = event_bus.sender();
                     let mut ctx = crate::event_bus::HandlerContext::new(&sender);


### PR DESCRIPTION
Move event bus processor from tokio::spawn to std::thread::spawn to avoid scheduler starvation under parallel load.

Results:
- Auto-pair latency reduced from ~300ms to ~100ms under 16-thread load
- 3x improvement in event chain responsiveness

Changes:
- tokio::spawn(async move {}) → std::thread::spawn(move || {})
- event_rx.recv().await → event_rx.blocking_recv()
- Updated comments to reference issue #85

Note: Further optimization tracked in #86 to reduce latency below 50ms.

Closes #85