### PR TITLE
refactor(event): rename InnerEvent to RuntimeEvent with scope support(#101)

### DIFF
--- a/lib/core/src/animation/controller.rs
+++ b/lib/core/src/animation/controller.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use tokio::sync::{RwLock, mpsc};
 
-use crate::event::InnerEvent;
+use crate::event::RuntimeEvent;
 
 use super::effect::{Effect, EffectId, EffectTarget};
 
@@ -192,7 +192,7 @@ impl AnimationController {
 /// # Returns
 /// Handle to send commands to the controller
 pub fn spawn_animation_controller(
-    event_tx: mpsc::Sender<InnerEvent>,
+    event_tx: mpsc::Sender<RuntimeEvent>,
     frame_rate: u8,
     state: Arc<RwLock<AnimationState>>,
 ) -> AnimationHandle {
@@ -248,7 +248,7 @@ pub fn spawn_animation_controller(
 
                         // Request re-render
                         tracing::debug!("==> Sending RenderSignal");
-                        let _ = event_tx.try_send(InnerEvent::RenderSignal);
+                        let _ = event_tx.try_send(RuntimeEvent::render_signal());
                         tracing::debug!("==> RenderSignal sent");
                     }
                 }

--- a/lib/core/src/animation/mod.rs
+++ b/lib/core/src/animation/mod.rs
@@ -61,7 +61,7 @@ use std::sync::Arc;
 
 use tokio::sync::{RwLock, mpsc};
 
-use crate::event::InnerEvent;
+use crate::event::RuntimeEvent;
 
 pub use {
     color::AnimatedColor,
@@ -95,7 +95,7 @@ impl AnimationSystem {
     /// * `event_tx` - Channel to send `RenderSignal` events to the runtime
     /// * `frame_rate` - Animation frame rate in fps (typically 30)
     #[must_use]
-    pub fn spawn(event_tx: mpsc::Sender<InnerEvent>, frame_rate: u8) -> Self {
+    pub fn spawn(event_tx: mpsc::Sender<RuntimeEvent>, frame_rate: u8) -> Self {
         let state = Arc::new(RwLock::new(AnimationState::default()));
         let handle = spawn_animation_controller(event_tx, frame_rate, Arc::clone(&state));
 

--- a/lib/core/src/buffer/mod.rs
+++ b/lib/core/src/buffer/mod.rs
@@ -226,7 +226,7 @@ impl Buffer {
     /// * `event_tx` - Channel to send `RenderSignal` when cache is updated
     pub fn start_saturator(
         &mut self,
-        event_tx: tokio::sync::mpsc::Sender<crate::event::InnerEvent>,
+        event_tx: tokio::sync::mpsc::Sender<crate::event::RuntimeEvent>,
     ) {
         // Only start if we have something to compute
         if self.syntax.is_none() && self.decoration_provider.is_none() {

--- a/lib/core/src/buffer/saturator.rs
+++ b/lib/core/src/buffer/saturator.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     decoration::DecorationProvider,
-    event::InnerEvent,
+    event::RuntimeEvent,
     render::{Decoration, DecorationCache, DecorationKind, HighlightCache, LineHighlight},
     syntax::SyntaxProvider,
 };
@@ -61,7 +61,7 @@ pub fn spawn_saturator(
     decoration: Option<Box<dyn DecorationProvider>>,
     highlight_cache: Arc<HighlightCache>,
     decoration_cache: Arc<DecorationCache>,
-    event_tx: mpsc::Sender<InnerEvent>,
+    event_tx: mpsc::Sender<RuntimeEvent>,
 ) -> SaturatorHandle {
     // Channel with buffer of 1 - only latest request matters
     let (tx, mut rx) = mpsc::channel::<SaturatorRequest>(1);
@@ -87,7 +87,7 @@ pub fn spawn_saturator(
 
             // Signal re-render if cache was updated
             if cache_updated {
-                let _ = event_tx.send(InnerEvent::RenderSignal).await;
+                let _ = event_tx.send(RuntimeEvent::render_signal()).await;
             }
         }
     });

--- a/lib/core/src/event/handler/command/dispatcher.rs
+++ b/lib/core/src/event/handler/command/dispatcher.rs
@@ -5,7 +5,7 @@ use {
         bind::CommandRef,
         command::{CommandContext, CommandRegistry, traits::OperatorMotionAction},
         event::{
-            InnerEvent,
+            RuntimeEvent,
             inner::{CommandEvent, VisualTextObjectAction},
         },
         modd::ModeState,
@@ -16,7 +16,7 @@ use {
 
 /// Handles command dispatch and mode transitions
 pub struct Dispatcher {
-    inner_tx: Sender<InnerEvent>,
+    inner_tx: Sender<RuntimeEvent>,
     current_buffer_id: usize,
     current_window_id: usize,
     command_registry: Arc<CommandRegistry>,
@@ -25,7 +25,7 @@ pub struct Dispatcher {
 impl Dispatcher {
     #[must_use]
     pub const fn new(
-        tx: Sender<InnerEvent>,
+        tx: Sender<RuntimeEvent>,
         buffer_id: usize,
         window_id: usize,
         command_registry: Arc<CommandRegistry>,
@@ -41,7 +41,7 @@ impl Dispatcher {
     /// Get the sender for sending events
     #[must_use]
     #[allow(dead_code)]
-    pub const fn sender(&self) -> &Sender<InnerEvent> {
+    pub const fn sender(&self) -> &Sender<RuntimeEvent> {
         &self.inner_tx
     }
 
@@ -49,7 +49,7 @@ impl Dispatcher {
     pub async fn update_mode(&self, new_mode: ModeState) {
         let _ = self
             .inner_tx
-            .send(InnerEvent::ModeChangeEvent(new_mode))
+            .send(RuntimeEvent::mode_change(new_mode))
             .await;
     }
 
@@ -64,7 +64,7 @@ impl Dispatcher {
 
         let _ = self
             .inner_tx
-            .send(InnerEvent::CommandEvent(CommandEvent {
+            .send(RuntimeEvent::command(CommandEvent {
                 command: cmd.clone(),
                 context: ctx,
             }))
@@ -83,7 +83,7 @@ impl Dispatcher {
     pub async fn send_pending_keys(&self, display: String) {
         let _ = self
             .inner_tx
-            .send(InnerEvent::PendingKeysEvent(display))
+            .send(RuntimeEvent::pending_keys(display))
             .await;
     }
 
@@ -113,11 +113,11 @@ impl Dispatcher {
         };
         let _ = self
             .inner_tx
-            .send(InnerEvent::ModeChangeEvent(new_mode))
+            .send(RuntimeEvent::mode_change(new_mode))
             .await;
         let _ = self
             .inner_tx
-            .send(InnerEvent::OperatorMotionEvent(action))
+            .send(RuntimeEvent::operator_motion(action))
             .await;
     }
 
@@ -125,7 +125,7 @@ impl Dispatcher {
     pub async fn send_visual_text_object(&self, action: VisualTextObjectAction) {
         let _ = self
             .inner_tx
-            .send(InnerEvent::VisualTextObjectEvent(action))
+            .send(RuntimeEvent::visual_text_object(action))
             .await;
     }
 
@@ -133,7 +133,7 @@ impl Dispatcher {
     pub async fn send_focus_insert_char(&self, c: char) {
         let _ = self
             .inner_tx
-            .send(InnerEvent::TextInputEvent(crate::event::TextInputEvent::InsertChar(c)))
+            .send(RuntimeEvent::text_input(crate::event::TextInputEvent::InsertChar(c)))
             .await;
     }
 
@@ -141,7 +141,7 @@ impl Dispatcher {
     pub async fn send_focus_delete_backward(&self) {
         let _ = self
             .inner_tx
-            .send(InnerEvent::TextInputEvent(crate::event::TextInputEvent::DeleteCharBackward))
+            .send(RuntimeEvent::text_input(crate::event::TextInputEvent::DeleteCharBackward))
             .await;
     }
 }

--- a/lib/core/src/event/handler/command/mod.rs
+++ b/lib/core/src/event/handler/command/mod.rs
@@ -10,7 +10,7 @@ use {
     crate::{
         bind::{CommandRef, KeyMap, KeyMapInner},
         command::{CommandRegistry, traits::OperatorMotionAction},
-        event::{InnerEvent, KeyEvent, Subscribe, VisualTextObjectAction},
+        event::{KeyEvent, RuntimeEvent, Subscribe, VisualTextObjectAction},
         interactor::InteractorRegistry,
         keystroke::{KeyNotationFormat, KeySequence, Keystroke},
         modd::{ModeState, OperatorType, SubMode},
@@ -50,7 +50,7 @@ impl Subscribe<KeyEvent> for CommandHandler {
 impl CommandHandler {
     #[must_use]
     pub fn new(
-        tx: Sender<InnerEvent>,
+        tx: Sender<RuntimeEvent>,
         mode_rx: watch::Receiver<ModeState>,
         keymap: KeyMap,
         command_registry: Arc<CommandRegistry>,

--- a/lib/core/src/event/handler/mod.rs
+++ b/lib/core/src/event/handler/mod.rs
@@ -1,5 +1,5 @@
 use {
-    super::{InnerEvent, inner::BufferEvent},
+    super::{RuntimeEvent, inner::BufferEvent},
     crate::event::{KeyEvent, Subscribe, key::KeyCode},
     reovim_sys::{cursor, event::KeyModifiers},
     tokio::sync::{broadcast::Receiver, mpsc::Sender},
@@ -12,7 +12,7 @@ pub use command::CommandHandler;
 pub struct PrintEventHandler {
     pub buffer_id: usize,
     key_event_rx: Option<Receiver<KeyEvent>>,
-    buffer_tx: Sender<InnerEvent>,
+    buffer_tx: Sender<RuntimeEvent>,
 }
 
 impl Subscribe<KeyEvent> for PrintEventHandler {
@@ -24,7 +24,7 @@ impl Subscribe<KeyEvent> for PrintEventHandler {
 impl PrintEventHandler {
     #[must_use]
     #[allow(clippy::missing_const_for_fn)]
-    pub fn new(buffer_id: usize, tx: Sender<InnerEvent>) -> Self {
+    pub fn new(buffer_id: usize, tx: Sender<RuntimeEvent>) -> Self {
         Self {
             buffer_id,
             key_event_rx: None,
@@ -34,7 +34,7 @@ impl PrintEventHandler {
 
     async fn send_event(&self, content: String) {
         self.buffer_tx
-            .send(InnerEvent::BufferEvent(BufferEvent::SetContent {
+            .send(RuntimeEvent::buffer(BufferEvent::SetContent {
                 buffer_id: self.buffer_id,
                 content,
             }))
@@ -59,7 +59,7 @@ impl PrintEventHandler {
 
 pub struct TerminateHandler {
     key_event_rx: Option<Receiver<KeyEvent>>,
-    kill_tx: Sender<InnerEvent>,
+    kill_tx: Sender<RuntimeEvent>,
 }
 
 impl Subscribe<KeyEvent> for TerminateHandler {
@@ -71,7 +71,7 @@ impl Subscribe<KeyEvent> for TerminateHandler {
 impl TerminateHandler {
     #[must_use]
     #[allow(clippy::missing_const_for_fn)]
-    pub fn new(tx: Sender<InnerEvent>) -> Self {
+    pub fn new(tx: Sender<RuntimeEvent>) -> Self {
         Self {
             key_event_rx: None,
             kill_tx: tx,
@@ -80,7 +80,7 @@ impl TerminateHandler {
 
     async fn send_event(&self) {
         self.kill_tx
-            .send(InnerEvent::KillSignal)
+            .send(RuntimeEvent::kill())
             .await
             .expect("failed to send terminate signal");
     }

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -5,7 +5,7 @@ use {reovim_sys::event::KeyModifiers, tokio::sync::oneshot};
 use crate::{
     bind::CommandRef,
     command::{CommandContext, traits::OperatorMotionAction},
-    event_bus::DynEvent,
+    event_bus::{DynEvent, EventScope},
     highlight::{Highlight, HighlightGroup},
     modd::{ComponentId, ModeState},
     plugin::PluginId,
@@ -15,111 +15,506 @@ use crate::{
     textobject::{SemanticTextObjectSpec, TextObject, WordTextObject},
 };
 
-pub enum InnerEvent {
-    BufferEvent(BufferEvent),
-    WindowEvent(WindowEvent),
-    CommandEvent(CommandEvent),
-    ModeChangeEvent(ModeState),
-    PendingKeysEvent(String),
-    HighlightEvent(HighlightEvent),
-    SyntaxEvent(SyntaxEvent),
+// =============================================================================
+// RuntimeEvent - Wrapper with scope tracking (like DynEvent)
+// =============================================================================
+
+/// Runtime event with scope tracking for deterministic synchronization.
+///
+/// This wrapper carries an optional `EventScope` that tracks the lifecycle
+/// of related events, enabling callers to wait until all events in a scope
+/// (and their children) complete.
+pub struct RuntimeEvent {
+    payload: RuntimeEventPayload,
+    scope: Option<EventScope>,
+}
+
+impl RuntimeEvent {
+    /// Create a new runtime event without scope tracking.
+    #[must_use]
+    pub const fn new(payload: RuntimeEventPayload) -> Self {
+        Self {
+            payload,
+            scope: None,
+        }
+    }
+
+    /// Attach a scope to this event for lifecycle tracking.
+    #[must_use]
+    pub fn with_scope(mut self, scope: EventScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Get a reference to the scope, if any.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // as_ref() is not const-stable
+    pub fn scope(&self) -> Option<&EventScope> {
+        self.scope.as_ref()
+    }
+
+    /// Take ownership of the scope, leaving None in its place.
+    #[allow(clippy::missing_const_for_fn)] // Option::take() is not const-stable
+    pub fn take_scope(&mut self) -> Option<EventScope> {
+        self.scope.take()
+    }
+
+    /// Get a reference to the payload.
+    #[must_use]
+    pub const fn payload(&self) -> &RuntimeEventPayload {
+        &self.payload
+    }
+
+    /// Consume self and return the payload.
+    #[must_use]
+    pub fn into_payload(self) -> RuntimeEventPayload {
+        self.payload
+    }
+}
+
+// Ergonomic conversion from any type that can become RuntimeEventPayload
+impl<T: Into<RuntimeEventPayload>> From<T> for RuntimeEvent {
+    fn from(payload: T) -> Self {
+        Self::new(payload.into())
+    }
+}
+
+// =============================================================================
+// RuntimeEventPayload - The actual event data (renamed from InnerEvent)
+// =============================================================================
+
+/// The actual event data, grouped into logical categories.
+pub enum RuntimeEventPayload {
+    // Buffer operations
+    Buffer(BufferEvent),
+
+    // Window management
+    Window(WindowEvent),
+
+    // Command execution
+    Command(CommandEvent),
+
+    // Editing operations
+    Editing(EditingEvent),
+
+    // Mode changes
+    Mode(ModeEvent),
+
+    // Visual updates
+    Render(RenderEvent),
+
+    // Settings/Options
+    Settings(SettingsEvent),
+
+    // External input
+    Input(InputEvent),
+
+    // File operations
+    File(FileEvent),
+
+    // RPC request
+    Rpc(RpcEvent),
+
+    // Plugin event
+    Plugin(PluginEventData),
+
+    // Lifecycle - terminate the runtime
+    Kill,
+}
+
+// =============================================================================
+// Sub-enum: Editing operations
+// =============================================================================
+
+/// Editing-related events
+pub enum EditingEvent {
+    /// Text input event (insert char, backspace, etc.)
+    TextInput(TextInputEvent),
     /// Operator + motion action (d+motion, y+motion, c+motion)
-    OperatorMotionEvent(OperatorMotionAction),
+    OperatorMotion(OperatorMotionAction),
     /// Visual mode text object selection (viw, vi(, vif, etc.)
-    VisualTextObjectEvent(VisualTextObjectAction),
-    RenderSignal,
-    KillSignal,
-    /// Terminal screen resize event
-    ScreenResizeEvent {
-        width: u16,
-        height: u16,
-    },
-    /// RPC request from server mode
-    RpcRequest {
-        /// Request ID
-        id: u64,
-        /// Method name
-        method: String,
-        /// Method parameters
-        params: serde_json::Value,
-        /// Channel to send the response
-        response_tx: oneshot::Sender<RpcResponse>,
-    },
-    /// Text input events (delegated to text input target)
-    TextInputEvent(TextInputEvent),
-    /// Plugin-defined event (type-erased)
-    ///
-    /// This variant enables plugins to define their own event types
-    /// that are dispatched through the event bus. During migration,
-    /// this runs alongside the existing hardcoded event handlers.
-    PluginEvent {
-        /// Plugin that sent this event (for routing)
-        plugin_id: PluginId,
-        /// Type-erased event payload
-        event: DynEvent,
-    },
-    /// Request to open a file (from explorer, commands, etc.)
-    OpenFileRequest {
-        /// Path to the file to open
-        path: PathBuf,
-    },
-    /// Request to open a file at a specific position (for LSP navigation)
-    OpenFileAtPositionRequest {
-        /// Path to the file to open
-        path: PathBuf,
-        /// Line number (0-indexed)
-        line: usize,
-        /// Column number (0-indexed)
-        column: usize,
-    },
-    /// Request to set a register's content
-    SetRegister {
-        /// Register name: None for unnamed, '+' for system clipboard, 'a'-'z' for named
-        register: Option<char>,
-        /// Text content to set
-        text: String,
-    },
-    // =========================================================================
-    // Settings/Option capability events
-    // =========================================================================
-    /// Set line number visibility
-    SetLineNumbers {
-        enabled: bool,
-    },
-    /// Set relative line number visibility
-    SetRelativeLineNumbers {
-        enabled: bool,
-    },
-    /// Set color theme
-    SetTheme {
-        name: String,
-    },
-    /// Set scrollbar visibility
-    SetScrollbar {
-        enabled: bool,
-    },
-    /// Set indent guide visibility
-    SetIndentGuide {
-        enabled: bool,
-    },
-    /// Set sign column configuration
-    SetSignColumn {
-        mode: SignColumnMode,
-    },
+    VisualTextObject(VisualTextObjectAction),
     /// Move cursor to specific position (from plugins like range-finder, LSP)
     MoveCursor {
         buffer_id: usize,
         line: u32,
         column: u32,
     },
-    /// Apply completion text to command line
-    ApplyCmdlineCompletion {
+    /// Set a register's content
+    SetRegister {
+        /// Register name: None for unnamed, '+' for system clipboard, 'a'-'z' for named
+        register: Option<char>,
+        /// Text content to set
         text: String,
-        replace_start: usize,
     },
-    /// Mouse event from terminal
-    MouseEvent(MouseEvent),
 }
+
+// =============================================================================
+// Sub-enum: Mode changes
+// =============================================================================
+
+/// Mode-related events
+pub enum ModeEvent {
+    /// Mode state change
+    Change(ModeState),
+    /// Pending keys display update
+    PendingKeys(String),
+}
+
+// =============================================================================
+// Sub-enum: Render updates
+// =============================================================================
+
+/// Render-related events
+pub enum RenderEvent {
+    /// Request a render cycle
+    Signal,
+    /// Highlight update
+    Highlight(HighlightEvent),
+    /// Syntax provider update
+    Syntax(SyntaxEvent),
+}
+
+// =============================================================================
+// Sub-enum: Settings
+// =============================================================================
+
+/// Settings/option events
+pub enum SettingsEvent {
+    /// Set line number visibility
+    LineNumbers { enabled: bool },
+    /// Set relative line number visibility
+    RelativeLineNumbers { enabled: bool },
+    /// Set color theme
+    Theme { name: String },
+    /// Set scrollbar visibility
+    Scrollbar { enabled: bool },
+    /// Set indent guide visibility
+    IndentGuide { enabled: bool },
+    /// Set sign column configuration
+    SignColumn { mode: SignColumnMode },
+    /// Apply completion text to command line
+    ApplyCmdlineCompletion { text: String, replace_start: usize },
+}
+
+// =============================================================================
+// Sub-enum: Input
+// =============================================================================
+
+/// External input events
+pub enum InputEvent {
+    /// Mouse event from terminal
+    Mouse(MouseEvent),
+    /// Terminal screen resize event
+    ScreenResize { width: u16, height: u16 },
+}
+
+// =============================================================================
+// Sub-enum: File operations
+// =============================================================================
+
+/// File operation events
+pub enum FileEvent {
+    /// Request to open a file (from explorer, commands, etc.)
+    Open { path: PathBuf },
+    /// Request to open a file at a specific position (for LSP navigation)
+    OpenAt {
+        path: PathBuf,
+        /// Line number (0-indexed)
+        line: usize,
+        /// Column number (0-indexed)
+        column: usize,
+    },
+}
+
+// =============================================================================
+// Sub-struct: RPC event
+// =============================================================================
+
+/// RPC request from server mode
+pub struct RpcEvent {
+    /// Request ID
+    pub id: u64,
+    /// Method name
+    pub method: String,
+    /// Method parameters
+    pub params: serde_json::Value,
+    /// Channel to send the response
+    pub response_tx: oneshot::Sender<RpcResponse>,
+}
+
+// =============================================================================
+// Sub-struct: Plugin event
+// =============================================================================
+
+/// Plugin-defined event (type-erased)
+pub struct PluginEventData {
+    /// Plugin that sent this event (for routing)
+    pub plugin_id: PluginId,
+    /// Type-erased event payload
+    pub event: DynEvent,
+}
+
+// =============================================================================
+// From implementations for sub-enums -> RuntimeEventPayload
+// =============================================================================
+
+impl From<BufferEvent> for RuntimeEventPayload {
+    fn from(e: BufferEvent) -> Self {
+        Self::Buffer(e)
+    }
+}
+
+impl From<WindowEvent> for RuntimeEventPayload {
+    fn from(e: WindowEvent) -> Self {
+        Self::Window(e)
+    }
+}
+
+impl From<CommandEvent> for RuntimeEventPayload {
+    fn from(e: CommandEvent) -> Self {
+        Self::Command(e)
+    }
+}
+
+impl From<EditingEvent> for RuntimeEventPayload {
+    fn from(e: EditingEvent) -> Self {
+        Self::Editing(e)
+    }
+}
+
+impl From<ModeEvent> for RuntimeEventPayload {
+    fn from(e: ModeEvent) -> Self {
+        Self::Mode(e)
+    }
+}
+
+impl From<RenderEvent> for RuntimeEventPayload {
+    fn from(e: RenderEvent) -> Self {
+        Self::Render(e)
+    }
+}
+
+impl From<SettingsEvent> for RuntimeEventPayload {
+    fn from(e: SettingsEvent) -> Self {
+        Self::Settings(e)
+    }
+}
+
+impl From<InputEvent> for RuntimeEventPayload {
+    fn from(e: InputEvent) -> Self {
+        Self::Input(e)
+    }
+}
+
+impl From<FileEvent> for RuntimeEventPayload {
+    fn from(e: FileEvent) -> Self {
+        Self::File(e)
+    }
+}
+
+impl From<RpcEvent> for RuntimeEventPayload {
+    fn from(e: RpcEvent) -> Self {
+        Self::Rpc(e)
+    }
+}
+
+impl From<PluginEventData> for RuntimeEventPayload {
+    fn from(e: PluginEventData) -> Self {
+        Self::Plugin(e)
+    }
+}
+
+// =============================================================================
+// Convenience constructors on RuntimeEvent
+// =============================================================================
+
+impl RuntimeEvent {
+    /// Create a render signal event.
+    #[must_use]
+    pub fn render_signal() -> Self {
+        RuntimeEventPayload::Render(RenderEvent::Signal).into()
+    }
+
+    /// Create a kill signal event.
+    #[must_use]
+    pub fn kill() -> Self {
+        RuntimeEventPayload::Kill.into()
+    }
+
+    /// Create a mode change event.
+    #[must_use]
+    pub fn mode_change(mode: ModeState) -> Self {
+        RuntimeEventPayload::Mode(ModeEvent::Change(mode)).into()
+    }
+
+    /// Create a pending keys event.
+    #[must_use]
+    pub fn pending_keys(keys: String) -> Self {
+        RuntimeEventPayload::Mode(ModeEvent::PendingKeys(keys)).into()
+    }
+
+    /// Create a buffer event.
+    #[must_use]
+    pub fn buffer(event: BufferEvent) -> Self {
+        RuntimeEventPayload::Buffer(event).into()
+    }
+
+    /// Create a window event.
+    #[must_use]
+    pub fn window(event: WindowEvent) -> Self {
+        RuntimeEventPayload::Window(event).into()
+    }
+
+    /// Create a command event.
+    #[must_use]
+    pub fn command(event: CommandEvent) -> Self {
+        RuntimeEventPayload::Command(event).into()
+    }
+
+    /// Create a highlight event.
+    #[must_use]
+    pub fn highlight(event: HighlightEvent) -> Self {
+        RuntimeEventPayload::Render(RenderEvent::Highlight(event)).into()
+    }
+
+    /// Create a syntax event.
+    #[must_use]
+    pub fn syntax(event: SyntaxEvent) -> Self {
+        RuntimeEventPayload::Render(RenderEvent::Syntax(event)).into()
+    }
+
+    /// Create a mouse event.
+    #[must_use]
+    pub fn mouse(event: MouseEvent) -> Self {
+        RuntimeEventPayload::Input(InputEvent::Mouse(event)).into()
+    }
+
+    /// Create a screen resize event.
+    #[must_use]
+    pub fn screen_resize(width: u16, height: u16) -> Self {
+        RuntimeEventPayload::Input(InputEvent::ScreenResize { width, height }).into()
+    }
+
+    /// Create an operator motion event.
+    #[must_use]
+    pub fn operator_motion(action: OperatorMotionAction) -> Self {
+        RuntimeEventPayload::Editing(EditingEvent::OperatorMotion(action)).into()
+    }
+
+    /// Create a visual text object event.
+    #[must_use]
+    pub fn visual_text_object(action: VisualTextObjectAction) -> Self {
+        RuntimeEventPayload::Editing(EditingEvent::VisualTextObject(action)).into()
+    }
+
+    /// Create a text input event.
+    #[must_use]
+    pub fn text_input(event: TextInputEvent) -> Self {
+        RuntimeEventPayload::Editing(EditingEvent::TextInput(event)).into()
+    }
+
+    /// Create an open file request.
+    #[must_use]
+    pub fn open_file(path: PathBuf) -> Self {
+        RuntimeEventPayload::File(FileEvent::Open { path }).into()
+    }
+
+    /// Create an open file at position request.
+    #[must_use]
+    pub fn open_file_at(path: PathBuf, line: usize, column: usize) -> Self {
+        RuntimeEventPayload::File(FileEvent::OpenAt { path, line, column }).into()
+    }
+
+    /// Create a set register event.
+    #[must_use]
+    pub fn set_register(register: Option<char>, text: String) -> Self {
+        RuntimeEventPayload::Editing(EditingEvent::SetRegister { register, text }).into()
+    }
+
+    /// Create a move cursor event.
+    #[must_use]
+    pub fn move_cursor(buffer_id: usize, line: u32, column: u32) -> Self {
+        RuntimeEventPayload::Editing(EditingEvent::MoveCursor {
+            buffer_id,
+            line,
+            column,
+        })
+        .into()
+    }
+
+    /// Create a plugin event.
+    #[must_use]
+    pub fn plugin(plugin_id: PluginId, event: DynEvent) -> Self {
+        RuntimeEventPayload::Plugin(PluginEventData { plugin_id, event }).into()
+    }
+
+    /// Create an RPC request event.
+    #[must_use]
+    pub fn rpc(
+        id: u64,
+        method: String,
+        params: serde_json::Value,
+        response_tx: oneshot::Sender<RpcResponse>,
+    ) -> Self {
+        RuntimeEventPayload::Rpc(RpcEvent {
+            id,
+            method,
+            params,
+            response_tx,
+        })
+        .into()
+    }
+
+    // === Settings convenience constructors ===
+
+    /// Create a set line numbers event.
+    #[must_use]
+    pub fn set_line_numbers(enabled: bool) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::LineNumbers { enabled }).into()
+    }
+
+    /// Create a set relative line numbers event.
+    #[must_use]
+    pub fn set_relative_line_numbers(enabled: bool) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::RelativeLineNumbers { enabled }).into()
+    }
+
+    /// Create a set theme event.
+    #[must_use]
+    pub fn set_theme(name: String) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::Theme { name }).into()
+    }
+
+    /// Create a set scrollbar event.
+    #[must_use]
+    pub fn set_scrollbar(enabled: bool) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::Scrollbar { enabled }).into()
+    }
+
+    /// Create a set indent guide event.
+    #[must_use]
+    pub fn set_indent_guide(enabled: bool) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::IndentGuide { enabled }).into()
+    }
+
+    /// Create a set sign column event.
+    #[must_use]
+    pub fn set_sign_column(mode: SignColumnMode) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::SignColumn { mode }).into()
+    }
+
+    /// Create an apply command line completion event.
+    #[must_use]
+    pub fn apply_cmdline_completion(text: String, replace_start: usize) -> Self {
+        RuntimeEventPayload::Settings(SettingsEvent::ApplyCmdlineCompletion { text, replace_start })
+            .into()
+    }
+}
+
+// =============================================================================
+// Existing types (unchanged)
+// =============================================================================
 
 /// Input events routed to the active focus target
 #[derive(Debug, Clone, Copy)]

--- a/lib/core/src/event/input.rs
+++ b/lib/core/src/event/input.rs
@@ -11,7 +11,7 @@ use {
 };
 
 use crate::{
-    event::{InnerEvent, key},
+    event::{RuntimeEvent, key},
     io::input::{EventStreamKeySource, KeySource},
 };
 
@@ -47,7 +47,7 @@ impl Default for InputEventBroker<EventStreamKeySource> {
 impl InputEventBroker<EventStreamKeySource> {
     /// Create an `InputEventBroker` with an event sender for resize events.
     #[must_use]
-    pub fn with_event_sender(event_sender: mpsc::Sender<InnerEvent>) -> Self {
+    pub fn with_event_sender(event_sender: mpsc::Sender<RuntimeEvent>) -> Self {
         Self {
             delay: Duration::from_millis(DEFAULT_DELAY),
             grace_period: Duration::ZERO,

--- a/lib/core/src/event/mod.rs
+++ b/lib/core/src/event/mod.rs
@@ -9,8 +9,10 @@ mod input;
 pub use {
     handler::{CommandHandler, PrintEventHandler, TerminateHandler},
     inner::{
-        BufferEvent, CommandEvent, HighlightEvent, InnerEvent, MouseButton, MouseEvent,
-        MouseEventKind, SyntaxEvent, TextInputEvent, VisualTextObjectAction, WindowEvent,
+        BufferEvent, CommandEvent, EditingEvent, FileEvent, HighlightEvent, InputEvent, ModeEvent,
+        MouseButton, MouseEvent, MouseEventKind, PluginEventData, RenderEvent, RpcEvent,
+        RuntimeEvent, RuntimeEventPayload, SettingsEvent, SyntaxEvent, TextInputEvent,
+        VisualTextObjectAction, WindowEvent,
     },
     input::*,
 };

--- a/lib/core/src/io/input.rs
+++ b/lib/core/src/io/input.rs
@@ -11,7 +11,7 @@ use {
     tokio::sync::mpsc,
 };
 
-use crate::event::InnerEvent;
+use crate::event::RuntimeEvent;
 
 /// Trait for abstracting key event sources.
 ///
@@ -135,7 +135,7 @@ impl KeySource for ChannelKeySource {
 pub struct EventStreamKeySource {
     stream: EventStream,
     /// Optional sender for resize events
-    event_sender: Option<mpsc::Sender<InnerEvent>>,
+    event_sender: Option<mpsc::Sender<RuntimeEvent>>,
 }
 
 impl Default for EventStreamKeySource {
@@ -156,7 +156,7 @@ impl EventStreamKeySource {
 
     /// Create a new event stream key source with a resize event sender.
     #[must_use]
-    pub fn with_event_sender(event_sender: mpsc::Sender<InnerEvent>) -> Self {
+    pub fn with_event_sender(event_sender: mpsc::Sender<RuntimeEvent>) -> Self {
         Self {
             stream: EventStream::new(),
             event_sender: Some(event_sender),
@@ -183,17 +183,14 @@ impl KeySource for EventStreamKeySource {
                 Poll::Ready(Some(Ok(Event::Resize(cols, rows)))) => {
                     // Send resize event if we have a sender
                     if let Some(ref sender) = self.event_sender {
-                        let _ = sender.try_send(InnerEvent::ScreenResizeEvent {
-                            width: cols,
-                            height: rows,
-                        });
+                        let _ = sender.try_send(RuntimeEvent::screen_resize(cols, rows));
                     }
                     // Continue polling for key events
                 }
                 Poll::Ready(Some(Ok(Event::Mouse(mouse_event)))) => {
                     // Forward mouse events to runtime
                     if let Some(ref sender) = self.event_sender {
-                        let _ = sender.try_send(InnerEvent::MouseEvent(mouse_event.into()));
+                        let _ = sender.try_send(RuntimeEvent::mouse(mouse_event.into()));
                     }
                     // Continue polling for key events
                 }

--- a/lib/core/src/plugin/runtime_context.rs
+++ b/lib/core/src/plugin/runtime_context.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::{
-    event::InnerEvent,
+    event::RuntimeEvent,
     event_bus::{DynEvent, Event, EventSender},
     modd::ModeState,
 };
@@ -22,15 +22,15 @@ use super::{PluginId, PluginStateRegistry};
 /// Context provided to plugins during runtime operations
 ///
 /// This provides plugins with controlled access to:
-/// - Event emission (both legacy InnerEvent and new plugin events)
+/// - Event emission (both legacy RuntimeEvent and new plugin events)
 /// - Read-only mode state observation
 /// - Plugin state registry access
 /// - Render requests
 pub struct RuntimeContext {
     /// Plugin ID for event attribution
     plugin_id: PluginId,
-    /// Sender for legacy InnerEvent system
-    inner_event_tx: mpsc::Sender<InnerEvent>,
+    /// Sender for legacy RuntimeEvent system
+    inner_event_tx: mpsc::Sender<RuntimeEvent>,
     /// Sender for new event bus system
     event_bus_sender: EventSender,
     /// Current mode state (snapshot)
@@ -48,7 +48,7 @@ impl RuntimeContext {
     #[must_use]
     pub fn new(
         plugin_id: PluginId,
-        inner_event_tx: mpsc::Sender<InnerEvent>,
+        inner_event_tx: mpsc::Sender<RuntimeEvent>,
         event_bus_sender: EventSender,
         mode_state: ModeState,
         state_registry: Arc<PluginStateRegistry>,
@@ -106,31 +106,28 @@ impl RuntimeContext {
         self.event_bus_sender.try_send(event);
     }
 
-    /// Emit a legacy InnerEvent
+    /// Emit a legacy RuntimeEvent
     ///
     /// Used during migration when plugins need to interact with
     /// the existing event system.
-    pub fn emit_inner(&self, event: InnerEvent) {
+    pub fn emit_inner(&self, event: RuntimeEvent) {
         let _ = self.inner_event_tx.try_send(event);
     }
 
-    /// Emit a plugin event wrapped in InnerEvent::PluginEvent
+    /// Emit a plugin event wrapped in RuntimeEvent
     ///
     /// This routes the event through the legacy system but marks it
     /// as a plugin event for proper dispatch.
     pub fn emit_plugin_event<E: Event>(&self, event: E) {
         let dyn_event = DynEvent::new(event);
-        let inner = InnerEvent::PluginEvent {
-            plugin_id: self.plugin_id.clone(),
-            event: dyn_event,
-        };
+        let inner = RuntimeEvent::plugin(self.plugin_id.clone(), dyn_event);
         let _ = self.inner_event_tx.try_send(inner);
     }
 
     /// Request a render after this event is processed
     pub fn request_render(&mut self) {
         self.render_requested = true;
-        let _ = self.inner_event_tx.try_send(InnerEvent::RenderSignal);
+        let _ = self.inner_event_tx.try_send(RuntimeEvent::render_signal());
     }
 
     // =========================================================================
@@ -163,7 +160,7 @@ impl RuntimeContext {
 /// Used by the Runtime when dispatching events to plugins.
 pub struct RuntimeContextBuilder {
     plugin_id: Option<PluginId>,
-    inner_event_tx: Option<mpsc::Sender<InnerEvent>>,
+    inner_event_tx: Option<mpsc::Sender<RuntimeEvent>>,
     event_bus_sender: Option<EventSender>,
     mode_state: Option<ModeState>,
     state_registry: Option<Arc<PluginStateRegistry>>,
@@ -193,7 +190,7 @@ impl RuntimeContextBuilder {
 
     /// Set the inner event sender
     #[must_use]
-    pub fn inner_event_tx(mut self, tx: mpsc::Sender<InnerEvent>) -> Self {
+    pub fn inner_event_tx(mut self, tx: mpsc::Sender<RuntimeEvent>) -> Self {
         self.inner_event_tx = Some(tx);
         self
     }

--- a/lib/core/src/plugin/state.rs
+++ b/lib/core/src/plugin/state.rs
@@ -38,7 +38,7 @@ use crate::{
     command::CommandRegistry,
     completion::SharedCompletionFactory,
     decoration::SharedDecorationFactory,
-    event::InnerEvent,
+    event::RuntimeEvent,
     render::{RenderStage, RenderStageRegistry},
     syntax::SharedSyntaxFactory,
     textobject::SharedSemanticTextObjectSource,
@@ -79,8 +79,8 @@ pub struct PluginStateRegistry {
     animation_handle: RwLock<Option<AnimationHandle>>,
     /// Shared animation state for querying active effects during render
     animation_state: RwLock<Option<Arc<TokioRwLock<AnimationState>>>>,
-    /// Inner event sender for plugins that need to send InnerEvent (e.g., completion saturator)
-    inner_event_tx: RwLock<Option<mpsc::Sender<InnerEvent>>>,
+    /// Inner event sender for plugins that need to send RuntimeEvent (e.g., completion saturator)
+    inner_event_tx: RwLock<Option<mpsc::Sender<RuntimeEvent>>>,
     /// Keymap reference for plugins that need to access keybindings
     keymap: RwLock<Option<Arc<KeyMap>>>,
     /// Command registry reference for plugins that need command metadata
@@ -244,17 +244,17 @@ impl PluginStateRegistry {
     /// Set the inner event sender (called by Runtime during startup)
     ///
     /// This allows plugins like completion to spawn background tasks that
-    /// can send InnerEvent (e.g., RenderSignal) back to the runtime.
-    pub fn set_inner_event_tx(&self, tx: mpsc::Sender<InnerEvent>) {
+    /// can send RuntimeEvent (e.g., RenderSignal) back to the runtime.
+    pub fn set_inner_event_tx(&self, tx: mpsc::Sender<RuntimeEvent>) {
         *self.inner_event_tx.write().unwrap() = Some(tx);
     }
 
     /// Get the inner event sender
     ///
-    /// Returns the inner event sender for plugins that need to send InnerEvent
+    /// Returns the inner event sender for plugins that need to send RuntimeEvent
     /// from background tasks (e.g., completion saturator sending RenderSignal).
     #[must_use]
-    pub fn inner_event_tx(&self) -> Option<mpsc::Sender<InnerEvent>> {
+    pub fn inner_event_tx(&self) -> Option<mpsc::Sender<RuntimeEvent>> {
         self.inner_event_tx.read().unwrap().clone()
     }
 

--- a/lib/core/src/plugin/traits.rs
+++ b/lib/core/src/plugin/traits.rs
@@ -4,7 +4,7 @@ use std::{any::TypeId, sync::Arc};
 
 use tokio::sync::mpsc;
 
-use crate::{event::InnerEvent, event_bus::EventBus};
+use crate::{event::RuntimeEvent, event_bus::EventBus};
 
 use super::{PluginContext, PluginStateRegistry};
 
@@ -177,13 +177,13 @@ pub trait Plugin: Send + Sync + 'static {
     ///
     /// * `bus` - The event bus (now active and processing events)
     /// * `state` - Shared reference to the plugin state registry
-    /// * `event_tx` - Optional sender for `InnerEvent` (for spawning background tasks
+    /// * `event_tx` - Optional sender for `RuntimeEvent` (for spawning background tasks
     ///   that need to signal re-renders). Plugins that don't need this can ignore it.
     fn boot(
         &self,
         _bus: &EventBus,
         _state: Arc<PluginStateRegistry>,
-        _event_tx: Option<mpsc::Sender<InnerEvent>>,
+        _event_tx: Option<mpsc::Sender<RuntimeEvent>>,
     ) {
         // Default: no boot-time initialization
     }

--- a/lib/core/src/rpc/server.rs
+++ b/lib/core/src/rpc/server.rs
@@ -17,7 +17,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use {
     crate::{
-        event::InnerEvent,
+        event::RuntimeEvent,
         frame::FrameBufferHandle,
         highlight::ColorMode,
         keystroke::Keystroke,
@@ -75,7 +75,7 @@ impl ServerConfig {
 /// Server coordinator that bridges stdio JSON-RPC with the runtime
 pub struct RpcServer {
     /// Channel to send events to runtime
-    event_tx: mpsc::Sender<InnerEvent>,
+    event_tx: mpsc::Sender<RuntimeEvent>,
     /// Channel to inject keys
     key_tx: mpsc::Sender<KeyEvent>,
     /// Handle to read captured frame buffer (for all screen content formats)
@@ -89,7 +89,7 @@ impl RpcServer {
     /// Create a new RPC server
     #[must_use]
     pub const fn new(
-        event_tx: mpsc::Sender<InnerEvent>,
+        event_tx: mpsc::Sender<RuntimeEvent>,
         key_tx: mpsc::Sender<KeyEvent>,
         frame_handle: Option<FrameBufferHandle>,
         notification_tx: mpsc::Sender<RpcNotification>,
@@ -229,19 +229,14 @@ impl RpcServer {
             methods::SERVER_KILL => {
                 // Kill the server - send KillSignal to runtime
                 tracing::info!("Kill command received, shutting down server");
-                let _ = self.event_tx.send(InnerEvent::KillSignal).await;
+                let _ = self.event_tx.send(RuntimeEvent::kill()).await;
                 Some(RpcResponse::success(id, serde_json::json!({ "status": "shutting_down" })))
             }
             _ => {
                 // Forward to runtime via event channel
                 let (response_tx, response_rx) = oneshot::channel();
 
-                let event = InnerEvent::RpcRequest {
-                    id,
-                    method: request.method,
-                    params: request.params,
-                    response_tx,
-                };
+                let event = RuntimeEvent::rpc(id, request.method, request.params, response_tx);
 
                 if self.event_tx.send(event).await.is_err() {
                     return Some(RpcResponse::error(

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -16,7 +16,7 @@ use {
         config::{ProfileConfig, ProfileManager},
         constants::EVENT_CHANNEL_CAPACITY,
         decoration::{DecorationStore, LanguageRendererRegistry},
-        event::InnerEvent,
+        event::RuntimeEvent,
         event_bus::{
             BufferClosed, DynEvent, EventBus, EventResult, EventSender, FileOpened, HandlerContext,
             core_events::ModeChanged,
@@ -49,8 +49,8 @@ pub struct Runtime {
     pub command_line: CommandLine,
     pub pending_keys: String,
     pub last_command: String,
-    pub tx: mpsc::Sender<InnerEvent>,
-    pub rx: mpsc::Receiver<InnerEvent>,
+    pub tx: mpsc::Sender<RuntimeEvent>,
+    pub rx: mpsc::Receiver<RuntimeEvent>,
     pub initial_file: Option<String>,
     pub(crate) showing_landing_page: bool,
     /// Watch channel sender for broadcasting mode changes
@@ -293,7 +293,7 @@ impl Runtime {
                     let current_mode = mode_tx.borrow().clone();
                     let new_mode = current_mode.set_interactor_id(event.target);
                     // Send through event loop to properly update runtime.mode_state
-                    let _ = tx.try_send(crate::event::InnerEvent::ModeChangeEvent(new_mode));
+                    let _ = tx.try_send(RuntimeEvent::mode_change(new_mode));
                     tracing::info!(
                         "Runtime: Requesting focus change to component '{}'",
                         event.target.0
@@ -310,7 +310,7 @@ impl Runtime {
                 .event_bus
                 .subscribe::<RequestModeChange, _>(100, move |event, _ctx| {
                     // Send through event loop to properly update runtime.mode_state
-                    let _ = tx.try_send(crate::event::InnerEvent::ModeChangeEvent(event.mode.clone()));
+                    let _ = tx.try_send(RuntimeEvent::mode_change(event.mode.clone()));
                     tracing::info!(
                         "Runtime: Requesting mode change to interactor='{}', edit_mode={:?}, sub_mode={:?}",
                         event.mode.interactor_id.0,
@@ -330,9 +330,7 @@ impl Runtime {
                 .subscribe::<RequestOpenFile, _>(100, move |event, _ctx| {
                     tracing::info!("Runtime: Requesting to open file: {:?}", event.path);
                     // Send OpenFileRequest to the runtime event loop
-                    let _ = tx.try_send(InnerEvent::OpenFileRequest {
-                        path: event.path.clone(),
-                    });
+                    let _ = tx.try_send(RuntimeEvent::open_file(event.path.clone()));
                     EventResult::Handled
                 });
         }
@@ -350,11 +348,11 @@ impl Runtime {
                         event.line,
                         event.column
                     );
-                    let _ = tx.try_send(InnerEvent::OpenFileAtPositionRequest {
-                        path: event.path.clone(),
-                        line: event.line,
-                        column: event.column,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::open_file_at(
+                        event.path.clone(),
+                        event.line,
+                        event.column,
+                    ));
                     EventResult::Handled
                 });
         }
@@ -367,10 +365,10 @@ impl Runtime {
                 .event_bus
                 .subscribe::<RequestSetRegister, _>(100, move |event, _ctx| {
                     tracing::debug!("Runtime: Requesting to set register {:?}", event.register);
-                    let _ = tx.try_send(InnerEvent::SetRegister {
-                        register: event.register,
-                        text: event.text.clone(),
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_register(
+                        event.register,
+                        event.text.clone(),
+                    ));
                     EventResult::Handled
                 });
         }
@@ -444,7 +442,7 @@ impl Runtime {
 
                     // Delete prefix first (for completion: replace typed prefix with full word)
                     for _ in 0..event.delete_prefix_len {
-                        let _ = tx.try_send(InnerEvent::TextInputEvent(
+                        let _ = tx.try_send(RuntimeEvent::text_input(
                             TextInputEvent::DeleteCharBackward,
                         ));
                     }
@@ -452,12 +450,12 @@ impl Runtime {
                     // Insert each character
                     for c in event.text.chars() {
                         let _ =
-                            tx.try_send(InnerEvent::TextInputEvent(TextInputEvent::InsertChar(c)));
+                            tx.try_send(RuntimeEvent::text_input(TextInputEvent::InsertChar(c)));
                     }
 
                     // If requested, move cursor left after insertion
                     if event.move_cursor_left {
-                        let _ = tx.try_send(InnerEvent::CommandEvent(CommandEvent {
+                        let _ = tx.try_send(RuntimeEvent::command(CommandEvent {
                             command: CommandRef::Registered(builtin::CURSOR_LEFT),
                             context: CommandContext::default(),
                         }));
@@ -532,15 +530,15 @@ impl Runtime {
                             };
 
                             // Send operator motion event (runtime will handle mode change)
-                            let _ = tx.try_send(InnerEvent::OperatorMotionEvent(action));
+                            let _ = tx.try_send(RuntimeEvent::operator_motion(action));
                         }
                         None => {
                             // Normal cursor move (no operator)
-                            let _ = tx.try_send(InnerEvent::MoveCursor {
-                                buffer_id: event.buffer_id,
-                                line: event.line,
-                                column: event.column,
-                            });
+                            let _ = tx.try_send(RuntimeEvent::move_cursor(
+                                event.buffer_id,
+                                event.line,
+                                event.column,
+                            ));
                         }
                     }
 
@@ -555,9 +553,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetLineNumbers, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetLineNumbers {
-                        enabled: event.enabled,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_line_numbers(event.enabled));
                     EventResult::Handled
                 });
         }
@@ -567,9 +563,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetRelativeLineNumbers, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetRelativeLineNumbers {
-                        enabled: event.enabled,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_relative_line_numbers(event.enabled));
                     EventResult::Handled
                 });
         }
@@ -579,9 +573,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetTheme, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetTheme {
-                        name: event.name.clone(),
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_theme(event.name.clone()));
                     EventResult::Handled
                 });
         }
@@ -591,9 +583,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetScrollbar, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetScrollbar {
-                        enabled: event.enabled,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_scrollbar(event.enabled));
                     EventResult::Handled
                 });
         }
@@ -603,9 +593,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetIndentGuide, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetIndentGuide {
-                        enabled: event.enabled,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::set_indent_guide(event.enabled));
                     EventResult::Handled
                 });
         }
@@ -615,7 +603,7 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestSetSignColumn, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::SetSignColumn { mode: event.mode });
+                    let _ = tx.try_send(RuntimeEvent::set_sign_column(event.mode));
                     EventResult::Handled
                 });
         }
@@ -627,10 +615,10 @@ impl Runtime {
             runtime
                 .event_bus
                 .subscribe::<RequestApplyCmdlineCompletion, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(InnerEvent::ApplyCmdlineCompletion {
-                        text: event.text.clone(),
-                        replace_start: event.replace_start,
-                    });
+                    let _ = tx.try_send(RuntimeEvent::apply_cmdline_completion(
+                        event.text.clone(),
+                        event.replace_start,
+                    ));
                     EventResult::Handled
                 });
         }

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -8,8 +8,9 @@ use crate::{
     animation::{AnimatedStyle, Effect, EffectId, EffectTarget},
     buffer::{Buffer, SelectionOps, TextOps},
     event::{
-        BufferEvent, CommandHandler, HighlightEvent, InnerEvent, InputEventBroker,
-        TerminateHandler, TextInputEvent, WindowEvent,
+        BufferEvent, CommandHandler, EditingEvent, FileEvent, HighlightEvent, InputEvent,
+        InputEventBroker, ModeEvent, RenderEvent, RuntimeEvent, RuntimeEventPayload,
+        SettingsEvent, SyntaxEvent, TerminateHandler, TextInputEvent, WindowEvent,
     },
     modd::{EditMode, ModeState, SubMode},
 };
@@ -73,7 +74,7 @@ impl Runtime {
                     // If any handler requested a render, send RenderSignal to main loop
                     if ctx.render_requested() {
                         tracing::info!("==> Render requested by event: {}", event_type);
-                        let _ = inner_tx.try_send(InnerEvent::RenderSignal);
+                        let _ = inner_tx.try_send(RuntimeEvent::render_signal());
                     }
                 }
             });
@@ -189,7 +190,7 @@ impl Runtime {
                     // If any handler requested a render, send RenderSignal to main loop
                     if ctx.render_requested() {
                         tracing::info!("==> Render requested by event: {}", event_type);
-                        let _ = inner_tx.try_send(InnerEvent::RenderSignal);
+                        let _ = inner_tx.try_send(RuntimeEvent::render_signal());
                     }
                 }
             });
@@ -273,10 +274,10 @@ impl Runtime {
                 ev = self.rx.recv() => {
                     if let Some(ev) = ev {
                         let loop_start = std::time::Instant::now();
-                        let ev_name = format!("{:?}", std::mem::discriminant(&ev));
+                        let ev_name = format!("{:?}", std::mem::discriminant(ev.payload()));
 
                         // Track user input for idle detection
-                        self.track_input_for_idle(&ev);
+                        self.track_input_for_idle(ev.payload());
 
                         if self.handle_event(ev) {
                             break;
@@ -287,7 +288,7 @@ impl Runtime {
                         let mut drained = 0;
                         while let Ok(ev) = self.rx.try_recv() {
                             drained += 1;
-                            self.track_input_for_idle(&ev);
+                            self.track_input_for_idle(ev.payload());
                             if self.handle_event(ev) {
                                 // Flush before breaking on quit
                                 self.flush_render();
@@ -306,7 +307,7 @@ impl Runtime {
                         );
                     } else {
                         self.tx
-                            .send(InnerEvent::KillSignal)
+                            .send(RuntimeEvent::kill())
                             .await
                             .expect("cannot broadcast kill signal");
                         break;
@@ -343,13 +344,13 @@ impl Runtime {
     }
 
     /// Track user input events for idle detection
-    fn track_input_for_idle(&mut self, ev: &InnerEvent) {
+    fn track_input_for_idle(&mut self, ev: &RuntimeEventPayload) {
         // Only track actual user input events
         let is_user_input = matches!(
             ev,
-            InnerEvent::CommandEvent(_)
-                | InnerEvent::PendingKeysEvent(_)
-                | InnerEvent::TextInputEvent(_)
+            RuntimeEventPayload::Command(_)
+                | RuntimeEventPayload::Mode(ModeEvent::PendingKeys(_))
+                | RuntimeEventPayload::Editing(EditingEvent::TextInput(_))
         );
 
         if is_user_input {
@@ -403,9 +404,13 @@ impl Runtime {
     #[allow(clippy::collapsible_if)]
     #[allow(clippy::match_same_arms)]
     #[allow(clippy::too_many_lines)]
-    pub(crate) fn handle_event(&mut self, ev: InnerEvent) -> bool {
-        match ev {
-            InnerEvent::BufferEvent(buffer_event) => match buffer_event {
+    pub(crate) fn handle_event(&mut self, mut ev: RuntimeEvent) -> bool {
+        // Extract scope for lifecycle tracking (will be used in Phase 4)
+        let _scope = ev.take_scope();
+
+        // Handle the payload
+        match ev.into_payload() {
+            RuntimeEventPayload::Buffer(buffer_event) => match buffer_event {
                 BufferEvent::SetContent { buffer_id, content } => {
                     if let Some(b) = self.buffers.get_mut(&buffer_id) {
                         b.set_content(&content);
@@ -435,25 +440,27 @@ impl Runtime {
                     self.request_render();
                 }
             },
-            InnerEvent::CommandEvent(cmd_event) => {
+            RuntimeEventPayload::Command(cmd_event) => {
                 if self.handle_command(cmd_event) {
                     return true;
                 }
             }
-            InnerEvent::ModeChangeEvent(new_mode) => {
-                self.handle_mode_change(new_mode);
-            }
-            InnerEvent::PendingKeysEvent(keys) => {
-                // If pending_keys is being cleared and had content, save as last_command
-                if keys.is_empty() && !self.pending_keys.is_empty() {
-                    self.last_command.clone_from(&self.pending_keys);
+            RuntimeEventPayload::Mode(mode_event) => match mode_event {
+                ModeEvent::Change(new_mode) => {
+                    self.handle_mode_change(new_mode);
                 }
-                // Update plugin state so which-key and other plugins can access pending keys
-                self.plugin_state.set_pending_keys(keys.clone());
-                self.pending_keys = keys;
-                self.request_render();
-            }
-            InnerEvent::WindowEvent(window_event) => match window_event {
+                ModeEvent::PendingKeys(keys) => {
+                    // If pending_keys is being cleared and had content, save as last_command
+                    if keys.is_empty() && !self.pending_keys.is_empty() {
+                        self.last_command.clone_from(&self.pending_keys);
+                    }
+                    // Update plugin state so which-key and other plugins can access pending keys
+                    self.plugin_state.set_pending_keys(keys.clone());
+                    self.pending_keys = keys;
+                    self.request_render();
+                }
+            },
+            RuntimeEventPayload::Window(window_event) => match window_event {
                 WindowEvent::FocusPlugin { id } => {
                     self.screen.focus_plugin(id);
                     self.request_render();
@@ -479,26 +486,28 @@ impl Runtime {
                     // Window management events - to be implemented
                 }
             },
-            InnerEvent::HighlightEvent(hl_event) => match hl_event {
-                HighlightEvent::Add {
-                    buffer_id,
-                    highlights,
-                } => {
-                    self.highlight_store.add(buffer_id, highlights);
+            RuntimeEventPayload::Render(render_event) => match render_event {
+                RenderEvent::Signal => {
                     self.request_render();
                 }
-                HighlightEvent::ClearGroup { buffer_id, group } => {
-                    self.highlight_store.clear_group(buffer_id, group);
-                    self.request_render();
-                }
-                HighlightEvent::ClearAll { buffer_id } => {
-                    self.highlight_store.clear_all(buffer_id);
-                    self.request_render();
-                }
-            },
-            InnerEvent::SyntaxEvent(syntax_event) => {
-                use crate::event::SyntaxEvent;
-                match syntax_event {
+                RenderEvent::Highlight(hl_event) => match hl_event {
+                    HighlightEvent::Add {
+                        buffer_id,
+                        highlights,
+                    } => {
+                        self.highlight_store.add(buffer_id, highlights);
+                        self.request_render();
+                    }
+                    HighlightEvent::ClearGroup { buffer_id, group } => {
+                        self.highlight_store.clear_group(buffer_id, group);
+                        self.request_render();
+                    }
+                    HighlightEvent::ClearAll { buffer_id } => {
+                        self.highlight_store.clear_all(buffer_id);
+                        self.request_render();
+                    }
+                },
+                RenderEvent::Syntax(syntax_event) => match syntax_event {
                     SyntaxEvent::Attach { buffer_id, syntax } => {
                         if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
                             buffer.attach_syntax(syntax);
@@ -536,173 +545,174 @@ impl Runtime {
                             self.request_render();
                         }
                     }
+                },
+            },
+            RuntimeEventPayload::Editing(editing_event) => match editing_event {
+                EditingEvent::TextInput(focus_event) => {
+                    self.handle_interactor_input(focus_event);
                 }
+                EditingEvent::OperatorMotion(action) => {
+                    self.handle_operator_motion(&action);
+                }
+                EditingEvent::VisualTextObject(action) => {
+                    self.handle_visual_text_object(&action);
+                }
+                EditingEvent::MoveCursor {
+                    buffer_id,
+                    line,
+                    column,
+                } => {
+                    tracing::debug!(
+                        "Runtime: Moving cursor to line={}, col={} in buffer={}",
+                        line,
+                        column,
+                        buffer_id
+                    );
+                    if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
+                        use crate::{buffer::CursorOps, motion::Motion};
+                        buffer.apply_motion(
+                            Motion::JumpTo { line, column },
+                            1, // count
+                        );
+                    } else {
+                        tracing::warn!("Runtime: Buffer {} not found for cursor move", buffer_id);
+                    }
+                }
+                EditingEvent::SetRegister { register, text } => {
+                    tracing::debug!(
+                        "Runtime: Setting register {:?} with text length {}",
+                        register,
+                        text.len()
+                    );
+                    self.registers.set_by_name(register, text);
+                }
+            },
+            RuntimeEventPayload::Settings(settings_event) => match settings_event {
+                SettingsEvent::LineNumbers { enabled } => {
+                    tracing::info!("Runtime: Setting line numbers: {}", enabled);
+                    self.screen.set_number(enabled);
+                }
+                SettingsEvent::RelativeLineNumbers { enabled } => {
+                    tracing::info!("Runtime: Setting relative line numbers: {}", enabled);
+                    self.screen.set_relative_number(enabled);
+                }
+                SettingsEvent::Theme { name } => {
+                    tracing::info!("Runtime: Setting theme: {}", name);
+                    if let Some(theme_name) = crate::highlight::ThemeName::parse(&name) {
+                        self.theme = crate::highlight::Theme::from_name(theme_name);
+                        self.rehighlight_all_buffers();
+                        // Request a render to apply the new theme immediately
+                        self.request_render();
+                    } else {
+                        tracing::warn!("Runtime: Unknown theme name: {}", name);
+                    }
+                }
+                SettingsEvent::Scrollbar { enabled } => {
+                    tracing::info!("Runtime: Setting scrollbar: {}", enabled);
+                    self.screen.set_scrollbar(enabled);
+                }
+                SettingsEvent::IndentGuide { enabled } => {
+                    tracing::info!("Runtime: Setting indent guide: {}", enabled);
+                    self.indent_analyzer.set_enabled(enabled);
+                }
+                SettingsEvent::SignColumn { mode } => {
+                    tracing::info!("Runtime: Setting sign column mode: {:?}", mode);
+                    self.screen.set_sign_column_mode(mode);
+                }
+                SettingsEvent::ApplyCmdlineCompletion {
+                    text,
+                    replace_start,
+                } => {
+                    tracing::debug!(
+                        "Runtime: Applying cmdline completion: {:?} at {}",
+                        text,
+                        replace_start
+                    );
+                    self.command_line.apply_completion(&text, replace_start);
+                    self.request_render();
+                }
+            },
+            RuntimeEventPayload::Input(input_event) => match input_event {
+                InputEvent::ScreenResize { width, height } => {
+                    tracing::debug!("Screen resize: {}x{}", width, height);
+                    self.screen.resize(width, height);
+                    self.request_render();
+                }
+                InputEvent::Mouse(mouse_event) => {
+                    self.handle_mouse_event(mouse_event);
+                }
+            },
+            RuntimeEventPayload::File(file_event) => match file_event {
+                FileEvent::Open { path } => {
+                    tracing::info!("Runtime: Opening file from request: {:?}", path);
+                    // Convert PathBuf to &str for open_file
+                    if let Some(path_str) = path.to_str() {
+                        self.open_file(path_str);
+                        self.screen.set_editor_buffer(self.active_buffer_id());
+                        self.request_render();
+                    } else {
+                        tracing::error!("Runtime: Invalid UTF-8 in file path: {:?}", path);
+                    }
+                }
+                FileEvent::OpenAt { path, line, column } => {
+                    tracing::info!(
+                        "Runtime: Opening file at position: {:?}:{}:{}",
+                        path,
+                        line,
+                        column
+                    );
+                    if let Some(path_str) = path.to_str() {
+                        self.open_file(path_str);
+                        self.screen.set_editor_buffer(self.active_buffer_id());
+                        // Set cursor position in the opened buffer
+                        if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id()) {
+                            // Ensure line is within bounds
+                            let max_line = buffer.contents.len().saturating_sub(1);
+                            let target_line = line.min(max_line);
+                            // Ensure column is within bounds for the target line
+                            let line_len = buffer
+                                .contents
+                                .get(target_line)
+                                .map_or(0, |l| l.inner.len());
+                            let target_col = column.min(line_len.saturating_sub(1).max(0));
+                            #[allow(clippy::cast_possible_truncation)]
+                            {
+                                buffer.cur.y = target_line as u16;
+                                buffer.cur.x = target_col as u16;
+                            }
+                            tracing::debug!(
+                                "Runtime: Cursor set to line={}, col={}",
+                                target_line,
+                                target_col
+                            );
+                        }
+                        self.request_render();
+                    } else {
+                        tracing::error!("Runtime: Invalid UTF-8 in file path: {:?}", path);
+                    }
+                }
+            },
+            RuntimeEventPayload::Rpc(rpc_event) => {
+                let response =
+                    self.handle_rpc_request(rpc_event.id, &rpc_event.method, &rpc_event.params);
+                let _ = rpc_event.response_tx.send(response);
             }
-            InnerEvent::RenderSignal => {
-                self.request_render();
-            }
-            InnerEvent::KillSignal => {
-                return true;
-            }
-            InnerEvent::OperatorMotionEvent(ref action) => {
-                self.handle_operator_motion(action);
-            }
-            InnerEvent::VisualTextObjectEvent(ref action) => {
-                self.handle_visual_text_object(action);
-            }
-            InnerEvent::ScreenResizeEvent { width, height } => {
-                tracing::debug!("Screen resize: {}x{}", width, height);
-                self.screen.resize(width, height);
-                self.request_render();
-            }
-            InnerEvent::MouseEvent(mouse_event) => {
-                self.handle_mouse_event(mouse_event);
-            }
-            InnerEvent::RpcRequest {
-                id,
-                method,
-                params,
-                response_tx,
-            } => {
-                let response = self.handle_rpc_request(id, &method, &params);
-                let _ = response_tx.send(response);
-            }
-            InnerEvent::TextInputEvent(focus_event) => {
-                self.handle_interactor_input(focus_event);
-            }
-            // Plugin-defined events - dispatched via event bus
-            InnerEvent::PluginEvent { plugin_id, event } => {
+            RuntimeEventPayload::Plugin(plugin_data) => {
                 tracing::debug!(
                     "Runtime: Dispatching plugin event from {}: {:?}",
-                    plugin_id,
-                    event.type_name()
+                    plugin_data.plugin_id,
+                    plugin_data.event.type_name()
                 );
                 // Dispatch to event bus - subscribers will receive the event
                 let sender = self.event_bus.sender();
                 let mut ctx = crate::event_bus::HandlerContext::new(&sender);
-                let _ = self.event_bus.dispatch(&event, &mut ctx);
+                let _ = self.event_bus.dispatch(&plugin_data.event, &mut ctx);
                 if ctx.render_requested() {
                     self.request_render();
                 }
             }
-            // File open request (from explorer, etc.)
-            InnerEvent::OpenFileRequest { path } => {
-                tracing::info!("Runtime: Opening file from request: {:?}", path);
-                // Convert PathBuf to &str for open_file
-                if let Some(path_str) = path.to_str() {
-                    self.open_file(path_str);
-                    self.screen.set_editor_buffer(self.active_buffer_id());
-                    self.request_render();
-                } else {
-                    tracing::error!("Runtime: Invalid UTF-8 in file path: {:?}", path);
-                }
-            }
-            // File open at position request (from LSP navigation)
-            InnerEvent::OpenFileAtPositionRequest { path, line, column } => {
-                tracing::info!("Runtime: Opening file at position: {:?}:{}:{}", path, line, column);
-                if let Some(path_str) = path.to_str() {
-                    self.open_file(path_str);
-                    self.screen.set_editor_buffer(self.active_buffer_id());
-                    // Set cursor position in the opened buffer
-                    if let Some(buffer) = self.buffers.get_mut(&self.active_buffer_id()) {
-                        // Ensure line is within bounds
-                        let max_line = buffer.contents.len().saturating_sub(1);
-                        let target_line = line.min(max_line);
-                        // Ensure column is within bounds for the target line
-                        let line_len = buffer
-                            .contents
-                            .get(target_line)
-                            .map_or(0, |l| l.inner.len());
-                        let target_col = column.min(line_len.saturating_sub(1).max(0));
-                        #[allow(clippy::cast_possible_truncation)]
-                        {
-                            buffer.cur.y = target_line as u16;
-                            buffer.cur.x = target_col as u16;
-                        }
-                        tracing::debug!(
-                            "Runtime: Cursor set to line={}, col={}",
-                            target_line,
-                            target_col
-                        );
-                    }
-                    self.request_render();
-                } else {
-                    tracing::error!("Runtime: Invalid UTF-8 in file path: {:?}", path);
-                }
-            }
-            // Set register content (from plugins)
-            InnerEvent::SetRegister { register, text } => {
-                tracing::debug!(
-                    "Runtime: Setting register {:?} with text length {}",
-                    register,
-                    text.len()
-                );
-                self.registers.set_by_name(register, text);
-            }
-            // Settings/Option capability events
-            InnerEvent::SetLineNumbers { enabled } => {
-                tracing::info!("Runtime: Setting line numbers: {}", enabled);
-                self.screen.set_number(enabled);
-            }
-            InnerEvent::SetRelativeLineNumbers { enabled } => {
-                tracing::info!("Runtime: Setting relative line numbers: {}", enabled);
-                self.screen.set_relative_number(enabled);
-            }
-            InnerEvent::SetTheme { name } => {
-                tracing::info!("Runtime: Setting theme: {}", name);
-                if let Some(theme_name) = crate::highlight::ThemeName::parse(&name) {
-                    self.theme = crate::highlight::Theme::from_name(theme_name);
-                    self.rehighlight_all_buffers();
-                    // Request a render to apply the new theme immediately
-                    self.request_render();
-                } else {
-                    tracing::warn!("Runtime: Unknown theme name: {}", name);
-                }
-            }
-            InnerEvent::SetScrollbar { enabled } => {
-                tracing::info!("Runtime: Setting scrollbar: {}", enabled);
-                self.screen.set_scrollbar(enabled);
-            }
-            InnerEvent::SetIndentGuide { enabled } => {
-                tracing::info!("Runtime: Setting indent guide: {}", enabled);
-                self.indent_analyzer.set_enabled(enabled);
-            }
-            InnerEvent::SetSignColumn { mode } => {
-                tracing::info!("Runtime: Setting sign column mode: {:?}", mode);
-                self.screen.set_sign_column_mode(mode);
-            }
-            InnerEvent::MoveCursor {
-                buffer_id,
-                line,
-                column,
-            } => {
-                tracing::debug!(
-                    "Runtime: Moving cursor to line={}, col={} in buffer={}",
-                    line,
-                    column,
-                    buffer_id
-                );
-                if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
-                    use crate::{buffer::CursorOps, motion::Motion};
-                    buffer.apply_motion(
-                        Motion::JumpTo { line, column },
-                        1, // count
-                    );
-                } else {
-                    tracing::warn!("Runtime: Buffer {} not found for cursor move", buffer_id);
-                }
-            }
-            InnerEvent::ApplyCmdlineCompletion {
-                text,
-                replace_start,
-            } => {
-                tracing::debug!(
-                    "Runtime: Applying cmdline completion: {:?} at {}",
-                    text,
-                    replace_start
-                );
-                self.command_line.apply_completion(&text, replace_start);
-                self.request_render();
+            RuntimeEventPayload::Kill => {
+                return true;
             }
         }
         false

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -688,7 +688,7 @@ impl Runtime {
                         // Emit quit - the event loop will handle it
                         let tx = self.tx.clone();
                         tokio::spawn(async move {
-                            let _ = tx.send(crate::event::InnerEvent::KillSignal).await;
+                            let _ = tx.send(crate::event::RuntimeEvent::kill()).await;
                         });
                     }
 

--- a/plugins/features/completion/src/lib.rs
+++ b/plugins/features/completion/src/lib.rs
@@ -366,7 +366,7 @@ impl Plugin for CompletionPlugin {
         &self,
         _bus: &EventBus,
         state: Arc<PluginStateRegistry>,
-        event_tx: Option<tokio::sync::mpsc::Sender<reovim_core::event::InnerEvent>>,
+        event_tx: Option<tokio::sync::mpsc::Sender<reovim_core::event::RuntimeEvent>>,
     ) {
         // Get event_tx from parameter or fall back to state registry
         let Some(event_tx) = event_tx.or_else(|| state.inner_event_tx()) else {

--- a/plugins/features/completion/src/saturator.rs
+++ b/plugins/features/completion/src/saturator.rs
@@ -15,7 +15,7 @@ use nucleo::{
 
 use reovim_core::{
     completion::{CompletionContext, CompletionItem},
-    event::InnerEvent,
+    event::RuntimeEvent,
 };
 
 use crate::{CompletionCache, cache::CompletionSnapshot, registry::SourceSupport};
@@ -96,7 +96,7 @@ impl CompletionSaturatorHandle {
 pub fn spawn_completion_saturator(
     sources: Arc<Vec<Arc<dyn SourceSupport>>>,
     cache: Arc<CompletionCache>,
-    event_tx: mpsc::Sender<InnerEvent>,
+    event_tx: mpsc::Sender<RuntimeEvent>,
     max_items: usize,
 ) -> CompletionSaturatorHandle {
     // Buffer of 1: only latest request matters
@@ -204,7 +204,7 @@ pub fn spawn_completion_saturator(
             tracing::debug!(item_count, "Completion results ready");
 
             // Signal render update
-            if let Err(e) = event_tx.send(InnerEvent::RenderSignal).await {
+            if let Err(e) = event_tx.send(RuntimeEvent::render_signal()).await {
                 tracing::warn!("Failed to send render signal: {}", e);
             }
         }
@@ -329,7 +329,10 @@ mod tests {
             .expect("timeout")
             .expect("channel closed");
 
-        assert!(matches!(event, InnerEvent::RenderSignal));
+        assert!(matches!(
+            event.into_payload(),
+            reovim_core::event::RuntimeEventPayload::Render(reovim_core::event::RenderEvent::Signal)
+        ));
 
         // Check cache
         let snapshot = cache.load();

--- a/plugins/features/completion/src/state.rs
+++ b/plugins/features/completion/src/state.rs
@@ -31,7 +31,7 @@ pub struct SharedCompletionManager {
     /// Each keystroke increments this; the timer checks if it's still current
     pub debounce_generation: AtomicU64,
     /// Inner event sender for sending CommandEvent after debounce
-    pub inner_event_tx: RwLock<Option<tokio::sync::mpsc::Sender<reovim_core::event::InnerEvent>>>,
+    pub inner_event_tx: RwLock<Option<tokio::sync::mpsc::Sender<reovim_core::event::RuntimeEvent>>>,
 }
 
 impl SharedCompletionManager {
@@ -54,7 +54,7 @@ impl SharedCompletionManager {
     /// Set the inner event sender (called during boot)
     pub fn set_inner_event_tx(
         &self,
-        tx: tokio::sync::mpsc::Sender<reovim_core::event::InnerEvent>,
+        tx: tokio::sync::mpsc::Sender<reovim_core::event::RuntimeEvent>,
     ) {
         *self.inner_event_tx.write().unwrap() = Some(tx);
     }
@@ -75,7 +75,7 @@ impl SharedCompletionManager {
     /// Request a render signal (used after debounce timeout)
     pub fn request_render(&self) {
         if let Some(tx) = self.inner_event_tx.read().unwrap().as_ref() {
-            let _ = tx.try_send(reovim_core::event::InnerEvent::RenderSignal);
+            let _ = tx.try_send(reovim_core::event::RuntimeEvent::render_signal());
         }
     }
 
@@ -85,7 +85,7 @@ impl SharedCompletionManager {
     /// The command will execute with proper buffer context.
     pub fn send_command_event(&self, event: reovim_core::event::CommandEvent) {
         if let Some(tx) = self.inner_event_tx.read().unwrap().as_ref() {
-            let _ = tx.try_send(reovim_core::event::InnerEvent::CommandEvent(event));
+            let _ = tx.try_send(reovim_core::event::RuntimeEvent::command(event));
         }
     }
 

--- a/plugins/features/lsp/src/lib.rs
+++ b/plugins/features/lsp/src/lib.rs
@@ -740,7 +740,7 @@ impl Plugin for LspPlugin {
         &self,
         bus: &EventBus,
         state: Arc<PluginStateRegistry>,
-        event_tx: Option<tokio::sync::mpsc::Sender<reovim_core::event::InnerEvent>>,
+        event_tx: Option<tokio::sync::mpsc::Sender<reovim_core::event::RuntimeEvent>>,
     ) {
         // Store event_tx in manager for triggering re-renders
         if let Some(tx) = event_tx {

--- a/plugins/features/lsp/src/manager.rs
+++ b/plugins/features/lsp/src/manager.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use {
-    reovim_core::event::InnerEvent,
+    reovim_core::event::RuntimeEvent,
     reovim_lsp::{DiagnosticCache, LspSaturatorHandle},
     tokio::sync::mpsc,
 };
@@ -111,7 +111,7 @@ pub struct LspManager {
     /// Hover cache for lock-free reads.
     pub hover_cache: HoverCache,
     /// Event sender for triggering re-renders.
-    pub event_tx: Option<mpsc::Sender<InnerEvent>>,
+    pub event_tx: Option<mpsc::Sender<RuntimeEvent>>,
     /// Whether the LSP server is running.
     pub running: bool,
     /// Last time a document was synced.
@@ -142,14 +142,14 @@ impl LspManager {
     }
 
     /// Set the event sender for triggering re-renders.
-    pub fn set_event_tx(&mut self, event_tx: mpsc::Sender<InnerEvent>) {
+    pub fn set_event_tx(&mut self, event_tx: mpsc::Sender<RuntimeEvent>) {
         self.event_tx = Some(event_tx);
     }
 
     /// Send a render signal to trigger a re-render.
     pub fn send_render_signal(&self) {
         if let Some(tx) = &self.event_tx {
-            let _ = tx.try_send(InnerEvent::RenderSignal);
+            let _ = tx.try_send(RuntimeEvent::render_signal());
         }
     }
 

--- a/plugins/features/which-key/src/lib.rs
+++ b/plugins/features/which-key/src/lib.rs
@@ -17,7 +17,7 @@ use {
     reovim_core::{
         bind::{CommandRef, KeymapScope, SubModeKind},
         command::CommandId,
-        event::InnerEvent,
+        event::RuntimeEvent,
         event_bus::{EventBus, EventResult, PluginBackspace, PluginTextInput, RequestModeChange},
         frame::FrameBuffer,
         highlight::Theme,
@@ -129,7 +129,7 @@ impl Plugin for WhichKeyPlugin {
         &self,
         _bus: &EventBus,
         state: Arc<PluginStateRegistry>,
-        event_tx: Option<mpsc::Sender<InnerEvent>>,
+        event_tx: Option<mpsc::Sender<RuntimeEvent>>,
     ) {
         tracing::info!("WhichKeyPlugin: boot() called");
         // Get cache from init_state

--- a/plugins/features/which-key/src/saturator.rs
+++ b/plugins/features/which-key/src/saturator.rs
@@ -7,7 +7,7 @@ use {
     reovim_core::{
         bind::{KeyMap, KeymapScope},
         command::registry::CommandRegistry,
-        event::InnerEvent,
+        event::RuntimeEvent,
         keystroke::KeySequence,
     },
     tokio::sync::mpsc,
@@ -40,7 +40,7 @@ impl WhichKeySaturatorHandle {
 /// Spawn background saturator task
 pub fn spawn_whichkey_saturator(
     cache: Arc<ArcSwap<WhichKeyCache>>,
-    event_tx: mpsc::Sender<InnerEvent>,
+    event_tx: mpsc::Sender<RuntimeEvent>,
     keymap: Arc<KeyMap>,
     command_registry: Arc<CommandRegistry>,
 ) -> WhichKeySaturatorHandle {
@@ -69,7 +69,7 @@ pub fn spawn_whichkey_saturator(
 
             // Signal re-render
             tracing::info!("WhichKey saturator: sending RenderSignal");
-            let _ = event_tx.send(InnerEvent::RenderSignal).await;
+            let _ = event_tx.send(RuntimeEvent::render_signal()).await;
         }
         tracing::warn!("WhichKey saturator task ended");
     });

--- a/runner/src/server.rs
+++ b/runner/src/server.rs
@@ -16,7 +16,7 @@ use std::{
 
 use {
     reovim_core::{
-        event::InnerEvent,
+        event::RuntimeEvent,
         io::input::ChannelKeySource,
         rpc::{
             RpcNotification, RpcRequest, RpcResponse, TransportConfig, TransportConnection,
@@ -103,15 +103,12 @@ pub async fn run_server(
                     }
                     Ok(Event::Resize(cols, rows)) => {
                         let _ = event_tx_resize
-                            .send(InnerEvent::ScreenResizeEvent {
-                                width: cols,
-                                height: rows,
-                            })
+                            .send(RuntimeEvent::screen_resize(cols, rows))
                             .await;
                     }
                     Ok(Event::Mouse(mouse_event)) => {
                         let _ = event_tx_resize
-                            .send(InnerEvent::MouseEvent(mouse_event.into()))
+                            .send(RuntimeEvent::mouse(mouse_event.into()))
                             .await;
                     }
                     Ok(_) => {} // Ignore other events (Focus, Paste)
@@ -213,7 +210,7 @@ fn spawn_persistent_server(
     server: Arc<RpcServer>,
     request_tx: mpsc::Sender<RpcRequest>,
     request_rx: mpsc::Receiver<RpcRequest>,
-    event_tx_for_shutdown: mpsc::Sender<InnerEvent>,
+    event_tx_for_shutdown: mpsc::Sender<RuntimeEvent>,
     test_mode: bool,
 ) {
     let conn_state = Arc::new(ConnectionState {
@@ -269,7 +266,7 @@ fn spawn_persistent_server(
         tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_secs(180)).await;
             tracing::info!("Test mode: 3 minutes elapsed, shutting down");
-            let _ = event_tx_for_shutdown.send(InnerEvent::KillSignal).await;
+            let _ = event_tx_for_shutdown.send(RuntimeEvent::kill()).await;
         });
     }
 }


### PR DESCRIPTION
Refactor the internal event system to support scope-based tracking:

- Rename `InnerEvent` enum to `RuntimeEventPayload`
- Create `RuntimeEvent` wrapper struct with optional `EventScope`
- Organize variants into logical sub-enums:
  - `EditingEvent`: TextInput, OperatorMotion, VisualTextObject, MoveCursor, SetRegister
  - `ModeEvent`: Change, PendingKeys
  - `RenderEvent`: Signal, Highlight, Syntax
  - `SettingsEvent`: LineNumbers, RelativeLineNumbers, Theme, Scrollbar, etc.
  - `InputEvent`: Mouse, ScreenResize
  - `FileEvent`: Open, OpenAt
- Add convenience constructors (RuntimeEvent::render_signal(), ::kill(), etc.)
- Update all 26 files to use new types directly (no backward compat alias)

This is Phase 3 of the EventScope refactor (#98). The scope field is extracted in handle_event() but not yet decremented - that comes in Phase 4 when RPC key injection creates and waits on scopes.

Part of: #98
Closes: #101