### PR TITLE
feat(bench): add comprehensive event bus and treesitter benchmarks (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Event bus and treesitter initialization benchmarks** (Issue #97) - Add benchmarks to measure latency sources
+  - `event_bus/dyn_event_new` - DynEvent creation overhead (~10.6ns)
+  - `event_bus/dispatch/handlers/*` - Dispatch latency by handler count (1: ~26ns, 100: ~360ns)
+  - `event_bus/dispatch_multi_type/*` - HashMap lookup with multiple event types (~25ns)
+  - `event_bus/dispatch_priority/*` - Priority-sorted handler dispatch (~42-88ns)
+  - `event_bus/dispatch_emit/*` - Cascading event emission (0: ~25ns, 10: ~106ns)
+  - `event_bus/dispatch_consumed/*` - Early exit on consumed events (~25-27ns)
+  - `event_bus/rwlock/*` - RwLock acquisition overhead (1: ~26ns, 100: ~124ns)
+  - `event_bus/subscribe` - Handler registration time (~200ns)
+  - `event_bus/bottleneck_blocking/*` - Slow handler blocking impact (100µs-10ms)
+  - `event_bus/bottleneck_queue/*` - Queue depth behind slow handler (~1ms baseline)
+  - `event_bus/bottleneck_sequential/*` - Multiple slow handlers (accumulates linearly)
+  - `event_bus/bottleneck_comparison/*` - Fast event latency with/without slow handlers (~25ns)
+  - `treesitter/query_compile/highlights/*` - Query compilation time per language (rust: ~26ms)
+  - `treesitter/register_language/*` - Full language registration time (rust: ~35ms)
+  - `treesitter/register_all_languages` - Total startup cost (~72ms)
+  - Made `HandlerContext::new()` public for benchmark access
+
 - **Dynamic content in DisplayRegistry** (Issue #57) - Allow plugins to show contextual status line info
   - `DisplayContext` struct for render context with `PluginStateRegistry` access
   - `DynamicDisplayFn` type alias for dynamic display callbacks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "reovim-lang-toml",
  "reovim-plugin-treesitter",
  "tempfile",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/lib/core/src/event_bus/bus.rs
+++ b/lib/core/src/event_bus/bus.rs
@@ -42,8 +42,10 @@ pub struct HandlerContext<'a> {
 
 impl<'a> HandlerContext<'a> {
     /// Create a new handler context
-    #[allow(dead_code)] // Will be used by runtime integration
-    pub(crate) fn new(event_tx: &'a EventSender) -> Self {
+    ///
+    /// Typically used by the runtime event loop, but exposed for benchmarking.
+    #[must_use]
+    pub fn new(event_tx: &'a EventSender) -> Self {
         Self {
             event_tx,
             render_requested: false,

--- a/perf/PERF-0.8.0-dev-747ed0a.md
+++ b/perf/PERF-0.8.0-dev-747ed0a.md
@@ -1,0 +1,273 @@
+# Performance Benchmarks v0.8.0-dev-747ed0a
+
+> Last updated: 2026-01-08T10:39:54Z | Commit: 747ed0a | Rust: 1.94.0-nightly
+
+## Metadata
+
+```toml
+[metadata]
+version = "0.8.0-dev-747ed0a"
+commit = "747ed0a"
+date = "2026-01-08T10:39:54Z"
+rust_version = "1.94.0-nightly"
+os = "Linux 6.17.9-arch1-1"
+```
+
+## Summary
+
+| Category | Benchmarks | Avg Time |
+|----------|------------|----------|
+| complete_cycle | 1 | 53.10 µs |
+| event_bus_bottleneck_blocking | 4 | 29.03 µs |
+| event_bus_bottleneck_comparison | 2 | 26.51 ns |
+| event_bus_bottleneck_queue | 4 | 1.00 ms |
+| event_bus_bottleneck_sequential | 3 | 7.67 ms |
+| event_bus_dispatch | 7 | 118.30 ns |
+| event_bus_dispatch_consumed | 4 | 27.49 ns |
+| event_bus_dispatch_emit | 4 | 58.05 ns |
+| event_bus_dispatch_multi_type | 4 | 26.38 ns |
+| event_bus_dispatch_priority | 3 | 61.14 ns |
+| event_bus_dyn_event_new | 1 | 10.40 ns |
+| event_bus_rwlock | 4 | 68.37 ns |
+| event_bus_subscribe | 1 | 177.58 ns |
+| frame_operations | 3 | 33.33 µs |
+| large_file | 2 | 42.99 ms |
+| render_data_changelog | 5 | 117.59 µs |
+| render_data_jjjjj | 2 | 207.63 µs |
+| render_data_real | 4 | 19.59 µs |
+| render_data_syntax_overhead | 2 | 19.95 µs |
+| throughput | 1 | 24.98 µs |
+| treesitter_query_compile | 8 | 10.96 ms |
+| treesitter_register_all_languages | 1 | 78.46 ms |
+| treesitter_register_language | 4 | 14.64 ms |
+| viewport_size | 4 | 45.30 µs |
+| window_render | 4 | 19.05 µs |
+| with_highlights | 1 | 25.11 µs |
+
+## Results
+
+```toml
+[results.complete_cycle]
+full_scroll_cycle = { mean = 53.10, median = 53.07, std_dev = 0.10, unit = "µs" }
+
+[results.event_bus_bottleneck_blocking]
+block_us_100 = { mean = 100.12, median = 100.11, std_dev = 0.05, unit = "µs" }
+block_us_1000 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+block_us_10000 = { mean = 10.00, median = 10.00, std_dev = 0.00, unit = "ms" }
+block_us_5000 = { mean = 5.00, median = 5.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_bottleneck_comparison]
+fast_only = { mean = 27.71, median = 27.73, std_dev = 0.13, unit = "ns" }
+fast_with_slow_registered = { mean = 25.31, median = 24.98, std_dev = 0.75, unit = "ns" }
+
+[results.event_bus_bottleneck_queue]
+queued_events_1 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_10 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_20 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_5 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_bottleneck_sequential]
+langs_1x5000us = { mean = 5.00, median = 5.00, std_dev = 0.00, unit = "ms" }
+langs_4x2500us = { mean = 10.00, median = 10.00, std_dev = 0.00, unit = "ms" }
+langs_8x1000us = { mean = 8.00, median = 8.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_dispatch]
+handlers_0 = { mean = 8.91, median = 8.91, std_dev = 0.02, unit = "ns" }
+handlers_1 = { mean = 24.68, median = 24.69, std_dev = 0.12, unit = "ns" }
+handlers_10 = { mean = 58.76, median = 58.73, std_dev = 0.21, unit = "ns" }
+handlers_100 = { mean = 397.01, median = 397.31, std_dev = 3.46, unit = "ns" }
+handlers_20 = { mean = 85.14, median = 85.08, std_dev = 0.75, unit = "ns" }
+handlers_5 = { mean = 42.08, median = 42.01, std_dev = 0.36, unit = "ns" }
+handlers_50 = { mean = 211.52, median = 208.31, std_dev = 7.45, unit = "ns" }
+
+[results.event_bus_dispatch_consumed]
+total_handlers_10 = { mean = 27.46, median = 27.46, std_dev = 0.17, unit = "ns" }
+total_handlers_20 = { mean = 27.46, median = 27.45, std_dev = 0.16, unit = "ns" }
+total_handlers_5 = { mean = 27.44, median = 27.41, std_dev = 0.13, unit = "ns" }
+total_handlers_50 = { mean = 27.59, median = 27.59, std_dev = 0.07, unit = "ns" }
+
+[results.event_bus_dispatch_emit]
+emits_0 = { mean = 25.07, median = 25.07, std_dev = 0.14, unit = "ns" }
+emits_1 = { mean = 32.90, median = 32.43, std_dev = 1.35, unit = "ns" }
+emits_10 = { mean = 109.01, median = 109.52, std_dev = 2.19, unit = "ns" }
+emits_5 = { mean = 65.22, median = 65.35, std_dev = 1.08, unit = "ns" }
+
+[results.event_bus_dispatch_multi_type]
+event_types_1 = { mean = 27.32, median = 27.34, std_dev = 0.21, unit = "ns" }
+event_types_10 = { mean = 27.54, median = 27.32, std_dev = 1.01, unit = "ns" }
+event_types_20 = { mean = 25.27, median = 24.76, std_dev = 1.01, unit = "ns" }
+event_types_5 = { mean = 25.38, median = 24.73, std_dev = 1.18, unit = "ns" }
+
+[results.event_bus_dispatch_priority]
+handlers_10 = { mean = 59.96, median = 58.86, std_dev = 1.66, unit = "ns" }
+handlers_20 = { mean = 85.56, median = 85.53, std_dev = 0.39, unit = "ns" }
+handlers_5 = { mean = 37.90, median = 37.84, std_dev = 0.28, unit = "ns" }
+
+[results.event_bus_dyn_event_new]
+event_bus_dyn_event_new = { mean = 10.40, median = 10.53, std_dev = 0.20, unit = "ns" }
+
+[results.event_bus_rwlock]
+registered_handlers_1 = { mean = 23.09, median = 23.09, std_dev = 0.10, unit = "ns" }
+registered_handlers_10 = { mean = 35.33, median = 35.39, std_dev = 0.26, unit = "ns" }
+registered_handlers_100 = { mean = 135.56, median = 135.49, std_dev = 1.04, unit = "ns" }
+registered_handlers_50 = { mean = 79.50, median = 79.41, std_dev = 0.41, unit = "ns" }
+
+[results.event_bus_subscribe]
+event_bus_subscribe = { mean = 177.58, median = 177.69, std_dev = 0.97, unit = "ns" }
+
+[results.frame_operations]
+buffer_fill_6000_cells = { mean = 29.35, median = 29.35, std_dev = 0.11, unit = "µs" }
+flush_full_screen = { mean = 51.53, median = 51.06, std_dev = 1.32, unit = "µs" }
+flush_scroll_simulation = { mean = 19.09, median = 19.29, std_dev = 0.71, unit = "µs" }
+
+[results.large_file]
+5000_lines_20_j_presses = { mean = 1.88, median = 1.90, std_dev = 0.06, unit = "ms" }
+5000_lines_render_data = { mean = 84.10, median = 84.10, std_dev = 0.12, unit = "µs" }
+
+[results.render_data_changelog]
+scroll_pos_0 = { mean = 118.77, median = 118.39, std_dev = 0.97, unit = "µs" }
+scroll_pos_100 = { mean = 119.05, median = 118.90, std_dev = 0.98, unit = "µs" }
+scroll_pos_1000 = { mean = 108.05, median = 106.78, std_dev = 2.39, unit = "µs" }
+scroll_pos_1500 = { mean = 120.28, median = 118.85, std_dev = 3.77, unit = "µs" }
+scroll_pos_500 = { mean = 121.78, median = 121.12, std_dev = 2.30, unit = "µs" }
+
+[results.render_data_jjjjj]
+20_j_presses = { mean = 414.22, median = 415.99, std_dev = 7.48, unit = "µs" }
+50_j_presses = { mean = 1.05, median = 1.05, std_dev = 0.01, unit = "ms" }
+
+[results.render_data_real]
+scroll_pos_0 = { mean = 19.10, median = 19.12, std_dev = 0.09, unit = "µs" }
+scroll_pos_150 = { mean = 21.31, median = 21.30, std_dev = 0.03, unit = "µs" }
+scroll_pos_300 = { mean = 18.93, median = 18.93, std_dev = 0.10, unit = "µs" }
+scroll_pos_50 = { mean = 19.01, median = 19.00, std_dev = 0.10, unit = "µs" }
+
+[results.render_data_syntax_overhead]
+with_syntax = { mean = 21.03, median = 20.92, std_dev = 0.24, unit = "µs" }
+without_syntax = { mean = 18.86, median = 18.80, std_dev = 0.11, unit = "µs" }
+
+[results.throughput]
+renders_per_second = { mean = 24.98, median = 25.02, std_dev = 0.19, unit = "µs" }
+
+[results.treesitter_query_compile]
+highlights_bash = { mean = 1.97, median = 1.96, std_dev = 0.02, unit = "ms" }
+highlights_c = { mean = 2.70, median = 2.69, std_dev = 0.02, unit = "ms" }
+highlights_javascript = { mean = 3.49, median = 3.47, std_dev = 0.05, unit = "ms" }
+highlights_json = { mean = 6.85, median = 6.85, std_dev = 0.01, unit = "µs" }
+highlights_markdown = { mean = 1.03, median = 1.03, std_dev = 0.01, unit = "ms" }
+highlights_python = { mean = 3.61, median = 3.67, std_dev = 0.14, unit = "ms" }
+highlights_rust = { mean = 23.06, median = 23.04, std_dev = 0.14, unit = "ms" }
+highlights_toml = { mean = 44.96, median = 44.97, std_dev = 0.29, unit = "µs" }
+
+[results.treesitter_register_all_languages]
+treesitter_register_all_languages = { mean = 78.46, median = 79.48, std_dev = 3.44, unit = "ms" }
+
+[results.treesitter_register_language]
+c = { mean = 8.46, median = 8.12, std_dev = 0.56, unit = "ms" }
+javascript = { mean = 8.11, median = 7.99, std_dev = 0.52, unit = "ms" }
+python = { mean = 8.17, median = 8.13, std_dev = 0.13, unit = "ms" }
+rust = { mean = 33.81, median = 33.78, std_dev = 0.20, unit = "ms" }
+
+[results.viewport_size]
+height_100 = { mean = 49.76, median = 50.09, std_dev = 0.85, unit = "µs" }
+height_200 = { mean = 97.19, median = 97.66, std_dev = 4.06, unit = "µs" }
+height_24 = { mean = 10.52, median = 10.50, std_dev = 0.07, unit = "µs" }
+height_50 = { mean = 23.75, median = 22.86, std_dev = 1.31, unit = "µs" }
+
+[results.window_render]
+buffer_lines_10 = { mean = 5.02, median = 5.00, std_dev = 0.05, unit = "µs" }
+buffer_lines_100 = { mean = 24.14, median = 24.10, std_dev = 0.46, unit = "µs" }
+buffer_lines_1000 = { mean = 24.57, median = 24.38, std_dev = 0.53, unit = "µs" }
+buffer_lines_10000 = { mean = 22.47, median = 22.46, std_dev = 0.09, unit = "µs" }
+
+[results.with_highlights]
+no_highlights = { mean = 25.11, median = 24.80, std_dev = 0.73, unit = "µs" }
+
+```
+
+## Detailed Results
+
+| Benchmark | Mean | Median | Std Dev | CI (95%) |
+|-----------|------|--------|---------|----------|
+| complete_cycle/full_scroll_cycle | 53.10 µs | 53.07 µs | 0.10 µs | [53.07, 53.14] µs |
+| event_bus_bottleneck_blocking/block_us/100 | 100.12 µs | 100.11 µs | 0.05 µs | [100.11, 100.14] µs |
+| event_bus_bottleneck_blocking/block_us/1000 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_blocking/block_us/10000 | 10.00 ms | 10.00 ms | 0.00 ms | [10.00, 10.00] ms |
+| event_bus_bottleneck_blocking/block_us/5000 | 5.00 ms | 5.00 ms | 0.00 ms | [5.00, 5.00] ms |
+| event_bus_bottleneck_comparison/fast_only | 27.71 ns | 27.73 ns | 0.13 ns | [27.67, 27.76] ns |
+| event_bus_bottleneck_comparison/fast_with_slow_registered | 25.31 ns | 24.98 ns | 0.75 ns | [25.06, 25.59] ns |
+| event_bus_bottleneck_queue/queued_events/1 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/10 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/20 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/5 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_sequential/langs/1x5000us | 5.00 ms | 5.00 ms | 0.00 ms | [5.00, 5.00] ms |
+| event_bus_bottleneck_sequential/langs/4x2500us | 10.00 ms | 10.00 ms | 0.00 ms | [10.00, 10.00] ms |
+| event_bus_bottleneck_sequential/langs/8x1000us | 8.00 ms | 8.00 ms | 0.00 ms | [8.00, 8.00] ms |
+| event_bus_dispatch/handlers/0 | 8.91 ns | 8.91 ns | 0.02 ns | [8.91, 8.92] ns |
+| event_bus_dispatch/handlers/1 | 24.68 ns | 24.69 ns | 0.12 ns | [24.63, 24.72] ns |
+| event_bus_dispatch/handlers/10 | 58.76 ns | 58.73 ns | 0.21 ns | [58.69, 58.83] ns |
+| event_bus_dispatch/handlers/100 | 397.01 ns | 397.31 ns | 3.46 ns | [395.85, 398.30] ns |
+| event_bus_dispatch/handlers/20 | 85.14 ns | 85.08 ns | 0.75 ns | [84.91, 85.43] ns |
+| event_bus_dispatch/handlers/5 | 42.08 ns | 42.01 ns | 0.36 ns | [41.96, 42.21] ns |
+| event_bus_dispatch/handlers/50 | 211.52 ns | 208.31 ns | 7.45 ns | [209.11, 214.35] ns |
+| event_bus_dispatch_consumed/total_handlers/10 | 27.46 ns | 27.46 ns | 0.17 ns | [27.39, 27.51] ns |
+| event_bus_dispatch_consumed/total_handlers/20 | 27.46 ns | 27.45 ns | 0.16 ns | [27.41, 27.52] ns |
+| event_bus_dispatch_consumed/total_handlers/5 | 27.44 ns | 27.41 ns | 0.13 ns | [27.40, 27.48] ns |
+| event_bus_dispatch_consumed/total_handlers/50 | 27.59 ns | 27.59 ns | 0.07 ns | [27.56, 27.61] ns |
+| event_bus_dispatch_emit/emits/0 | 25.07 ns | 25.07 ns | 0.14 ns | [25.02, 25.11] ns |
+| event_bus_dispatch_emit/emits/1 | 32.90 ns | 32.43 ns | 1.35 ns | [32.49, 33.42] ns |
+| event_bus_dispatch_emit/emits/10 | 109.01 ns | 109.52 ns | 2.19 ns | [108.30, 109.83] ns |
+| event_bus_dispatch_emit/emits/5 | 65.22 ns | 65.35 ns | 1.08 ns | [64.80, 65.56] ns |
+| event_bus_dispatch_multi_type/event_types/1 | 27.32 ns | 27.34 ns | 0.21 ns | [27.24, 27.39] ns |
+| event_bus_dispatch_multi_type/event_types/10 | 27.54 ns | 27.32 ns | 1.01 ns | [27.28, 27.95] ns |
+| event_bus_dispatch_multi_type/event_types/20 | 25.27 ns | 24.76 ns | 1.01 ns | [24.93, 25.64] ns |
+| event_bus_dispatch_multi_type/event_types/5 | 25.38 ns | 24.73 ns | 1.18 ns | [24.98, 25.81] ns |
+| event_bus_dispatch_priority/handlers/10 | 59.96 ns | 58.86 ns | 1.66 ns | [59.40, 60.57] ns |
+| event_bus_dispatch_priority/handlers/20 | 85.56 ns | 85.53 ns | 0.39 ns | [85.42, 85.70] ns |
+| event_bus_dispatch_priority/handlers/5 | 37.90 ns | 37.84 ns | 0.28 ns | [37.81, 38.00] ns |
+| event_bus_dyn_event_new | 10.40 ns | 10.53 ns | 0.20 ns | [10.33, 10.47] ns |
+| event_bus_rwlock/registered_handlers/1 | 23.09 ns | 23.09 ns | 0.10 ns | [23.05, 23.13] ns |
+| event_bus_rwlock/registered_handlers/10 | 35.33 ns | 35.39 ns | 0.26 ns | [35.23, 35.41] ns |
+| event_bus_rwlock/registered_handlers/100 | 135.56 ns | 135.49 ns | 1.04 ns | [135.15, 135.87] ns |
+| event_bus_rwlock/registered_handlers/50 | 79.50 ns | 79.41 ns | 0.41 ns | [79.37, 79.66] ns |
+| event_bus_subscribe | 177.58 ns | 177.69 ns | 0.97 ns | [177.24, 177.92] ns |
+| frame_operations/buffer_fill_6000_cells | 29.35 µs | 29.35 µs | 0.11 µs | [29.32, 29.39] µs |
+| frame_operations/flush_full_screen | 51.53 µs | 51.06 µs | 1.32 µs | [51.12, 52.04] µs |
+| frame_operations/flush_scroll_simulation | 19.09 µs | 19.29 µs | 0.71 µs | [18.83, 19.33] µs |
+| large_file/5000_lines_20_j_presses | 1.88 ms | 1.90 ms | 0.06 ms | [1.86, 1.90] ms |
+| large_file/5000_lines_render_data | 84.10 µs | 84.10 µs | 0.12 µs | [84.05, 84.14] µs |
+| render_data_changelog/scroll_pos/0 | 118.77 µs | 118.39 µs | 0.97 µs | [118.43, 119.12] µs |
+| render_data_changelog/scroll_pos/100 | 119.05 µs | 118.90 µs | 0.98 µs | [118.72, 119.41] µs |
+| render_data_changelog/scroll_pos/1000 | 108.05 µs | 106.78 µs | 2.39 µs | [107.26, 108.94] µs |
+| render_data_changelog/scroll_pos/1500 | 120.28 µs | 118.85 µs | 3.77 µs | [119.12, 121.74] µs |
+| render_data_changelog/scroll_pos/500 | 121.78 µs | 121.12 µs | 2.30 µs | [121.02, 122.63] µs |
+| render_data_jjjjj/20_j_presses | 414.22 µs | 415.99 µs | 7.48 µs | [411.17, 416.31] µs |
+| render_data_jjjjj/50_j_presses | 1.05 ms | 1.05 ms | 0.01 ms | [1.05, 1.05] ms |
+| render_data_real/scroll_pos/0 | 19.10 µs | 19.12 µs | 0.09 µs | [19.07, 19.14] µs |
+| render_data_real/scroll_pos/150 | 21.31 µs | 21.30 µs | 0.03 µs | [21.30, 21.32] µs |
+| render_data_real/scroll_pos/300 | 18.93 µs | 18.93 µs | 0.10 µs | [18.90, 18.97] µs |
+| render_data_real/scroll_pos/50 | 19.01 µs | 19.00 µs | 0.10 µs | [18.98, 19.05] µs |
+| render_data_syntax_overhead/with_syntax | 21.03 µs | 20.92 µs | 0.24 µs | [20.95, 21.12] µs |
+| render_data_syntax_overhead/without_syntax | 18.86 µs | 18.80 µs | 0.11 µs | [18.82, 18.90] µs |
+| throughput/renders_per_second | 24.98 µs | 25.02 µs | 0.19 µs | [24.92, 25.05] µs |
+| treesitter_query_compile/highlights/bash | 1.97 ms | 1.96 ms | 0.02 ms | [1.96, 1.98] ms |
+| treesitter_query_compile/highlights/c | 2.70 ms | 2.69 ms | 0.02 ms | [2.69, 2.70] ms |
+| treesitter_query_compile/highlights/javascript | 3.49 ms | 3.47 ms | 0.05 ms | [3.47, 3.51] ms |
+| treesitter_query_compile/highlights/json | 6.85 µs | 6.85 µs | 0.01 µs | [6.85, 6.86] µs |
+| treesitter_query_compile/highlights/markdown | 1.03 ms | 1.03 ms | 0.01 ms | [1.03, 1.03] ms |
+| treesitter_query_compile/highlights/python | 3.61 ms | 3.67 ms | 0.14 ms | [3.56, 3.65] ms |
+| treesitter_query_compile/highlights/rust | 23.06 ms | 23.04 ms | 0.14 ms | [23.01, 23.11] ms |
+| treesitter_query_compile/highlights/toml | 44.96 µs | 44.97 µs | 0.29 µs | [44.86, 45.06] µs |
+| treesitter_register_all_languages | 78.46 ms | 79.48 ms | 3.44 ms | [77.17, 79.60] ms |
+| treesitter_register_language/c | 8.46 ms | 8.12 ms | 0.56 ms | [8.27, 8.66] ms |
+| treesitter_register_language/javascript | 8.11 ms | 7.99 ms | 0.52 ms | [7.93, 8.30] ms |
+| treesitter_register_language/python | 8.17 ms | 8.13 ms | 0.13 ms | [8.13, 8.22] ms |
+| treesitter_register_language/rust | 33.81 ms | 33.78 ms | 0.20 ms | [33.74, 33.88] ms |
+| viewport_size/height/100 | 49.76 µs | 50.09 µs | 0.85 µs | [49.42, 50.01] µs |
+| viewport_size/height/200 | 97.19 µs | 97.66 µs | 4.06 µs | [95.77, 98.65] µs |
+| viewport_size/height/24 | 10.52 µs | 10.50 µs | 0.07 µs | [10.50, 10.54] µs |
+| viewport_size/height/50 | 23.75 µs | 22.86 µs | 1.31 µs | [23.30, 24.21] µs |
+| window_render/buffer_lines/10 | 5.02 µs | 5.00 µs | 0.05 µs | [5.00, 5.04] µs |
+| window_render/buffer_lines/100 | 24.14 µs | 24.10 µs | 0.46 µs | [24.02, 24.33] µs |
+| window_render/buffer_lines/1000 | 24.57 µs | 24.38 µs | 0.53 µs | [24.41, 24.78] µs |
+| window_render/buffer_lines/10000 | 22.47 µs | 22.46 µs | 0.09 µs | [22.44, 22.51] µs |
+| with_highlights/no_highlights | 25.11 µs | 24.80 µs | 0.73 µs | [24.87, 25.39] µs |

--- a/tools/bench/Cargo.toml
+++ b/tools/bench/Cargo.toml
@@ -17,6 +17,7 @@ reovim-lang-python = { path = "../../plugins/languages/python" }
 reovim-lang-json = { path = "../../plugins/languages/json" }
 reovim-lang-toml = { path = "../../plugins/languages/toml" }
 reovim-lang-bash = { path = "../../plugins/languages/bash" }
+tree-sitter = "0.26"
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 

--- a/tools/bench/benches/bench_modules/event_bus.rs
+++ b/tools/bench/benches/bench_modules/event_bus.rs
@@ -1,0 +1,565 @@
+//! Event bus dispatch benchmarks
+//!
+//! Measures synchronous dispatch performance and DynEvent overhead.
+//! These benchmarks help identify latency sources in the event system (Issue #86).
+
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion};
+use reovim_core::event_bus::{DynEvent, Event, EventBus, EventResult, HandlerContext};
+
+/// Test event for benchmarking
+#[derive(Debug)]
+struct BenchEvent {
+    value: u64,
+}
+
+impl Event for BenchEvent {}
+
+/// Benchmark DynEvent creation (type erasure + Box allocation)
+pub fn bench_dyn_event_creation(c: &mut Criterion) {
+    c.bench_function("event_bus/dyn_event_new", |b| {
+        b.iter(|| {
+            let event = BenchEvent { value: 42 };
+            black_box(DynEvent::new(event))
+        });
+    });
+}
+
+/// Benchmark dispatch with varying handler counts
+///
+/// Tests handler counts from 0 to 100 to understand scaling behavior.
+/// Real-world usage typically has 5-30 handlers per event type.
+pub fn bench_dispatch_handler_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/dispatch");
+
+    for handler_count in [0, 1, 5, 10, 20, 50, 100] {
+        // Setup: Create bus and register handlers
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        for _ in 0..handler_count {
+            let counter_clone = Arc::clone(&counter);
+            bus.subscribe::<BenchEvent, _>(100, move |event, _ctx| {
+                counter_clone.fetch_add(event.value, Ordering::Relaxed);
+                EventResult::Handled
+            });
+        }
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("handlers", handler_count),
+            &handler_count,
+            |b, _| {
+                b.iter(|| {
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Additional event types for multi-type benchmarks
+#[derive(Debug)]
+struct BenchEvent2 {
+    value: u64,
+}
+impl Event for BenchEvent2 {}
+
+#[derive(Debug)]
+struct BenchEvent3 {
+    value: u64,
+}
+impl Event for BenchEvent3 {}
+
+/// Benchmark dispatch with multiple event types registered
+///
+/// Tests HashMap lookup performance when multiple event types are registered.
+/// This simulates a realistic scenario where many plugins register handlers.
+pub fn bench_dispatch_many_event_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/dispatch_multi_type");
+
+    for event_type_count in [1, 5, 10, 20] {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Register handlers for the target event type
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<BenchEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        // Register handlers for other event types to fill the HashMap
+        for i in 0..event_type_count {
+            let counter_clone = Arc::clone(&counter);
+            if i % 2 == 0 {
+                bus.subscribe::<BenchEvent2, _>(100, move |event, _ctx| {
+                    counter_clone.fetch_add(event.value, Ordering::Relaxed);
+                    EventResult::Handled
+                });
+            } else {
+                bus.subscribe::<BenchEvent3, _>(100, move |event, _ctx| {
+                    counter_clone.fetch_add(event.value, Ordering::Relaxed);
+                    EventResult::Handled
+                });
+            }
+        }
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("event_types", event_type_count),
+            &event_type_count,
+            |b, _| {
+                b.iter(|| {
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark handler registration (subscribe)
+pub fn bench_handler_registration(c: &mut Criterion) {
+    c.bench_function("event_bus/subscribe", |b| {
+        b.iter(|| {
+            let bus = EventBus::new(16);
+            bus.subscribe::<BenchEvent, _>(100, |_, _| EventResult::Handled);
+            black_box(bus)
+        });
+    });
+}
+
+/// Benchmark dispatch with handlers at different priority levels
+///
+/// Tests the overhead of priority sorting during registration and dispatch.
+/// Handlers are registered with varying priorities to test sort stability.
+pub fn bench_dispatch_priority_sorted(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/dispatch_priority");
+
+    for handler_count in [5, 10, 20] {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Register handlers with varying priorities (not in order)
+        for i in 0..handler_count {
+            let counter_clone = Arc::clone(&counter);
+            // Assign priorities in reverse order to test sorting
+            let priority = (handler_count - i) as u32 * 10;
+            bus.subscribe::<BenchEvent, _>(priority, move |event, _ctx| {
+                counter_clone.fetch_add(event.value, Ordering::Relaxed);
+                EventResult::Handled
+            });
+        }
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("handlers", handler_count),
+            &handler_count,
+            |b, _| {
+                b.iter(|| {
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark dispatch where handlers emit additional events
+///
+/// Tests the latency when handlers trigger cascading events (common in plugins).
+/// This measures the overhead of ctx.emit() during dispatch.
+pub fn bench_dispatch_with_emit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/dispatch_emit");
+
+    for emit_count in [0, 1, 5, 10] {
+        let bus = EventBus::new(256);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<BenchEvent, _>(100, move |event, ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            // Emit additional events to test chaining overhead
+            for _ in 0..emit_count {
+                ctx.emit(BenchEvent2 { value: 1 });
+            }
+            EventResult::Handled
+        });
+
+        // Handler for the emitted events
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<BenchEvent2, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("emits", emit_count),
+            &emit_count,
+            |b, _| {
+                b.iter(|| {
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark RwLock acquisition overhead during dispatch
+///
+/// This measures the read lock acquisition time which is relevant for
+/// understanding contention issues in multi-threaded scenarios.
+pub fn bench_rwlock_acquisition(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/rwlock");
+
+    // Test with different numbers of registered event types
+    for type_count in [1, 10, 50, 100] {
+        let bus = EventBus::new(16);
+
+        // Register handlers for many different event types to grow the HashMap
+        for i in 0..type_count {
+            if i % 3 == 0 {
+                bus.subscribe::<BenchEvent, _>(100, |_, _| EventResult::Handled);
+            } else if i % 3 == 1 {
+                bus.subscribe::<BenchEvent2, _>(100, |_, _| EventResult::Handled);
+            } else {
+                bus.subscribe::<BenchEvent3, _>(100, |_, _| EventResult::Handled);
+            }
+        }
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("registered_handlers", type_count),
+            &type_count,
+            |b, _| {
+                b.iter(|| {
+                    // Dispatch to non-existent event type to measure pure lock overhead
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark consumed event (early exit)
+///
+/// Tests performance when a handler returns EventResult::Consumed
+/// which should stop propagation to subsequent handlers.
+pub fn bench_dispatch_consumed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/dispatch_consumed");
+
+    for handler_count in [5, 10, 20, 50] {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // First handler consumes the event
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<BenchEvent, _>(50, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Consumed // Early exit
+        });
+
+        // These handlers should never be called
+        for _ in 1..handler_count {
+            let counter_clone = Arc::clone(&counter);
+            bus.subscribe::<BenchEvent, _>(100, move |event, _ctx| {
+                counter_clone.fetch_add(event.value, Ordering::Relaxed);
+                EventResult::Handled
+            });
+        }
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("total_handlers", handler_count),
+            &handler_count,
+            |b, _| {
+                b.iter(|| {
+                    let event = DynEvent::new(BenchEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&event, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// =============================================================================
+// BOTTLENECK SIMULATION BENCHMARKS
+// =============================================================================
+// These benchmarks simulate the actual bottleneck scenario where a slow handler
+// (like tree-sitter query compilation) blocks subsequent event dispatch.
+
+/// Event type that represents a "fast" event (like auto-pair's RequestInsertText)
+#[derive(Debug)]
+struct FastEvent {
+    value: u64,
+}
+impl Event for FastEvent {}
+
+/// Event type that triggers slow processing (like RegisterLanguage)
+#[derive(Debug)]
+struct SlowEvent {
+    work_duration_us: u64,
+}
+impl Event for SlowEvent {}
+
+/// Simulates CPU-intensive work (like Query::new())
+#[inline(never)]
+fn simulate_cpu_work(duration_us: u64) {
+    let start = std::time::Instant::now();
+    let target = Duration::from_micros(duration_us);
+    // Busy-wait to simulate CPU work (more accurate than sleep for short durations)
+    while start.elapsed() < target {
+        black_box(0u64.wrapping_add(1));
+    }
+}
+
+/// Benchmark: Slow handler blocks fast event dispatch
+///
+/// This simulates the real bottleneck: a RegisterLanguage handler doing
+/// query compilation blocks BufferModified events from being processed.
+pub fn bench_blocking_handler(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/bottleneck_blocking");
+    group.measurement_time(Duration::from_secs(3));
+
+    // Test with different blocking durations (in microseconds)
+    // Real tree-sitter: rust=26ms, c=2.8ms, etc.
+    for block_us in [100, 1000, 5000, 10000] {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Slow handler that blocks (simulates query compilation)
+        bus.subscribe::<SlowEvent, _>(50, move |event, _ctx| {
+            simulate_cpu_work(event.work_duration_us);
+            EventResult::Handled
+        });
+
+        // Fast handler (simulates auto-pair)
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<FastEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("block_us", block_us),
+            &block_us,
+            |b, &block_us| {
+                b.iter(|| {
+                    // First dispatch the slow event (blocks the bus)
+                    let slow = DynEvent::new(SlowEvent {
+                        work_duration_us: block_us,
+                    });
+                    let mut ctx = HandlerContext::new(&sender);
+                    bus.dispatch(&slow, &mut ctx);
+
+                    // Then dispatch the fast event (should be fast after blocking)
+                    let fast = DynEvent::new(FastEvent { value: 1 });
+                    let mut ctx = HandlerContext::new(&sender);
+                    black_box(bus.dispatch(&fast, &mut ctx))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Queue depth impact on latency
+///
+/// Simulates multiple events queued behind a slow handler.
+/// This is what happens when user types while languages are registering.
+pub fn bench_queue_behind_slow_handler(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/bottleneck_queue");
+    group.measurement_time(Duration::from_secs(3));
+
+    // Number of fast events queued behind slow event
+    for queue_depth in [1, 5, 10, 20] {
+        let bus = EventBus::new(256);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Slow handler (simulates 1ms query compilation)
+        bus.subscribe::<SlowEvent, _>(50, move |event, _ctx| {
+            simulate_cpu_work(event.work_duration_us);
+            EventResult::Handled
+        });
+
+        // Fast handler
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<FastEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        group.bench_with_input(
+            BenchmarkId::new("queued_events", queue_depth),
+            &queue_depth,
+            |b, &queue_depth| {
+                b.iter(|| {
+                    // Dispatch slow event first
+                    let slow = DynEvent::new(SlowEvent {
+                        work_duration_us: 1000, // 1ms
+                    });
+                    let mut ctx = HandlerContext::new(&sender);
+                    bus.dispatch(&slow, &mut ctx);
+
+                    // Dispatch multiple fast events (queued behind slow)
+                    for i in 0..queue_depth {
+                        let fast = DynEvent::new(FastEvent { value: i as u64 });
+                        let mut ctx = HandlerContext::new(&sender);
+                        bus.dispatch(&fast, &mut ctx);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Multiple slow handlers in sequence
+///
+/// Simulates what happens when multiple languages register at startup.
+/// Each language's query compilation adds to the total blocking time.
+pub fn bench_sequential_slow_handlers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/bottleneck_sequential");
+    group.measurement_time(Duration::from_secs(5));
+
+    // Simulates registering N languages, each taking some time
+    for (lang_count, per_lang_us) in [(1, 5000), (4, 2500), (8, 1000)] {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Slow handler
+        bus.subscribe::<SlowEvent, _>(50, move |event, _ctx| {
+            simulate_cpu_work(event.work_duration_us);
+            EventResult::Handled
+        });
+
+        // Fast handler
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<FastEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+        let label = format!("{}x{}us", lang_count, per_lang_us);
+
+        group.bench_with_input(BenchmarkId::new("langs", label), &(), |b, _| {
+            b.iter(|| {
+                // Register N languages (each blocks)
+                for _ in 0..lang_count {
+                    let slow = DynEvent::new(SlowEvent {
+                        work_duration_us: per_lang_us,
+                    });
+                    let mut ctx = HandlerContext::new(&sender);
+                    bus.dispatch(&slow, &mut ctx);
+                }
+
+                // Then dispatch the fast event
+                let fast = DynEvent::new(FastEvent { value: 1 });
+                let mut ctx = HandlerContext::new(&sender);
+                black_box(bus.dispatch(&fast, &mut ctx))
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark: Fast event latency WITH vs WITHOUT blocking
+///
+/// Directly measures the latency difference when a slow handler is present.
+/// This quantifies the impact of the bottleneck.
+pub fn bench_latency_with_without_blocking(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_bus/bottleneck_comparison");
+
+    // WITHOUT blocking - baseline fast event dispatch
+    {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<FastEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        group.bench_function("fast_only", |b| {
+            b.iter(|| {
+                let fast = DynEvent::new(FastEvent { value: 1 });
+                let mut ctx = HandlerContext::new(&sender);
+                black_box(bus.dispatch(&fast, &mut ctx))
+            });
+        });
+    }
+
+    // WITH blocking - slow handler registered (but not triggered)
+    {
+        let bus = EventBus::new(16);
+        let counter = Arc::new(AtomicU64::new(0));
+
+        // Register slow handler (exists but not called in this benchmark)
+        bus.subscribe::<SlowEvent, _>(50, move |event, _ctx| {
+            simulate_cpu_work(event.work_duration_us);
+            EventResult::Handled
+        });
+
+        let counter_clone = Arc::clone(&counter);
+        bus.subscribe::<FastEvent, _>(100, move |event, _ctx| {
+            counter_clone.fetch_add(event.value, Ordering::Relaxed);
+            EventResult::Handled
+        });
+
+        let sender = bus.sender();
+
+        group.bench_function("fast_with_slow_registered", |b| {
+            b.iter(|| {
+                let fast = DynEvent::new(FastEvent { value: 1 });
+                let mut ctx = HandlerContext::new(&sender);
+                black_box(bus.dispatch(&fast, &mut ctx))
+            });
+        });
+    }
+
+    group.finish();
+}

--- a/tools/bench/benches/bench_modules/mod.rs
+++ b/tools/bench/benches/bench_modules/mod.rs
@@ -1,5 +1,7 @@
-//! Render benchmark modules
+//! Benchmark modules
 
 pub mod common;
+pub mod event_bus;
 pub mod render_pipeline;
+pub mod treesitter_init;
 pub mod window;

--- a/tools/bench/benches/bench_modules/treesitter_init.rs
+++ b/tools/bench/benches/bench_modules/treesitter_init.rs
@@ -1,0 +1,110 @@
+//! Treesitter initialization benchmarks
+//!
+//! Measures query compilation time - the main bottleneck identified in #86.
+//! Tree-sitter query compilation during language registration blocks the event bus,
+//! causing auto-pair latency of ~100ms+ when opening files.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion};
+use reovim_plugin_treesitter::{LanguageSupport, TreesitterManager};
+use tree_sitter::Query;
+
+/// Benchmark pure query compilation (bypassing cache)
+/// This is the actual bottleneck - tree_sitter::Query::new()
+pub fn bench_query_compilation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("treesitter/query_compile");
+
+    // Define languages with their highlight query sizes
+    let languages: Vec<(&str, Box<dyn LanguageSupport + Send + Sync>)> = vec![
+        ("rust", Box::new(reovim_lang_rust::RustLanguage)),
+        ("c", Box::new(reovim_lang_c::CLanguage)),
+        (
+            "javascript",
+            Box::new(reovim_lang_javascript::JavaScriptLanguage),
+        ),
+        ("python", Box::new(reovim_lang_python::PythonLanguage)),
+        ("bash", Box::new(reovim_lang_bash::BashLanguage)),
+        ("json", Box::new(reovim_lang_json::JsonLanguage)),
+        ("toml", Box::new(reovim_lang_toml::TomlLanguage)),
+        (
+            "markdown",
+            Box::new(reovim_lang_markdown::MarkdownLanguage),
+        ),
+    ];
+
+    for (name, lang) in &languages {
+        let ts_lang = lang.tree_sitter_language();
+        let query_src = lang.highlights_query();
+
+        group.bench_with_input(BenchmarkId::new("highlights", name), &(), |b, _| {
+            b.iter(|| {
+                // Direct Query::new - bypasses cache, measures pure compilation
+                let query = Query::new(black_box(&ts_lang), black_box(query_src));
+                black_box(query)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark full language registration (all query types)
+pub fn bench_language_registration(c: &mut Criterion) {
+    let mut group = c.benchmark_group("treesitter/register_language");
+
+    // Test individual language registration
+    group.bench_function("rust", |b| {
+        b.iter(|| {
+            let mut manager = TreesitterManager::new();
+            manager.register_language(Arc::new(reovim_lang_rust::RustLanguage));
+            black_box(manager)
+        });
+    });
+
+    group.bench_function("c", |b| {
+        b.iter(|| {
+            let mut manager = TreesitterManager::new();
+            manager.register_language(Arc::new(reovim_lang_c::CLanguage));
+            black_box(manager)
+        });
+    });
+
+    group.bench_function("javascript", |b| {
+        b.iter(|| {
+            let mut manager = TreesitterManager::new();
+            manager.register_language(Arc::new(reovim_lang_javascript::JavaScriptLanguage));
+            black_box(manager)
+        });
+    });
+
+    group.bench_function("python", |b| {
+        b.iter(|| {
+            let mut manager = TreesitterManager::new();
+            manager.register_language(Arc::new(reovim_lang_python::PythonLanguage));
+            black_box(manager)
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark total startup time - all languages
+pub fn bench_all_languages_registration(c: &mut Criterion) {
+    c.bench_function("treesitter/register_all_languages", |b| {
+        b.iter(|| {
+            let mut manager = TreesitterManager::new();
+            manager.register_language(Arc::new(reovim_lang_rust::RustLanguage));
+            manager.register_language(Arc::new(reovim_lang_c::CLanguage));
+            manager.register_language(Arc::new(reovim_lang_javascript::JavaScriptLanguage));
+            manager.register_language(Arc::new(reovim_lang_python::PythonLanguage));
+            manager.register_language(Arc::new(reovim_lang_json::JsonLanguage));
+            manager.register_language(Arc::new(reovim_lang_toml::TomlLanguage));
+            manager.register_language(Arc::new(reovim_lang_bash::BashLanguage));
+            manager.register_language(Arc::new(reovim_lang_markdown::MarkdownLanguage));
+            manager.register_language(Arc::new(reovim_lang_markdown::MarkdownInlineLanguage));
+            black_box(manager)
+        });
+    });
+}

--- a/tools/bench/benches/render.rs
+++ b/tools/bench/benches/render.rs
@@ -1,23 +1,36 @@
-//! Render performance benchmarks for reovim
+//! Performance benchmarks for reovim
 //!
 //! Run with: `cargo bench -p reovim-bench`
 //!
 //! Benchmark groups:
 //! - window_*: `Window::render()` benchmarks (no syntax)
 //! - render_data_*: Real render pipeline benchmarks (RenderData::from_buffer with syntax)
+//! - event_bus_*: Event bus dispatch latency benchmarks (Issue #86)
+//! - treesitter_*: Query compilation time benchmarks (Issue #86)
 
 mod bench_modules;
 
 use {criterion::Criterion, std::time::Duration};
 
-use bench_modules::window::{
-    bench_render_throughput, bench_window_render, bench_window_viewport_size,
-    bench_window_with_highlights,
+use bench_modules::event_bus::{
+    bench_blocking_handler, bench_dispatch_consumed, bench_dispatch_handler_count,
+    bench_dispatch_many_event_types, bench_dispatch_priority_sorted, bench_dispatch_with_emit,
+    bench_dyn_event_creation, bench_handler_registration, bench_latency_with_without_blocking,
+    bench_queue_behind_slow_handler, bench_rwlock_acquisition, bench_sequential_slow_handlers,
 };
 
 use bench_modules::render_pipeline::{
     bench_complete_cycle, bench_frame_operations, bench_large_file, bench_render_data_changelog,
     bench_render_data_jjjjj, bench_render_data_markdown, bench_render_data_syntax_overhead,
+};
+
+use bench_modules::treesitter_init::{
+    bench_all_languages_registration, bench_language_registration, bench_query_compilation,
+};
+
+use bench_modules::window::{
+    bench_render_throughput, bench_window_render, bench_window_viewport_size,
+    bench_window_with_highlights,
 };
 
 fn window_benches(c: &mut Criterion) {
@@ -37,6 +50,37 @@ fn render_pipeline_benches(c: &mut Criterion) {
     bench_complete_cycle(c);
 }
 
+fn event_bus_benches(c: &mut Criterion) {
+    bench_dyn_event_creation(c);
+    bench_dispatch_handler_count(c);
+    bench_dispatch_many_event_types(c);
+    bench_dispatch_priority_sorted(c);
+    bench_dispatch_with_emit(c);
+    bench_dispatch_consumed(c);
+    bench_rwlock_acquisition(c);
+    bench_handler_registration(c);
+}
+
+/// Bottleneck simulation benchmarks
+///
+/// These benchmarks simulate the actual issue (#86) where slow handlers
+/// block fast event dispatch. Use these to verify improvements from:
+/// - Issue #93: Lazy query compilation
+/// - Issue #94: Background query compilation
+/// - Issue #95: Priority event channel
+fn bottleneck_benches(c: &mut Criterion) {
+    bench_blocking_handler(c);
+    bench_queue_behind_slow_handler(c);
+    bench_sequential_slow_handlers(c);
+    bench_latency_with_without_blocking(c);
+}
+
+fn treesitter_init_benches(c: &mut Criterion) {
+    bench_query_compilation(c);
+    bench_language_registration(c);
+    bench_all_languages_registration(c);
+}
+
 fn main() {
     let mut criterion = Criterion::default()
         .measurement_time(Duration::from_secs(1))
@@ -46,6 +90,9 @@ fn main() {
 
     window_benches(&mut criterion);
     render_pipeline_benches(&mut criterion);
+    event_bus_benches(&mut criterion);
+    treesitter_init_benches(&mut criterion);
+    bottleneck_benches(&mut criterion);
 
     criterion.final_summary();
 }

--- a/tools/perf-report/src/main.rs
+++ b/tools/perf-report/src/main.rs
@@ -338,7 +338,7 @@ fn cmd_bench(cli: &Cli, version: &str, no_clean: bool) -> Result<(), Box<dyn std
     // Step 2: Run benchmarks
     println!("Running benchmarks...\n");
     let status = Command::new("cargo")
-        .args(["bench", "-p", "reovim-core"])
+        .args(["bench", "-p", "reovim-bench"])
         .status()?;
 
     if !status.success() {
@@ -359,7 +359,7 @@ fn cmd_update(cli: &Cli, version: &str) -> Result<(), Box<dyn std::error::Error>
     let results = read_criterion_results(&cli.criterion_dir);
 
     if results.is_empty() {
-        eprintln!("No benchmark results found. Run `cargo bench -p reovim-core` first.");
+        eprintln!("No benchmark results found. Run `cargo bench -p reovim-bench` first.");
         std::process::exit(1);
     }
 


### PR DESCRIPTION
## Summary
- Add comprehensive event bus dispatch benchmarks
- Add treesitter query compilation benchmarks
- Add bottleneck simulation benchmarks for verifying future improvements
- Generate baseline performance report (PERF-0.8.0-dev-747ed0a.md)

## Key Findings

| Component | Latency | Verdict |
|-----------|---------|---------|
| Event bus dispatch (1 handler) | 25ns | ✅ NOT bottleneck |
| Event bus dispatch (100 handlers) | 397ns | ✅ NOT bottleneck |
| Treesitter register all languages | **78ms** | ❌ **THE bottleneck** |

## Benchmarks Added

### Event Bus (12 benchmark groups)
- `event_bus/dispatch/handlers/*` - Dispatch with 0-100 handlers
- `event_bus/dispatch_multi_type/*` - HashMap lookup with multiple event types
- `event_bus/dispatch_priority/*` - Priority-sorted handler dispatch
- `event_bus/dispatch_emit/*` - Cascading event emission
- `event_bus/dispatch_consumed/*` - Early exit on consumed events
- `event_bus/rwlock/*` - RwLock acquisition overhead

### Bottleneck Simulation (4 groups)
- `event_bus/bottleneck_blocking/*` - Slow handler blocking impact
- `event_bus/bottleneck_queue/*` - Queue depth behind slow handler
- `event_bus/bottleneck_sequential/*` - Multiple slow handlers
- `event_bus/bottleneck_comparison/*` - Fast event baseline

### Treesitter (3 groups)
- `treesitter/query_compile/highlights/*` - Per-language query compilation
- `treesitter/register_language/*` - Full language registration
- `treesitter/register_all_languages` - Total startup cost (~78ms)

## How to Verify Future Improvements

```bash
# After lazy compilation (#93)
cargo bench -p reovim-bench -- "treesitter/register_all"
# Expected: ~78ms → <1ms

# After background compilation (#94) or priority channel (#95)
cargo bench -p reovim-bench -- "bottleneck"
# Expected: fast events not delayed by slow handlers

# Full comparison
cargo bench -p reovim-bench -- "event_bus|treesitter"

Closes #97