### PR TITLE
fix(treesitter): use lazy compilation in syntax factory (#93)

### DIFF
--- a/plugins/features/treesitter/src/factory.rs
+++ b/plugins/features/treesitter/src/factory.rs
@@ -33,15 +33,11 @@ impl SyntaxFactory for TreesitterSyntaxFactory {
             // Get the registered language
             let registered = manager.registry().get(&language_id)?;
 
-            // Get the pre-compiled highlights query
-            let query = manager
-                .query_cache()
-                .get(&language_id, QueryType::Highlights)?;
+            // Get or compile highlights query (lazy compilation)
+            let query = manager.get_cached_query(&language_id, QueryType::Highlights)?;
 
-            // Check for injection query
-            let injection_query = manager
-                .query_cache()
-                .get(&language_id, QueryType::Injections);
+            // Check for injection query (lazy compilation)
+            let injection_query = manager.get_cached_query(&language_id, QueryType::Injections);
 
             // Create syntax provider - use injection-aware version if available
             let syntax = if injection_query.is_some() {

--- a/plugins/features/treesitter/src/injection.rs
+++ b/plugins/features/treesitter/src/injection.rs
@@ -367,11 +367,12 @@ impl InjectionManager {
                     return None;
                 }
                 let registered = registered.unwrap();
-                let query = m.query_cache().get(language_id, QueryType::Highlights);
+                // Use lazy compilation - query will be compiled on first access
+                let query = m.get_cached_query(language_id, QueryType::Highlights);
                 if query.is_none() {
                     tracing::debug!(
                         language_id = %language_id,
-                        "Injection layer skipped: highlights query not cached"
+                        "Injection layer skipped: highlights query compilation failed"
                     );
                     return None;
                 }


### PR DESCRIPTION
Factory and injection code called query_cache().get() which only reads cached queries. With lazy compilation, queries aren't cached until first access via get_cached_query().

Fixes:
- factory.rs: Use get_cached_query() for highlights and injections
- injection.rs: Use get_cached_query() for injection layer highlights