### PR TITLE
feat(reo-cli): add --format flag to keys command with raw_ansi default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **reo-cli**: Changed default output format for `keys` command from `plain_text` to `raw_ansi` for better visual feedback (Issue #134)
+- **reo-cli**: Added `--format` flag to `keys` command to allow choosing output format (raw_ansi, plain_text, cell_grid)
+
 ## [0.8.0] - 2026-01-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ cargo run -p reo-cli -- list
 cargo run -- --server Cargo.toml &  # Note: prints "Listening on 127.0.0.1:12521"
 
 # Do testing with reo-cli
-cargo run -p reo-cli -- keys 'gg'
+cargo run -p reo-cli -- keys 'gg'  # Default: raw_ansi (colored output)
+cargo run -p reo-cli -- keys --format plain_text 'gg'  # Plain text output
 
 # Kill ONLY the server you just started
 cargo run -p reo-cli -- --tcp 127.0.0.1:12521 kill
@@ -143,8 +144,10 @@ cargo run -- --listen-tcp 9000
 
 # Run reo-cli client
 cargo run -p reo-cli -- list              # List running servers
-cargo run -p reo-cli -- keys 'iHello<Esc>'  # Inject keys, show status (screen + mode + cursor)
+cargo run -p reo-cli -- keys 'iHello<Esc>'  # Inject keys, show status (colored output by default)
 cargo run -p reo-cli -- --tcp 127.0.0.1:12522 keys 'j'  # Connect to specific server
+cargo run -p reo-cli -- keys --format plain_text 'gg'  # Plain text output
+cargo run -p reo-cli -- keys --format cell_grid 'gg'  # JSON cell grid
 cargo run -p reo-cli -- -i                # Interactive REPL mode
 
 # View logs (timestamped files)

--- a/README.md
+++ b/README.md
@@ -143,8 +143,13 @@ A CLI client tool is available for interacting with the server:
 # List running servers
 reo-cli list
 
-# Inject keys and show status (screen + mode + cursor)
+# Inject keys and show status (colored output by default)
 reo-cli keys 'iHello<Esc>'
+
+# Choose output format
+reo-cli keys --format plain_text 'gg'     # Plain text
+reo-cli keys --format raw_ansi 'gg'       # ANSI colors (default)
+reo-cli keys --format cell_grid 'gg'      # JSON cell grid
 
 # Connect to custom address
 reo-cli --tcp localhost:9000 keys 'j'

--- a/docs/reference/server-mode.md
+++ b/docs/reference/server-mode.md
@@ -146,7 +146,9 @@ The `reo-cli` tool provides command-line access to reovim servers.
 reo-cli list
 
 # Inject keys and show status
-reo-cli keys 'iHello<Esc>'
+reo-cli keys 'iHello<Esc>'               # Default: colored output
+reo-cli keys --format plain_text 'gg'    # Plain text output
+reo-cli keys --format cell_grid 'gg'     # JSON cell grid
 
 # Get screen content
 reo-cli screen

--- a/tools/reo-cli/src/main.rs
+++ b/tools/reo-cli/src/main.rs
@@ -52,6 +52,10 @@ enum Commands {
     Keys {
         /// Key sequence (e.g., "iHello<Esc>")
         keys: String,
+
+        /// Output format (`raw_ansi`, `plain_text`, `cell_grid`)
+        #[arg(long, default_value = "raw_ansi")]
+        format: String,
     },
 
     /// Get selection state
@@ -203,9 +207,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let command = cli.command.unwrap();
 
     // Keys command: inject keys then show status
-    if let Commands::Keys { ref keys } = command {
+    if let Commands::Keys {
+        ref keys,
+        ref format,
+    } = command
+    {
         commands::cmd_keys(&mut client, keys).await?;
-        return show_status(&mut client).await;
+        return show_status(&mut client, format).await;
     }
 
     // All other commands - return JSON
@@ -246,9 +254,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Show default status: screen capture, mode, and cursor
-async fn show_status(client: &mut client::ReoClient) -> Result<(), Box<dyn std::error::Error>> {
+async fn show_status(
+    client: &mut client::ReoClient,
+    format: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get screen capture
-    let capture = commands::cmd_screen_content(client, "plain_text").await?;
+    let capture = commands::cmd_screen_content(client, format).await?;
     if let Some(content) = capture.get("content").and_then(Value::as_str) {
         println!("{content}");
     }


### PR DESCRIPTION
Add --format flag to reo-cli keys command to allow users to choose screen output format (raw_ansi, plain_text, cell_grid).

Changes:
- Add format parameter to Keys command struct with raw_ansi default
- Update show_status() to accept and use format parameter
- Update documentation with format flag examples

Breaking Change: Default output format changed from plain_text to raw_ansi for better visual feedback. Users who need plain text can use --format plain_text.

Fixes: #134