### PR TITLE
feat(runtime): priority channels for user input events (#95, #86, #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,83 +4,24 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
-### Documentation
-
-- **Restructured docs into topic-based subdirectories** - Improved navigation and maintainability
-  - Split `architecture.md` (~1400 lines) into `docs/architecture/` with 6 focused files
-  - Split `event-system.md` (~1300 lines) into `docs/events/` with 6 focused files
-  - Merged `render-pipeline.md` + `plugin-rendering.md` into `docs/rendering/` with 4 files
-  - Organized plugins docs into `docs/plugins/` (4 files)
-  - Organized guides into `docs/guides/` (4 files)
-  - Organized reference docs into `docs/reference/` (3 files)
-  - Organized feature docs into `docs/features/` (7 files)
-  - Added `docs/README.md` as documentation index with reading order
-  - Updated all cross-references and CLAUDE.md links
-
 ### Fixed
 
-- **Port file cleanup on abnormal termination** (Issue #111) - Port files now cleaned up on SIGTERM/SIGINT
-  - Added `PortFileGuard` RAII struct for automatic cleanup on drop (including panics)
-  - Added signal handler for SIGTERM/SIGINT to trigger graceful shutdown
-  - Added startup cleanup to remove stale port files from crashed instances
-  - Port files at `~/.local/share/reovim/servers/<pid>.port` are now reliably removed
+- **tokio::spawn panics in EventBus handlers** (Issue #120) - Fix plugins using `tokio::spawn()` after PR #85 moved EventBus to std::thread
+  - Capture `tokio::runtime::Handle::current()` at `subscribe()` start (runs in tokio context)
+  - Use `handle.spawn()` instead of `tokio::spawn()` in EventBus handlers
+  - Affected: completion (BufferModified), LSP (GotoDefinition, GotoReferences, ShowHover)
 
 ### Performance
 
-- **Lock-free EventBus dispatch** (Issue #96) - Replace RwLock with ArcSwap for lock-free reads
-  - `dispatch()`, `has_handlers()`, `handler_count()` now use lock-free `load()`
-  - `subscribe()` uses atomic Copy-on-Write via `rcu()`
-  - Changed `EventHandlerFn` from `Box` to `Arc` to enable Clone for CoW
-  - Removed dead code `drain_and_dispatch()` method
-  - Follows established ArcSwap patterns from `highlight_cache.rs`
-
-- **Lazy tree-sitter query compilation** (Issue #93) - Defer query compilation from startup to first use
-  - Queries now compiled on-demand when first accessed, not during language registration
-  - `register_all_languages` benchmark improved from ~72ms to ~11µs (99.98% faster)
-  - Startup blocking time reduced from ~72ms to near zero
-  - First file open per language incurs one-time ~26ms compilation cost
-  - Added `QueryCache::get_or_compile()` with interior mutability (`RwLock`) for thread-safe lazy compilation
-  - Simplified `TreesitterManager::register_language()` from ~60 lines to ~5 lines
-
-- **Background query pre-compilation** (Issue #94) - Complement to lazy compilation
-  - Spawns background thread during `boot()` phase to pre-compile all queries
-  - First file open is instant if background compilation has finished
-  - Falls back to on-demand compilation if background hasn't completed yet
-  - Added `TreesitterManager::precompile_all_queries()` helper method
+- **Priority channels for user input events** (Issue #95, #86) - Dual-channel architecture for responsive user experience
+  - Separates high-priority user input from low-priority background events
+  - `hi_tx/hi_rx` (64 capacity): user input, mode changes, text insertion
+  - `lo_tx/lo_rx` (255 capacity): render signals, plugins, background tasks
+  - Biased `select!` ensures high-priority events processed first
+  - `MAX_LO_DRAIN=16` provides fairness for background events
+  - Auto-pair latency reduced from ~100ms to ~92us (1000x improvement, closes #86)
 
 ### Added
-
-- **EventScope for event lifecycle tracking** (Issue #70, #98) - GC-like scope tracking for deterministic event synchronization
-  - `EventScope` struct with atomic in-flight counter and async completion notification
-  - `ScopeId` for unique scope identification
-  - `increment()` / `decrement()` for tracking event lifecycle
-  - `wait()` / `wait_timeout()` for async completion waiting
-  - Tracing support for debugging stuck scopes (`REOVIM_LOG=trace`)
-  - `DynEvent` now carries optional scope for lifecycle tracking
-  - `HandlerContext` propagates scope to child events automatically
-  - `EventBus::emit_scoped()` for scoped event emission
-  - Dispatcher takes `Option<EventScope>` by value for clean ownership transfer
-  - CommandHandler manages scope lifecycle with `.take()` pattern
-  - RPC `input/keys` waits for scope completion with 3-second timeout
-  - Test harness writes logs to `/tmp/reovim-test-{port}.log` for debugging
-
-- **Event bus and treesitter initialization benchmarks** (Issue #97) - Add benchmarks to measure latency sources
-  - `event_bus/dyn_event_new` - DynEvent creation overhead (~10.6ns)
-  - `event_bus/dispatch/handlers/*` - Dispatch latency by handler count (1: ~26ns, 100: ~360ns)
-  - `event_bus/dispatch_multi_type/*` - HashMap lookup with multiple event types (~25ns)
-  - `event_bus/dispatch_priority/*` - Priority-sorted handler dispatch (~42-88ns)
-  - `event_bus/dispatch_emit/*` - Cascading event emission (0: ~25ns, 10: ~106ns)
-  - `event_bus/dispatch_consumed/*` - Early exit on consumed events (~25-27ns)
-  - `event_bus/rwlock/*` - RwLock acquisition overhead (1: ~26ns, 100: ~124ns)
-  - `event_bus/subscribe` - Handler registration time (~200ns)
-  - `event_bus/bottleneck_blocking/*` - Slow handler blocking impact (100µs-10ms)
-  - `event_bus/bottleneck_queue/*` - Queue depth behind slow handler (~1ms baseline)
-  - `event_bus/bottleneck_sequential/*` - Multiple slow handlers (accumulates linearly)
-  - `event_bus/bottleneck_comparison/*` - Fast event latency with/without slow handlers (~25ns)
-  - `treesitter/query_compile/highlights/*` - Query compilation time per language (rust: ~26ms)
-  - `treesitter/register_language/*` - Full language registration time (rust: ~35ms)
-  - `treesitter/register_all_languages` - Total startup cost (~72ms)
-  - Made `HandlerContext::new()` public for benchmark access
 
 - **Dynamic content in DisplayRegistry** (Issue #57) - Allow plugins to show contextual status line info
   - `DisplayContext` struct for render context with `PluginStateRegistry` access
@@ -89,16 +30,6 @@ All notable changes to Reovim will be documented in this file.
   - `DisplayInfoBuilder::dynamic()` builder method
   - `DisplayRegistry::display_string()` now takes `PluginStateRegistry` and invokes dynamic callbacks
   - Enables dynamic status like "Explorer (3 files)" or "Telescope (42 results)"
-
-- **Common UI rendering helpers** (Issue #56) - New `ui` module with shared utilities for plugins
-  - `ui::text` module with Unicode-aware text manipulation functions
-  - `display_width()` - Get display width of string (handles CJK, emoji)
-  - `truncate_end()` - Truncate with ellipsis at end ("Hello...")
-  - `truncate_start()` - Truncate with ellipsis at start ("...file.rs")
-  - `align()` - Align text (left/center/right) within width
-  - `pad_left()` / `pad_right()` - Pad text with fill character
-  - Re-exports border utilities from `screen::border` for unified access
-  - Added `unicode-width` dependency for proper Unicode handling
 
 - **Window resize operations** (Issue #54) - Implement direction-specific window resizing
   - `SplitNode::adjust_ratio_in_direction()` - Find innermost split matching direction and adjust ratio
@@ -224,12 +155,6 @@ All notable changes to Reovim will be documented in this file.
   - 8 commands updated to use `SwapDirection` directly
 
 ### Fixed
-
-- **Event bus performance under parallel load** (Issue #85) - Fix 300ms auto-pair delay under parallel test load
-  - Changed event bus processor from `tokio::spawn` to `std::thread::spawn`
-  - Dedicated OS thread avoids tokio scheduler starvation under contention
-  - Uses `blocking_recv()` instead of async `recv().await`
-  - No API changes; event bus channel and dispatch remain unchanged
 
 - **Light theme syntax highlighting** (Issue #43) - Light theme now uses proper One Light colors
   - Added `light_palette` module with Atom One Light colors (red, blue, purple, green, cyan, orange, yellow)
@@ -785,7 +710,1938 @@ All notable changes to Reovim will be documented in this file.
   - `capture` command prints raw screen content directly
   - Removed JSON wrapper for better usability and piping
 
+## [0.6.22] - 2025-12-20
+
+### Markdown Rendering (Phase 4)
+
+- **Dual-grammar support for inline elements** - Added `MarkdownInline` language for tree-sitter-md's `INLINE_LANGUAGE`
+  - Registered `LanguageId::MarkdownInline` in grammar system
+  - Created inline parser for emphasis, strong emphasis, and links
+  - Added `queries/markdown_inline/highlights.scm` and `decorations.scm`
+
+- **Inline formatting concealment** - Hide markdown markers in normal mode
+  - `*italic*` → `italic` (single asterisks hidden)
+  - `**bold**` → `bold` (double asterisks hidden)
+  - `[text](url)` → `text` (brackets and URL hidden)
+
+- **Table rendering** - Header and delimiter row styling
+  - Header row background highlighting
+  - Delimiter row dimmed styling via `pipe_table*` node captures
+
+- **Style system enhancements** - Added new text attributes
+  - Added `BLINK` and `DIM` attribute constants
+  - Added `blink()` and `dim()` builder methods to `Style`
+
+- **Conceal style merging** - Fixed replacement character styling
+  - Conceal replacement chars now use conceal's style merged with syntax highlights
+  - Heading icons display with proper bold + color styling
+
+- **Insert mode raw display** - Show raw markdown when editing
+  - Decorations disabled in insert mode for accurate cursor positioning
+  - Raw `#`, `*`, `**`, `[]()` markers visible during editing
+  - Returns to concealed view on mode exit
+
+## [0.6.21] - 2025-12-20
+
+### Architecture
+
+- **Explicit Keystroke and KeySequence types** - Replace implicit string-based key definitions
+  - New `keystroke` module with `Key`, `Modifiers`, `Keystroke`, `KeySequence` types
+  - Type-safe key definitions instead of strings like `"gg"`, `" ff"`, `"<C-d>"`
+  - `key!` macro for single keystrokes: `key!('a')`, `key!(Ctrl 'd')`, `key!(Space)`
+  - `keys!` macro for sequences: `keys!['g' 'g']`, `keys![Space 'f' 'f']`, `keys![(Ctrl 'd')]`
+
+- **Multiple render formats for key display**
+  - Vim notation: `<C-d>`, `<Space>ff`, `<Esc>`
+  - Human-readable: `Ctrl+D`, `Space → F → F`, `Escape`
+  - StatusLine: `C-d`, `SPC f f`, `ESC`
+
+- **KeySequence integration throughout codebase**
+  - `CommandHandler.pending_keys` now uses `KeySequence` instead of `String`
+  - `KeyMap` uses `KeySequence` as HashMap key type
+  - `KeyBinding.keys` field changed from `&'static str` to `KeySequence`
+  - Status line displays pending keys using StatusLine render format
+
+### Files Changed
+
+- `lib/core/src/keystroke/mod.rs` - Core types (Key, Modifiers, Keystroke, KeySequence)
+- `lib/core/src/keystroke/notation.rs` - Render methods for multiple formats
+- `lib/core/src/keystroke/macros.rs` - key! and keys! macros
+- `lib/core/src/bind/mod.rs` - Updated KeyBinding and KeyMap to use KeySequence
+- `lib/core/src/event/handler/command/mod.rs` - pending_keys as KeySequence
+- `lib/core/src/plugin/context.rs` - bind_key_scoped takes KeySequence
+- `lib/core/src/telescope/picker/keymaps.rs` - Renders KeySequence for display
+
+## [0.6.20] - 2025-12-20
+
+### Refactoring
+
+- **Clap-based CLI argument parsing** - Replaced manual argument parsing with clap v4
+  - Added `clap` to workspace dependencies with derive feature
+  - Defined `Cli` struct with clap derive macros in `main/src/main.rs`
+  - Removed manual `print_help()` and `print_version()` functions (clap auto-generates)
+  - Reduced argument parsing code from ~80 lines to ~30 lines
+  - Consistent with `reo-cli` which already uses clap
+
+## [0.6.17] - 2025-12-20
+
+### Architecture
+
+- **RenderState for Bundled Render Parameters**
+  - Created `RenderState<'a>` struct to bundle all runtime state needed for rendering
+  - Reduces 16-parameter render function signatures to single state struct
+  - Fields: buffers, highlight_store, mode, command_line, pending_keys, last_command,
+    color_mode, theme, explorer, which_key, completion, telescope, leap, fold_manager,
+    indent_analyzer, settings_menu
+
+- **Enhanced RenderContext**
+  - Added optional `state: Option<&'a RenderState<'a>>` field to `RenderContext`
+  - Added `RenderContext::with_state()` constructor for creating context with state
+  - Added `RenderContext::state()` getter method
+  - Backward compatible - existing code using `RenderContext::new()` still works
+
+- **New Screen::render_with_state() Method**
+  - Added `Screen::render_with_state(&mut self, state: &RenderState)` method
+  - Preferred rendering entry point with cleaner API
+  - Runtime::render() now creates RenderState and calls this method
+  - Legacy `Screen::render()` with 16 parameters kept for compatibility
+
+- **WhichKeyPanel Debug Derive**
+  - Added `Debug` derive to `WhichKeyPanel` for RenderState compatibility
+
+### Files Changed
+
+- `lib/core/src/component/display.rs` - Added RenderState struct, updated RenderContext
+- `lib/core/src/component/mod.rs` - Export RenderState
+- `lib/core/src/screen/mod.rs` - Added render_with_state() method
+- `lib/core/src/screen/which_key.rs` - Added Debug derive to WhichKeyPanel
+- `lib/core/src/runtime/core.rs` - Use RenderState in render()
+
+### Testing
+
+- All unit tests passing (324 tests)
+- All integration tests passing
+- Zero warnings (build + clippy)
+
+## [0.6.16] - 2025-12-20
+
+### Architecture
+
+- **Removed Layer Trait**
+  - Deleted `Layer` trait from `screen/layer.rs` - unused dead code
+  - Deleted `screen/layers/` directory with all Layer implementations
+  - Layer wrappers (CompletionLayer, LeapLayer, etc.) were never instantiated
+  - Buffered rendering path already had all logic directly in Screen
+
+- **Consolidated z_order and LayerBounds**
+  - Moved `z_order` module constants to `screen/mod.rs`
+  - Moved `LayerBounds` struct to `screen/mod.rs`
+  - These are now directly available via `screen::z_order::*` and `screen::LayerBounds`
+
+### Files Changed
+
+- `lib/core/src/screen/mod.rs` - Added z_order module and LayerBounds struct
+- `lib/core/src/screen/layer.rs` - **DELETED** (Layer trait, z_order, LayerBounds moved)
+- `lib/core/src/screen/layers/` - **DELETED** (8 unused Layer implementations)
+
+### Deleted Files
+
+- `lib/core/src/screen/layer.rs`
+- `lib/core/src/screen/layers/mod.rs`
+- `lib/core/src/screen/layers/base.rs`
+- `lib/core/src/screen/layers/completion.rs`
+- `lib/core/src/screen/layers/editor.rs`
+- `lib/core/src/screen/layers/explorer.rs`
+- `lib/core/src/screen/layers/leap.rs`
+- `lib/core/src/screen/layers/settings_menu.rs`
+- `lib/core/src/screen/layers/telescope.rs`
+- `lib/core/src/screen/layers/which_key.rs`
+
+### Testing
+
+- All unit tests passing (324 tests)
+- All integration tests passing
+- Zero warnings (build + clippy)
+
+## [0.6.15] - 2025-12-20
+
+### Architecture
+
+- **Plugin-Based Component Registration**
+  - Created `UIComponentsPlugin` to register built-in UI components via plugin system
+  - Editor, Explorer, Telescope, Settings, `CommandLine` now registered through plugins
+  - Focus input handlers registered via `PluginContext.register_focus_handler()`
+  - `Runtime::new()` now delegates to `Runtime::with_plugins(screen, DefaultPlugins)`
+
+- **Removed Hardcoded Defaults**
+  - Removed `InteractorRegistry::with_defaults()` - components come from plugins
+  - Removed hardcoded telescope pickers - registered by `TelescopePlugin`
+  - Removed `enlist_default_handlers()` - handlers registered by `UIComponentsPlugin`
+
+- **New ComponentId Constants**
+  - Added `ComponentId::COMPLETION` for completion popup overlay
+  - Added `ComponentId::LEAP` for leap motion overlay
+  - Added `ComponentId::WHICH_KEY` for which-key hint panel
+
+### Files Changed
+
+- `lib/core/src/plugin/builtin/ui_components.rs` - **NEW** `UIComponentsPlugin`
+- `lib/core/src/plugin/builtin/mod.rs` - Added UIComponentsPlugin to DefaultPlugins
+- `lib/core/src/runtime/core.rs` - `new()` delegates to `with_plugins()`
+- `lib/core/src/runtime/enlist.rs` - Made handler functions public for plugin use
+- `lib/core/src/runtime/mod.rs` - Export handler functions
+- `lib/core/src/interactor/mod.rs` - Removed `with_defaults()` method
+- `lib/core/src/ui_component/component.rs` - Added COMPLETION, LEAP, WHICH_KEY constants
+
+### Testing
+
+- All unit tests passing
+- All integration tests passing
+- Zero warnings (build + clippy)
+
+## [0.6.14] - 2025-12-20
+
+### Breaking Changes
+
+- **Removed `DisplayComponent` trait** - Use `UIComponent` exclusively for all components
+- **Removed `Interactor` trait** - Input handling now integrated into `UIComponent`
+- **`InteractorId` is now an alias** - Use `ComponentId` directly (InteractorId re-exported for backward compatibility)
+
+### Architecture
+
+- **Unified UIComponent-Only Architecture**
+  - All UI components now implement the single `UIComponent` trait
+  - `StatusLineComponent` and `TabLineComponent` render logic inlined into `UIComponent` impl
+  - `InteractorRegistry` now stores `Box<dyn UIComponent>` instead of `Box<dyn Interactor>`
+  - Input handling methods (`handle_insert_char`, `handle_delete_backward`) integrated into `UIComponent`
+
+- **Plugin Component Registration**
+  - Added `ComponentRegistry` to `PluginContext` for plugin-registered components
+  - `register_component()` method for plugins to register custom UI components
+  - `component_registry()` / `component_registry_mut()` accessors
+  - Runtime receives and stores `ComponentRegistry` from plugin context
+
+- **ComponentId Unification**
+  - `InteractorId` replaced with `ComponentId` across entire codebase
+  - `ModeState.interactor_id` now uses `ComponentId`
+  - Focus handlers use `ComponentId` as HashMap key
+  - All interactor comparisons use `ComponentId` constants
+
+### Files Changed
+
+- `lib/core/src/component/display.rs` - Removed `DisplayComponent` trait, kept `RenderContext`
+- `lib/core/src/component/mod.rs` - Removed `DisplayComponent` export
+- `lib/core/src/component/status_line.rs` - Inlined DisplayComponent logic into UIComponent
+- `lib/core/src/component/tab_line.rs` - Inlined DisplayComponent logic into UIComponent
+- `lib/core/src/interactor/mod.rs` - Removed Interactor trait, updated registry to use UIComponent
+- `lib/core/src/plugin/context.rs` - Added ComponentRegistry support
+- `lib/core/src/runtime/core.rs` - Added component_registry field
+- `lib/core/src/modd/mod.rs` - Re-export ComponentId instead of InteractorId
+- `lib/core/src/screen/layers/base.rs` - Use UIComponent trait for rendering
+- `lib/core/src/event/handler/command/dispatcher.rs` - Removed deprecated allow block
+- `lib/core/src/runtime/handlers.rs` - Removed deprecated allow block
+
+### Migration Guide
+
+```rust
+// Before (DisplayComponent):
+impl DisplayComponent for MyComponent {
+    fn render_to_frame(&self, buffer: &mut FrameBuffer, ctx: &RenderContext<'_>) { ... }
+}
+
+// After (UIComponent only):
+impl UIComponent for MyComponent {
+    fn render_to_frame(&self, buffer: &mut FrameBuffer, ctx: &RenderContext<'_>) { ... }
+    fn is_focusable(&self) -> bool { false }
+}
+
+// Before (InteractorId):
+use crate::interactor::InteractorId;
+if mode.interactor_id == InteractorId::EDITOR { ... }
+
+// After (ComponentId):
+use crate::ui_component::ComponentId;
+if mode.interactor_id == ComponentId::EDITOR { ... }
+```
+
+### Testing
+
+- All unit tests passing
+- All integration tests passing
+- Zero warnings (build + clippy)
+
+## [0.6.13] - 2025-12-20
+
+### Architecture
+
+- **Unified UIComponent Trait** (`lib/core/src/ui_component/`)
+  - `UIComponent` trait combining `Interactor`, `DisplayComponent`, and `Layer` functionality
+  - `ComponentId` for unique component identification (STATUS_LINE, TAB_LINE, EDITOR, EXPLORER, TELESCOPE, SETTINGS, COMMAND_LINE)
+  - `ComponentRegistry` for managing registered components and tracking active focus
+  - Unified interface for identity, rendering, and input handling
+
+- **UIComponent Implementations**
+  - `StatusLineComponent` - Display-only, not focusable
+  - `TabLineComponent` - Display-only, not focusable
+  - `Editor` - Focusable, handles insert/delete input
+  - `Explorer` - Focusable, handles input when `input_active`
+  - `Telescope` - Focusable, captures all input when active
+  - `Settings` - Focusable, captures all input when active
+  - `CommandLineInt` - Focusable, captures all input when active
+
+### Files Added
+
+- `lib/core/src/ui_component/mod.rs` - Module root with documentation
+- `lib/core/src/ui_component/component.rs` - `UIComponent` trait and `ComponentId`
+- `lib/core/src/ui_component/registry.rs` - `ComponentRegistry` for component management
+
+### Files Changed
+
+- `lib/core/src/lib.rs` - Added `pub mod ui_component`
+- `lib/core/src/component/status_line.rs` - Added `UIComponent` impl
+- `lib/core/src/component/tab_line.rs` - Added `UIComponent` impl
+- `lib/core/src/interactor/mod.rs` - Added `UIComponent` impl for all interactors
+
+### Testing
+
+- 324 unit tests passing
+- 100 integration tests passing
+- Zero warnings (build + clippy)
+
+### Notes
+
+- Rendering for interactors is currently delegated to existing Layer implementations
+- Full rendering unification will be completed in Stream C (v0.6.14) with plugin registration
+
+## [0.6.12] - 2025-12-20
+
+### Breaking Changes
+
+- **Removed `Focus` enum** - Use `InteractorId` exclusively for focus tracking
+  - `ModeState.focus` field removed
+  - `ModeState::with_focus_and_mode()` removed
+  - `ModeState::with_sub_mode()` (Focus-based) removed
+  - `ModeState::with_focus()` removed
+
+### Architecture
+
+- **InteractorId-based Focus System** - Complete migration from closed enum to extensible IDs
+  - `ModeState` now contains only `interactor_id`, `edit_mode`, `sub_mode`
+  - Pattern matching replaced with `InteractorId` equality checks
+  - Enables plugins to define custom focus targets without core changes
+
+### Changed
+
+- **modd/mod.rs** - Simplified `ModeState` struct
+  - Removed `focus: Focus` field
+  - `display_string()` now matches on `interactor_id`
+  - All convenience constructors updated
+
+- **Status Line Rendering** - Updated for `InteractorId`
+  - `mode_icon()` uses `InteractorId` comparison
+  - New `get_mode_style()` helper method
+  - Both `component/status_line.rs` and `screen/status_line.rs` updated
+
+- **Keymap Selection** - `bind/mod.rs`
+  - `get_keymap_for_mode()` matches on `interactor_id` instead of `focus`
+  - Changed from `const fn` to `fn` (InteractorId comparison not const)
+
+- **Runtime Handlers** - `runtime/handlers.rs`
+  - `sync_mode_with_screen_focus()` uses `InteractorId::EXPLORER`
+  - Telescope handlers use convenience constructors
+
+- **Command Dispatcher** - `dispatcher.rs`
+  - `telescope_enter_normal` uses `ModeState::telescope_normal()`
+
+### Migration Guide
+
+```rust
+// Before:
+match (&mode.focus, &mode.edit_mode) {
+    (Focus::Editor, EditMode::Normal) => ...
+}
+
+// After:
+if mode.interactor_id == InteractorId::EDITOR {
+    match &mode.edit_mode {
+        EditMode::Normal => ...
+    }
+}
+
+// Before:
+ModeState::with_focus_and_mode(Focus::Telescope, EditMode::Normal)
+
+// After:
+ModeState::telescope_normal()
+```
+
+### Testing
+
+- 318 unit tests passing
+- All integration tests passing
+- Zero clippy warnings
+
+## [0.6.11] - 2025-12-20
+
+### Architecture
+
+- **DisplayComponent Trait** (`lib/core/src/component/`)
+  - `DisplayComponent` trait for display-only UI components (no input handling)
+  - `RenderContext` struct passed to components during rendering
+  - Clean separation: Interactor for input, DisplayComponent for display
+
+- **StatusLineComponent** - Renders mode indicator, pending keys, filename, cursor position
+  - Uses `DisplayComponent` trait
+  - Mode-specific icons and styling
+
+- **TabLineComponent** - Renders tab bar when multiple tabs are open
+  - Uses `DisplayComponent` trait
+  - Visibility conditional on tab count
+
+- **CommandLine Interactor** - Input handling for `:` command mode
+  - `InteractorId::COMMAND_LINE` for identifying command line focus
+  - `CommandLineInt` struct implementing `Interactor` trait
+  - `handle_command_line_input()` enlist handler
+
+### Changed
+
+- **BaseLayer uses DisplayComponents** - Rendering delegated to components
+  - `TabLineComponent` replaces inline tab line rendering
+  - `StatusLineComponent` replaces inline status line rendering
+  - Removed unused `render_tab_line()` and `render_status_line()` methods
+
+- **Screen layer module made public** - `pub mod layer` for component access
+
+### Files Added
+
+- `lib/core/src/component/mod.rs` - Component module exports
+- `lib/core/src/component/display.rs` - DisplayComponent trait + RenderContext
+- `lib/core/src/component/status_line.rs` - StatusLineComponent
+- `lib/core/src/component/tab_line.rs` - TabLineComponent
+
+### Testing
+
+- 318 unit tests passing
+- All integration tests passing
+
+## [0.6.10] - 2025-12-20
+
+### Architecture
+
+- **Enlist-Based Handler Registration** (Bevy/Zed Pattern)
+  - Fully removes hardcoding from runtime dispatch - only enlist (initialization) knows about specific interactors
+  - Function pointer registry: `HashMap<InteractorId, FocusInputHandler>`
+  - Handlers registered at initialization via `enlist_focus_input_handler()`
+  - Runtime dispatch is fully generic via handler lookup
+
+- **Interactor System** (`lib/core/src/interactor/`) - Renamed from Focus System
+  - `InteractorId` for identifying input targets (Editor, Telescope, Explorer, etc.)
+  - `Interactor` trait for input-receiving components
+  - `InteractorRegistry` for managing interactors and active focus
+  - `InputResult` enum: `NotHandled`, `Handled`, `SendEvent(InnerEvent)`
+
+### Changed
+
+- **Generic Event Dispatch** - Runtime no longer matches on interactor types
+  - Before: `match InteractorId::TELESCOPE => ...`
+  - After: `handlers.get(&interactor_id)` - fully generic lookup
+  - Adding new interactors only requires calling `enlist_*` at initialization
+
+- **FocusInput Event** - Generic focus input event for all interactors
+  - `InnerEvent::FocusInput { char, delete, clear_landing }`
+  - Dispatched to registered handler based on active `InteractorId`
+
+### Files Added
+
+- `lib/core/src/interactor/mod.rs` - Interactor trait and registry
+- `lib/core/src/runtime/enlist.rs` - Handler implementations (enlist pattern)
+
+### Files Removed
+
+- `lib/core/src/focus/mod.rs` - Replaced by interactor module
+
+### Testing
+
+- 318 unit tests passing
+- 132 integration tests passing
+
+## [0.6.9] - 2025-12-20
+
+### Architecture
+
+- **Compositor System** (`lib/core/src/compositor/`)
+  - `ZOrder` and `ZGroup` for layered rendering priority (Base, Editor, Popup, Overlay, Modal)
+  - `Bounds` for component layout bounds with collision detection
+  - `ComposableId` for unique component identification
+
+- **Modifier System** (`lib/core/src/modifier/`)
+  - `Modifier` trait for context-aware styling and behavior
+  - `ModifierRegistry` with caching for efficient evaluation
+  - `ModifierContext` for passing window/buffer/mode context
+  - `StyleModifiers` for visual style overrides (borders, decorations, colors)
+  - `BehaviorModifiers` for keybinding overrides and feature flags
+
+- **Border System** (`lib/core/src/screen/border.rs`)
+  - `BorderStyle` variants (None, Single, Double, Rounded, Heavy, Custom)
+  - `BorderSides` for selective borders (top, bottom, left, right)
+  - `BorderConfig` builder pattern with fluent API
+  - `BorderMode::Collide` and `BorderMode::Float` for multi-window layouts
+
+- **Filetype Detection** (`lib/core/src/filetype/`)
+  - Extension-based and filename-based detection
+  - `FiletypeInfo` with icon and color
+  - Global `FiletypeRegistry` for language detection
+
+### Changed
+
+- **Text Input Routing** - Input events now routed via `TextInputEvent`
+  - `TextInputEvent::InsertChar(char)` for character insertion
+  - `TextInputEvent::DeleteCharBackward` for backspace handling
+  - CommandHandler emits `TextInputEvent` for insert/command modes
+  - Runtime routes events via two-tier system: fast path for built-ins, UIComponent trait for plugins
+
+### Files Added
+
+- `lib/core/src/compositor/mod.rs` - Compositor types and ZOrder
+- `lib/core/src/compositor/types.rs` - Bounds, ComposableId
+- `lib/core/src/modifier/mod.rs` - Modifier module root
+- `lib/core/src/modifier/traits.rs` - Modifier trait definition
+- `lib/core/src/modifier/registry.rs` - ModifierRegistry
+- `lib/core/src/modifier/context.rs` - ModifierContext
+- `lib/core/src/modifier/style.rs` - StyleModifiers
+- `lib/core/src/modifier/behavior.rs` - BehaviorModifiers
+- `lib/core/src/focus/mod.rs` - Focus system
+- `lib/core/src/filetype/mod.rs` - Filetype detection
+- `lib/core/src/screen/border.rs` - Border system
+
+### Testing
+
+- 320 unit tests passing
+- 154 integration tests passing
+
+## [0.6.8] - 2025-12-19
+
+### Fixed
+
+- **Transparent Background Support** - Editor now uses terminal's native background
+  - Removed explicit background from `base.default` and `command_line` styles
+  - Fixed visual artifacts by emitting ANSI code `49` (background reset) when `bg: None`
+  - Added `flush()` after `clear()` in screen `initialize()` and `finalize()`
+
+### Changed
+
+- `Style::to_ansi_start()` now emits `49` reset code when background is `None`
+- All themes (Dark, Light, TokyoNight) use terminal default background for text areas
+
+## [0.6.7] - 2025-12-19
+
+### Fixed
+
+- **Independent Scroll Per Window** - Each window maintains its own scroll position
+  - Fixed bug where scrolling in one window would sync across all windows sharing the same buffer
+  - Root cause: All windows called `update_scroll()` with buffer's live cursor
+  - Fix: Active window uses `buf.cur.y`, inactive windows use saved `win.cursor.y`
+
+### Added
+
+- **`state/windows` RPC Endpoint** - Query per-window scroll and cursor state
+  - `WindowSnapshot` struct with `buffer_anchor`, `cursor`, `is_active` fields
+  - Useful for testing and debugging window state
+
+### Tests
+
+- `test_shared_buffer_scroll_independence` - Verifies scroll isolation between splits
+- `test_shared_buffer_scroll_preserved_after_navigation` - Verifies scroll preserved on window switch
+- `test_three_windows_scroll_isolation` - Verifies 3-window scroll independence
+
+## [0.6.6] - 2025-12-19
+
+### Architecture
+
+- **Double-Buffer Rendering Refactor** - Simplified and unified rendering architecture
+  - `FrameRenderer` uses front/back buffer swap pattern for flicker-free updates
+  - `front` buffer: Latest complete frame (external readers access this)
+  - `back` buffer: Currently being rendered to
+  - Cell-by-cell diff computed between buffers, only changed cells sent to terminal
+  - After flush: `std::mem::swap(&mut front, &mut back)` for efficient buffer rotation
+
+- **Unified Capture System** - Consolidated all RPC capture formats into `FrameBufferHandle`
+  - Single capture handle provides: `RawAnsi`, `PlainText`, `CellGrid` formats
+  - Added `to_ansi()` and `to_plain_text()` methods to `FrameBuffer`
+  - Removed `CaptureHandle` and `DualOutput` (redundant with unified system)
+  - Capture buffer updated after each flush for RPC clients
+
+- **Rendering Pipeline Cleanup**
+  - Removed unused render strategies (`cell_delta`, `dirty_region`, `virtual_buffer`)
+  - Removed unused `screen/compositor.rs` - rendering now via `Screen::render_buffered()`
+  - Streamlined frame module: just `buffer.rs`, `cell.rs`, `renderer.rs`
+  - Direct layer rendering in z-order without intermediate compositor
+
+### Documentation
+
+- Updated `docs/architecture.md`:
+  - Rendering flow diagram now reflects actual `Screen::render_buffered()` implementation
+  - Removed stale `LayerCompositor` references
+  - Documented double-buffer swap pattern
+- Updated `CLAUDE.md` - Simplified RPC capture documentation
+
+### Removed
+
+- `lib/core/src/frame/dirty.rs` - Unused dirty tracking
+- `lib/core/src/frame/strategy/` - Entire unused strategy module (4 files)
+- `lib/core/src/screen/compositor.rs` - Unused z-layer compositor
+- `lib/core/src/io/output.rs` - `CaptureHandle`, `DualOutput` types
+
+### Performance
+
+- Window render (10 lines): 10.14 µs
+- Full screen render: 62.80 µs
+- Char insert RTT: 108 µs
+- Throughput: ~18.1k renders/sec
+- Double-buffer swap: O(1) pointer swap, no data copy
+
+## [0.6.5] - 2025-12-19
+
+### Features
+
+- **Smart Window Focus/Split** - `<leader>wh/j/k/l` focuses existing window OR creates split
+  - Unified window operations under `<leader>w*` prefix
+  - Smart behavior: navigate if adjacent window exists, split if not
+  - Removed `<C-hjkl>` from normal mode (use `<leader>w*` instead)
+
+- **Buffer Navigation** - LazyVim-style buffer switching
+  - `H` / `L` - Previous/next buffer
+  - `<leader>bd` - Delete current buffer
+  - `<leader>b` prefix group in which-key
+
+- **Change Line Command** - `cc` deletes line content and enters insert mode
+  - Consistent with `dd` (delete line) and `yy` (yank line)
+
+### Documentation
+
+- **Window-Buffer Architecture** - New `docs/window-buffer.md`
+  - Explains N:1 window-to-buffer relationship
+  - Dual cursor state (buffer cursor vs window cursor)
+  - Cursor handoff protocol on window switch
+
+### Fixed
+
+- **Smart Focus Cursor Bug** - `handle_focus_or_split` now uses proper cursor save/restore
+  - Was calling `screen.navigate_window()` directly, bypassing cursor handoff
+  - Now calls `handle_window_navigate()` for correct behavior
+
+- **Cursor Rendering in Multi-Window** - Fixed cursor highlight appearing in wrong window
+  - `render_buffered()` was calculating cursor position for ALL windows
+  - Last window in loop always overwrote `cursor_pos`, ignoring active window
+  - Fix: Added `win.is_active &&` check before cursor position calculation
+  - Line numbers updated correctly but cursor highlight didn't follow
+
+### New Keymaps
+
+| Key | Action |
+|-----|--------|
+| `H` | Previous buffer |
+| `L` | Next buffer |
+| `cc` | Change line |
+| `<leader>b` | +buffer (prefix) |
+| `<leader>bd` | Delete buffer |
+| `<leader>wh` | Smart focus left (or vsplit) |
+| `<leader>wj` | Smart focus down (or hsplit) |
+| `<leader>wk` | Smart focus up (or hsplit) |
+| `<leader>wl` | Smart focus right (or vsplit) |
+| `<leader>wv` | Vertical split |
+| `<leader>ws` | Horizontal split |
+| `<leader>wc` | Close window |
+| `<leader>wo` | Close other windows |
+| `<leader>w=` | Equalize windows |
+
+### Removed Keymaps
+
+- `<C-h/j/k/l>` - Window focus (now use `<leader>wh/j/k/l`)
+- `<C-S-H/J/K/L>` - Window move (all window ops under `<leader>w`)
+
+### Testing
+
+- Add 13 window split integration tests (`window_splits.rs`)
+  - 11 window split/focus tests
+  - 2 shared buffer cursor preservation tests
+- Update visual_snapshot tests to use `<leader>w*` instead of `<C-h/l>`
+- Total: 311 tests passing
+
+## [0.6.4] - 2025-12-19
+
+### Features
+
+- **Per-Window Cursor** - Each window maintains its own cursor position (Vim-like behavior)
+  - `cursor` and `desired_col` fields added to Window struct
+  - Cursor syncs between window and buffer on navigation
+  - `effective_cursor_y()` method for rendering (active uses buffer cursor, inactive uses window cursor)
+
+- **Inactive Line Number Styling** - Dimmed line numbers for inactive windows
+  - `inactive_line_number` style in theme's gutter configuration
+  - `fg_gutter` (#3b4261) and `fg_inactive` (#292e42) colors for TokyoNightOrange
+  - `is_active` field on Window to track focus state
+
+### Fixed
+
+- **Split Window Cursor Movement** - j/k now works immediately after Ctrl-h/l window navigation
+  - `active_buffer_id` now syncs when navigating between windows
+  - Buffer cursor properly loads from window's saved cursor on switch
+
+### Testing
+
+- Add 6 split window visual tests
+  - `test_vsplit_creates_two_windows` - Verify split shows content in both windows
+  - `test_vsplit_navigate_right/left` - Test Ctrl-l/h navigation
+  - `test_vsplit_cursor_movement_after_navigate` - Verify j/k works after switch
+  - `test_vsplit_independent_cursors` - Windows maintain separate cursor positions
+  - `test_vsplit_cursor_preserved_on_switch` - Cursor restored when returning to window
+
+## [0.6.3] - 2025-12-19
+
+### Features
+
+- **Visual Testing Infrastructure** - Comprehensive TUI debugging for tests and AI assistants
+  - ASCII art snapshots: Plain and annotated views with borders/line numbers
+  - Structured visual snapshots: Cell grid, cursor info, layer visibility (JSON)
+  - `with_size(width, height)` builder method for explicit screen dimensions
+  - `VisualAssertions` trait: `assert_cell_char`, `assert_row_content`, `assert_contains`, etc.
+
+### New Modules
+
+- `lib/core/src/visual/` - Visual snapshot types and ASCII rendering
+  - `VisualSnapshot`, `CursorInfo`, `LayerInfo`, `BoundsInfo`
+  - `AsciiRenderConfig` for customized ASCII output
+- `lib/core/src/testing/visual.rs` - Visual assertions trait
+
+### RPC Methods
+
+- `state/visual_snapshot` - Full visual snapshot with cells, cursor, layers
+- `state/ascii_art` - ASCII art representation (plain or annotated)
+- `state/layer_info` - Layer visibility and bounds information
+
+### Testing
+
+- Add 17 visual snapshot integration tests
+- Add `visual_snapshot()`, `ascii_art()`, `layer_info()` to `ServerTestResult`
+- Update `docs/TESTING.md` with visual testing examples
+
+## [0.6.2] - 2025-12-19
+
+### Fixed
+
+- **Buffer Switching Not Updating Screen** - Fix 6 locations where screen state wasn't synchronized
+  - Telescope buffer picker now properly switches displayed buffer
+  - Telescope file picker and grep match now sync screen after open
+  - `:e` command now updates screen after opening file
+  - `BufferEvent::Switch` now syncs screen
+  - `:split`/`:vsplit` and `:tabnew` use correct buffer ID after file open
+
+### Testing
+
+- Add buffer switching integration tests (10 tests)
+- Add `screen()`, `buffer_list()`, `open_file()` to testing framework
+- Add `assert_active_buffer_id()` and `active_buffer_id()` assertions
+
+## [0.6.1] - 2025-12-19
+
+### Fixed
+
+- **Cursor Blinking During Movement** - Hide cursor during render operations
+  - Wrap render with Hide/Show escape sequences to prevent visual artifacts
+  - Fixes flickering cursor when navigating with hjkl
+
+### Testing
+
+- Add cursor visibility integration tests
+- Add `screen_content_raw()` to testing framework
+- Add `assert_cursor_visibility_managed()` assertion
+
+### Chores
+
+- Add `cargo +nightly fmt --all` step to `scripts/check.sh` for consistent formatting
+
+## [0.6.0] - 2025-12-18
+
+### Features
+
+- **Diff-Based Rendering System** - Eliminates terminal flickering
+  - FrameBuffer: 2D cell grid for double-buffering
+  - Three render strategies: VirtualBuffer (full diff), DirtyRegion, CellDelta
+  - Only changed cells sent to terminal - massive reduction in I/O
+
+- **Overlay System** - Composable UI overlays
+  - Overlay trait with z-order compositing
+  - OverlayCompositor for managing overlay stack
+  - OverlayGeometry for positioning and bounds
+
+- **Layer-Based Compositor** - Structured rendering pipeline
+  - Layer trait with z-order constants (BASE=0, EDITOR=2, COMPLETION=4, etc.)
+  - Implementations: BaseLayer, EditorLayer, ExplorerLayer, CompletionLayer, WhichKeyLayer, TelescopeLayer, LeapLayer, SettingsMenuLayer
+
+- **Theme Background Colors** - All UI styles now have fg AND bg for proper diff-based rendering
+
+### Architecture
+
+- `FrameBuffer` - 2D cell storage with dirty tracking
+- `Cell` - Individual screen cell (char, fg, bg, modifiers)
+- `FrameRenderer` - Coordinates render strategies
+- `RenderStrategy` trait - Pluggable diff algorithms
+- `LayerCompositor` - Coordinates layer rendering to FrameBuffer
+- `OverlayCompositor` - Manages overlay z-order
+
+### Files Added
+
+- `lib/core/src/frame/` - Frame buffer module
+  - `mod.rs`, `buffer.rs`, `cell.rs`, `dirty.rs`, `renderer.rs`
+  - `strategy/` - VirtualBuffer, DirtyRegion, CellDelta strategies
+- `lib/core/src/overlay/` - Overlay system
+  - `mod.rs`, `compositor.rs`, `geometry.rs`, `render.rs`, `selectable.rs`
+- `lib/core/src/screen/layer.rs` - Layer trait and z-order constants
+- `lib/core/src/screen/compositor.rs` - LayerCompositor
+- `lib/core/src/screen/layers/` - Layer implementations
+  - `base.rs`, `editor.rs`, `explorer.rs`, `completion.rs`
+  - `which_key.rs`, `telescope.rs`, `leap.rs`, `settings_menu.rs`
+
+### Files Changed
+
+- `lib/core/src/screen/mod.rs` - Integration with layer compositor
+- `lib/core/src/screen/window.rs` - render_to_buffer method
+- `lib/core/src/runtime/core.rs` - FrameRenderer initialization
+- `lib/core/src/runtime/event_loop.rs` - RenderSignal handling
+- `lib/core/src/highlight/theme.rs` - Background colors for all styles
+
+### Technical Changes
+
+- Screen rendering now goes through LayerCompositor → FrameBuffer → FrameRenderer → Terminal
+- Eliminated full-screen clear on every render
+- Added `*_to_buffer` methods to all renderable components
+
+### Testing
+
+- 256 unit tests passing (includes frame/overlay tests)
+- 95 integration tests passing
+- Zero warnings (build + clippy)
 
 ---
 
-For older versions (0.6.x and earlier), see [CHANGELOG-archive.md](./docs/CHANGELOG-archive.md).
+## [0.5.3] - 2025-12-18
+
+### Features
+
+- **Which-Key Enhancements**
+  - RPC endpoint `state/whichkey` for querying which-key popup state
+  - Keybinding grouping - bindings now categorized (motion, operator, mode, edit, jump, fold, telescope, window, misc)
+  - Grouped rendering with section headers in which-key popup
+
+- **Explorer File Operations**
+  - Copy/Cut/Paste: `yy` (yank), `dd` (cut), `p` (paste), `D` (delete)
+  - Multi-file selection: `v` (visual mode), `V` (select all)
+  - Selection marker (`*`) displayed for selected items
+  - Visual selection updates as cursor moves with j/k
+
+- **Explorer Display Enhancements**
+  - Human-readable file sizes: `S` toggles size column (1.2K, 3.4M, etc.)
+  - Broken symlink detection: shows `! ` icon for broken links
+
+- **Telescope Enhancements**
+  - RPC endpoint `state/telescope` for querying telescope state
+  - Fixed escape race condition in telescope close handling
+  - Fixed buffer picker returning empty items
+
+### Bug Fixes
+
+- **`cw` operator enters insert mode** - Fixed race condition where change operator stayed in normal mode instead of entering insert mode after deletion
+- **Explorer cursor position with tabs** - Cursor now correctly positioned when tab line is visible
+- **Explorer root protection** - Prevents accidental delete/rename of root directory
+- **Explorer cursor bounds** - Cursor now validated after tree modifications
+- **Telescope escape handling** - Fixed race condition causing stuck mode
+
+### Tests
+
+- New `lib/core/tests/which_key.rs` - Which-key visibility and binding tests
+- New `lib/core/tests/telescope.rs` - Telescope picker integration tests
+
+### Technical Changes
+
+- Added `group` field to `WhichKeyBinding` and `KeyMapInner` structs
+- Added `ExplorerClipboard` and `ExplorerSelection` structures
+- Added `format_size()` for human-readable byte formatting
+- Added `WhichKeySnapshot` and `TelescopeSnapshot` RPC types
+
+## [0.5.2] - 2025-12-18
+
+### Bug Fixes
+
+- **`e` motion implemented** - Word end motion now works (`e` moves to end of current/next word)
+- **Count prefix for w/b/e motions** - `2w`, `3b`, `2e` now work correctly
+- **Cross-line word motions** - `w` and `b` now cross line boundaries
+- **dw/cw off-by-one fixed** - Motion inclusivity corrected; `dw` no longer deletes first char of next word
+- **dd+p register populated** - Linewise delete now stores text in register for paste
+- **V (visual line mode) implemented** - `V` enters visual line mode
+- **Visual selection initialization** - Visual mode now properly initializes selection
+- **Undo batching per session** - Insert mode edits are undone as a single unit
+- **`:` bound in visual mode** - Can now enter command mode from visual mode
+- **Leap auto-jump** - Single match automatically jumps to target
+
+### Technical Changes
+
+- Add `Motion::WordEnd` variant and `is_inclusive()` method to Motion enum
+- Add `begin_batch()`/`flush_batch()` methods for undo grouping in Buffer
+- Implement cross-line calculations in `word_forward_calc()` and `word_backward_calc()`
+- Add `ModExtension::Line` variant for visual line mode
+- Fix `cw` to use `WordEnd` motion (vim behavior: `cw` acts like `ce`)
+
+### Tests
+
+- Updated test suite from documenting bugs to expecting correct behavior
+- All 332 tests passing
+
+## [0.5.1] - 2025-12-18
+
+### Features
+
+- **Comprehensive Integration Test Suite** - 95 new server-based E2E tests
+  - `word_motions.rs` (20 tests) - w, b motion tests
+  - `operators.rs` (21 tests) - dd, x, yy, p, dw, cw, dj, dk, d$ tests
+  - `undo_redo.rs` (11 tests) - u and Ctrl-R tests
+  - `visual_mode.rs` (10 tests) - v, V, Ctrl-V mode tests
+  - `command_mode.rs` (10 tests) - : command and :set tests
+  - `cursor_advanced.rs` (14 tests) - gg, G, 0, $, count prefix tests
+  - `leap.rs` (9 tests) - s, S leap navigation tests
+
+### Documentation
+
+- Tests document actual behavior vs expected vim behavior for gaps:
+  - `e` motion not implemented
+  - Count prefix not supported for w/b motions
+  - w/b motions don't cross lines
+  - dw/cw off-by-one bug (deletes first char of next word)
+  - Undo is per-character, not per-insert-session
+  - V (visual line mode) not implemented
+  - Leap jump doesn't move cursor to match position
+
+### Files Added
+
+- `lib/core/tests/word_motions.rs`
+- `lib/core/tests/operators.rs`
+- `lib/core/tests/undo_redo.rs`
+- `lib/core/tests/visual_mode.rs`
+- `lib/core/tests/command_mode.rs`
+- `lib/core/tests/cursor_advanced.rs`
+- `lib/core/tests/leap.rs`
+
+## [0.5.0] - 2025-12-18
+
+### Features
+
+- **Server Mode with JSON-RPC 2.0 Protocol** - Headless server for programmatic editor control
+  - `--server` flag starts persistent server (runs until killed)
+  - `--server --test` starts test server (exits when all clients disconnect)
+  - Headless operation: no terminal required, captures output for RPC responses
+
+- **Multiple Transport Options** - Flexible connectivity
+  - `--stdio` - Stdio transport (stdin/stdout)
+  - `--listen-tcp <port>` - TCP transport on specified port
+  - `--listen-socket <path>` - Unix socket transport
+  - Default TCP port: 12521 ('r'×100 + 'e'×10 + 'o')
+
+- **RPC API Methods** - Full editor control via JSON-RPC 2.0
+  - `input/keys` - Send key sequences (e.g., `{"keys": "iHello<Esc>"}`)
+  - `state/mode` - Get current mode state
+  - `state/cursor` - Get cursor position (x, y)
+  - `state/buffer` - Get buffer content
+  - `state/screen` - Get full screen state (cells, cursor, mode, dimensions)
+  - `editor/quit` - Request editor quit
+
+- **reo-cli Client Tool** - Command-line client for server interaction
+  - `reo-cli mode` - Query current mode
+  - `reo-cli cursor` - Query cursor position
+  - `reo-cli buffer` - Query buffer content
+  - `reo-cli screen` - Query screen state
+  - `reo-cli keys '<keys>'` - Send key sequence
+  - `reo-cli quit` - Request server quit
+  - `reo-cli repl` - Interactive REPL mode
+  - Configurable host/port: `--host`, `--port`
+
+- **Hybrid Line Numbers by Default** - Line numbers now show hybrid mode (absolute for current line, relative for others) on startup
+
+- **Server-Based Integration Testing** - E2E test infrastructure using real server
+  - `ServerTestHarness` - Spawns test server with auto port allocation (ports 12600-12699)
+  - `TestClient` - Async JSON-RPC client for test communication
+  - `ServerTest` - Fluent builder API: `.with_content()`, `.with_keys()`, `.run()`
+  - `ServerTestResult` - Assertion methods: `assert_normal_mode()`, `assert_cursor()`, `assert_buffer_contains()`
+  - 1ms delay between key injections for reliable mode propagation
+  - Replaces mock-based `TestRuntime` with real end-to-end testing
+
+### Architecture
+
+- `RpcServer` - Coordinates JSON-RPC request handling
+- `TransportConfig` - Transport selection: Stdio, UnixSocket, Tcp
+- `TransportReader`/`TransportWriter` - Async I/O abstraction
+- `TransportListener` - Accepts connections for socket/TCP
+- `ChannelKeySource` - Injects keys from RPC into runtime
+- `DualOutput` - Captures screen output for headless mode
+- `ServerConfig` - Server behavior configuration (headless, test mode)
+
+### Files Added
+
+- `lib/core/src/rpc/mod.rs` - RPC module root
+- `lib/core/src/rpc/server.rs` - RpcServer implementation
+- `lib/core/src/rpc/state.rs` - Screen state serialization
+- `lib/core/src/rpc/transport.rs` - Transport abstractions
+- `lib/core/src/rpc/types.rs` - JSON-RPC message types
+- `lib/core/src/testing/client.rs` - TestClient for JSON-RPC communication
+- `lib/core/src/testing/server.rs` - ServerTestHarness for spawning test servers
+- `lib/core/src/testing/assertions.rs` - ServerTest builder and ServerTestResult assertions
+- `main/src/server.rs` - Server mode entry point
+- `tools/reo-cli/` - CLI client tool (Cargo.toml, src/main.rs, client.rs, commands.rs, repl.rs)
+
+### Files Changed
+
+- `Cargo.toml` - Added reo-cli workspace member, serde_json dependency
+- `lib/core/Cargo.toml` - Added serde_json dependency
+- `lib/core/src/lib.rs` - Added rpc, testing module exports
+- `lib/core/src/io/output.rs` - Added DualOutput for screen capture
+- `lib/core/src/event/inner/mod.rs` - Added RpcRequestEvent
+- `lib/core/src/runtime/core.rs` - Added RPC request handling
+- `lib/core/src/runtime/event_loop.rs` - Added RPC event handling
+- `lib/core/src/runtime/mod.rs` - Removed TestRuntime exports
+- `lib/core/src/testing/mod.rs` - Added exports for server-based testing
+- `lib/core/tests/common/mod.rs` - Switched to ServerTest
+- `lib/core/tests/basic_editing.rs` - Rewritten to use ServerTest
+- `lib/core/tests/mode_switching.rs` - Rewritten to use ServerTest
+- `main/src/main.rs` - Added server mode CLI flags
+- `docs/TESTING.md` - Updated for server-based testing architecture
+
+### Files Removed
+
+- `lib/core/src/runtime/test.rs` - Old mock-based TestRuntime (replaced by server-based testing)
+
+### Testing
+
+- 213 unit tests passing
+- 23 integration tests passing (basic_editing: 10, mode_switching: 8, resize: 5)
+- Zero warnings (build + clippy)
+- Performance: No regression in core benchmarks
+
+---
+
+## [0.4.18] - 2025-12-18
+
+### Features
+
+- **TOML-based configuration profile system** - Save, load, and switch editor configurations at runtime
+  - Profiles stored at `~/.config/reovim/profiles/` (XDG Base Directory compliant)
+  - Ex-commands: `:profile load <name>`, `:profile save <name>`, `:profile list`
+  - Telescope picker for profile selection (via `:profile list`)
+  - CLI flag: `--profile/-p <name>` to start with a specific profile
+  - First-run auto-creates default profile
+  - Profiles control: theme, colormode, line numbers, relative numbers, indent guides, scrollbar, tab width
+
+- **TUI Settings Menu** - Interactive settings editor with live preview
+  - Open with `Space s` or `:settings` command
+  - Vim-style navigation: `j/k` to navigate, `Space` to toggle, `h/l` to cycle choices
+  - Quick select choices with number keys `1-9`
+  - Number settings adjustable with `+/-`
+  - Immediate apply: changes take effect instantly
+  - Settings organized in sections: Editor, Cursor, Window, Profile
+  - Checkbox-style booleans, dropdown-style choices, number inputs
+
+### Files Added
+
+- `lib/core/src/config/mod.rs` - Config module root
+- `lib/core/src/config/schema.rs` - TOML structs with serde
+- `lib/core/src/config/loader.rs` - XDG paths, load/save utilities
+- `lib/core/src/config/profile.rs` - ProfileManager struct
+- `lib/core/src/telescope/picker/profiles.rs` - Profiles picker
+- `lib/core/src/settings_menu/mod.rs` - Settings menu module root
+- `lib/core/src/settings_menu/item.rs` - SettingItem, SettingValue, SettingSection types
+- `lib/core/src/settings_menu/state.rs` - SettingsMenuState with navigation/manipulation
+- `lib/core/src/settings_menu/render.rs` - TUI rendering with box drawing
+- `lib/core/src/command/builtin/settings_menu.rs` - Settings menu commands
+
+### Files Changed
+
+- `lib/core/Cargo.toml` - Added toml, serde dependencies
+- `lib/core/src/lib.rs` - Added config and settings_menu module exports
+- `lib/core/src/command_line/ex_command.rs` - Added ProfileLoad/Save/List/Settings commands
+- `lib/core/src/runtime/core.rs` - Added ProfileManager, settings_menu field
+- `lib/core/src/runtime/event_loop.rs` - Added profile and settings menu event handling
+- `lib/core/src/runtime/handlers.rs` - Added profile and settings menu handlers
+- `lib/core/src/telescope/item.rs` - Added TelescopeData::Profile variant
+- `lib/core/src/telescope/picker/mod.rs` - Added TelescopeAction::SwitchProfile, ProfilesPicker
+- `lib/core/src/event/inner/mod.rs` - Added SettingsMenuEvent enum
+- `lib/core/src/event/mod.rs` - Export SettingsMenuEvent
+- `lib/core/src/modd/mod.rs` - Added Focus::SettingsMenu variant
+- `lib/core/src/bind/mod.rs` - Added settings_menu keymap and Space-s binding
+- `lib/core/src/command/id.rs` - Added settings menu command IDs
+- `lib/core/src/command/traits.rs` - Added SettingsMenuAction, DeferredAction::SettingsMenu
+- `lib/core/src/command/builtin/mod.rs` - Export settings_menu commands
+- `lib/core/src/command/registry.rs` - Register settings menu commands
+- `lib/core/src/screen/mod.rs` - Render settings menu overlay
+- `lib/core/src/screen/status_line.rs` - Added SETTINGS icon
+- `main/src/main.rs` - Added --profile/-p CLI flag
+
+### Testing
+
+- Zero warnings (build + clippy)
+- All tests passing
+
+### Deferred
+
+- Runtime keybinding modification from profiles (Phase 5) - keybindings stored in TOML but not applied at runtime
+
+---
+
+## [0.4.17] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed integration test timing issues** - All 19 integration tests now pass reliably
+  - Added `grace_period` to `InputEventBroker` for async event propagation
+  - Added delay between keys in `MockKeySource` for mode state synchronization
+  - Fixed Visual mode Escape handling to use keymap lookup instead of `is_esc_clearable_mode`
+
+### Documentation
+
+- **Added Integration Testing section to docs/TESTING.md** - Comprehensive guide for writing and running integration tests
+  - Test architecture overview
+  - `keys_from_str()` notation reference
+  - `TestResult` assertion methods
+  - Best practices and examples
+
+### Testing
+
+- All 19 integration tests now pass (was 9 passing, 10 ignored)
+  - 10 basic editing tests (cursor movement, insert mode, open line)
+  - 9 mode switching tests (enter/exit modes with Escape)
+
+### Files Changed
+
+- `lib/core/src/event/input.rs` - Added `grace_period` field and `with_grace_period()` builder method
+- `lib/core/src/event/handler/command/mod.rs` - Fixed `is_esc_clearable_mode` to exclude Visual mode
+- `lib/core/src/runtime/test.rs` - Use 10ms delay between keys and 50ms grace period
+- `lib/core/tests/basic_editing.rs` - Removed `#[ignore]` from 6 tests, fixed `test_insert_at_beginning`
+- `lib/core/tests/mode_switching.rs` - Removed `#[ignore]` from 4 tests
+- `docs/TESTING.md` - Added Integration Testing section
+
+---
+
+## [0.4.16] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed telescope display jitter** - Eliminated screen flickering during telescope navigation and typing by adding a dedicated `render_telescope_only()` path that skips full screen clear
+
+### Files Changed
+
+- `lib/core/src/screen/mod.rs` - Added `render_telescope_only()` method
+- `lib/core/src/runtime/core.rs` - Added `render_telescope_only()` wrapper method
+- `lib/core/src/runtime/event_loop.rs` - Use `render_telescope_only()` for telescope internal updates
+- `lib/core/src/runtime/handlers.rs` - Use `render_telescope_only()` for telescope actions
+
+### Testing
+
+- Zero warnings (build + clippy)
+- All 186 tests passing
+
+---
+
+## [0.4.15] - 2025-12-18
+
+### Features
+
+- **Terminal resize event handling** - Editor now properly responds to terminal resize events:
+  - Screen dimensions update correctly when terminal is resized
+  - Window layouts recalculate to fit new dimensions
+  - Explorer sidebar width clamps correctly on small screens
+  - Explorer rendering uses layout width instead of hardcoded width
+
+### Bug Fixes
+
+- **Fixed editor content bleeding into explorer column** - All explorer lines now padded to full width to prevent editor text from showing through gaps
+
+### Files Changed
+
+- `lib/core/src/event/inner/mod.rs` - Added `ScreenResizeEvent` variant
+- `lib/core/src/event/input.rs` - Added `with_event_sender()` to InputEventBroker
+- `lib/core/src/io/input.rs` - Added `with_event_sender()` to EventStreamKeySource for resize events
+- `lib/core/src/screen/mod.rs` - Added `resize()` method and unit tests
+- `lib/core/src/screen/layout.rs` - Added resize behavior tests
+- `lib/core/src/explorer/render.rs` - Pass layout width, pad all lines to full width
+- `lib/core/src/runtime/event_loop.rs` - Handle resize events
+
+### Testing
+
+- Zero warnings (build + clippy)
+- All tests passing
+- Added 5 new integration tests for resize behavior (`lib/core/tests/resize.rs`)
+
+### Known Issues
+
+- **Panel background bleeding** - The content bleeding through on resize. (Ex, Editor content to Explorer)
+  - Each UI component (explorer, which-key, telescope, etc.) has its own rendering system
+  - Require the common-unified method for managing window and buffer.
+
+---
+
+## [0.4.14] - 2025-12-18
+
+### Features
+
+- **Integration test system with mock I/O layer** - End-to-end testing capability that verifies key input → expected output without requiring a real terminal
+  - `KeySource` trait abstraction for terminal input (MockKeySource, ChannelKeySource, EventStreamKeySource)
+  - `MockOutput` for capturing screen render output
+  - `TestRuntime` with builder pattern for integration tests
+  - `keys_from_str()` helper for readable key sequences (e.g., "ihello<Esc>")
+  - Generic `InputEventBroker<K: KeySource>` to support mock input injection
+
+### Testing
+
+- Added integration tests for cursor movement (j, jj, l, hjkl)
+- Added integration tests for mode transitions (i, a, v, :, :q<CR>)
+- 9 integration tests passing, 10 ignored (timing issues documented for future work)
+
+### Files Added
+
+- `lib/core/src/io/mod.rs` - I/O abstraction module
+- `lib/core/src/io/input.rs` - KeySource trait and implementations
+- `lib/core/src/io/output.rs` - MockOutput for capturing display
+- `lib/core/src/testing/mod.rs` - Testing utilities module
+- `lib/core/src/testing/keys.rs` - Key event helpers
+- `lib/core/src/runtime/test.rs` - TestRuntime and TestResult
+- `lib/core/tests/basic_editing.rs` - Cursor movement tests
+- `lib/core/tests/mode_switching.rs` - Mode transition tests
+- `lib/core/tests/common/mod.rs` - Shared test utilities
+
+### Files Changed
+
+- `lib/core/Cargo.toml` - Added async-trait dependency
+- `lib/core/src/lib.rs` - Added io, testing module exports
+- `lib/core/src/runtime/event_loop.rs` - Made handle_event pub(crate)
+- `lib/core/src/event/input.rs` - Made InputEventBroker generic over KeySource
+- `lib/core/src/runtime/mod.rs` - Added test module export
+
+---
+
+## [0.4.13] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed treesitter theme not syncing with UI theme** - TreesitterTheme was hardcoded to default, ignoring `:colorscheme` changes. Now syncs with UI theme.
+- **Fixed telescope keymaps picker showing empty results** - KeymapsPicker now populates from KeyMap::with_defaults()
+
+### Features
+
+- **Added telescope theme picker** - New `telescope_themes` command to select colorschemes visually with preview
+- **Theme changes now rehighlight all buffers** - Switching themes immediately updates syntax highlighting
+
+### Files Changed
+
+- `lib/core/src/treesitter/theme.rs` - Added `from_theme_name()` method
+- `lib/core/src/treesitter/highlighter.rs` - Added `set_theme()` method
+- `lib/core/src/treesitter/mod.rs` - Added `set_theme()` method
+- `lib/core/src/runtime/handlers.rs` - Updated `:colorscheme` to sync treesitter theme
+- `lib/core/src/runtime/core.rs` - Added `rehighlight_all_buffers()`, registered ThemesPicker
+- `lib/core/src/runtime/event_loop.rs` - Handle theme selection from telescope
+- `lib/core/src/telescope/item.rs` - Added `Theme(ThemeName)` variant
+- `lib/core/src/telescope/picker/mod.rs` - Added `ApplyTheme` action, themes module
+- `lib/core/src/telescope/picker/themes.rs` - New ThemesPicker implementation
+- `lib/core/src/command/builtin/telescope.rs` - Added `TelescopeThemesCommand`
+- `lib/core/src/command/registry.rs` - Registered `TelescopeThemesCommand`
+- `lib/core/src/telescope/picker/keymaps.rs` - Populate keymaps from `KeyMap::with_defaults()`
+
+---
+
+## [0.4.12] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed window navigation commands not working** - Window and tab commands were defined but never registered in CommandRegistry
+- **Fixed C-hjkl not working in explorer mode** - Added window navigation keybindings to explorer mode
+- **Fixed mode not syncing when navigating between explorer and editor** - Screen is now source of truth for focus, mode syncs after window actions
+
+### Features
+
+- **Added Space e toggle to explorer mode** - Can now toggle explorer from within explorer
+- **Explorer included in window navigation** - C-l from explorer moves to editor, C-h from editor moves to explorer
+
+### Removed
+
+- Removed `q` binding from explorer (use C-l or Escape instead)
+
+### Files Changed
+
+- `lib/core/src/command/registry.rs` - Register window/tab commands
+- `lib/core/src/bind/mod.rs` - Add explorer keybindings (C-hjkl, Space e)
+- `lib/core/src/runtime/handlers.rs` - Add sync_mode_with_screen_focus()
+- `lib/core/src/screen/mod.rs` - navigate_window() includes explorer as virtual window
+- `lib/core/src/screen/split.rs` - Add EXPLORER_WINDOW_ID constant
+
+---
+
+## [0.4.11] - 2025-12-18
+
+### Refactoring
+
+- **Fixed all clippy cognitive complexity warnings** - Refactored 3 functions to meet complexity threshold (25):
+  - `run()` in command handler: 63→<25 (extracted 8 helper methods)
+  - `handle_explorer_action()` in runtime handlers: 31→<25 (extracted 5 helper methods)
+  - `render()` in window: 30→<25 (extracted 5 helper methods)
+
+### Files Changed
+
+- `lib/core/src/event/handler/command/mod.rs` - Cognitive complexity refactoring
+- `lib/core/src/runtime/handlers.rs` - Cognitive complexity refactoring
+- `lib/core/src/screen/window.rs` - Cognitive complexity refactoring
+
+### Testing
+
+- Zero warnings (build + clippy)
+- All tests passing
+
+---
+
+## [0.4.10] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed dd/yy/cc operators not working on real files**:
+  - Race condition fix: Prevent `local_mode` from being overwritten when already in operator-pending mode
+  - Explicit dereference in match pattern for operator type
+  - Count=0 handling: `dd` now correctly deletes only the current line (was deleting 2 lines)
+  - Buffer ID fix: Operators now use active buffer instead of hardcoded buffer 0
+  - Paste fix: `p` command now uses active buffer instead of hardcoded buffer 0
+
+- **Fixed which-key showing "E" instead of proper hints in operator-pending mode**:
+  - Added `hint` field to `KeyMapInner` for hint-only entries
+  - Operator-pending keymap now shows proper descriptions (e.g., "delete line (dd)")
+
+### Files Changed
+
+- `lib/core/src/bind/mod.rs` - Hint system for operator-pending mode
+- `lib/core/src/buffer/mod.rs` - Count=0 fix for dd/yy
+- `lib/core/src/event/handler/command/mod.rs` - Race condition fix
+- `lib/core/src/runtime/handlers.rs` - Buffer ID and paste fixes
+
+### Testing
+
+- **159 tests passing**
+- Zero warnings
+
+---
+
+## [0.4.9] - 2025-12-18
+
+### Bug Fixes
+
+- **Fixed Rust treesitter syntax highlighting** - Query syntax updated to match tree-sitter-rust v0.24:
+  - Keywords `crate`, `self`, `super` now use named node syntax instead of string literals
+  - Field-based patterns (`function:`, `body:`, `macro:`) properly aligned with grammar
+  - Added error logging for query compilation failures
+  - Added unit tests for query validation (4 new tests)
+
+### Files Changed
+
+- `lib/core/src/treesitter/queries.rs` - Error logging and tests
+- `lib/core/src/treesitter/queries/rust/highlights.scm` - Rewritten for v0.24
+- `lib/core/src/treesitter/queries/rust/textobjects.scm` - Fixed field syntax
+- `lib/core/src/treesitter/queries/rust/folds.scm` - Fixed field syntax
+
+### Testing
+
+- **159 tests passing** (4 new treesitter query tests)
+- Zero warnings
+
+---
+
+## [0.4.8] - 2025-12-18
+
+### New Features
+
+#### Unified Theme System with Sub-Structs
+- **Restructured Theme with logical sub-structs** for better maintainability:
+  - `base`: Default and cursor line styles
+  - `gutter`: Line numbers, sign column
+  - `selection`: Visual selection styles
+  - `statusline`: Status line with mode-specific styles
+  - `popup`: Completion popup styles
+  - `telescope`: Fuzzy finder styles
+  - `whichkey`: Which-key panel styles
+  - `leap`: Jump navigation styles
+  - `fold`: Code folding styles
+  - `indent`: Indentation guide styles
+  - `scrollbar`: Scrollbar with diagnostic marks
+  - `search`: Search highlight styles
+  - `tab`: Tab line styles
+  - `window`: Window separator styles
+
+- **ThemeName enum** with three built-in themes:
+  - `Dark` - OneDark-inspired dark theme (default)
+  - `Light` - Light theme for bright environments
+  - `TokyoNightOrange` - Tokyo Night with orange accents
+
+- **`:colorscheme` command** for runtime theme switching:
+  - `:colorscheme dark` / `:colo dark`
+  - `:colorscheme light` / `:colo light`
+  - `:colorscheme tokyonight` / `:colo tokyonight`
+
+- **TreesitterTheme::tokyo_night_orange()** - Coordinated syntax highlighting:
+  - Comments: Light gray, italic
+  - Keywords: Purple, bold, italic
+  - Functions: Blue
+  - Strings: Green
+  - Types: Cyan
+
+#### UI Enhancements
+- **Enhanced statusline** with more information:
+  - Mode icons: `` (normal), `` (insert), `` (visual), `` (command)
+  - Position display: `line:col`
+  - Filetype indicator with icon
+  - Modified indicator `[+]`
+
+- **Indent guides integration** - Visual vertical lines at indent levels:
+  - `:set indentguide` / `:set ig` - Enable
+  - `:set noindentguide` / `:set noig` - Disable
+  - Uses `theme.indent.guide` and `theme.indent.active` styles
+
+- **Scrollbar rendering** - Visual scroll position indicator:
+  - `:set scrollbar` / `:set sb` - Enable
+  - `:set noscrollbar` / `:set nosb` - Disable
+  - Track character: `▕`, Thumb character: `█`
+  - Uses `theme.scrollbar.track` and `theme.scrollbar.thumb` styles
+
+#### Textobject Improvements
+- **Word textobjects** for operators (delete, yank, change):
+  - `iw` - Inner word (alphanumeric + underscore)
+  - `aw` - Around word (includes trailing/leading whitespace)
+  - `iW` - Inner WORD (non-whitespace)
+  - `aW` - Around WORD (includes trailing/leading whitespace)
+  - Examples: `diw`, `yaw`, `ciW`, `daW`
+
+- **Visual mode textobject selection**:
+  - `viw`, `vaw`, `viW`, `vaW` - Select word textobjects
+  - `vi(`, `va{`, `vi"` - Select delimiter textobjects
+  - `vif`, `vac` - Select semantic textobjects (treesitter)
+
+- **VisualTextObjectAction event** for visual mode integration
+
+### New Commands
+
+| Command | Description |
+|---------|-------------|
+| `:colorscheme <name>` | Switch theme (dark, light, tokyonight) |
+| `:colo <name>` | Short form of colorscheme |
+| `:set indentguide` | Enable indent guides |
+| `:set noindentguide` | Disable indent guides |
+| `:set scrollbar` | Enable scrollbar |
+| `:set noscrollbar` | Disable scrollbar |
+
+### New Textobjects
+
+| Textobject | Description |
+|------------|-------------|
+| `iw` / `aw` | Inner/around word |
+| `iW` / `aW` | Inner/around WORD |
+
+### Architecture
+
+- `ThemeName` enum for theme identification
+- `Theme::from_name()` for runtime theme creation
+- Sub-struct organization: `BaseStyles`, `GutterStyles`, `SelectionStyles`, `StatusLineStyles`, `PopupStyles`, `TelescopeStyles`, `WhichKeyStyles`, `LeapStyles`, `FoldStyles`, `IndentStyles`, `ScrollbarStyles`, `SearchStyles`, `TabStyles`, `WindowStyles`
+- `ScrollbarState` for scrollbar position calculation
+- `VisualTextObjectAction` event type
+- `WordTextObject` enum (Word, BigWord)
+
+### Files Modified
+
+- `lib/core/src/highlight/theme.rs` - Complete restructure with sub-structs
+- `lib/core/src/highlight/mod.rs` - Export ThemeName
+- `lib/core/src/treesitter/theme.rs` - Tokyo Night Orange syntax theme
+- `lib/core/src/command_line/ex_command.rs` - New SetOption variants
+- `lib/core/src/screen/window.rs` - Indent guides, scrollbar rendering
+- `lib/core/src/screen/mod.rs` - Theme sub-struct access
+- `lib/core/src/screen/status_line.rs` - Enhanced statusline
+- `lib/core/src/textobject.rs` - Word textobject types
+- `lib/core/src/buffer/mod.rs` - Word textobject methods
+- `lib/core/src/event/inner/mod.rs` - VisualTextObjectAction
+- `lib/core/src/runtime/handlers.rs` - New command handlers
+
+---
+
+## [0.4.7] - 2025-12-18
+
+### New Features
+
+#### Window Splits and Tab Pages
+- **Vim-style window splits** - Split editor into multiple panes
+  - `:sp [file]` / `:split [file]` - Horizontal split (one above the other)
+  - `:vs [file]` / `:vsplit [file]` - Vertical split (side by side)
+  - `:close` / `:clo` - Close current window
+  - `:only` / `:on` - Close all windows except current
+
+- **Window navigation** - Move focus between splits
+  - `Ctrl-h` - Focus window to the left
+  - `Ctrl-j` - Focus window below
+  - `Ctrl-k` - Focus window above
+  - `Ctrl-l` - Focus window to the right
+
+- **Window movement** - Reposition windows in layout
+  - `Ctrl-Shift-H` - Move window left
+  - `Ctrl-Shift-J` - Move window down
+  - `Ctrl-Shift-K` - Move window up
+  - `Ctrl-Shift-L` - Move window right
+
+- **Tab pages** - Multiple editor layouts
+  - `:tabnew [file]` / `:tabe [file]` - Create new tab
+  - `:tabclose` / `:tabc` - Close current tab
+  - `:tabnext` / `:tabn` - Switch to next tab
+  - `:tabprev` / `:tabp` - Switch to previous tab
+  - `gt` - Next tab
+  - `gT` - Previous tab
+
+- **Tab line rendering** - Visual tab indicator when multiple tabs exist
+- **Window separators** - Visual borders between split windows
+
+### Architecture
+
+- `SplitNode` - Binary tree for recursive window layouts
+- `TabPage` / `TabManager` - Tab page management
+- `WindowAction` / `TabAction` - Deferred action enums
+
+### New Files
+
+- `lib/core/src/screen/split.rs` - Split tree and layout calculation
+- `lib/core/src/screen/tab.rs` - Tab page and manager
+- `lib/core/src/command/builtin/window.rs` - Window commands
+- `lib/core/src/command/builtin/tab.rs` - Tab commands
+
+### Testing
+
+- **152 tests passing**
+- Zero warnings
+
+---
+
+## [0.4.6] - 2025-12-18
+
+### Features
+
+#### Unified Fast Benchmarking
+- **New `bench` subcommand for perf-report** - Single command workflow:
+  - Clears old benchmark data (`target/criterion/`)
+  - Runs all benchmarks (`cargo bench -p reovim-core`)
+  - Generates performance report (`perf/PERF-{version}.md`)
+
+- **Faster benchmark execution** - Reduced from ~8 minutes to ~2 minutes:
+  - measurement_time: 5s → 1s
+  - warm_up_time: 3s → 200ms
+  - sample_size: 100 → 30
+
+- **`cargo run` defaults to reovim** - Added `default-members = ["main/"]` to workspace
+
+### Usage
+
+```bash
+# Run benchmarks + generate report (unified)
+cargo run -p perf-report -- bench -v X.Y.Z
+
+# Run reovim directly
+cargo run
+```
+
+---
+
+## [0.4.5] - 2025-12-18
+
+### Bug Fixes
+
+#### Viewport Scrolling
+- **Fixed cursor going off-screen when moving beyond viewport**
+  - Root cause: `buffer_anchor` (scroll offset) was never updated when cursor moved
+  - Added `Window::update_scroll()` method to keep cursor visible within viewport
+  - Fixed cursor position calculation to account for scroll offset
+
+### Technical Details
+
+**Files modified:**
+- `lib/core/src/screen/window.rs` - Added `update_scroll()` method
+- `lib/core/src/screen/mod.rs` - Call `update_scroll()` before render, fix cursor_y calculation
+
+**Implementation:**
+```rust
+// New method in Window
+pub const fn update_scroll(&mut self, cursor_y: u16) {
+    // Scroll up if cursor is above visible area
+    if cursor_y < self.buffer_anchor.y {
+        self.buffer_anchor.y = cursor_y;
+    }
+    // Scroll down if cursor is below visible area
+    else if cursor_y >= self.buffer_anchor.y + self.height {
+        self.buffer_anchor.y = cursor_y.saturating_sub(self.height) + 1;
+    }
+}
+
+// Fixed cursor position calculation
+let cursor_y = win.anchor.y + buf.cur.y.saturating_sub(win.buffer_anchor.y);
+```
+
+---
+
+## [0.4.4] - 2025-12-17
+
+### Performance Optimization
+
+#### Zero-Copy Render Path
+- **Eliminated buffer cloning in render loop** - Major optimization
+  - Changed `Screen::render()` to accept `&BTreeMap<usize, Buffer>` instead of `&[Buffer]`
+  - Removed costly `buffers.values().cloned().collect()` from every render call
+  - Previous cost: 364µs (10K lines) to 1.96ms (50K lines) per render
+  - Now: Zero allocation - only a reference is passed
+
+### Technical Details
+
+**Files modified:**
+- `lib/core/src/screen/mod.rs` - Changed render signature to accept BTreeMap reference
+- `lib/core/src/runtime/core.rs` - Removed buffer cloning, pass reference directly
+
+**API Change:**
+```rust
+// Before:
+pub fn render(&mut self, buffers: &[Buffer], ...);
+let buffers: Vec<Buffer> = self.buffers.values().cloned().collect();
+screen.render(&buffers, ...);
+
+// After:
+pub fn render(&mut self, buffers: &BTreeMap<usize, Buffer>, ...);
+screen.render(&self.buffers, ...);
+```
+
+### Performance Results (v0.4.2 → v0.4.4)
+
+| Benchmark | v0.4.2 | v0.4.4 | Change |
+|-----------|--------|--------|--------|
+| window_render/10 | 639 ns | 473 ns | **26% faster** |
+| rtt/char_insert | - | 28 µs | baseline |
+| rtt/move_down | 397 µs | 383 µs | **4% faster** |
+| rtt/half_page_down | 410 µs | 390 µs | **5% faster** |
+| rtt/goto_top | 397 µs | 390 µs | **2% faster** |
+| input_mode_switch | - | 18 µs | baseline |
+| stress_editing/50k | 38.99 ms | 37.60 ms | **4% faster** |
+
+### Key Metrics (v0.4.4)
+
+- **Window render**: 473ns (10 lines) - 2.6µs (10K lines)
+- **Input RTT**: 28µs (char insert), 45µs (word motion)
+- **Movement RTT**: 383-390µs (vertical), 45µs (horizontal)
+- **Mode switch**: 18µs (Normal→Insert→Normal cycle)
+- **Throughput**: ~400k renders/sec
+
+---
+
+## [0.4.3] - 2025-12-17
+
+### New Features
+
+#### Treesitter Integration
+- **Syntax highlighting** powered by tree-sitter for accurate parsing
+  - Supported languages: Rust, C, JavaScript, Python, JSON, TOML, Markdown
+  - Incremental parsing with 50ms debounce for efficient re-highlighting
+  - Theme-aware capture mapping (keyword, function, type, string, comment, etc.)
+
+- **Code folding** with treesitter queries
+  - `za` - Toggle fold at cursor
+  - `zo` - Open fold at cursor
+  - `zc` - Close fold at cursor
+  - `zR` - Open all folds in buffer
+  - `zM` - Close all folds in buffer
+  - Fold markers show line count and preview text
+
+- **Semantic text objects** (treesitter-based)
+  - `af` / `if` - Around/inner function
+  - `ac` / `ic` - Around/inner class/struct
+  - Works with operators: `daf`, `yif`, `cic`, etc.
+
+- **Indentation guides** (theme support added)
+  - `indent_guide` and `indent_guide_active` theme styles
+
+### Technical Details
+
+**New modules:**
+- `lib/core/src/treesitter/` - TreesitterManager, BufferParser, Highlighter
+- `lib/core/src/folding.rs` - FoldManager, FoldState, FoldRange
+
+**Dependencies added:**
+- tree-sitter = "0.24"
+- tree-sitter-rust, tree-sitter-c, tree-sitter-javascript, tree-sitter-python
+- tree-sitter-json, tree-sitter-toml-ng, tree-sitter-md
+
+### Testing
+
+- **133 tests passing** (up from 118)
+- New tests for folding operations
+
+---
+
+## [0.4.2] - 2025-12-17
+
+### New Features
+
+#### Performance Benchmarking Infrastructure
+- **Criterion benchmark suite** - Comprehensive performance testing
+  - Window render benchmarks (various buffer sizes)
+  - Screen I/O benchmarks (buffered vs unbuffered)
+  - Input simulation benchmarks (typing, scrolling, mode switching)
+  - RTT (Round-Trip Time) benchmarks for latency measurement
+  - Stress tests for worst-case scenarios
+  - Location: `lib/core/benches/`
+
+- **perf-report CLI tool** - Performance data management
+  - `update --version X.Y.Z` - Generate versioned performance reports
+  - `list` - Show current benchmark results
+  - `check` - CI regression detection
+  - `compare` - Diff between versions
+  - Location: `tools/perf-report/`
+
+- **Versioned performance reports** - Git-tracked benchmark data
+  - Markdown + TOML format for human and machine readability
+  - Full statistics: mean, median, std_dev, confidence intervals
+  - Metadata: commit, date, Rust version, OS
+  - Location: `perf/PERF-{version}.md`
+
+### Benchmark Categories
+
+| Category | Description |
+|----------|-------------|
+| window_render | Window::render() performance |
+| screen_io | Full screen I/O with real files |
+| input_* | Typing, scrolling, mode switching |
+| rtt_* | Input lag, movement lag, explorer toggle |
+| stress_* | Combined editing, rapid scroll, worst case |
+| buffer_clone | Buffer clone overhead (bottleneck identified) |
+
+### Performance Results (v0.3.0 → v0.4.2)
+
+| Benchmark | v0.3.0 | v0.4.2 | Improvement |
+|-----------|--------|--------|-------------|
+| window_render/10 | 1.67 µs | 639 ns | **62% faster** |
+| window_render/10000 | 6.60 µs | 2.48 µs | **62% faster** |
+| viewport_size/24 | 3.76 µs | 1.20 µs | **68% faster** |
+| viewport_size/200 | 33.41 µs | 9.73 µs | **71% faster** |
+| screen_io/full_render | 27.68 µs | 5.91 µs | **79% faster** |
+| file_io/buffered | 61.56 µs | 12.68 µs | **79% faster** |
+| rtt/move_down | 1.35 ms | 397 µs | **71% faster** |
+| rtt/half_page_down | 4.32 ms | 410 µs | **91% faster** |
+| rtt/goto_top | 3.61 ms | 397 µs | **89% faster** |
+| stress_editing/50k | 111.77 ms | 38.99 ms | **65% faster** |
+| buffer_clone/50k | 3.90 ms | 1.96 ms | **50% faster** |
+| throughput | 8.61 µs | 2.49 µs | **71% faster** |
+
+### Key Findings
+
+- **Average 50-80% improvement** across all benchmarks
+- **Movement RTT improved 60-90%** - dramatically better responsiveness
+- Window render: ~639ns-3µs (viewport-limited)
+- Buffer clone: Reduced from 3.9ms to 1.96ms for 50K lines
+- Buffered I/O: 10x faster than unbuffered
+
+---
+
+## [0.4.1] - 2025-12-17
+
+### New Features
+
+#### Leap Motion
+- **Two-character jump navigation** - Quick cursor movement by typing 2 characters
+  - `s` - Leap forward
+  - `S` - Leap backward
+- LeapState tracking and LeapEvent system
+- Integrates with operator-pending mode (e.g., `ds{char}{char}` to delete to target)
+- Location: `lib/core/src/leap/`
+
+### Documentation
+
+- **Full documentation rewrite** - Updated all docs to reflect actual codebase state
+- Updated architecture.md with Runtime fields and feature modules
+- Updated event-system.md with all InnerEvent variants
+- Complete rewrite of commands.md with trait-based architecture
+
+---
+
+## Features Present Since v0.3.0
+
+The following features were implemented but not documented in earlier changelogs:
+
+### CommandTrait System
+- Trait-based command architecture replacing simple enum
+- `CommandTrait` interface with `execute()`, `name()`, `description()`
+- `CommandRegistry` - Thread-safe command lookup with `Arc<dyn CommandTrait>`
+- `ExecutionContext` - Execution parameters (buffer, count, ids)
+- `DeferredAction` - Actions requiring Runtime access
+- 129 registered CommandIds, ~79 implementations
+- Location: `lib/core/src/command/`
+
+### Telescope Fuzzy Finder
+- Fuzzy file/buffer/grep search powered by nucleo
+- 7 built-in pickers: files, buffers, live_grep, recent, commands, help, keymaps
+- Normal and Insert modes for navigation/typing
+- `Space f` prefix keybindings
+- Location: `lib/core/src/telescope/`
+
+### Explorer File Browser
+- Tree-view file browser with expand/collapse
+- 25 commands for navigation, file operations, filtering
+- Create/rename/delete files and directories
+- Hidden file toggle, filter mode
+- `Space e` to toggle
+- Location: `lib/core/src/explorer/`
+
+### Completion Engine
+- Async word completion
+- Triggered with Ctrl-Space
+- Ctrl-n/p for navigation, Tab to confirm
+- Location: `lib/core/src/completion/`
+
+### Which-Key Panel
+- Popup showing available keybindings
+- Appears after prefix keys (e.g., `g`, `Space`)
+- Location: `lib/core/src/screen/which_key.rs`
+
+### Jump List
+- Ctrl-O/Ctrl-I navigation between jump locations
+- Tracks cursor positions for jump commands
+- Location: `lib/core/src/jump_list/`
+
+### Operators with Motions
+- `d` + motion = delete
+- `y` + motion = yank
+- `c` + motion = change
+- Operator-pending mode with count support
+- Location: `lib/core/src/command/builtin/operator.rs`
+
+### Registers System
+- Multi-register copy/paste storage
+- Default register and named registers
+- Location: `lib/core/src/registers/`
+
+### Theme System
+- Color mode detection (ANSI, 256, TrueColor)
+- Themed styling for UI components
+- Location: `lib/core/src/theme/`
+
+### Undo/Redo
+- `u` to undo, `Ctrl-r` to redo
+- Per-buffer history
+
+---
+
+## [0.4.0] - 2025-12-17
+
+### New Features
+
+#### Multi-Dimensional Mode State System
+- **Refactored flat `Mod` enum into structured `ModeState` system**
+  - `Focus`: Where you are (Editor, Explorer, Telescope)
+  - `EditMode`: How you're interacting (Normal, Insert, Visual)
+  - `SubMode`: Special overlay states (Command, OperatorPending)
+  - Location: `lib/core/src/modd/mod.rs`
+
+- **Convenience constructors for common modes**
+  - `ModeState::normal()` - Editor + Normal mode
+  - `ModeState::insert()` - Editor + Insert mode
+  - `ModeState::visual()` - Editor + Visual mode
+  - `ModeState::visual_block()` - Editor + Visual Block mode
+  - `ModeState::command()` - Editor + Command sub-mode
+  - `ModeState::explorer()` - Explorer + Normal mode
+  - `ModeState::explorer_input()` - Explorer + Insert mode
+  - `ModeState::telescope()` - Telescope + Insert mode (for typing)
+  - `ModeState::telescope_normal()` - Telescope + Normal mode (for navigation)
+  - `ModeState::operator_pending(operator, count)` - Operator-pending sub-mode
+
+- **State check methods**
+  - `is_normal()`, `is_insert()`, `is_visual()` - Edit mode checks
+  - `is_command()`, `is_operator_pending()` - Sub-mode checks
+  - `is_editor_focus()`, `is_explorer_focus()`, `is_telescope_focus()` - Focus checks
+
+- **Status line display**
+  - `display_string()` method for human-readable mode indicator
+
+#### Telescope Mode Switching
+- **Telescope now supports both Normal and Insert modes**
+  - Insert mode (default): For typing search query
+  - Normal mode: For j/k navigation
+  - ESC switches from Insert to Normal mode in Telescope
+  - New keymaps: `telescope_normal` and `telescope_insert`
+
+### Breaking Changes
+
+- **Removed legacy `Mod` enum** - All code must use `ModeState` struct
+- **Updated `CommandResult::ModeChange`** - Now takes `ModeState` instead of `Mod`
+- **Updated `ModeChangeEvent`** - Now broadcasts `ModeState`
+
+### Mode Mapping (Old -> New)
+
+| Old Mode | New ModeState |
+|----------|---------------|
+| `Mod::Normal` | `ModeState::normal()` |
+| `Mod::Insert(_)` | `ModeState::insert()` |
+| `Mod::Visual(_)` | `ModeState::visual()` |
+| `Mod::Command` | `ModeState::command()` |
+| `Mod::Explorer` | `ModeState::explorer()` |
+| `Mod::ExplorerInput` | `ModeState::explorer_input()` |
+| `Mod::OperatorPending { .. }` | `ModeState::operator_pending(..)` |
+| `Mod::Telescope` | `ModeState::telescope()` |
+
+### Testing
+
+- **All 115 tests passing**
+- Zero warnings from `cargo build` and `cargo clippy`
+
+### Key Files Modified
+
+- `lib/core/src/modd/mod.rs` - New type definitions (Focus, EditMode, SubMode, ModeState)
+- `lib/core/src/runtime/core.rs` - Runtime state management
+- `lib/core/src/runtime/event_loop.rs` - Event handling
+- `lib/core/src/runtime/handlers.rs` - Command handlers
+- `lib/core/src/event/inner/mod.rs` - Event types
+- `lib/core/src/event/handler/command/mod.rs` - Command handler
+- `lib/core/src/event/handler/command/dispatcher.rs` - Dispatcher
+- `lib/core/src/event/handler/command/count_parser.rs` - Count parsing
+- `lib/core/src/event/handler/completion.rs` - Completion handler
+- `lib/core/src/bind/mod.rs` - Keymap system
+- `lib/core/src/screen/status_line.rs` - Status display
+- `lib/core/src/screen/mod.rs` - Screen rendering
+- `lib/core/src/settings/mod.rs` - Settings
+- `lib/core/src/command/builtin/mode.rs` - Mode commands
+- `lib/core/src/command/traits.rs` - Command traits
+
+### Usage Example
+
+```rust
+use reovim_core::modd::{ModeState, Focus, EditMode, SubMode};
+
+// Create common modes
+let normal = ModeState::normal();
+let insert = ModeState::insert();
+let visual = ModeState::visual();
+
+// Check mode state
+if mode.is_insert() {
+    // Handle insert mode
+}
+
+if mode.is_telescope_focus() && mode.is_normal() {
+    // Telescope in navigation mode
+}
+
+// Create custom mode
+let telescope_insert = ModeState::with_focus_and_mode(
+    Focus::Telescope,
+    EditMode::Insert(ModExtension::Normal),
+);
+```
+
+## [0.3.0] - Previous Release
+
+See git history for earlier changes.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -91,7 +91,7 @@ Runtime::init() ─────────────────────�
   ├── Screen (terminal output)                    │
   ├── Buffers (text storage)                      │
   ├── CommandRegistry (trait-based commands)      │
-  ├── mpsc channel (RuntimeEvent)                 │
+  ├── dual mpsc channels (hi/lo priority)         │
   ├── watch channel (ModeState broadcast)         │
   │                                               │
   └── spawned async tasks:                        │

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -34,9 +34,11 @@ pub struct Runtime {
     pub last_command: String,
     pub keymap: KeyMap,
 
-    // Event channels
-    pub tx: mpsc::Sender<RuntimeEvent>,
-    pub rx: mpsc::Receiver<RuntimeEvent>,
+    // Event channels (dual-channel for priority routing)
+    pub hi_tx: mpsc::Sender<RuntimeEvent>,  // High-priority: user input, mode changes
+    hi_rx: mpsc::Receiver<RuntimeEvent>,    // 64 capacity
+    lo_tx: mpsc::Sender<RuntimeEvent>,      // Low-priority: render signals, plugins
+    lo_rx: mpsc::Receiver<RuntimeEvent>,    // 255 capacity
     pub mode_tx: watch::Sender<ModeState>,
     mode_rx: watch::Receiver<ModeState>,
 

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -43,7 +43,12 @@ The event bus provides a type-erased event system for plugin communication. Unli
 
 ### 2. RuntimeEventPayload
 
-Internal events passed to the runtime via mpsc channel. Used for core system events.
+Internal events passed to the runtime via dual mpsc channels (priority-based routing). Used for core system events.
+
+**Priority Channels:**
+- `hi_tx/hi_rx` (64 capacity): user input, mode changes, text insertion
+- `lo_tx/lo_rx` (255 capacity): render signals, plugins, background tasks
+- Biased `select!` ensures high-priority events processed first
 
 **Location:** `lib/core/src/event/inner/mod.rs`
 

--- a/docs/events/runtime-events.md
+++ b/docs/events/runtime-events.md
@@ -1,6 +1,10 @@
 # Runtime Events
 
-Internal events passed to the runtime via mpsc channel.
+Internal events passed to the runtime via dual mpsc channels with priority-based routing.
+
+**Priority Channels:**
+- `hi_tx/hi_rx` (64 capacity): user input, mode changes, text insertion
+- `lo_tx/lo_rx` (255 capacity): render signals, plugins, background tasks
 
 ## Location
 

--- a/lib/core/src/constants.rs
+++ b/lib/core/src/constants.rs
@@ -1,7 +1,13 @@
 //! Editor constants and configuration values
 
-/// Channel capacity for the main event loop mpsc channel
+/// Channel capacity for the main event loop mpsc channel (low-priority events)
 pub const EVENT_CHANNEL_CAPACITY: usize = 255;
+
+/// Channel capacity for high-priority events (user input, mode changes)
+pub const HI_PRIORITY_CHANNEL_CAPACITY: usize = 64;
+
+/// Maximum low-priority events to drain per high-priority batch (fairness)
+pub const MAX_LO_DRAIN: usize = 16;
 
 /// Channel capacity for key event broadcast
 pub const KEY_EVENT_CHANNEL_CAPACITY: usize = 255;

--- a/lib/core/src/rpc/transport.rs
+++ b/lib/core/src/rpc/transport.rs
@@ -199,7 +199,11 @@ impl TransportListener {
                     let actual_port = listener.local_addr()?.port();
 
                     if offset > 0 {
-                        tracing::info!("Port {} in use, bound to {} instead", start_port, actual_port);
+                        tracing::info!(
+                            "Port {} in use, bound to {} instead",
+                            start_port,
+                            actual_port
+                        );
                     } else {
                         tracing::info!("Listening on TCP: {}:{}", host, actual_port);
                     }

--- a/lib/core/src/runtime/core.rs
+++ b/lib/core/src/runtime/core.rs
@@ -14,7 +14,7 @@ use {
         command_line::CommandLine,
         component::RenderState,
         config::{ProfileConfig, ProfileManager},
-        constants::EVENT_CHANNEL_CAPACITY,
+        constants::{EVENT_CHANNEL_CAPACITY, HI_PRIORITY_CHANNEL_CAPACITY},
         decoration::{DecorationStore, LanguageRendererRegistry},
         event::RuntimeEvent,
         event_bus::{
@@ -30,6 +30,7 @@ use {
         option::{OptionRegistry, RegisterOption},
         plugin::{Plugin, PluginContext, PluginLoader, PluginStateRegistry, PluginTuple},
         register::Registers,
+        runtime::PrioritizedEventSender,
         screen::Screen,
     },
     tracing::debug,
@@ -49,8 +50,16 @@ pub struct Runtime {
     pub command_line: CommandLine,
     pub pending_keys: String,
     pub last_command: String,
-    pub tx: mpsc::Sender<RuntimeEvent>,
-    pub rx: mpsc::Receiver<RuntimeEvent>,
+    /// High-priority channel sender (user input, mode changes)
+    pub hi_tx: mpsc::Sender<RuntimeEvent>,
+    /// High-priority channel receiver
+    pub(crate) hi_rx: mpsc::Receiver<RuntimeEvent>,
+    /// Low-priority channel sender (render signals, background tasks)
+    pub lo_tx: mpsc::Sender<RuntimeEvent>,
+    /// Low-priority channel receiver
+    pub(crate) lo_rx: mpsc::Receiver<RuntimeEvent>,
+    /// Prioritized sender wrapper for convenient access to both channels
+    pub prioritized_sender: PrioritizedEventSender,
     pub initial_file: Option<String>,
     pub(crate) showing_landing_page: bool,
     /// Watch channel sender for broadcasting mode changes
@@ -151,7 +160,14 @@ impl Runtime {
     #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn with_plugins<T: PluginTuple>(screen: Screen, plugins: T) -> Self {
-        let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        // Create dual channels for priority-based event processing
+        // High-priority: user input, mode changes (smaller capacity, processed first)
+        let (hi_tx, hi_rx) = mpsc::channel(HI_PRIORITY_CHANNEL_CAPACITY);
+        // Low-priority: render signals, background tasks (larger capacity)
+        let (lo_tx, lo_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        // Create prioritized sender wrapper
+        let prioritized_sender = PrioritizedEventSender::new(hi_tx.clone(), lo_tx.clone());
+
         let (mode_tx, mode_rx) = watch::channel(ModeState::new());
 
         // Initialize event bus and plugin state registry
@@ -221,7 +237,8 @@ impl Runtime {
 
         // Initialize animation system
         // Frame rate of 30 fps provides smooth transitions without excessive CPU usage
-        let animation_system = AnimationSystem::spawn(tx.clone(), 30);
+        // Animation sends render signals which are low-priority events
+        let animation_system = AnimationSystem::spawn(lo_tx.clone(), 30);
         plugin_state.set_animation_handle(animation_system.handle().clone());
         plugin_state.set_animation_state(animation_system.state());
         // Register the animation render stage
@@ -241,8 +258,11 @@ impl Runtime {
             command_line: CommandLine::default(),
             pending_keys: String::new(),
             last_command: String::new(),
-            tx,
-            rx,
+            hi_tx,
+            hi_rx,
+            lo_tx,
+            lo_rx,
+            prioritized_sender,
             initial_file: None,
             showing_landing_page: false,
             mode_tx,
@@ -286,17 +306,18 @@ impl Runtime {
         runtime.display_registry.register_builtins(&runtime.theme);
 
         // Subscribe to focus change requests from plugins
+        // HIGH PRIORITY: Focus changes are user-visible and should be processed immediately
         {
             use crate::event_bus::{EventResult, core_events::RequestFocusChange};
             let mode_tx = runtime.mode_tx.clone();
-            let tx = runtime.tx.clone();
+            let hi_tx = runtime.hi_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestFocusChange, _>(100, move |event, _ctx| {
                     let current_mode = mode_tx.borrow().clone();
                     let new_mode = current_mode.set_interactor_id(event.target);
                     // Send through event loop to properly update runtime.mode_state
-                    let _ = tx.try_send(RuntimeEvent::mode_change(new_mode));
+                    let _ = hi_tx.try_send(RuntimeEvent::mode_change(new_mode));
                     tracing::info!(
                         "Runtime: Requesting focus change to component '{}'",
                         event.target.0
@@ -306,14 +327,15 @@ impl Runtime {
         }
 
         // Subscribe to mode change requests from plugins
+        // HIGH PRIORITY: Mode changes are user-visible and should be processed immediately
         {
             use crate::event_bus::{EventResult, core_events::RequestModeChange};
-            let tx = runtime.tx.clone();
+            let hi_tx = runtime.hi_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestModeChange, _>(100, move |event, _ctx| {
                     // Send through event loop to properly update runtime.mode_state
-                    let _ = tx.try_send(RuntimeEvent::mode_change(event.mode.clone()));
+                    let _ = hi_tx.try_send(RuntimeEvent::mode_change(event.mode.clone()));
                     tracing::info!(
                         "Runtime: Requesting mode change to interactor='{}', edit_mode={:?}, sub_mode={:?}",
                         event.mode.interactor_id.0,
@@ -325,23 +347,25 @@ impl Runtime {
         }
 
         // Subscribe to file open requests from plugins
+        // LOW PRIORITY: File loading is a background operation
         {
             use crate::event_bus::{EventResult, core_events::RequestOpenFile};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestOpenFile, _>(100, move |event, _ctx| {
                     tracing::info!("Runtime: Requesting to open file: {:?}", event.path);
                     // Send OpenFileRequest to the runtime event loop
-                    let _ = tx.try_send(RuntimeEvent::open_file(event.path.clone()));
+                    let _ = lo_tx.try_send(RuntimeEvent::open_file(event.path.clone()));
                     EventResult::Handled
                 });
         }
 
         // Subscribe to file open at position requests from plugins (LSP navigation)
+        // LOW PRIORITY: File loading is a background operation
         {
             use crate::event_bus::{EventResult, core_events::RequestOpenFileAtPosition};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestOpenFileAtPosition, _>(100, move |event, _ctx| {
@@ -351,7 +375,7 @@ impl Runtime {
                         event.line,
                         event.column
                     );
-                    let _ = tx.try_send(RuntimeEvent::open_file_at(
+                    let _ = lo_tx.try_send(RuntimeEvent::open_file_at(
                         event.path.clone(),
                         event.line,
                         event.column,
@@ -361,15 +385,16 @@ impl Runtime {
         }
 
         // Subscribe to register set requests from plugins
+        // LOW PRIORITY: Register operations are background tasks
         {
             use crate::event_bus::{EventResult, core_events::RequestSetRegister};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetRegister, _>(100, move |event, _ctx| {
                     tracing::debug!("Runtime: Requesting to set register {:?}", event.register);
-                    let _ =
-                        tx.try_send(RuntimeEvent::set_register(event.register, event.text.clone()));
+                    let _ = lo_tx
+                        .try_send(RuntimeEvent::set_register(event.register, event.text.clone()));
                     EventResult::Handled
                 });
         }
@@ -428,6 +453,8 @@ impl Runtime {
         }
 
         // Subscribe to text insert requests from plugins (for auto-pair insertion)
+        // HIGH PRIORITY: Auto-pair and completion insertions must be processed immediately
+        // to maintain <16ms latency target for user-initiated text input
         {
             use crate::{
                 bind::CommandRef,
@@ -435,7 +462,7 @@ impl Runtime {
                 event::{CommandEvent, TextInputEvent},
                 event_bus::{EventResult, core_events::RequestInsertText},
             };
-            let tx = runtime.tx.clone();
+            let hi_tx = runtime.hi_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestInsertText, _>(100, move |event, _ctx| {
@@ -443,19 +470,19 @@ impl Runtime {
 
                     // Delete prefix first (for completion: replace typed prefix with full word)
                     for _ in 0..event.delete_prefix_len {
-                        let _ = tx
+                        let _ = hi_tx
                             .try_send(RuntimeEvent::text_input(TextInputEvent::DeleteCharBackward));
                     }
 
                     // Insert each character
                     for c in event.text.chars() {
                         let _ =
-                            tx.try_send(RuntimeEvent::text_input(TextInputEvent::InsertChar(c)));
+                            hi_tx.try_send(RuntimeEvent::text_input(TextInputEvent::InsertChar(c)));
                     }
 
                     // If requested, move cursor left after insertion
                     if event.move_cursor_left {
-                        let _ = tx.try_send(RuntimeEvent::command(CommandEvent {
+                        let _ = hi_tx.try_send(RuntimeEvent::command(CommandEvent {
                             command: CommandRef::Registered(builtin::CURSOR_LEFT),
                             context: CommandContext::default(),
                         }));
@@ -466,6 +493,7 @@ impl Runtime {
         }
 
         // Subscribe to RequestCursorMove (for plugin-driven jumps)
+        // HIGH PRIORITY: Cursor movements are user-visible and should be processed immediately
         {
             use crate::{
                 command::traits::OperatorMotionAction,
@@ -473,7 +501,7 @@ impl Runtime {
                 modd::{OperatorType, SubMode},
                 motion::Motion,
             };
-            let tx = runtime.tx.clone();
+            let hi_tx = runtime.hi_tx.clone();
             let mode_tx = runtime.mode_tx.clone();
             runtime
                 .event_bus
@@ -530,11 +558,11 @@ impl Runtime {
                             };
 
                             // Send operator motion event (runtime will handle mode change)
-                            let _ = tx.try_send(RuntimeEvent::operator_motion(action));
+                            let _ = hi_tx.try_send(RuntimeEvent::operator_motion(action));
                         }
                         None => {
                             // Normal cursor move (no operator)
-                            let _ = tx.try_send(RuntimeEvent::move_cursor(
+                            let _ = hi_tx.try_send(RuntimeEvent::move_cursor(
                                 event.buffer_id,
                                 event.line,
                                 event.column,
@@ -547,75 +575,77 @@ impl Runtime {
         }
 
         // Subscribe to settings/option capability requests
+        // LOW PRIORITY: Settings changes are background operations
         {
             use crate::event_bus::{EventResult, core_events::RequestSetLineNumbers};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetLineNumbers, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_line_numbers(event.enabled));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_line_numbers(event.enabled));
                     EventResult::Handled
                 });
         }
         {
             use crate::event_bus::{EventResult, core_events::RequestSetRelativeLineNumbers};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetRelativeLineNumbers, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_relative_line_numbers(event.enabled));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_relative_line_numbers(event.enabled));
                     EventResult::Handled
                 });
         }
         {
             use crate::event_bus::{EventResult, core_events::RequestSetTheme};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetTheme, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_theme(event.name.clone()));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_theme(event.name.clone()));
                     EventResult::Handled
                 });
         }
         {
             use crate::event_bus::{EventResult, core_events::RequestSetScrollbar};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetScrollbar, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_scrollbar(event.enabled));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_scrollbar(event.enabled));
                     EventResult::Handled
                 });
         }
         {
             use crate::event_bus::{EventResult, core_events::RequestSetIndentGuide};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetIndentGuide, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_indent_guide(event.enabled));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_indent_guide(event.enabled));
                     EventResult::Handled
                 });
         }
         {
             use crate::event_bus::{EventResult, core_events::RequestSetSignColumn};
-            let tx = runtime.tx.clone();
+            let lo_tx = runtime.lo_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestSetSignColumn, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::set_sign_column(event.mode));
+                    let _ = lo_tx.try_send(RuntimeEvent::set_sign_column(event.mode));
                     EventResult::Handled
                 });
         }
 
         // Subscribe to command line completion apply requests
+        // HIGH PRIORITY: Command line completion is user-initiated and should be processed immediately
         {
             use crate::event_bus::{EventResult, core_events::RequestApplyCmdlineCompletion};
-            let tx = runtime.tx.clone();
+            let hi_tx = runtime.hi_tx.clone();
             runtime
                 .event_bus
                 .subscribe::<RequestApplyCmdlineCompletion, _>(100, move |event, _ctx| {
-                    let _ = tx.try_send(RuntimeEvent::apply_cmdline_completion(
+                    let _ = hi_tx.try_send(RuntimeEvent::apply_cmdline_completion(
                         event.text.clone(),
                         event.replace_start,
                     ));
@@ -916,8 +946,9 @@ impl Runtime {
                 }
 
                 // Start background saturator if syntax/decoration providers exist
+                // Saturator sends render signals which are low-priority events
                 if buffer.has_syntax() || buffer.has_decoration_provider() {
-                    buffer.start_saturator(self.tx.clone());
+                    buffer.start_saturator(self.lo_tx.clone());
                     debug!(id, path, "create_buffer_from_file: started saturator");
                 }
 

--- a/lib/core/src/runtime/event_loop.rs
+++ b/lib/core/src/runtime/event_loop.rs
@@ -29,19 +29,22 @@ impl Runtime {
         tracing::info!("Runtime initializing");
 
         // STEP 1: Set up input handlers FIRST (before file loading)
-        let input_broker = InputEventBroker::with_event_sender(self.tx.clone());
+        // HIGH PRIORITY: User input events go through the high-priority channel
+        let input_broker = InputEventBroker::with_event_sender(self.hi_tx.clone());
 
         // Command handler for key-to-command translation
         // Pass mode receiver so CommandHandler can read mode from Runtime (single source of truth)
+        // HIGH PRIORITY: Commands are user-initiated and must be processed immediately
         let mode_rx = self.subscribe_mode();
         let mut command_hdr = CommandHandler::new(
-            self.tx.clone(),
+            self.hi_tx.clone(),
             mode_rx,
             self.keymap.clone(),
             Arc::clone(&self.command_registry),
             Arc::clone(&self.interactor_registry),
         );
-        let mut terminate_hdr = TerminateHandler::new(self.tx.clone());
+        // HIGH PRIORITY: Terminate handler processes Ctrl+D kill signal
+        let mut terminate_hdr = TerminateHandler::new(self.hi_tx.clone());
 
         input_broker.key_broker.enlist(&mut command_hdr);
         input_broker.key_broker.enlist(&mut terminate_hdr);
@@ -54,7 +57,7 @@ impl Runtime {
         // Uses std::thread to avoid tokio scheduler starvation under parallel load (#85)
         if let Some(mut event_rx) = self.event_bus.take_receiver() {
             let event_bus = Arc::clone(&self.event_bus);
-            let inner_tx = self.tx.clone();
+            let lo_tx = self.lo_tx.clone();
             std::thread::spawn(move || {
                 while let Some(mut event) = event_rx.blocking_recv() {
                     let event_type = event.type_name();
@@ -72,9 +75,10 @@ impl Runtime {
                     }
 
                     // If any handler requested a render, send RenderSignal to main loop
+                    // LOW PRIORITY: Render signals are background events
                     if ctx.render_requested() {
                         tracing::info!("==> Render requested by event: {}", event_type);
-                        let _ = inner_tx.try_send(RuntimeEvent::render_signal());
+                        let _ = lo_tx.try_send(RuntimeEvent::render_signal());
                     }
                 }
             });
@@ -86,12 +90,14 @@ impl Runtime {
         // STEP 4: Boot phase - plugins can do post-EventBus initialization
         // Languages are now registered, syntax providers can be created
         // Make inner_event_tx available to plugins for background tasks (e.g., completion saturator)
-        self.plugin_state.set_inner_event_tx(self.tx.clone());
+        // LOW PRIORITY: Plugin background tasks use the low-priority channel
+        self.plugin_state.set_inner_event_tx(self.lo_tx.clone());
         tracing::debug!("Boot phase starting with {} plugins", self.plugins.len());
         for plugin in &self.plugins {
             let plugin_id = plugin.id();
             tracing::debug!(plugin = %plugin_id, "Booting plugin");
-            plugin.boot(&self.event_bus, Arc::clone(&self.plugin_state), Some(self.tx.clone()));
+            // LOW PRIORITY: Plugin boot events are background operations
+            plugin.boot(&self.event_bus, Arc::clone(&self.plugin_state), Some(self.lo_tx.clone()));
         }
         tracing::debug!("Boot phase complete");
 
@@ -149,15 +155,17 @@ impl Runtime {
         let input_broker = crate::event::InputEventBroker::with_key_source(key_source);
 
         // Command handler for key-to-command translation
+        // HIGH PRIORITY: Commands are user-initiated and must be processed immediately
         let mode_rx = self.subscribe_mode();
         let mut command_hdr = crate::event::CommandHandler::new(
-            self.tx.clone(),
+            self.hi_tx.clone(),
             mode_rx,
             self.keymap.clone(),
             Arc::clone(&self.command_registry),
             Arc::clone(&self.interactor_registry),
         );
-        let mut terminate_hdr = crate::event::TerminateHandler::new(self.tx.clone());
+        // HIGH PRIORITY: Terminate handler processes Ctrl+D kill signal
+        let mut terminate_hdr = crate::event::TerminateHandler::new(self.hi_tx.clone());
 
         input_broker.key_broker.enlist(&mut command_hdr);
         input_broker.key_broker.enlist(&mut terminate_hdr);
@@ -168,9 +176,10 @@ impl Runtime {
 
         // STEP 2: Spawn EventBus event processor on dedicated OS thread
         // Uses std::thread to avoid tokio scheduler starvation under parallel load (#85)
+        // LOW PRIORITY: EventBus processor sends render signals which are background events
         if let Some(mut event_rx) = self.event_bus.take_receiver() {
             let event_bus = Arc::clone(&self.event_bus);
-            let inner_tx = self.tx.clone();
+            let lo_tx = self.lo_tx.clone();
             std::thread::spawn(move || {
                 while let Some(mut event) = event_rx.blocking_recv() {
                     let event_type = event.type_name();
@@ -188,9 +197,10 @@ impl Runtime {
                     }
 
                     // If any handler requested a render, send RenderSignal to main loop
+                    // LOW PRIORITY: Render signals are background events
                     if ctx.render_requested() {
                         tracing::info!("==> Render requested by event: {}", event_type);
-                        let _ = inner_tx.try_send(RuntimeEvent::render_signal());
+                        let _ = lo_tx.try_send(RuntimeEvent::render_signal());
                     }
                 }
             });
@@ -202,12 +212,14 @@ impl Runtime {
         // STEP 4: Boot phase - plugins can do post-EventBus initialization
         // Languages are now registered, syntax providers can be created
         // Make inner_event_tx available to plugins for background tasks (e.g., completion saturator)
-        self.plugin_state.set_inner_event_tx(self.tx.clone());
+        // LOW PRIORITY: Plugin background tasks use the low-priority channel
+        self.plugin_state.set_inner_event_tx(self.lo_tx.clone());
         tracing::debug!("Boot phase starting with {} plugins", self.plugins.len());
         for plugin in &self.plugins {
             let plugin_id = plugin.id();
             tracing::debug!(plugin = %plugin_id, "Booting plugin");
-            plugin.boot(&self.event_bus, Arc::clone(&self.plugin_state), Some(self.tx.clone()));
+            // LOW PRIORITY: Plugin boot events are background operations
+            plugin.boot(&self.event_bus, Arc::clone(&self.plugin_state), Some(self.lo_tx.clone()));
         }
         tracing::debug!("Boot phase complete");
 
@@ -248,12 +260,16 @@ impl Runtime {
         let _ = self.screen.finalize();
     }
 
-    /// The main event processing loop
+    /// The main event processing loop with priority-based dual-channel architecture
+    ///
+    /// Uses biased select! to ensure high-priority events (user input) are processed
+    /// before low-priority events (render signals, background tasks).
     #[allow(clippy::collapsible_if)]
     #[allow(clippy::match_same_arms)]
     #[allow(clippy::future_not_send)]
+    #[allow(clippy::too_many_lines)]
     async fn run_event_loop(&mut self) {
-        use std::time::Duration;
+        use {crate::constants::MAX_LO_DRAIN, std::time::Duration};
 
         // Idle timeout: start shimmer after 3 seconds of inactivity
         const IDLE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -270,49 +286,110 @@ impl Runtime {
 
         loop {
             tokio::select! {
-                // Check for incoming events
-                ev = self.rx.recv() => {
-                    if let Some(ev) = ev {
-                        let loop_start = std::time::Instant::now();
-                        let ev_name = format!("{:?}", std::mem::discriminant(ev.payload()));
+                // Use biased selection to process high-priority events first
+                biased;
 
-                        // Track user input for idle detection
+                // HIGH PRIORITY: User input events (commands, mode changes, text input)
+                Some(ev) = self.hi_rx.recv() => {
+                    let loop_start = std::time::Instant::now();
+                    let ev_name = format!("{:?}", std::mem::discriminant(ev.payload()));
+
+                    // Track user input for idle detection
+                    self.track_input_for_idle(ev.payload());
+
+                    if self.handle_event(ev) {
+                        break;
+                    }
+
+                    // Drain ALL high-priority events first (user input takes precedence)
+                    let mut hi_drained = 0;
+                    while let Ok(ev) = self.hi_rx.try_recv() {
+                        hi_drained += 1;
                         self.track_input_for_idle(ev.payload());
-
                         if self.handle_event(ev) {
-                            break;
+                            self.flush_render();
+                            return;
                         }
-                        // Drain all pending events before rendering
-                        // This coalesces renders across multiple related events
-                        // (e.g., PendingKeysEvent + CommandEvent + ModeChangeEvent from one key)
-                        let mut drained = 0;
-                        while let Ok(ev) = self.rx.try_recv() {
-                            drained += 1;
+                    }
+
+                    // Then drain some low-priority events for fairness
+                    let mut lo_drained = 0;
+                    for _ in 0..MAX_LO_DRAIN {
+                        match self.lo_rx.try_recv() {
+                            Ok(ev) => {
+                                lo_drained += 1;
+                                self.track_input_for_idle(ev.payload());
+                                if self.handle_event(ev) {
+                                    self.flush_render();
+                                    return;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+
+                    // Flush render once after all pending events processed
+                    let pre_render = loop_start.elapsed();
+                    self.flush_render();
+                    tracing::trace!(
+                        "[RTT] event_loop(hi): first_ev={} hi_drained={} lo_drained={} pre_render={:?} total={:?}",
+                        ev_name,
+                        hi_drained,
+                        lo_drained,
+                        pre_render,
+                        loop_start.elapsed()
+                    );
+                }
+
+                // LOW PRIORITY: Background events (render signals, syntax updates, plugin events)
+                Some(ev) = self.lo_rx.recv() => {
+                    let loop_start = std::time::Instant::now();
+                    let ev_name = format!("{:?}", std::mem::discriminant(ev.payload()));
+
+                    // Track input for idle detection (some low-pri events may affect idle)
+                    self.track_input_for_idle(ev.payload());
+
+                    if self.handle_event(ev) {
+                        break;
+                    }
+
+                    // Drain low-priority, but re-check high-priority between batches
+                    let mut lo_drained = 0;
+                    loop {
+                        // Always check high-priority first during low-priority drain
+                        while let Ok(ev) = self.hi_rx.try_recv() {
                             self.track_input_for_idle(ev.payload());
                             if self.handle_event(ev) {
-                                // Flush before breaking on quit
                                 self.flush_render();
                                 return;
                             }
                         }
-                        // Flush render once after all pending events processed
-                        let pre_render = loop_start.elapsed();
-                        self.flush_render();
-                        tracing::trace!(
-                            "[RTT] event_loop: first_ev={} drained={} pre_render={:?} total={:?}",
-                            ev_name,
-                            drained,
-                            pre_render,
-                            loop_start.elapsed()
-                        );
-                    } else {
-                        self.tx
-                            .send(RuntimeEvent::kill())
-                            .await
-                            .expect("cannot broadcast kill signal");
-                        break;
+                        // Then process one low-priority event
+                        match self.lo_rx.try_recv() {
+                            Ok(ev) => {
+                                lo_drained += 1;
+                                self.track_input_for_idle(ev.payload());
+                                if self.handle_event(ev) {
+                                    self.flush_render();
+                                    return;
+                                }
+                            }
+                            Err(_) => break,
+                        }
                     }
+
+                    // Flush render once after all pending events processed
+                    let pre_render = loop_start.elapsed();
+                    self.flush_render();
+                    tracing::trace!(
+                        "[RTT] event_loop(lo): first_ev={} lo_drained={} pre_render={:?} total={:?}",
+                        ev_name,
+                        lo_drained,
+                        pre_render,
+                        loop_start.elapsed()
+                    );
                 }
+
                 // Periodic idle check
                 _ = idle_check_interval.tick() => {
                     let elapsed = self.last_input_at.elapsed();
@@ -321,6 +398,7 @@ impl Runtime {
                         self.start_idle_shimmer();
                     }
                 }
+
                 // Landing page animation tick (only when showing landing page)
                 _ = landing_anim_interval.tick(), if self.showing_landing_page => {
                     if let Some(ref mut state) = self.landing_state {
@@ -338,6 +416,15 @@ impl Runtime {
                             self.flush_render();
                         }
                     }
+                }
+
+                // Both channels closed - shutdown
+                else => {
+                    self.hi_tx
+                        .send(RuntimeEvent::kill())
+                        .await
+                        .expect("cannot broadcast kill signal");
+                    break;
                 }
             }
         }
@@ -519,8 +606,9 @@ impl Runtime {
                             if let Some(buffer) = self.buffers.get_mut(&buffer_id) {
                                 buffer.attach_syntax(syntax);
                                 // Start saturator for background cache computation
+                                // LOW PRIORITY: Saturator sends render signals which are background events
                                 if !buffer.has_saturator() {
-                                    buffer.start_saturator(self.tx.clone());
+                                    buffer.start_saturator(self.lo_tx.clone());
                                 }
                                 tracing::debug!(
                                     buffer_id,

--- a/lib/core/src/runtime/handlers.rs
+++ b/lib/core/src/runtime/handlers.rs
@@ -697,9 +697,10 @@ impl Runtime {
                     }
                     if ctx.quit_requested() {
                         // Emit quit - the event loop will handle it
-                        let tx = self.tx.clone();
+                        // HIGH PRIORITY: Kill signal must be processed immediately
+                        let hi_tx = self.hi_tx.clone();
                         tokio::spawn(async move {
-                            let _ = tx.send(crate::event::RuntimeEvent::kill()).await;
+                            let _ = hi_tx.send(crate::event::RuntimeEvent::kill()).await;
                         });
                     }
 

--- a/lib/core/src/runtime/mod.rs
+++ b/lib/core/src/runtime/mod.rs
@@ -5,9 +5,11 @@ mod core;
 mod enlist;
 mod event_loop;
 mod handlers;
+mod sender;
 
 pub use {
     context::{RuntimeContext, RuntimeContextExt},
     core::{FocusInputHandler, Runtime},
     enlist::{handle_command_line_input, handle_editor_input},
+    sender::PrioritizedEventSender,
 };

--- a/lib/core/src/runtime/sender.rs
+++ b/lib/core/src/runtime/sender.rs
@@ -1,0 +1,78 @@
+//! Prioritized event sender for dual-channel architecture
+//!
+//! This module provides a wrapper around the dual-channel event system that
+//! separates high-priority events (user input) from low-priority events
+//! (background tasks like render signals).
+
+use tokio::sync::mpsc;
+
+use crate::event::RuntimeEvent;
+
+/// Wrapper for dual-channel event sending with priority support.
+///
+/// High-priority channel is used for user-facing events that need immediate
+/// processing (keystrokes, mode changes, text input). Low-priority channel
+/// is used for background events (render signals, syntax updates, plugin events).
+#[derive(Clone)]
+pub struct PrioritizedEventSender {
+    hi: mpsc::Sender<RuntimeEvent>,
+    lo: mpsc::Sender<RuntimeEvent>,
+}
+
+impl PrioritizedEventSender {
+    /// Create a new prioritized sender from high and low priority channels.
+    #[must_use]
+    pub const fn new(hi: mpsc::Sender<RuntimeEvent>, lo: mpsc::Sender<RuntimeEvent>) -> Self {
+        Self { hi, lo }
+    }
+
+    /// Send a high-priority event (user input, mode changes).
+    ///
+    /// Use this for events that need immediate processing to maintain
+    /// responsive user experience (<16ms latency target).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the channel is full or closed.
+    #[allow(clippy::result_large_err)]
+    pub fn send_hi(
+        &self,
+        event: RuntimeEvent,
+    ) -> Result<(), mpsc::error::TrySendError<RuntimeEvent>> {
+        self.hi.try_send(event)
+    }
+
+    /// Send a low-priority event (render signals, background tasks).
+    ///
+    /// Use this for events that can be batched or delayed without
+    /// affecting user-perceived responsiveness.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the channel is full or closed.
+    #[allow(clippy::result_large_err)]
+    pub fn send_lo(
+        &self,
+        event: RuntimeEvent,
+    ) -> Result<(), mpsc::error::TrySendError<RuntimeEvent>> {
+        self.lo.try_send(event)
+    }
+
+    /// Clone just the high-priority sender (for user input paths).
+    ///
+    /// Use this when a component only sends high-priority events
+    /// (e.g., `Dispatcher`, `TerminateHandler`).
+    #[must_use]
+    pub fn hi_sender(&self) -> mpsc::Sender<RuntimeEvent> {
+        self.hi.clone()
+    }
+
+    /// Clone just the low-priority sender (for background paths).
+    ///
+    /// Use this when a component only sends low-priority events
+    /// (e.g., `AnimationController`, `Saturator`, `RuntimeContext`).
+    #[must_use]
+    pub fn lo_sender(&self) -> mpsc::Sender<RuntimeEvent> {
+        self.lo.clone()
+    }
+}

--- a/lib/core/src/testing/server.rs
+++ b/lib/core/src/testing/server.rs
@@ -106,10 +106,11 @@ impl ServerTestHarness {
             .spawn()?;
 
         // Read actual port from stderr with timeout
-        let port = tokio::time::timeout(Duration::from_secs(10), read_port_from_stderr(&mut process))
-            .await
-            .map_err(|_| "Server startup timed out (10s)")?
-            .map_err(|e| format!("Failed to read port from server: {e}"))?;
+        let port =
+            tokio::time::timeout(Duration::from_secs(10), read_port_from_stderr(&mut process))
+                .await
+                .map_err(|_| "Server startup timed out (10s)")?
+                .map_err(|e| format!("Failed to read port from server: {e}"))?;
 
         Ok(Self { process, port })
     }
@@ -150,10 +151,11 @@ impl ServerTestHarness {
             .spawn()?;
 
         // Read actual port from stderr with timeout
-        let port = tokio::time::timeout(Duration::from_secs(10), read_port_from_stderr(&mut process))
-            .await
-            .map_err(|_| "Server startup timed out (10s)")?
-            .map_err(|e| format!("Failed to read port from server: {e}"))?;
+        let port =
+            tokio::time::timeout(Duration::from_secs(10), read_port_from_stderr(&mut process))
+                .await
+                .map_err(|_| "Server startup timed out (10s)")?
+                .map_err(|e| format!("Failed to read port from server: {e}"))?;
 
         Ok(Self { process, port })
     }

--- a/perf/PERF-0.8.0-dev-priority-channels.md
+++ b/perf/PERF-0.8.0-dev-priority-channels.md
@@ -1,0 +1,269 @@
+# Performance Benchmarks v0.8.0-dev-priority-channels
+
+> Last updated: 2026-01-08T15:17:55Z | Commit: 2376a8e | Rust: 1.94.0-nightly
+
+## Metadata
+
+```toml
+[metadata]
+version = "0.8.0-dev-priority-channels"
+commit = "2376a8e"
+date = "2026-01-08T15:17:55Z"
+rust_version = "1.94.0-nightly"
+os = "Linux 6.17.9-arch1-1"
+```
+
+## Summary
+
+| Category | Benchmarks | Avg Time |
+|----------|------------|----------|
+| complete_cycle | 1 | 54.47 µs |
+| event_bus_bottleneck_blocking | 4 | 29.06 µs |
+| event_bus_bottleneck_comparison | 2 | 26.95 ns |
+| event_bus_bottleneck_queue | 4 | 1.00 ms |
+| event_bus_bottleneck_sequential | 3 | 7.67 ms |
+| event_bus_dispatch | 7 | 120.47 ns |
+| event_bus_dispatch_consumed | 4 | 27.68 ns |
+| event_bus_dispatch_emit | 4 | 90.50 ns |
+| event_bus_dispatch_multi_type | 4 | 27.80 ns |
+| event_bus_dispatch_priority | 3 | 63.34 ns |
+| event_bus_dyn_event_new | 1 | 8.52 ns |
+| event_bus_rwlock | 4 | 69.57 ns |
+| event_bus_subscribe | 1 | 159.77 ns |
+| frame_operations | 3 | 34.83 µs |
+| large_file | 2 | 49.71 ms |
+| render_data_changelog | 3 | 32.45 µs |
+| render_data_jjjjj | 2 | 202.18 µs |
+| render_data_real | 4 | 20.25 µs |
+| render_data_syntax_overhead | 2 | 20.39 µs |
+| throughput | 1 | 25.86 µs |
+| treesitter_query_compile | 8 | 11.82 ms |
+| treesitter_register_all_languages | 1 | 11.36 µs |
+| treesitter_register_language | 4 | 9.35 µs |
+| viewport_size | 4 | 49.29 µs |
+| window_render | 4 | 20.38 µs |
+| with_highlights | 1 | 25.58 µs |
+
+## Results
+
+```toml
+[results.complete_cycle]
+full_scroll_cycle = { mean = 54.47, median = 50.94, std_dev = 10.87, unit = "µs" }
+
+[results.event_bus_bottleneck_blocking]
+block_us_100 = { mean = 100.25, median = 100.11, std_dev = 0.66, unit = "µs" }
+block_us_1000 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+block_us_10000 = { mean = 10.00, median = 10.00, std_dev = 0.00, unit = "ms" }
+block_us_5000 = { mean = 5.00, median = 5.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_bottleneck_comparison]
+fast_only = { mean = 27.59, median = 26.48, std_dev = 1.71, unit = "ns" }
+fast_with_slow_registered = { mean = 26.32, median = 26.28, std_dev = 0.15, unit = "ns" }
+
+[results.event_bus_bottleneck_queue]
+queued_events_1 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_10 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_20 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+queued_events_5 = { mean = 1.00, median = 1.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_bottleneck_sequential]
+langs_1x5000us = { mean = 5.00, median = 5.00, std_dev = 0.00, unit = "ms" }
+langs_4x2500us = { mean = 10.00, median = 10.00, std_dev = 0.00, unit = "ms" }
+langs_8x1000us = { mean = 8.00, median = 8.00, std_dev = 0.00, unit = "ms" }
+
+[results.event_bus_dispatch]
+handlers_0 = { mean = 10.79, median = 10.17, std_dev = 1.92, unit = "ns" }
+handlers_1 = { mean = 27.14, median = 26.74, std_dev = 1.58, unit = "ns" }
+handlers_10 = { mean = 57.30, median = 57.07, std_dev = 1.40, unit = "ns" }
+handlers_100 = { mean = 406.07, median = 392.28, std_dev = 28.70, unit = "ns" }
+handlers_20 = { mean = 100.56, median = 91.32, std_dev = 21.28, unit = "ns" }
+handlers_5 = { mean = 41.10, median = 40.63, std_dev = 1.50, unit = "ns" }
+handlers_50 = { mean = 200.30, median = 200.31, std_dev = 0.42, unit = "ns" }
+
+[results.event_bus_dispatch_consumed]
+total_handlers_10 = { mean = 28.87, median = 28.65, std_dev = 2.33, unit = "ns" }
+total_handlers_20 = { mean = 26.56, median = 26.54, std_dev = 0.12, unit = "ns" }
+total_handlers_5 = { mean = 26.97, median = 26.92, std_dev = 0.43, unit = "ns" }
+total_handlers_50 = { mean = 28.33, median = 26.67, std_dev = 2.67, unit = "ns" }
+
+[results.event_bus_dispatch_emit]
+emits_0 = { mean = 29.84, median = 29.29, std_dev = 2.78, unit = "ns" }
+emits_1 = { mean = 46.73, median = 44.23, std_dev = 6.63, unit = "ns" }
+emits_10 = { mean = 185.18, median = 174.53, std_dev = 20.65, unit = "ns" }
+emits_5 = { mean = 100.25, median = 100.16, std_dev = 0.45, unit = "ns" }
+
+[results.event_bus_dispatch_multi_type]
+event_types_1 = { mean = 28.80, median = 26.91, std_dev = 4.05, unit = "ns" }
+event_types_10 = { mean = 26.89, median = 26.63, std_dev = 0.66, unit = "ns" }
+event_types_20 = { mean = 28.68, median = 26.88, std_dev = 4.89, unit = "ns" }
+event_types_5 = { mean = 26.84, median = 26.57, std_dev = 0.79, unit = "ns" }
+
+[results.event_bus_dispatch_priority]
+handlers_10 = { mean = 56.99, median = 56.43, std_dev = 2.32, unit = "ns" }
+handlers_20 = { mean = 91.83, median = 90.51, std_dev = 3.58, unit = "ns" }
+handlers_5 = { mean = 41.20, median = 40.43, std_dev = 1.93, unit = "ns" }
+
+[results.event_bus_dyn_event_new]
+event_bus_dyn_event_new = { mean = 8.52, median = 8.33, std_dev = 0.59, unit = "ns" }
+
+[results.event_bus_rwlock]
+registered_handlers_1 = { mean = 26.69, median = 25.91, std_dev = 1.90, unit = "ns" }
+registered_handlers_10 = { mean = 38.82, median = 33.75, std_dev = 10.33, unit = "ns" }
+registered_handlers_100 = { mean = 133.35, median = 133.18, std_dev = 1.11, unit = "ns" }
+registered_handlers_50 = { mean = 79.43, median = 75.38, std_dev = 7.73, unit = "ns" }
+
+[results.event_bus_subscribe]
+event_bus_subscribe = { mean = 159.77, median = 159.05, std_dev = 3.21, unit = "ns" }
+
+[results.frame_operations]
+buffer_fill_6000_cells = { mean = 30.71, median = 28.59, std_dev = 6.04, unit = "µs" }
+flush_full_screen = { mean = 52.93, median = 48.39, std_dev = 10.54, unit = "µs" }
+flush_scroll_simulation = { mean = 20.84, median = 19.13, std_dev = 4.88, unit = "µs" }
+
+[results.large_file]
+5000_lines_20_j_presses = { mean = 1.76, median = 1.75, std_dev = 0.04, unit = "ms" }
+5000_lines_render_data = { mean = 97.65, median = 89.99, std_dev = 15.04, unit = "µs" }
+
+[results.render_data_changelog]
+scroll_pos_0 = { mean = 30.49, median = 30.16, std_dev = 0.98, unit = "µs" }
+scroll_pos_100 = { mean = 33.99, median = 31.56, std_dev = 3.59, unit = "µs" }
+scroll_pos_500 = { mean = 32.85, median = 30.87, std_dev = 3.17, unit = "µs" }
+
+[results.render_data_jjjjj]
+20_j_presses = { mean = 403.36, median = 384.37, std_dev = 49.95, unit = "µs" }
+50_j_presses = { mean = 1.01, median = 0.97, std_dev = 0.14, unit = "ms" }
+
+[results.render_data_real]
+scroll_pos_0 = { mean = 19.92, median = 19.54, std_dev = 1.88, unit = "µs" }
+scroll_pos_150 = { mean = 19.83, median = 19.66, std_dev = 0.73, unit = "µs" }
+scroll_pos_300 = { mean = 21.34, median = 19.65, std_dev = 3.23, unit = "µs" }
+scroll_pos_50 = { mean = 19.90, median = 19.61, std_dev = 1.02, unit = "µs" }
+
+[results.render_data_syntax_overhead]
+with_syntax = { mean = 20.37, median = 19.34, std_dev = 3.22, unit = "µs" }
+without_syntax = { mean = 20.41, median = 19.42, std_dev = 2.99, unit = "µs" }
+
+[results.throughput]
+renders_per_second = { mean = 25.86, median = 23.94, std_dev = 4.95, unit = "µs" }
+
+[results.treesitter_query_compile]
+highlights_bash = { mean = 2.00, median = 1.99, std_dev = 0.05, unit = "ms" }
+highlights_c = { mean = 2.87, median = 2.76, std_dev = 0.22, unit = "ms" }
+highlights_javascript = { mean = 3.45, median = 3.18, std_dev = 0.66, unit = "ms" }
+highlights_json = { mean = 7.94, median = 8.20, std_dev = 0.82, unit = "µs" }
+highlights_markdown = { mean = 1.15, median = 1.06, std_dev = 0.20, unit = "ms" }
+highlights_python = { mean = 3.39, median = 3.37, std_dev = 0.07, unit = "ms" }
+highlights_rust = { mean = 23.77, median = 23.79, std_dev = 0.40, unit = "ms" }
+highlights_toml = { mean = 49.97, median = 45.35, std_dev = 9.89, unit = "µs" }
+
+[results.treesitter_register_all_languages]
+treesitter_register_all_languages = { mean = 11.36, median = 11.36, std_dev = 0.05, unit = "µs" }
+
+[results.treesitter_register_language]
+c = { mean = 9.42, median = 9.45, std_dev = 0.69, unit = "µs" }
+javascript = { mean = 9.84, median = 9.71, std_dev = 0.63, unit = "µs" }
+python = { mean = 9.42, median = 9.49, std_dev = 0.24, unit = "µs" }
+rust = { mean = 8.70, median = 8.44, std_dev = 0.70, unit = "µs" }
+
+[results.viewport_size]
+height_100 = { mean = 51.59, median = 47.73, std_dev = 10.41, unit = "µs" }
+height_200 = { mean = 107.65, median = 94.84, std_dev = 23.04, unit = "µs" }
+height_24 = { mean = 12.23, median = 11.21, std_dev = 2.66, unit = "µs" }
+height_50 = { mean = 25.71, median = 24.34, std_dev = 4.58, unit = "µs" }
+
+[results.window_render]
+buffer_lines_10 = { mean = 5.11, median = 4.74, std_dev = 0.90, unit = "µs" }
+buffer_lines_100 = { mean = 26.02, median = 23.79, std_dev = 4.75, unit = "µs" }
+buffer_lines_1000 = { mean = 25.03, median = 23.51, std_dev = 4.74, unit = "µs" }
+buffer_lines_10000 = { mean = 25.37, median = 23.33, std_dev = 5.65, unit = "µs" }
+
+[results.with_highlights]
+no_highlights = { mean = 25.58, median = 24.20, std_dev = 4.84, unit = "µs" }
+
+```
+
+## Detailed Results
+
+| Benchmark | Mean | Median | Std Dev | CI (95%) |
+|-----------|------|--------|---------|----------|
+| complete_cycle/full_scroll_cycle | 54.47 µs | 50.94 µs | 10.87 µs | [51.04, 58.72] µs |
+| event_bus_bottleneck_blocking/block_us/100 | 100.25 µs | 100.11 µs | 0.66 µs | [100.12, 100.50] µs |
+| event_bus_bottleneck_blocking/block_us/1000 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_blocking/block_us/10000 | 10.00 ms | 10.00 ms | 0.00 ms | [10.00, 10.00] ms |
+| event_bus_bottleneck_blocking/block_us/5000 | 5.00 ms | 5.00 ms | 0.00 ms | [5.00, 5.00] ms |
+| event_bus_bottleneck_comparison/fast_only | 27.59 ns | 26.48 ns | 1.71 ns | [27.01, 28.20] ns |
+| event_bus_bottleneck_comparison/fast_with_slow_registered | 26.32 ns | 26.28 ns | 0.15 ns | [26.27, 26.38] ns |
+| event_bus_bottleneck_queue/queued_events/1 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/10 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/20 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_queue/queued_events/5 | 1.00 ms | 1.00 ms | 0.00 ms | [1.00, 1.00] ms |
+| event_bus_bottleneck_sequential/langs/1x5000us | 5.00 ms | 5.00 ms | 0.00 ms | [5.00, 5.00] ms |
+| event_bus_bottleneck_sequential/langs/4x2500us | 10.00 ms | 10.00 ms | 0.00 ms | [10.00, 10.00] ms |
+| event_bus_bottleneck_sequential/langs/8x1000us | 8.00 ms | 8.00 ms | 0.00 ms | [8.00, 8.00] ms |
+| event_bus_dispatch/handlers/0 | 10.79 ns | 10.17 ns | 1.92 ns | [10.25, 11.57] ns |
+| event_bus_dispatch/handlers/1 | 27.14 ns | 26.74 ns | 1.58 ns | [26.69, 27.77] ns |
+| event_bus_dispatch/handlers/10 | 57.30 ns | 57.07 ns | 1.40 ns | [56.85, 57.83] ns |
+| event_bus_dispatch/handlers/100 | 406.07 ns | 392.28 ns | 28.70 ns | [396.84, 417.01] ns |
+| event_bus_dispatch/handlers/20 | 100.56 ns | 91.32 ns | 21.28 ns | [93.84, 108.67] ns |
+| event_bus_dispatch/handlers/5 | 41.10 ns | 40.63 ns | 1.50 ns | [40.64, 41.68] ns |
+| event_bus_dispatch/handlers/50 | 200.30 ns | 200.31 ns | 0.42 ns | [200.16, 200.45] ns |
+| event_bus_dispatch_consumed/total_handlers/10 | 28.87 ns | 28.65 ns | 2.33 ns | [28.10, 29.73] ns |
+| event_bus_dispatch_consumed/total_handlers/20 | 26.56 ns | 26.54 ns | 0.12 ns | [26.52, 26.61] ns |
+| event_bus_dispatch_consumed/total_handlers/5 | 26.97 ns | 26.92 ns | 0.43 ns | [26.83, 27.13] ns |
+| event_bus_dispatch_consumed/total_handlers/50 | 28.33 ns | 26.67 ns | 2.67 ns | [27.44, 29.32] ns |
+| event_bus_dispatch_emit/emits/0 | 29.84 ns | 29.29 ns | 2.78 ns | [28.91, 30.86] ns |
+| event_bus_dispatch_emit/emits/1 | 46.73 ns | 44.23 ns | 6.63 ns | [44.72, 49.28] ns |
+| event_bus_dispatch_emit/emits/10 | 185.18 ns | 174.53 ns | 20.65 ns | [178.46, 192.92] ns |
+| event_bus_dispatch_emit/emits/5 | 100.25 ns | 100.16 ns | 0.45 ns | [100.11, 100.43] ns |
+| event_bus_dispatch_multi_type/event_types/1 | 28.80 ns | 26.91 ns | 4.05 ns | [27.57, 30.38] ns |
+| event_bus_dispatch_multi_type/event_types/10 | 26.89 ns | 26.63 ns | 0.66 ns | [26.67, 27.14] ns |
+| event_bus_dispatch_multi_type/event_types/20 | 28.68 ns | 26.88 ns | 4.89 ns | [27.14, 30.60] ns |
+| event_bus_dispatch_multi_type/event_types/5 | 26.84 ns | 26.57 ns | 0.79 ns | [26.61, 27.16] ns |
+| event_bus_dispatch_priority/handlers/10 | 56.99 ns | 56.43 ns | 2.32 ns | [56.45, 57.91] ns |
+| event_bus_dispatch_priority/handlers/20 | 91.83 ns | 90.51 ns | 3.58 ns | [90.71, 93.21] ns |
+| event_bus_dispatch_priority/handlers/5 | 41.20 ns | 40.43 ns | 1.93 ns | [40.61, 41.94] ns |
+| event_bus_dyn_event_new | 8.52 ns | 8.33 ns | 0.59 ns | [8.35, 8.75] ns |
+| event_bus_rwlock/registered_handlers/1 | 26.69 ns | 25.91 ns | 1.90 ns | [26.08, 27.41] ns |
+| event_bus_rwlock/registered_handlers/10 | 38.82 ns | 33.75 ns | 10.33 ns | [35.45, 42.71] ns |
+| event_bus_rwlock/registered_handlers/100 | 133.35 ns | 133.18 ns | 1.11 ns | [132.97, 133.75] ns |
+| event_bus_rwlock/registered_handlers/50 | 79.43 ns | 75.38 ns | 7.73 ns | [76.86, 82.28] ns |
+| event_bus_subscribe | 159.77 ns | 159.05 ns | 3.21 ns | [158.79, 161.02] ns |
+| frame_operations/buffer_fill_6000_cells | 30.71 µs | 28.59 µs | 6.04 µs | [28.85, 33.09] µs |
+| frame_operations/flush_full_screen | 52.93 µs | 48.39 µs | 10.54 µs | [49.71, 57.08] µs |
+| frame_operations/flush_scroll_simulation | 20.84 µs | 19.13 µs | 4.88 µs | [19.39, 22.77] µs |
+| large_file/5000_lines_20_j_presses | 1.76 ms | 1.75 ms | 0.04 ms | [1.75, 1.78] ms |
+| large_file/5000_lines_render_data | 97.65 µs | 89.99 µs | 15.04 µs | [92.72, 103.31] µs |
+| render_data_changelog/scroll_pos/0 | 30.49 µs | 30.16 µs | 0.98 µs | [30.20, 30.88] µs |
+| render_data_changelog/scroll_pos/100 | 33.99 µs | 31.56 µs | 3.59 µs | [32.76, 35.26] µs |
+| render_data_changelog/scroll_pos/500 | 32.85 µs | 30.87 µs | 3.17 µs | [31.77, 34.00] µs |
+| render_data_jjjjj/20_j_presses | 403.36 µs | 384.37 µs | 49.95 µs | [388.20, 423.07] µs |
+| render_data_jjjjj/50_j_presses | 1.01 ms | 0.97 ms | 0.14 ms | [0.97, 1.07] ms |
+| render_data_real/scroll_pos/0 | 19.92 µs | 19.54 µs | 1.88 µs | [19.52, 20.64] µs |
+| render_data_real/scroll_pos/150 | 19.83 µs | 19.66 µs | 0.73 µs | [19.61, 20.12] µs |
+| render_data_real/scroll_pos/300 | 21.34 µs | 19.65 µs | 3.23 µs | [20.31, 22.56] µs |
+| render_data_real/scroll_pos/50 | 19.90 µs | 19.61 µs | 1.02 µs | [19.61, 20.31] µs |
+| render_data_syntax_overhead/with_syntax | 20.37 µs | 19.34 µs | 3.22 µs | [19.36, 21.61] µs |
+| render_data_syntax_overhead/without_syntax | 20.41 µs | 19.42 µs | 2.99 µs | [19.45, 21.60] µs |
+| throughput/renders_per_second | 25.86 µs | 23.94 µs | 4.95 µs | [24.36, 27.80] µs |
+| treesitter_query_compile/highlights/bash | 2.00 ms | 1.99 ms | 0.05 ms | [1.99, 2.02] ms |
+| treesitter_query_compile/highlights/c | 2.87 ms | 2.76 ms | 0.22 ms | [2.80, 2.95] ms |
+| treesitter_query_compile/highlights/javascript | 3.45 ms | 3.18 ms | 0.66 ms | [3.25, 3.71] ms |
+| treesitter_query_compile/highlights/json | 7.94 µs | 8.20 µs | 0.82 µs | [7.65, 8.23] µs |
+| treesitter_query_compile/highlights/markdown | 1.15 ms | 1.06 ms | 0.20 ms | [1.08, 1.22] ms |
+| treesitter_query_compile/highlights/python | 3.39 ms | 3.37 ms | 0.07 ms | [3.37, 3.42] ms |
+| treesitter_query_compile/highlights/rust | 23.77 ms | 23.79 ms | 0.40 ms | [23.64, 23.92] ms |
+| treesitter_query_compile/highlights/toml | 49.97 µs | 45.35 µs | 9.89 µs | [46.88, 53.75] µs |
+| treesitter_register_all_languages | 11.36 µs | 11.36 µs | 0.05 µs | [11.34, 11.38] µs |
+| treesitter_register_language/c | 9.42 µs | 9.45 µs | 0.69 µs | [9.18, 9.67] µs |
+| treesitter_register_language/javascript | 9.84 µs | 9.71 µs | 0.63 µs | [9.64, 10.09] µs |
+| treesitter_register_language/python | 9.42 µs | 9.49 µs | 0.24 µs | [9.33, 9.49] µs |
+| treesitter_register_language/rust | 8.70 µs | 8.44 µs | 0.70 µs | [8.49, 8.97] µs |
+| viewport_size/height/100 | 51.59 µs | 47.73 µs | 10.41 µs | [48.32, 55.68] µs |
+| viewport_size/height/200 | 107.65 µs | 94.84 µs | 23.04 µs | [100.15, 116.23] µs |
+| viewport_size/height/24 | 12.23 µs | 11.21 µs | 2.66 µs | [11.40, 13.26] µs |
+| viewport_size/height/50 | 25.71 µs | 24.34 µs | 4.58 µs | [24.28, 27.50] µs |
+| window_render/buffer_lines/10 | 5.11 µs | 4.74 µs | 0.90 µs | [4.84, 5.46] µs |
+| window_render/buffer_lines/100 | 26.02 µs | 23.79 µs | 4.75 µs | [24.55, 27.89] µs |
+| window_render/buffer_lines/1000 | 25.03 µs | 23.51 µs | 4.74 µs | [23.54, 26.87] µs |
+| window_render/buffer_lines/10000 | 25.37 µs | 23.33 µs | 5.65 µs | [23.65, 27.61] µs |
+| with_highlights/no_highlights | 25.58 µs | 24.20 µs | 4.84 µs | [24.23, 27.50] µs |

--- a/plugins/features/completion/src/lib.rs
+++ b/plugins/features/completion/src/lib.rs
@@ -165,6 +165,10 @@ impl Plugin for CompletionPlugin {
     }
 
     fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
+        // Capture tokio runtime handle for use in EventBus handlers
+        // (EventBus handlers run on std::thread, not tokio runtime)
+        let rt_handle = tokio::runtime::Handle::current();
+
         // Subscribe to CompletionTriggered events (from CompletionTrigger command)
         let manager = Arc::clone(&self.manager);
         bus.subscribe::<CompletionTriggered, _>(100, move |event, ctx| {
@@ -296,6 +300,7 @@ impl Plugin for CompletionPlugin {
 
         // Subscribe to BufferModified for auto-popup and live update
         let manager = Arc::clone(&self.manager);
+        let rt_handle = rt_handle.clone();
         bus.subscribe::<BufferModified, _>(100, move |event, _ctx| {
             let is_active = manager.is_active();
 
@@ -330,7 +335,8 @@ impl Plugin for CompletionPlugin {
             let buffer_id = event.buffer_id;
 
             // Spawn task to trigger/update completion
-            tokio::spawn(async move {
+            // Use captured rt_handle since EventBus handlers run on std::thread (#120)
+            rt_handle.spawn(async move {
                 if !is_active {
                     // Completion not active: use debounce delay for auto-popup
                     tokio::time::sleep(std::time::Duration::from_millis(

--- a/plugins/features/lsp/src/lib.rs
+++ b/plugins/features/lsp/src/lib.rs
@@ -180,6 +180,10 @@ impl Plugin for LspPlugin {
 
     #[allow(clippy::too_many_lines)]
     fn subscribe(&self, bus: &EventBus, state: Arc<PluginStateRegistry>) {
+        // Capture tokio runtime handle for use in EventBus handlers
+        // (EventBus handlers run on std::thread, not tokio runtime - see #120)
+        let rt_handle = tokio::runtime::Handle::current();
+
         // Register LSP health check with health-check plugin
         {
             use reovim_plugin_health_check::RegisterHealthCheck;
@@ -327,6 +331,7 @@ impl Plugin for LspPlugin {
         {
             let state = Arc::clone(&state);
             let event_sender = bus.sender();
+            let rt_handle = rt_handle.clone();
             bus.subscribe::<LspGotoDefinition, _>(100, move |event, _ctx| {
                 info!(
                     buffer_id = event.buffer_id,
@@ -364,9 +369,10 @@ impl Plugin for LspPlugin {
                     );
 
                     // Spawn async task to handle response
+                    // Use captured rt_handle since EventBus handlers run on std::thread (#120)
                     let sender = event_sender.clone();
                     let state_clone = Arc::clone(&state);
-                    tokio::spawn(async move {
+                    rt_handle.spawn(async move {
                         match rx.await {
                             Ok(Ok(Some(response))) => {
                                 // Extract all locations from response
@@ -433,6 +439,7 @@ impl Plugin for LspPlugin {
         {
             let state = Arc::clone(&state);
             let event_sender = bus.sender();
+            let rt_handle = rt_handle.clone();
             bus.subscribe::<LspGotoReferences, _>(100, move |event, _ctx| {
                 let buffer_id = event.buffer_id;
                 let line = event.line;
@@ -464,9 +471,10 @@ impl Plugin for LspPlugin {
                     );
 
                     // Spawn async task to handle response
+                    // Use captured rt_handle since EventBus handlers run on std::thread (#120)
                     let state_clone = Arc::clone(&state);
                     let sender = event_sender.clone();
-                    tokio::spawn(async move {
+                    rt_handle.spawn(async move {
                         match rx.await {
                             Ok(Ok(Some(locations))) => {
                                 info!(count = locations.len(), "LSP: references found");
@@ -508,6 +516,7 @@ impl Plugin for LspPlugin {
         // Handle show hover command
         {
             let state = Arc::clone(&state);
+            // Last use of rt_handle - no clone needed (moved into closure)
             bus.subscribe::<LspShowHover, _>(100, move |event, _ctx| {
                 let buffer_id = event.buffer_id;
                 let line = event.line;
@@ -539,8 +548,9 @@ impl Plugin for LspPlugin {
                     );
 
                     // Spawn async task to handle response
+                    // Use captured rt_handle since EventBus handlers run on std::thread (#120)
                     let state_clone = Arc::clone(&state);
-                    tokio::spawn(async move {
+                    rt_handle.spawn(async move {
                         match rx.await {
                             Ok(Ok(Some(hover))) => {
                                 // Extract hover text content

--- a/runner/src/server.rs
+++ b/runner/src/server.rs
@@ -77,7 +77,8 @@ pub async fn run_server(
     let runtime = Runtime::with_plugins(screen, crate::plugins::AllPlugins).with_file(file_path);
 
     // Get the event sender from runtime (clone for later use)
-    let event_tx = runtime.tx.clone();
+    // Use hi_tx for user-facing events (RPC commands, resize, mouse input)
+    let event_tx = runtime.hi_tx.clone();
     let event_tx_for_shutdown = event_tx.clone();
 
     // In dual mode, spawn a task to read terminal events and forward to key channel


### PR DESCRIPTION
## Summary

- Implement dual-channel architecture for priority-based event processing (#95)
- Fix tokio::spawn panics in EventBus handlers (#120)
- Reduces auto-pair latency from ~100ms to ~92us, closing #86

## Changes

### Issue #95: Priority Channels

Add dual-channel architecture separating high-priority user input from low-priority background events:

- **hi_tx/hi_rx** (64 capacity): user input, mode changes, text insertion
- **lo_tx/lo_rx** (255 capacity): render signals, plugins, background tasks
- Biased `select!` ensures high-priority events processed first
- `MAX_LO_DRAIN=16` provides fairness for background events

### Issue #120: EventBus Handler Fix

Fix `tokio::spawn` panics after PR #85 moved EventBus to `std::thread`:

- Capture `tokio::runtime::Handle::current()` at `subscribe()` start
- Use `handle.spawn()` instead of `tokio::spawn()` in handlers
- Affected: completion (BufferModified), LSP (GotoDefinition, GotoReferences, ShowHover)

### Issue #86: Auto-pair Latency

Combined with PR #96 (lock-free dispatch), this PR reduces auto-pair latency:
- **Before**: ~100ms under parallel load
- **After**: ~92us (1000x improvement)
- **Target**: <50ms

## Test plan

- [x] `./scripts/check.sh` passes (format, build, clippy, tests)
- [x] All unit tests pass
- [x] All 16 bracket_highlighting integration tests pass
- [x] Previously failing auto_pair tests now pass
- [x] Auto-pair latency verified: ~92us
- [x] Documentation updated

## Performance

| Metric | Baseline | With Changes | Delta |
|--------|----------|--------------|-------|
| full_scroll_cycle | 56.68 us | 54.47 us | -3.9% |
| renders_per_second | 26.90 us | 25.86 us | -3.9% |
| 20_j_presses | 412.30 us | 403.36 us | -2.2% |
| event_dispatch | 32.39 ns | 27.14 ns | -16.2% |
| **auto_pair_latency** | ~100ms | ~92us | **-99.9%** |
