### PR TITLE
feat(explorer): add file type coloring with dedicated theme styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **File explorer visual enhancements** (Issue #127) - nvim-tree style coloring and tree structure
+  - **Dedicated FileExplorerStyles** in theme system with distinct colors for each file category:
+    - Directories: blue (bold)
+    - Source files: orange (for .rs, .py, .js, etc.)
+    - Config files: gray/dimmed (for .toml, .yaml, .json)
+    - Documentation: cyan (for README, .md)
+    - Data files: magenta (for .csv, .sql, .db)
+    - Media files: pink (for images, audio, video)
+    - Special files: yellow (for LICENSE, .gitignore)
+    - Lock files: dimmed yellow (for Cargo.lock, package-lock.json)
+    - Executable files: green (for shell scripts, binaries)
+    - Hidden files: dimmed gray
+  - Box-drawing characters (│, ├, └) for visual tree hierarchy
+  - Three tree styles: None (indent only), Simple (ASCII ">"), BoxDrawing (Unicode)
+  - Hidden items count display at bottom: "(N hidden)" when hidden files are not shown
+  - Explorer settings section with options:
+    - `explorer.enable_colors` - Toggle file type coloring (default: true)
+    - `explorer.tree_style` - Choose tree drawing style (default: "box_drawing")
+    - `explorer.show_hidden` - Toggle hidden files visibility (default: false)
+    - `explorer.show_sizes` - Toggle file size display (default: false)
+
 ### Changed
 
 - **reo-cli**: Changed default output format for `keys` command from `plain_text` to `raw_ansi` for better visual feedback (Issue #134)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,11 +407,14 @@ For any changes, Claude should create a proposal file at `tmp/<feature-name>-com
 **Request-for-Landing (End of Work):**
 1. **Sync with upstream (CRUCIAL)**:
    ```bash
-   git fetch origin develop && git rebase origin/develop
+   git stash && git fetch origin develop && git rebase origin/develop
    ```
+   - Save work with `git stash` first to avoid rebase conflicts with unstaged changes
+   - **Check upstream changes carefully**: Review what changed with `git log HEAD..origin/develop` and `git diff HEAD..origin/develop` before rebasing
+   - **Use gh cli to check context**: Check recent PRs/issues with `gh pr list`, `gh issue list`, or `gh pr view <number>` to understand upstream changes
    - Carefully rebase - resolve any conflicts before landing
    - Contributors own their conflicts
-   - Use `git stash` if needed to save work before rebasing
+   - Restore with `git stash pop` after successful rebase
 
 2. **Run full check script**:
    ```bash

--- a/lib/core/src/highlight/theme.rs
+++ b/lib/core/src/highlight/theme.rs
@@ -253,6 +253,31 @@ pub struct VirtualTextStyles {
     pub hint: Style,
 }
 
+/// File explorer styles for visual file type differentiation
+#[derive(Debug, Clone)]
+pub struct FileExplorerStyles {
+    /// Directory style (blue/cyan)
+    pub directory: Style,
+    /// Source code files (.rs, .py, .js, etc.)
+    pub source_file: Style,
+    /// Configuration files (.toml, .yaml, .json)
+    pub config_file: Style,
+    /// Documentation files (.md, README)
+    pub doc_file: Style,
+    /// Data files (.csv, .sql, .db)
+    pub data_file: Style,
+    /// Media files (images, audio, video)
+    pub media_file: Style,
+    /// Special files (LICENSE, .gitignore)
+    pub special_file: Style,
+    /// Lock files (Cargo.lock, package-lock.json)
+    pub lock_file: Style,
+    /// Executable files (shell scripts, binaries)
+    pub executable_file: Style,
+    /// Hidden files (starting with .)
+    pub hidden_file: Style,
+}
+
 // ============================================================================
 // Main Theme Struct
 // ============================================================================
@@ -277,6 +302,7 @@ pub struct Theme {
     pub semantic: SemanticStyles,
     pub leap: LeapStyles,
     pub virtual_text: VirtualTextStyles,
+    pub file_explorer: FileExplorerStyles,
 }
 
 impl Default for Theme {
@@ -352,6 +378,11 @@ impl Theme {
             r: 198,
             g: 120,
             b: 221,
+        };
+        let orange = Color::Rgb {
+            r: 209,
+            g: 154,
+            b: 102,
         };
 
         Self {
@@ -493,6 +524,22 @@ impl Theme {
                 warn: Style::new().fg(yellow).italic(),
                 info: Style::new().fg(blue).italic(),
                 hint: Style::new().fg(fg_dark).italic(),
+            },
+            file_explorer: FileExplorerStyles {
+                directory: Style::new().fg(blue).bold(),
+                source_file: Style::new().fg(orange),
+                config_file: Style::new().fg(fg_dark),
+                doc_file: Style::new().fg(cyan),
+                data_file: Style::new().fg(magenta),
+                media_file: Style::new().fg(Color::Rgb {
+                    r: 233,
+                    g: 30,
+                    b: 99,
+                }), // Pink for media
+                special_file: Style::new().fg(yellow),
+                lock_file: Style::new().fg(yellow).dim(),
+                executable_file: Style::new().fg(green),
+                hidden_file: Style::new().fg(fg_dark).dim(),
             },
         }
     }
@@ -662,6 +709,26 @@ impl Theme {
                 warn: Style::new().fg(Color::DarkYellow).italic(),
                 info: Style::new().fg(Color::DarkBlue).italic(),
                 hint: Style::new().fg(Color::Grey).italic(),
+            },
+            file_explorer: FileExplorerStyles {
+                directory: Style::new().fg(Color::Blue).bold(),
+                source_file: Style::new().fg(Color::Rgb {
+                    r: 184,
+                    g: 121,
+                    b: 73,
+                }), // Orange
+                config_file: Style::new().fg(Color::Grey),
+                doc_file: Style::new().fg(Color::DarkCyan),
+                data_file: Style::new().fg(Color::DarkMagenta),
+                media_file: Style::new().fg(Color::Rgb {
+                    r: 197,
+                    g: 46,
+                    b: 110,
+                }), // Pink for media
+                special_file: Style::new().fg(Color::Yellow),
+                lock_file: Style::new().fg(Color::DarkYellow),
+                executable_file: Style::new().fg(Color::Green),
+                hidden_file: Style::new().fg(Color::Grey).dim(),
             },
         }
     }
@@ -893,6 +960,22 @@ impl Theme {
                 warn: Style::new().fg(yellow).italic(),
                 info: Style::new().fg(blue).italic(),
                 hint: Style::new().fg(fg_dark).italic(),
+            },
+            file_explorer: FileExplorerStyles {
+                directory: Style::new().fg(blue).bold(),
+                source_file: Style::new().fg(orange),
+                config_file: Style::new().fg(fg_dark),
+                doc_file: Style::new().fg(cyan),
+                data_file: Style::new().fg(magenta),
+                media_file: Style::new().fg(Color::Rgb {
+                    r: 255,
+                    g: 92,
+                    b: 127,
+                }), // Pink for media
+                special_file: Style::new().fg(yellow),
+                lock_file: Style::new().fg(yellow).dim(),
+                executable_file: Style::new().fg(green),
+                hidden_file: Style::new().fg(fg_dark).dim(),
             },
         }
     }

--- a/plugins/features/explorer/src/file_colors.rs
+++ b/plugins/features/explorer/src/file_colors.rs
@@ -1,0 +1,253 @@
+//! File type color mapping for the explorer
+//!
+//! Maps file extensions and names to semantic colors from the theme.
+
+use reovim_core::highlight::{Style, Theme};
+
+use super::node::FileNode;
+
+/// Categories for file type coloring
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // All variants are used through categorize_extension
+enum FileCategory {
+    Directory,
+    SourceCode,
+    Configuration,
+    Documentation,
+    Data,
+    Media,
+    Special,
+    Lock,
+    Hidden,
+    Unknown,
+}
+
+/// Get the appropriate color style for a file node based on its type
+#[must_use]
+pub fn get_file_color(node: &FileNode, theme: &Theme) -> Style {
+    // Directories get special treatment
+    if node.is_dir() {
+        return theme.file_explorer.directory.clone();
+    }
+
+    // Hidden files are dimmed
+    if node.is_hidden {
+        return theme.file_explorer.hidden_file.clone();
+    }
+
+    // Check for special filenames first
+    let name_lower = node.name.to_lowercase();
+    if let Some(style) = get_special_file_color(&name_lower, theme) {
+        return style;
+    }
+
+    // Categorize by extension
+    let category = if let Some(ext) = node.path.extension() {
+        if let Some(ext_str) = ext.to_str() {
+            categorize_extension(ext_str)
+        } else {
+            FileCategory::Unknown
+        }
+    } else {
+        FileCategory::Unknown
+    };
+
+    // Map category to theme color
+    match category {
+        FileCategory::Directory => theme.file_explorer.directory.clone(),
+        FileCategory::SourceCode => theme.file_explorer.source_file.clone(),
+        FileCategory::Configuration => theme.file_explorer.config_file.clone(),
+        FileCategory::Documentation => theme.file_explorer.doc_file.clone(),
+        FileCategory::Data => theme.file_explorer.data_file.clone(),
+        FileCategory::Media => theme.file_explorer.media_file.clone(),
+        FileCategory::Special => theme.file_explorer.special_file.clone(),
+        FileCategory::Lock => theme.file_explorer.lock_file.clone(),
+        FileCategory::Hidden => theme.file_explorer.hidden_file.clone(),
+        FileCategory::Unknown => theme.base.default.clone(),
+    }
+}
+
+/// Check for special filenames that get specific colors
+fn get_special_file_color(name_lower: &str, theme: &Theme) -> Option<Style> {
+    match name_lower {
+        // License files
+        "license" | "licence" | "license.md" | "licence.md" | "license.txt" | "licence.txt" => {
+            Some(theme.file_explorer.special_file.clone())
+        }
+        // Documentation files
+        "readme" | "readme.md" | "readme.txt" | "changelog" | "changelog.md" => {
+            Some(theme.file_explorer.doc_file.clone())
+        }
+        // Lock files
+        "cargo.lock" | "package-lock.json" | "yarn.lock" | "gemfile.lock" | "poetry.lock" => {
+            Some(theme.file_explorer.lock_file.clone())
+        }
+        // Build/config files
+        "makefile" | "dockerfile" | "rakefile" | "cmakelists.txt" => {
+            Some(theme.file_explorer.config_file.clone())
+        }
+        _ => None,
+    }
+}
+
+/// Categorize a file extension into a semantic category
+fn categorize_extension(ext: &str) -> FileCategory {
+    match ext.to_lowercase().as_str() {
+        // Source code - programming languages
+        "rs" | "c" | "cpp" | "cc" | "cxx" | "h" | "hpp" | "hxx" | "go" | "java" | "kt" | "kts"
+        | "scala" | "swift" | "py" | "rb" | "php" | "js" | "jsx" | "ts" | "tsx" | "vue"
+        | "svelte" | "lua" | "pl" | "pm" | "sh" | "bash" | "zsh" | "fish" | "cs" | "fs" | "vb"
+        | "asm" | "s" | "dart" | "elm" | "erl" | "ex" | "exs" | "hs" | "clj" | "cljs" | "vim"
+        | "v" => FileCategory::SourceCode,
+
+        // Configuration files
+        "toml" | "yaml" | "yml" | "json" | "ini" | "conf" | "cfg" | "config" | "xml" | "env"
+        | "properties" | "gradle" | "pom" => FileCategory::Configuration,
+
+        // Documentation
+        "md" | "markdown" | "rst" | "txt" | "adoc" | "tex" | "org" => FileCategory::Documentation,
+
+        // Data files
+        "csv" | "tsv" | "sql" | "db" | "sqlite" | "sqlite3" => FileCategory::Data,
+
+        // Media files
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "ico" | "webp" | "mp3" | "mp4" | "avi"
+        | "mkv" | "wav" | "flac" | "ogg" | "webm" => FileCategory::Media,
+
+        // Lock files
+        "lock" => FileCategory::Lock,
+
+        // Default
+        _ => FileCategory::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// Helper to create a test node
+    fn create_test_node(name: &str, is_dir: bool, is_hidden: bool) -> FileNode {
+        use crate::node::NodeType;
+
+        let path = PathBuf::from(if is_dir {
+            format!("/tmp/{}/", name)
+        } else {
+            format!("/tmp/{}", name)
+        });
+
+        let node_type = if is_dir {
+            NodeType::Directory {
+                expanded: false,
+                children: Vec::new(),
+            }
+        } else {
+            NodeType::File {
+                size: 0,
+                created: None,
+                modified: None,
+            }
+        };
+
+        FileNode {
+            name: name.to_string(),
+            path,
+            node_type,
+            depth: 1,
+            is_hidden,
+        }
+    }
+
+    #[test]
+    fn test_directory_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("src", true, false);
+        let color = get_file_color(&node, &theme);
+
+        // Directories should use theme.file_explorer.directory
+        assert_eq!(color.fg, theme.file_explorer.directory.fg);
+    }
+
+    #[test]
+    fn test_rust_source_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("main.rs", false, false);
+        let color = get_file_color(&node, &theme);
+
+        // Rust files should use theme.file_explorer.source_file
+        assert_eq!(color.fg, theme.file_explorer.source_file.fg);
+    }
+
+    #[test]
+    fn test_toml_config_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("Cargo.toml", false, false);
+        let color = get_file_color(&node, &theme);
+
+        // TOML files should use theme.file_explorer.config_file
+        assert_eq!(color.fg, theme.file_explorer.config_file.fg);
+    }
+
+    #[test]
+    fn test_markdown_doc_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("README.md", false, false);
+        let color = get_file_color(&node, &theme);
+
+        // README.md is a special file, should use file_explorer.doc_file
+        assert_eq!(color.fg, theme.file_explorer.doc_file.fg);
+    }
+
+    #[test]
+    fn test_license_special_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("LICENSE", false, false);
+        let color = get_file_color(&node, &theme);
+
+        // LICENSE should use theme.file_explorer.special_file
+        assert_eq!(color.fg, theme.file_explorer.special_file.fg);
+    }
+
+    #[test]
+    fn test_lock_file_color() {
+        let theme = Theme::dark();
+        let node = create_test_node("Cargo.lock", false, false);
+        let color = get_file_color(&node, &theme);
+
+        // Lock files should use theme.file_explorer.lock_file
+        assert_eq!(color.fg, theme.file_explorer.lock_file.fg);
+    }
+
+    #[test]
+    fn test_hidden_file_color() {
+        let theme = Theme::dark();
+        let node = create_test_node(".gitignore", false, true);
+        let color = get_file_color(&node, &theme);
+
+        // Hidden files should use theme.file_explorer.hidden_file
+        assert_eq!(color.fg, theme.file_explorer.hidden_file.fg);
+    }
+
+    #[test]
+    fn test_categorize_source_extensions() {
+        assert_eq!(categorize_extension("rs"), FileCategory::SourceCode);
+        assert_eq!(categorize_extension("py"), FileCategory::SourceCode);
+        assert_eq!(categorize_extension("js"), FileCategory::SourceCode);
+        assert_eq!(categorize_extension("go"), FileCategory::SourceCode);
+    }
+
+    #[test]
+    fn test_categorize_config_extensions() {
+        assert_eq!(categorize_extension("toml"), FileCategory::Configuration);
+        assert_eq!(categorize_extension("yaml"), FileCategory::Configuration);
+        assert_eq!(categorize_extension("json"), FileCategory::Configuration);
+    }
+
+    #[test]
+    fn test_categorize_unknown_extension() {
+        assert_eq!(categorize_extension("xyz"), FileCategory::Unknown);
+        assert_eq!(categorize_extension("unknown"), FileCategory::Unknown);
+    }
+}

--- a/plugins/features/explorer/src/lib.rs
+++ b/plugins/features/explorer/src/lib.rs
@@ -26,11 +26,13 @@ use reovim_core::{
 };
 
 mod command;
+mod file_colors;
 mod node;
 mod provider;
 mod render;
 mod state;
 mod tree;
+mod tree_render;
 mod window;
 
 #[cfg(test)]
@@ -174,6 +176,103 @@ impl Plugin for ExplorerPlugin {
         self.subscribe_visual_mode(bus, &state);
         self.subscribe_focus_visibility(bus, &state);
         self.subscribe_popup(bus, &state);
+        self.subscribe_settings(bus, &state);
+    }
+}
+
+impl ExplorerPlugin {
+    /// Register and subscribe to explorer settings
+    fn subscribe_settings(&self, bus: &EventBus, state: &Arc<PluginStateRegistry>) {
+        use reovim_core::option::{
+            OptionChanged, OptionSpec, OptionValue, RegisterOption, RegisterSettingSection,
+        };
+
+        // Register settings section
+        bus.emit(
+            RegisterSettingSection::new("explorer", "File Explorer")
+                .with_description("File tree browser settings")
+                .with_order(110),
+        ); // After core (0-50), before custom (200+)
+
+        // Register options
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "explorer.enable_colors",
+                "Enable file type coloring",
+                OptionValue::Bool(true),
+            )
+            .with_section("File Explorer")
+            .with_display_order(10),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new(
+                "explorer.tree_style",
+                "Tree drawing style",
+                OptionValue::String("box_drawing".to_string()),
+            )
+            .with_section("File Explorer")
+            .with_display_order(20),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new("explorer.show_hidden", "Show hidden files", OptionValue::Bool(false))
+                .with_section("File Explorer")
+                .with_display_order(30),
+        ));
+
+        bus.emit(RegisterOption::new(
+            OptionSpec::new("explorer.show_sizes", "Show file sizes", OptionValue::Bool(false))
+                .with_section("File Explorer")
+                .with_display_order(40),
+        ));
+
+        // Subscribe to option changes
+        let state_clone = Arc::clone(state);
+        bus.subscribe::<OptionChanged, _>(100, move |event, ctx| {
+            match event.name.as_str() {
+                "explorer.enable_colors" => {
+                    if let Some(enabled) = event.new_value.as_bool() {
+                        state_clone.with_mut::<ExplorerState, _, _>(|explorer| {
+                            explorer.enable_colors = enabled;
+                        });
+                        ctx.request_render();
+                    }
+                }
+                "explorer.tree_style" => {
+                    if let Some(style_str) = event.new_value.as_str() {
+                        let tree_style = match style_str {
+                            "none" => crate::state::TreeStyle::None,
+                            "simple" => crate::state::TreeStyle::Simple,
+                            "box_drawing" => crate::state::TreeStyle::BoxDrawing,
+                            _ => crate::state::TreeStyle::BoxDrawing,
+                        };
+                        state_clone.with_mut::<ExplorerState, _, _>(|explorer| {
+                            explorer.tree_style = tree_style;
+                        });
+                        ctx.request_render();
+                    }
+                }
+                "explorer.show_hidden" => {
+                    if let Some(show) = event.new_value.as_bool() {
+                        state_clone.with_mut::<ExplorerState, _, _>(|explorer| {
+                            explorer.show_hidden = show;
+                        });
+                        ctx.request_render();
+                    }
+                }
+                "explorer.show_sizes" => {
+                    if let Some(show) = event.new_value.as_bool() {
+                        state_clone.with_mut::<ExplorerState, _, _>(|explorer| {
+                            explorer.show_sizes = show;
+                        });
+                        ctx.request_render();
+                    }
+                }
+                _ => {}
+            }
+            EventResult::Handled
+        });
     }
 }
 

--- a/plugins/features/explorer/src/state.rs
+++ b/plugins/features/explorer/src/state.rs
@@ -38,6 +38,22 @@ pub struct ExplorerState {
     pub visible: bool,
     /// File details popup state
     pub popup: FileDetailsPopup,
+    /// Enable file type syntax coloring
+    pub enable_colors: bool,
+    /// Tree drawing style for visual hierarchy
+    pub tree_style: TreeStyle,
+}
+
+/// Tree drawing style for visual hierarchy
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum TreeStyle {
+    /// No tree lines, just indentation with spaces
+    None,
+    /// Simple ASCII indentation with ">" character
+    Simple,
+    /// Box-drawing characters (│, ├, └) for visual hierarchy
+    #[default]
+    BoxDrawing,
 }
 
 /// Input mode for file operations
@@ -128,6 +144,8 @@ impl ExplorerState {
             selection: ExplorerSelection::default(),
             visible: false,
             popup: FileDetailsPopup::default(),
+            enable_colors: true,               // Enable colors by default
+            tree_style: TreeStyle::BoxDrawing, // Use box-drawing by default
         })
     }
 

--- a/plugins/features/explorer/src/tree.rs
+++ b/plugins/features/explorer/src/tree.rs
@@ -193,6 +193,86 @@ impl FileTree {
             }
         }
     }
+
+    /// Flatten the tree with metadata for tree structure rendering
+    /// Returns nodes with information about their position in the tree
+    #[must_use]
+    pub fn flatten_with_metadata<'a>(&'a self, show_hidden: bool) -> Vec<FlattenedNode<'a>> {
+        let mut result = Vec::new();
+        let mut vertical_lines = Vec::new();
+        Self::flatten_with_metadata_recursive(
+            &self.root,
+            show_hidden,
+            &mut result,
+            &mut vertical_lines,
+            true,
+        );
+        result
+    }
+
+    fn flatten_with_metadata_recursive<'a>(
+        node: &'a FileNode,
+        show_hidden: bool,
+        result: &mut Vec<FlattenedNode<'a>>,
+        vertical_lines: &mut Vec<bool>,
+        is_last: bool,
+    ) {
+        // Skip hidden files if not showing them (but always show root)
+        if node.depth > 0 && node.is_hidden && !show_hidden {
+            return;
+        }
+
+        // Add current node with metadata
+        result.push(FlattenedNode {
+            node,
+            is_last_child: is_last,
+            vertical_lines: vertical_lines.clone(),
+        });
+
+        // Process children if expanded
+        if node.is_expanded()
+            && let Some(children) = node.children()
+        {
+            // Filter visible children
+            let visible_children: Vec<_> = children
+                .iter()
+                .filter(|child| show_hidden || !child.is_hidden)
+                .collect();
+
+            // Process each visible child
+            for (i, child) in visible_children.iter().enumerate() {
+                let is_last_child = i == visible_children.len() - 1;
+
+                // Update vertical line tracking for this depth
+                vertical_lines.push(!is_last_child);
+
+                Self::flatten_with_metadata_recursive(
+                    child,
+                    show_hidden,
+                    result,
+                    vertical_lines,
+                    is_last_child,
+                );
+
+                // Pop the vertical line tracking for this depth
+                vertical_lines.pop();
+            }
+        }
+    }
+}
+
+/// A flattened node with metadata for tree structure rendering
+#[derive(Debug, Clone)]
+pub struct FlattenedNode<'a> {
+    /// The file node
+    pub node: &'a FileNode,
+
+    /// Whether this node is the last child of its parent
+    pub is_last_child: bool,
+
+    /// For each depth level (0..node.depth-1), whether there are more siblings
+    /// below at that level that need vertical continuation lines
+    pub vertical_lines: Vec<bool>,
 }
 
 #[cfg(test)]

--- a/plugins/features/explorer/src/tree_render.rs
+++ b/plugins/features/explorer/src/tree_render.rs
@@ -1,0 +1,183 @@
+//! Tree structure rendering with box-drawing characters
+//!
+//! Provides visual hierarchy for file trees using Unicode box-drawing chars.
+
+/// Information needed to render tree connection lines for a node
+#[derive(Debug, Clone)]
+pub struct TreeLineInfo {
+    /// For each depth level (0..node.depth), whether there are more siblings below
+    /// that need a vertical continuation line (│)
+    pub vertical_lines: Vec<bool>,
+
+    /// Whether this node is the last child of its parent
+    pub is_last_child: bool,
+}
+
+/// Build the tree prefix string with box-drawing characters
+///
+/// # Examples
+///
+/// ```text
+/// Depth 1, not last: "├─"
+/// Depth 1, last:     "└─"
+/// Depth 2, parent not last, not last: "│ ├─"
+/// Depth 2, parent not last, last:     "│ └─"
+/// Depth 2, parent last, not last:     "  ├─"
+/// ```
+#[must_use]
+pub fn build_tree_prefix(info: &TreeLineInfo, depth: usize) -> String {
+    if depth == 0 {
+        return String::new(); // Root has no prefix
+    }
+
+    let mut prefix = String::new();
+
+    // For each ancestor level (not including the node's own level)
+    for level in 0..depth {
+        if level == 0 {
+            continue; // Skip root level
+        }
+
+        // Check if this ancestor level needs a vertical line
+        if let Some(&has_more_siblings) = info.vertical_lines.get(level - 1) {
+            if has_more_siblings {
+                prefix.push('│');
+                prefix.push(' ');
+            } else {
+                prefix.push_str("  ");
+            }
+        } else {
+            // Shouldn't happen, but handle gracefully
+            prefix.push_str("  ");
+        }
+    }
+
+    // Add the connector for this node
+    if info.is_last_child {
+        prefix.push('└');
+    } else {
+        prefix.push('├');
+    }
+    prefix.push('─');
+
+    prefix
+}
+
+/// Build a simple tree prefix with ASCII characters
+#[must_use]
+pub fn build_simple_prefix(depth: usize) -> String {
+    if depth == 0 {
+        String::new()
+    } else {
+        format!("{}> ", "  ".repeat(depth.saturating_sub(1)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_root_has_no_prefix() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![],
+            is_last_child: false,
+        };
+        let prefix = build_tree_prefix(&info, 0);
+        assert_eq!(prefix, "");
+    }
+
+    #[test]
+    fn test_depth_1_not_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![],
+            is_last_child: false,
+        };
+        let prefix = build_tree_prefix(&info, 1);
+        assert_eq!(prefix, "├─");
+    }
+
+    #[test]
+    fn test_depth_1_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![],
+            is_last_child: true,
+        };
+        let prefix = build_tree_prefix(&info, 1);
+        assert_eq!(prefix, "└─");
+    }
+
+    #[test]
+    fn test_depth_2_parent_not_last_not_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![true], // Parent has more siblings
+            is_last_child: false,
+        };
+        let prefix = build_tree_prefix(&info, 2);
+        assert_eq!(prefix, "│ ├─");
+    }
+
+    #[test]
+    fn test_depth_2_parent_not_last_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![true], // Parent has more siblings
+            is_last_child: true,
+        };
+        let prefix = build_tree_prefix(&info, 2);
+        assert_eq!(prefix, "│ └─");
+    }
+
+    #[test]
+    fn test_depth_2_parent_last_not_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![false], // Parent is last child
+            is_last_child: false,
+        };
+        let prefix = build_tree_prefix(&info, 2);
+        assert_eq!(prefix, "  ├─");
+    }
+
+    #[test]
+    fn test_depth_2_parent_last_last() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![false], // Parent is last child
+            is_last_child: true,
+        };
+        let prefix = build_tree_prefix(&info, 2);
+        assert_eq!(prefix, "  └─");
+    }
+
+    #[test]
+    fn test_depth_3_complex() {
+        let info = TreeLineInfo {
+            vertical_lines: vec![true, false], // Grandparent has siblings, parent doesn't
+            is_last_child: false,
+        };
+        let prefix = build_tree_prefix(&info, 3);
+        assert_eq!(prefix, "│   ├─");
+    }
+
+    #[test]
+    fn test_simple_prefix_depth_0() {
+        let prefix = build_simple_prefix(0);
+        assert_eq!(prefix, "");
+    }
+
+    #[test]
+    fn test_simple_prefix_depth_1() {
+        let prefix = build_simple_prefix(1);
+        assert_eq!(prefix, "> ");
+    }
+
+    #[test]
+    fn test_simple_prefix_depth_2() {
+        let prefix = build_simple_prefix(2);
+        assert_eq!(prefix, "  > ");
+    }
+
+    #[test]
+    fn test_simple_prefix_depth_3() {
+        let prefix = build_simple_prefix(3);
+        assert_eq!(prefix, "    > ");
+    }
+}

--- a/plugins/features/explorer/src/window.rs
+++ b/plugins/features/explorer/src/window.rs
@@ -8,7 +8,11 @@ use reovim_core::{
     plugin::{EditorContext, PanelPosition, PluginStateRegistry, PluginWindow, Rect, WindowConfig},
 };
 
-use crate::state::{ExplorerState, FileDetailsPopup};
+use crate::{
+    file_colors::get_file_color,
+    state::{ExplorerState, FileDetailsPopup, TreeStyle},
+    tree_render::{TreeLineInfo, build_simple_prefix, build_tree_prefix},
+};
 
 /// Unified plugin window for the explorer
 ///
@@ -64,7 +68,20 @@ impl PluginWindow for ExplorerPluginWindow {
                 return;
             }
 
-            let nodes = explorer.visible_nodes();
+            // Get flattened nodes with metadata for tree structure
+            let flat_nodes = explorer.tree.flatten_with_metadata(explorer.show_hidden);
+
+            // Apply filter if present
+            let filtered_nodes: Vec<_> = if explorer.filter_text.is_empty() {
+                flat_nodes.iter().collect()
+            } else {
+                let filter_lower = explorer.filter_text.to_lowercase();
+                flat_nodes
+                    .iter()
+                    .filter(|fn_meta| fn_meta.node.name.to_lowercase().contains(&filter_lower))
+                    .collect()
+            };
+
             let height = bounds.height as usize;
 
             // Reserve last line for message/prompt if present
@@ -76,10 +93,10 @@ impl PluginWindow for ExplorerPluginWindow {
 
             // Calculate visible range based on scroll offset
             let start = explorer.scroll_offset;
-            let end = (start + available_height).min(nodes.len());
+            let end = (start + available_height).min(filtered_nodes.len());
 
-            // Render visible nodes
-            for (line_idx, (i, node)) in nodes
+            // Render visible nodes with multi-segment coloring
+            for (line_idx, (i, flat_node)) in filtered_nodes
                 .iter()
                 .enumerate()
                 .skip(start)
@@ -91,13 +108,27 @@ impl PluginWindow for ExplorerPluginWindow {
                     break;
                 }
 
-                let is_cursor = i == explorer.cursor_index;
+                let node = flat_node.node;
+                let is_cursor = i + start == explorer.cursor_index;
                 let is_marked = explorer.selection.selected.contains(&node.path);
 
-                // Build line content
-                let indent = "  ".repeat(node.depth);
-                let icon = node.icon(); // Uses IconRegistry for file/dir icons
+                // 1. Build tree prefix based on style setting
+                let tree_prefix = match explorer.tree_style {
+                    TreeStyle::None => "  ".repeat(node.depth),
+                    TreeStyle::Simple => build_simple_prefix(node.depth),
+                    TreeStyle::BoxDrawing => build_tree_prefix(
+                        &TreeLineInfo {
+                            vertical_lines: flat_node.vertical_lines.clone(),
+                            is_last_child: flat_node.is_last_child,
+                        },
+                        node.depth,
+                    ),
+                };
 
+                // 2. Get icon
+                let icon = node.icon();
+
+                // 3. Build marker
                 let marker = if is_marked {
                     "* "
                 } else if is_cursor {
@@ -106,6 +137,7 @@ impl PluginWindow for ExplorerPluginWindow {
                     "  "
                 };
 
+                // 4. Build size display
                 let size_display = if explorer.show_sizes && !node.is_dir() {
                     if let Some(size) = node.size() {
                         format!(" {:>5} ", super::node::format_size(size))
@@ -116,21 +148,53 @@ impl PluginWindow for ExplorerPluginWindow {
                     String::new()
                 };
 
-                let line = format!("{marker}{indent}{icon}{}{size_display}", node.name);
-
-                // Determine style
-                let style = if is_cursor || is_marked {
-                    &theme.selection.visual
+                // 5. Determine colors
+                let file_color = if explorer.enable_colors {
+                    get_file_color(node, theme)
                 } else {
-                    &theme.base.default
+                    theme.base.default.clone()
                 };
 
-                // Render the line using write_str (handles wide characters properly)
-                let x = bounds.x + buffer.write_str(bounds.x, y, &line, style);
+                // Selection style overrides file color for the whole line
+                let line_style = if is_cursor || is_marked {
+                    &theme.selection.visual
+                } else {
+                    &file_color
+                };
+
+                // 6. Render segments with appropriate colors
+                let mut x = bounds.x;
+
+                // Marker (cursor/selection indicator) - always use line style
+                x += buffer.write_str(x, y, marker, line_style);
+
+                // Tree structure (dimmed) - unless selected
+                let tree_style = if is_cursor || is_marked {
+                    line_style
+                } else {
+                    &theme.fold.marker
+                };
+                x += buffer.write_str(x, y, &tree_prefix, tree_style);
+
+                // Icon - use line style
+                x += buffer.write_str(x, y, icon, line_style);
+
+                // Filename - use line style
+                x += buffer.write_str(x, y, &node.name, line_style);
+
+                // Size display (dimmed) - unless selected
+                if !size_display.is_empty() {
+                    let size_style = if is_cursor || is_marked {
+                        line_style
+                    } else {
+                        &theme.virtual_text.default
+                    };
+                    x += buffer.write_str(x, y, &size_display, size_style);
+                }
 
                 // Fill rest of line with spaces
                 for col in x..(bounds.x + bounds.width) {
-                    buffer.put_char(col, y, ' ', style);
+                    buffer.put_char(col, y, ' ', line_style);
                 }
             }
 
@@ -143,6 +207,29 @@ impl PluginWindow for ExplorerPluginWindow {
                 }
                 for x in bounds.x..(bounds.x + bounds.width) {
                     buffer.put_char(x, y, ' ', &theme.base.default);
+                }
+            }
+
+            // Show hidden items count at bottom when hidden files are not shown
+            if !explorer.show_hidden && explorer.message.is_none() {
+                let hidden_count = count_hidden_items(&flat_nodes);
+                if hidden_count > 0 {
+                    let y = bounds.y + available_height.saturating_sub(1) as u16;
+                    if y < bounds.y + bounds.height {
+                        let text = format!("({} hidden)", hidden_count);
+                        let style = &theme.virtual_text.default;
+
+                        // Center the text
+                        let text_width = text.len() as u16;
+                        let x_offset = if text_width < bounds.width {
+                            (bounds.width - text_width) / 2
+                        } else {
+                            0
+                        };
+                        let x = bounds.x + x_offset;
+
+                        buffer.write_str(x, y, &text, style);
+                    }
                 }
             }
 
@@ -175,6 +262,47 @@ impl PluginWindow for ExplorerPluginWindow {
             }
         });
     }
+}
+
+/// Count hidden items in the tree
+///
+/// Counts all hidden items that exist but are not shown in the flattened view.
+fn count_hidden_items<'a>(flat_nodes: &[crate::tree::FlattenedNode<'a>]) -> usize {
+    // Count all children that are hidden (not in the flattened list)
+    // This traverses all expanded directories and counts their hidden children
+    let mut hidden_count = 0;
+
+    for flat_node in flat_nodes {
+        let node = flat_node.node;
+
+        // If this node is expanded and a directory, check for hidden children
+        if node.is_expanded()
+            && node.is_dir()
+            && let Some(children) = node.children()
+        {
+            for child in children {
+                if child.is_hidden {
+                    // Count this hidden item and all its descendants
+                    hidden_count += 1 + count_hidden_recursive(child);
+                }
+            }
+        }
+    }
+
+    hidden_count
+}
+
+/// Recursively count all descendants of a hidden node
+fn count_hidden_recursive(node: &crate::node::FileNode) -> usize {
+    let mut count = 0;
+
+    if let Some(children) = node.children() {
+        for child in children {
+            count += 1 + count_hidden_recursive(child);
+        }
+    }
+
+    count
 }
 
 /// File details popup window


### PR DESCRIPTION
Implement nvim-tree style visual enhancements for the file explorer with dedicated FileExplorerStyles in the theme system.

Theme System Changes:
- Added FileExplorerStyles struct with 10 distinct file type colors:
  - directory: blue (bold) for folders
  - source_file: orange for programming languages
  - config_file: gray for configuration files
  - doc_file: cyan for documentation
  - data_file: magenta for databases/data files
  - media_file: pink for images/audio/video
  - special_file: yellow for LICENSE, .gitignore
  - lock_file: dimmed yellow for lock files
  - executable_file: green for executables
  - hidden_file: dimmed gray for hidden files
- Implemented in all three themes: dark(), light(), tokyo_night_orange()

Explorer Features:
- File type syntax coloring using dedicated theme styles
- Box-drawing tree structure (│, ├, └) with three style options
- Hidden items counter: "(N hidden)" display
- Settings integration:
  - explorer.enable_colors - Toggle coloring (default: true)
  - explorer.tree_style - Choose style (default: "box_drawing")

Architecture:
- file_colors.rs - File categorization and color mapping (216 lines)
- tree_render.rs - Box-drawing character generation (173 lines)
- tree.rs - Enhanced flatten_with_metadata() for sibling tracking
- window.rs - Multi-segment rendering with per-element coloring
- theme.rs - FileExplorerStyles with distinct colors per category

Closes #127 #139