### PR TITLE
perf(treesitter): add background query pre-compilation (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to Reovim will be documented in this file.
   - Added `QueryCache::get_or_compile()` with interior mutability (`RwLock`) for thread-safe lazy compilation
   - Simplified `TreesitterManager::register_language()` from ~60 lines to ~5 lines
 
+- **Background query pre-compilation** (Issue #94) - Complement to lazy compilation
+  - Spawns background thread during `boot()` phase to pre-compile all queries
+  - First file open is instant if background compilation has finished
+  - Falls back to on-demand compilation if background hasn't completed yet
+  - Added `TreesitterManager::precompile_all_queries()` helper method
+
 ### Added
 
 - **EventScope for event lifecycle tracking** (Issue #70, #98) - GC-like scope tracking for deterministic event synchronization

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ version = "0.8.0-dev"
 dependencies = [
  "reovim-core",
  "reovim-sys",
+ "tokio",
  "tracing",
  "tree-sitter",
 ]

--- a/lib/core/src/event/inner/mod.rs
+++ b/lib/core/src/event/inner/mod.rs
@@ -507,8 +507,11 @@ impl RuntimeEvent {
     /// Create an apply command line completion event.
     #[must_use]
     pub fn apply_cmdline_completion(text: String, replace_start: usize) -> Self {
-        RuntimeEventPayload::Settings(SettingsEvent::ApplyCmdlineCompletion { text, replace_start })
-            .into()
+        RuntimeEventPayload::Settings(SettingsEvent::ApplyCmdlineCompletion {
+            text,
+            replace_start,
+        })
+        .into()
     }
 }
 

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -365,10 +365,8 @@ impl Runtime {
                 .event_bus
                 .subscribe::<RequestSetRegister, _>(100, move |event, _ctx| {
                     tracing::debug!("Runtime: Requesting to set register {:?}", event.register);
-                    let _ = tx.try_send(RuntimeEvent::set_register(
-                        event.register,
-                        event.text.clone(),
-                    ));
+                    let _ =
+                        tx.try_send(RuntimeEvent::set_register(event.register, event.text.clone()));
                     EventResult::Handled
                 });
         }
@@ -442,9 +440,8 @@ impl Runtime {
 
                     // Delete prefix first (for completion: replace typed prefix with full word)
                     for _ in 0..event.delete_prefix_len {
-                        let _ = tx.try_send(RuntimeEvent::text_input(
-                            TextInputEvent::DeleteCharBackward,
-                        ));
+                        let _ = tx
+                            .try_send(RuntimeEvent::text_input(TextInputEvent::DeleteCharBackward));
                     }
 
                     // Insert each character

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -9,8 +9,8 @@ use crate::{
     buffer::{Buffer, SelectionOps, TextOps},
     event::{
         BufferEvent, CommandHandler, EditingEvent, FileEvent, HighlightEvent, InputEvent,
-        InputEventBroker, ModeEvent, RenderEvent, RuntimeEvent, RuntimeEventPayload,
-        SettingsEvent, SyntaxEvent, TerminateHandler, TextInputEvent, WindowEvent,
+        InputEventBroker, ModeEvent, RenderEvent, RuntimeEvent, RuntimeEventPayload, SettingsEvent,
+        SyntaxEvent, TerminateHandler, TextInputEvent, WindowEvent,
     },
     modd::{EditMode, ModeState, SubMode},
 };

--- a/plugins/features/completion/src/saturator.rs
+++ b/plugins/features/completion/src/saturator.rs
@@ -331,7 +331,9 @@ mod tests {
 
         assert!(matches!(
             event.into_payload(),
-            reovim_core::event::RuntimeEventPayload::Render(reovim_core::event::RenderEvent::Signal)
+            reovim_core::event::RuntimeEventPayload::Render(
+                reovim_core::event::RenderEvent::Signal
+            )
         ));
 
         // Check cache

--- a/plugins/features/treesitter/Cargo.toml
+++ b/plugins/features/treesitter/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 reovim-core.workspace = true
 reovim-sys.workspace = true
 tracing.workspace = true
+tokio.workspace = true
 
 # Tree-sitter core only - language grammars are in language plugins
 tree-sitter = "0.26"

--- a/plugins/features/treesitter/src/lib.rs
+++ b/plugins/features/treesitter/src/lib.rs
@@ -6,9 +6,13 @@
 
 use std::sync::Arc;
 
-use reovim_core::{
-    event_bus::{EventBus, EventResult, FileOpened},
-    plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
+use {
+    reovim_core::{
+        event::RuntimeEvent,
+        event_bus::{EventBus, EventResult, FileOpened},
+        plugin::{Plugin, PluginContext, PluginId, PluginStateRegistry},
+    },
+    tokio::sync::mpsc,
 };
 
 pub mod edit;
@@ -198,5 +202,27 @@ impl Plugin for TreesitterPlugin {
         }
 
         tracing::debug!("TreesitterPlugin: subscribed to events");
+    }
+
+    fn boot(
+        &self,
+        _bus: &EventBus,
+        _state: Arc<PluginStateRegistry>,
+        _event_tx: Option<mpsc::Sender<RuntimeEvent>>,
+    ) {
+        // Spawn background thread to pre-compile all queries
+        // This runs after all languages are registered, before first file opens
+        let manager = Arc::clone(&self.manager);
+        std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            let count = manager.with(|m| m.precompile_all_queries());
+            let elapsed = start.elapsed();
+            tracing::info!(
+                queries = count,
+                elapsed_ms = elapsed.as_millis(),
+                "Background query precompilation finished"
+            );
+        });
+        tracing::debug!("TreesitterPlugin: spawned background query precompilation");
     }
 }

--- a/plugins/features/treesitter/src/manager.rs
+++ b/plugins/features/treesitter/src/manager.rs
@@ -210,6 +210,37 @@ impl TreesitterManager {
         self.get_or_compile_query(language_id, query_type)
     }
 
+    /// Pre-compile all queries for all registered languages
+    ///
+    /// This is called from a background thread during startup to warm the cache.
+    /// Returns the number of queries successfully compiled.
+    pub fn precompile_all_queries(&self) -> usize {
+        let language_ids = self.registry.language_ids();
+        let mut count = 0;
+
+        for lang_id in &language_ids {
+            // Compile all query types for each language
+            for query_type in [
+                QueryType::Highlights,
+                QueryType::Folds,
+                QueryType::TextObjects,
+                QueryType::Decorations,
+                QueryType::Injections,
+            ] {
+                if self.get_or_compile_query(lang_id, query_type).is_some() {
+                    count += 1;
+                }
+            }
+        }
+
+        tracing::debug!(
+            languages = language_ids.len(),
+            queries = count,
+            "Background query precompilation complete"
+        );
+        count
+    }
+
     /// Get the language registry
     #[must_use]
     pub fn registry(&self) -> &LanguageRegistry {

--- a/tools/bench/benches/bench_modules/event_bus.rs
+++ b/tools/bench/benches/bench_modules/event_bus.rs
@@ -3,13 +3,19 @@
 //! Measures synchronous dispatch performance and DynEvent overhead.
 //! These benchmarks help identify latency sources in the event system (Issue #86).
 
-use std::hint::black_box;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    hint::black_box,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
-use criterion::{BenchmarkId, Criterion};
-use reovim_core::event_bus::{DynEvent, Event, EventBus, EventResult, HandlerContext};
+use {
+    criterion::{BenchmarkId, Criterion},
+    reovim_core::event_bus::{DynEvent, Event, EventBus, EventResult, HandlerContext},
+};
 
 /// Test event for benchmarking
 #[derive(Debug)]
@@ -213,17 +219,13 @@ pub fn bench_dispatch_with_emit(c: &mut Criterion) {
 
         let sender = bus.sender();
 
-        group.bench_with_input(
-            BenchmarkId::new("emits", emit_count),
-            &emit_count,
-            |b, _| {
-                b.iter(|| {
-                    let event = DynEvent::new(BenchEvent { value: 1 });
-                    let mut ctx = HandlerContext::new(&sender);
-                    black_box(bus.dispatch(&event, &mut ctx))
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("emits", emit_count), &emit_count, |b, _| {
+            b.iter(|| {
+                let event = DynEvent::new(BenchEvent { value: 1 });
+                let mut ctx = HandlerContext::new(&sender);
+                black_box(bus.dispatch(&event, &mut ctx))
+            });
+        });
     }
 
     group.finish();

--- a/tools/bench/benches/bench_modules/treesitter_init.rs
+++ b/tools/bench/benches/bench_modules/treesitter_init.rs
@@ -4,12 +4,13 @@
 //! Tree-sitter query compilation during language registration blocks the event bus,
 //! causing auto-pair latency of ~100ms+ when opening files.
 
-use std::hint::black_box;
-use std::sync::Arc;
+use std::{hint::black_box, sync::Arc};
 
-use criterion::{BenchmarkId, Criterion};
-use reovim_plugin_treesitter::{LanguageSupport, TreesitterManager};
-use tree_sitter::Query;
+use {
+    criterion::{BenchmarkId, Criterion},
+    reovim_plugin_treesitter::{LanguageSupport, TreesitterManager},
+    tree_sitter::Query,
+};
 
 /// Benchmark pure query compilation (bypassing cache)
 /// This is the actual bottleneck - tree_sitter::Query::new()
@@ -20,18 +21,12 @@ pub fn bench_query_compilation(c: &mut Criterion) {
     let languages: Vec<(&str, Box<dyn LanguageSupport + Send + Sync>)> = vec![
         ("rust", Box::new(reovim_lang_rust::RustLanguage)),
         ("c", Box::new(reovim_lang_c::CLanguage)),
-        (
-            "javascript",
-            Box::new(reovim_lang_javascript::JavaScriptLanguage),
-        ),
+        ("javascript", Box::new(reovim_lang_javascript::JavaScriptLanguage)),
         ("python", Box::new(reovim_lang_python::PythonLanguage)),
         ("bash", Box::new(reovim_lang_bash::BashLanguage)),
         ("json", Box::new(reovim_lang_json::JsonLanguage)),
         ("toml", Box::new(reovim_lang_toml::TomlLanguage)),
-        (
-            "markdown",
-            Box::new(reovim_lang_markdown::MarkdownLanguage),
-        ),
+        ("markdown", Box::new(reovim_lang_markdown::MarkdownLanguage)),
     ];
 
     for (name, lang) in &languages {


### PR DESCRIPTION
Spawn background thread during boot() phase to pre-compile all tree-sitter queries. Combined with lazy compilation from #93, this eliminates both startup blocking (~72ms) and first-file-open latency.

- Add precompile_all_queries() to TreesitterManager
- Implement boot() to spawn background compilation thread
- Queries compile in parallel with startup, ready before first file

Closes #94