### PR TITLE
feat: complete enhanced markdown decorations (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to Reovim will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Enhanced Markdown Decorations** (Epic #89) - Complete markdown rendering overhaul
+  - **Phase 1: Heading Decorations** (#90)
+    - Heading indentation by level (H1=0, H2=1 space, H3=2 spaces, etc.)
+    - Inline code span background styling with backtick concealment
+    - Link background styling for distinct link appearance
+    - Strikethrough styling with `~~` marker concealment
+  - **Phase 2: Horizontal Rules and Blockquotes** (#91)
+    - Horizontal rules: `---`/`***`/`___` → full-width `────────` line
+    - Blockquotes: `>` → `│ ` vertical bar with background color
+  - **Phase 3: Table Border Decorations** (#92)
+    - Visual unicode borders (─│┌┐└┘├┤┬┴┼) around markdown tables
+    - Cells expand to uniform width with proper padding
+    - New `MarkdownTableBorderStage` render stage
+    - `virtual_lines` system in RenderData for rendering lines above/below content
+
 ### Fixed
+
+- **Cursor no longer moves into padding areas in decorated tables** (#89)
+  - Added `col_mapping` to `DecorationKind::Conceal` for buffer→visual column translation
+  - Position-based mapping algorithm that skips padding areas
+  - Cursor stays on content characters, jumps directly to trailing space/pipe
+
+- **Visual mode now disables decorations on selected lines** (#89)
+  - Replaced single-line `is_insert_mode` with `skip_decoration_lines: HashSet<usize>`
+  - In visual mode, all selected lines show raw markdown (like insert mode)
+  - Works with visual (`v`), visual line (`V`), and visual block (`Ctrl-V`) modes
 
 - **Multiple Conceal decorations per line now render correctly** (Issue #143)
   - Changed from single-index iterator to multi-decoration lookup

--- a/lib/core/src/animation/stage.rs
+++ b/lib/core/src/animation/stage.rs
@@ -148,6 +148,7 @@ mod tests {
             decorations: vec![vec![], vec![]],
             signs: vec![None, None],
             virtual_texts: vec![None, None],
+            virtual_lines: std::collections::BTreeMap::new(),
             buffer_id: 1,
             window_id: 1,
             window_bounds: Bounds {
@@ -157,6 +158,7 @@ mod tests {
                 height: 24,
             },
             cursor: (0, 0),
+            skip_decoration_lines: std::collections::HashSet::new(),
         }
     }
 

--- a/lib/core/src/buffer/mod.rs
+++ b/lib/core/src/buffer/mod.rs
@@ -467,6 +467,7 @@ impl Buffer {
                             end_col: span.end_col as usize,
                             kind: DecorationKind::Conceal {
                                 replacement: Some(replacement),
+                                col_mapping: None,
                             },
                         });
                         // If there's a style, also add it as a background decoration
@@ -485,7 +486,10 @@ impl Buffer {
                         line_decorations[line_idx].push(Decoration {
                             start_col: span.start_col as usize,
                             end_col: span.end_col as usize,
-                            kind: DecorationKind::Conceal { replacement: None },
+                            kind: DecorationKind::Conceal {
+                                replacement: None,
+                                col_mapping: None,
+                            },
                         });
                     }
                 }

--- a/lib/core/src/buffer/saturator.rs
+++ b/lib/core/src/buffer/saturator.rs
@@ -360,6 +360,7 @@ fn update_decorations(
                         end_col: span.end_col as usize,
                         kind: DecorationKind::Conceal {
                             replacement: Some(replacement),
+                            col_mapping: None,
                         },
                     });
                     // If there's a style, also add it as a background decoration
@@ -378,7 +379,10 @@ fn update_decorations(
                     line_decorations[line_idx].push(Decoration {
                         start_col: span.start_col as usize,
                         end_col: span.end_col as usize,
-                        kind: DecorationKind::Conceal { replacement: None },
+                        kind: DecorationKind::Conceal {
+                            replacement: None,
+                            col_mapping: None,
+                        },
                     });
                 }
             }

--- a/lib/core/src/render/decoration_cache.rs
+++ b/lib/core/src/render/decoration_cache.rs
@@ -189,6 +189,7 @@ mod tests {
             end_col: end,
             kind: DecorationKind::Conceal {
                 replacement: Some("...".to_string()),
+                col_mapping: None,
             },
         }
     }

--- a/lib/core/src/render/mod.rs
+++ b/lib/core/src/render/mod.rs
@@ -14,6 +14,8 @@ pub use {
     registry::RenderStageRegistry, stage::RenderStage,
 };
 
+use std::collections::{BTreeMap, HashSet};
+
 use crate::{highlight::Style, sign::LineSign};
 
 /// Data flowing through the render pipeline
@@ -39,6 +41,11 @@ pub struct RenderData {
     /// Populated by plugins via `RenderStage` transforms (e.g., LSP diagnostics)
     pub virtual_texts: Vec<Option<VirtualTextEntry>>,
 
+    /// Virtual lines to render above/below buffer lines
+    /// Key: (`line_index`, position), Value: virtual line entry
+    /// Used for table borders, decorative separators, etc.
+    pub virtual_lines: BTreeMap<(usize, VirtualLinePosition), VirtualLineEntry>,
+
     /// Metadata
     pub buffer_id: usize,
     pub window_id: usize,
@@ -46,6 +53,10 @@ pub struct RenderData {
 
     /// Cursor position (line, column) for bracket matching etc.
     pub cursor: (usize, usize),
+
+    /// Lines to skip decorations on (insert mode cursor line, visual selection lines)
+    /// Stages should check this set and avoid adding decorations to these lines
+    pub skip_decoration_lines: HashSet<usize>,
 }
 
 impl RenderData {
@@ -77,19 +88,35 @@ impl RenderData {
         let deco_start = std::time::Instant::now();
         let mut decorations = buffer.decoration_cache.get_ready_decorations(line_count);
 
-        // In insert mode, disable decorations on cursor line to show raw syntax
+        // Build set of lines to skip decorations on
+        let mut skip_decoration_lines = HashSet::new();
+
+        // In insert mode, skip cursor line
         if mode.is_insert() {
-            let cursor_line = buffer.cur.y as usize;
-            if cursor_line < decorations.len() {
-                decorations[cursor_line].clear();
+            skip_decoration_lines.insert(buffer.cur.y as usize);
+        }
+
+        // In visual mode, skip ALL selected lines
+        if mode.is_visual() && buffer.selection.active {
+            use crate::buffer::SelectionOps;
+            let (start, end) = buffer.selection_bounds();
+            for line_idx in start.y as usize..=end.y as usize {
+                skip_decoration_lines.insert(line_idx);
+            }
+        }
+
+        // Clear cached decorations for skipped lines
+        for &line_idx in &skip_decoration_lines {
+            if line_idx < decorations.len() {
+                decorations[line_idx].clear();
             }
         }
 
         tracing::trace!(
-            "[RTT] from_buffer: decoration_cache_read={:?} lines={} insert_mode={}",
+            "[RTT] from_buffer: decoration_cache_read={:?} lines={} skip_lines={}",
             deco_start.elapsed(),
             line_count,
-            mode.is_insert()
+            skip_decoration_lines.len()
         );
 
         Self {
@@ -103,6 +130,7 @@ impl RenderData {
             decorations,
             signs: vec![None; line_count],
             virtual_texts: vec![None; line_count],
+            virtual_lines: BTreeMap::new(),
             buffer_id: buffer.id,
             window_id: window.id,
             window_bounds: Bounds {
@@ -112,7 +140,32 @@ impl RenderData {
                 height: window.height,
             },
             cursor: (buffer.cur.y as usize, buffer.cur.x as usize),
+            skip_decoration_lines,
         }
+    }
+
+    /// Get column mapping for cursor line if a full-line Conceal exists with mapping
+    ///
+    /// Returns the column mapping (`buffer_col` → `visual_col`) if the cursor line has
+    /// a full-line Conceal decoration with a column mapping. This is used for
+    /// positioning the cursor correctly when decorations change column positions.
+    #[must_use]
+    pub fn cursor_col_mapping(&self) -> Option<&[u16]> {
+        let cursor_line = self.cursor.0;
+        let line_len = self.lines.get(cursor_line)?.len();
+        self.decorations.get(cursor_line)?.iter().find_map(|deco| {
+            // Check for full-line conceal with column mapping
+            if deco.start_col == 0
+                && deco.end_col >= line_len
+                && let DecorationKind::Conceal {
+                    col_mapping: Some(m),
+                    ..
+                } = &deco.kind
+            {
+                return Some(m.as_slice());
+            }
+            None
+        })
     }
 }
 
@@ -158,7 +211,13 @@ pub struct Decoration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecorationKind {
     /// Conceal text with replacement
-    Conceal { replacement: Option<String> },
+    Conceal {
+        replacement: Option<String>,
+        /// Optional column mapping for cursor position (`buffer_col` → `visual_col`)
+        /// When present, maps each buffer column index to its visual column in the replacement
+        /// Used for full-line conceals that change column positions (e.g., table expansion)
+        col_mapping: Option<Vec<u16>>,
+    },
     /// Background highlight
     Background { style: Style },
     /// Inline virtual text
@@ -187,6 +246,31 @@ pub struct VirtualTextEntry {
     /// Style for rendering
     pub style: Style,
     /// Priority (higher wins when multiple on same line)
+    pub priority: u32,
+}
+
+/// Position for virtual line relative to a buffer line
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VirtualLinePosition {
+    /// Insert above the buffer line
+    Before,
+    /// Insert below the buffer line
+    After,
+}
+
+/// A virtual line entry (entire line not in buffer)
+///
+/// Used for rendering decorative elements that span full lines:
+/// - Table top/bottom borders (┌───┬───┐, └───┴───┘)
+/// - Section separators
+/// - Fold previews
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtualLineEntry {
+    /// Text content of the virtual line
+    pub text: String,
+    /// Style for rendering
+    pub style: Style,
+    /// Priority (higher wins on conflict at same position)
     pub priority: u32,
 }
 

--- a/lib/core/src/screen/mod.rs
+++ b/lib/core/src/screen/mod.rs
@@ -555,6 +555,56 @@ impl Screen {
         data
     }
 
+    /// Calculate adjusted scroll offset to ensure cursor is visible with virtual lines
+    ///
+    /// Virtual lines take up display rows, so we may need to scroll further to keep
+    /// the cursor visible. Returns `Some(new_offset)` if adjustment needed, `None` otherwise.
+    #[allow(clippy::cast_possible_truncation)]
+    fn calculate_scroll_adjustment_for_virtual_lines(
+        render_data: &crate::render::RenderData,
+        current_scroll: u16,
+        window_height: u16,
+        cursor_line: u16,
+    ) -> Option<u16> {
+        use crate::render::VirtualLinePosition;
+
+        // Count virtual lines in the viewport that appear at or before cursor
+        let mut display_rows_used = 0u16;
+        let scroll_start = current_scroll as usize;
+        let cursor_idx = cursor_line as usize;
+
+        // Count ALL display rows from scroll to cursor (don't return early)
+        for line_idx in scroll_start..=cursor_idx {
+            // Count Before virtual lines
+            if render_data
+                .virtual_lines
+                .contains_key(&(line_idx, VirtualLinePosition::Before))
+            {
+                display_rows_used += 1;
+            }
+
+            // Count the buffer line itself
+            display_rows_used += 1;
+
+            // Count After virtual lines (except for cursor line - it's after cursor)
+            if line_idx < cursor_idx
+                && render_data
+                    .virtual_lines
+                    .contains_key(&(line_idx, VirtualLinePosition::After))
+            {
+                display_rows_used += 1;
+            }
+        }
+
+        // AFTER counting everything, check if adjustment needed
+        if display_rows_used > window_height {
+            let overshoot = display_rows_used - window_height;
+            Some(current_scroll + overshoot)
+        } else {
+            None
+        }
+    }
+
     /// Render pipeline data to frame buffer
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::cast_possible_truncation)]
@@ -567,7 +617,7 @@ impl Screen {
         theme: &Theme,
         buffer: &Buffer,
     ) {
-        use crate::render::{DecorationKind, LineVisibility};
+        use crate::render::{DecorationKind, LineVisibility, VirtualLinePosition};
 
         // Get effective cursor position (active window uses buffer cursor, inactive uses window cursor)
         let cursor_y = if window.is_active {
@@ -637,6 +687,32 @@ impl Screen {
         let start_line = scroll_offset as usize;
         for (idx, line) in render_data.lines.iter().enumerate().skip(start_line) {
             let line_idx = idx;
+            if display_row >= window.height {
+                break;
+            }
+
+            // Render virtual lines BEFORE this buffer line
+            if let Some(vl) = render_data
+                .virtual_lines
+                .get(&(line_idx, VirtualLinePosition::Before))
+            {
+                if display_row >= window.height {
+                    break;
+                }
+                let screen_y = window.anchor.y + display_row;
+                let gutter_total = sign_column_width + num_width as u16 + 1; // +1 for padding
+                let mut col = window.anchor.x + gutter_total;
+                let max_col = window.anchor.x + window.width;
+                for ch in vl.text.chars() {
+                    if col >= max_col {
+                        break;
+                    }
+                    frame_buffer.put_char(col, screen_y, ch, &vl.style);
+                    col += 1;
+                }
+                display_row += 1;
+            }
+
             if display_row >= window.height {
                 break;
             }
@@ -819,7 +895,7 @@ impl Screen {
 
                         // Handle conceal decorations (with optional background style)
                         if let Some(deco) = conceal_deco
-                            && let DecorationKind::Conceal { replacement } = &deco.kind
+                            && let DecorationKind::Conceal { replacement, .. } = &deco.kind
                         {
                             // Only output replacement at start of decoration span
                             if char_idx == deco.start_col
@@ -978,6 +1054,28 @@ impl Screen {
 
                     display_row += 1;
                 }
+            }
+
+            // Render virtual lines AFTER this buffer line
+            if let Some(vl) = render_data
+                .virtual_lines
+                .get(&(line_idx, VirtualLinePosition::After))
+            {
+                if display_row >= window.height {
+                    continue;
+                }
+                let screen_y = window.anchor.y + display_row;
+                let gutter_total = sign_column_width + num_width as u16 + 1;
+                let mut col = window.anchor.x + gutter_total;
+                let max_col = window.anchor.x + window.width;
+                for ch in vl.text.chars() {
+                    if col >= max_col {
+                        break;
+                    }
+                    frame_buffer.put_char(col, screen_y, ch, &vl.style);
+                    col += 1;
+                }
+                display_row += 1;
             }
         }
 
@@ -1227,7 +1325,7 @@ impl Screen {
         windows_to_render.sort_by_key(|w| w.z_order);
 
         // Render all windows
-        for win in &windows_to_render {
+        for win in &mut windows_to_render {
             // Handle PluginBuffer windows differently
             if let crate::content::WindowContentSource::PluginBuffer { provider, .. } = &win.source
             {
@@ -1321,6 +1419,32 @@ impl Screen {
                 );
                 let pipeline_time = pipeline_start.elapsed();
 
+                // Adjust scroll if virtual lines would push cursor off-screen
+                let current_scroll = win.buffer_anchor().map_or(0, |a| a.y);
+                if let Some(new_scroll) = Self::calculate_scroll_adjustment_for_virtual_lines(
+                    &render_data,
+                    current_scroll,
+                    win.height,
+                    buf.cur.y,
+                ) {
+                    // Update both the cloned window and the original
+                    if let Some(mut anchor) = win.buffer_anchor() {
+                        anchor.y = new_scroll;
+                        win.set_buffer_anchor(anchor);
+                    }
+                    if let Some(editor_idx) = editor_win_idx
+                        && let Some(mut anchor) = self.windows[editor_idx].buffer_anchor()
+                    {
+                        anchor.y = new_scroll;
+                        self.windows[editor_idx].set_buffer_anchor(anchor);
+                    }
+                    tracing::trace!(
+                        "[VLINE] adjusted scroll: {} -> {} for virtual lines",
+                        current_scroll,
+                        new_scroll
+                    );
+                }
+
                 // Render pipeline data to frame buffer
                 let fb_start = std::time::Instant::now();
                 self.render_data_to_framebuffer(&render_data, win, buffer, theme, buf);
@@ -1332,15 +1456,43 @@ impl Screen {
 
                 // Calculate cursor position only for the ACTIVE window (and if editor is focused)
                 if win.is_active {
+                    use crate::render::VirtualLinePosition;
+
                     let line_num_width = win.line_number_width(buf.contents.len());
                     // Use max width for cursor position (assume signs present in auto mode)
                     let sign_width = win.sign_column_mode.effective_width(true);
-                    let cursor_x = win.anchor.x + sign_width + line_num_width + buf.cur.x;
+
+                    // Apply column mapping for decorated lines (e.g., table expansion)
+                    let visual_cursor_col = render_data
+                        .cursor_col_mapping()
+                        .and_then(|mapping| mapping.get(buf.cur.x as usize).copied())
+                        .unwrap_or(buf.cur.x);
+                    let cursor_x = win.anchor.x + sign_width + line_num_width + visual_cursor_col;
+
+                    // Calculate virtual line offset for cursor position
+                    // Virtual lines rendered BEFORE buffer lines shift the cursor down
+                    let scroll_offset = win.buffer_anchor().map_or(0, |a| a.y);
+                    let cursor_buffer_line = buf.cur.y;
+
+                    // Count virtual lines that appear visually before the cursor line
+                    // - Before: renders before line N, count if N <= cursor
+                    // - After: renders after line N, count if N < cursor (before cursor line)
+                    let virtual_line_offset: u16 = render_data
+                        .virtual_lines
+                        .keys()
+                        .filter(|(line_idx, pos)| {
+                            let line = *line_idx as u16;
+                            line >= scroll_offset
+                                && match pos {
+                                    VirtualLinePosition::Before => line <= cursor_buffer_line,
+                                    VirtualLinePosition::After => line < cursor_buffer_line,
+                                }
+                        })
+                        .count() as u16;
+
                     let cursor_y = win.anchor.y
-                        + buf
-                            .cur
-                            .y
-                            .saturating_sub(win.buffer_anchor().map_or(0, |a| a.y));
+                        + cursor_buffer_line.saturating_sub(scroll_offset)
+                        + virtual_line_offset;
                     cursor_pos = Some((cursor_x, cursor_y));
                 }
             }

--- a/lib/core/tests/virtual_text.rs
+++ b/lib/core/tests/virtual_text.rs
@@ -493,6 +493,7 @@ fn create_test_render_data(line_count: usize) -> RenderData {
         decorations: vec![Vec::new(); line_count],
         signs: vec![None; line_count],
         virtual_texts: vec![None; line_count],
+        virtual_lines: std::collections::BTreeMap::new(),
         buffer_id: 1,
         window_id: 1,
         window_bounds: Bounds {
@@ -502,5 +503,6 @@ fn create_test_render_data(line_count: usize) -> RenderData {
             height: 24,
         },
         cursor: (0, 0),
+        skip_decoration_lines: std::collections::HashSet::new(),
     }
 }

--- a/plugins/features/lsp/src/stage.rs
+++ b/plugins/features/lsp/src/stage.rs
@@ -436,6 +436,7 @@ mod tests {
             decorations: vec![Vec::new(); line_count],
             signs: vec![None; line_count],
             virtual_texts: vec![None; line_count],
+            virtual_lines: std::collections::BTreeMap::new(),
             buffer_id: 1,
             window_id: 1,
             window_bounds: Bounds {
@@ -445,6 +446,7 @@ mod tests {
                 height: 24,
             },
             cursor: (0, 0),
+            skip_decoration_lines: std::collections::HashSet::new(),
         }
     }
 

--- a/plugins/features/range-finder/src/tests/fold_tests/mod.rs
+++ b/plugins/features/range-finder/src/tests/fold_tests/mod.rs
@@ -152,6 +152,7 @@ fn test_fold_render_stage_no_folds() {
         decorations: vec![Vec::new(); 3],
         signs: vec![None; 3],
         virtual_texts: vec![None; 3],
+        virtual_lines: std::collections::BTreeMap::new(),
         buffer_id: 1,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {
@@ -161,6 +162,7 @@ fn test_fold_render_stage_no_folds() {
             height: 24,
         },
         cursor: (0, 0),
+        skip_decoration_lines: std::collections::HashSet::new(),
     };
 
     // Create render context
@@ -210,6 +212,7 @@ fn test_fold_render_stage_with_collapsed_fold() {
         decorations: vec![Vec::new(); 5],
         signs: vec![None; 5],
         virtual_texts: vec![None; 5],
+        virtual_lines: std::collections::BTreeMap::new(),
         buffer_id: 1,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {
@@ -219,6 +222,7 @@ fn test_fold_render_stage_with_collapsed_fold() {
             height: 24,
         },
         cursor: (0, 0),
+        skip_decoration_lines: std::collections::HashSet::new(),
     };
 
     let theme = Theme::default();
@@ -277,6 +281,7 @@ fn test_fold_render_stage_multiple_folds() {
         decorations: vec![Vec::new(); 9],
         signs: vec![None; 9],
         virtual_texts: vec![None; 9],
+        virtual_lines: std::collections::BTreeMap::new(),
         buffer_id: 2,
         window_id: 0,
         window_bounds: reovim_core::render::Bounds {
@@ -286,6 +291,7 @@ fn test_fold_render_stage_multiple_folds() {
             height: 24,
         },
         cursor: (0, 0),
+        skip_decoration_lines: std::collections::HashSet::new(),
     };
 
     let theme = Theme::default();

--- a/plugins/languages/markdown/src/config.rs
+++ b/plugins/languages/markdown/src/config.rs
@@ -11,6 +11,9 @@ pub struct HeadingConfig {
     pub styles: [Style; 6],
     /// Background styles for each heading level (None = no background)
     pub backgrounds: [Option<Style>; 6],
+    /// Spaces to indent per heading level (H2+)
+    /// H1 = 0 spaces, H2 = 1*indent, H3 = 2*indent, etc.
+    pub indent_per_level: u8,
 }
 
 impl Default for HeadingConfig {
@@ -78,6 +81,7 @@ impl Default for HeadingConfig {
                 None,
                 None,
             ],
+            indent_per_level: 0,
         }
     }
 }
@@ -166,6 +170,16 @@ pub struct InlineConfig {
     pub conceal_links: bool,
     /// Style for link text
     pub link_style: Style,
+    /// Optional background for links (applied in addition to link_style)
+    pub link_background: Option<Style>,
+    /// Style for inline code spans (`code`)
+    pub code_span_style: Style,
+    /// Whether to conceal the backtick markers
+    pub conceal_code_span: bool,
+    /// Style for strikethrough text (~~text~~)
+    pub strikethrough_style: Style,
+    /// Whether to conceal ~~ markers
+    pub conceal_strikethrough: bool,
 }
 
 impl Default for InlineConfig {
@@ -188,6 +202,88 @@ impl Default for InlineConfig {
                 g: 207,
                 b: 255,
             }),
+            link_background: Some(Style::new().bg(Color::Rgb {
+                r: 30,
+                g: 40,
+                b: 50,
+            })),
+            code_span_style: Style::new()
+                .bg(Color::Rgb {
+                    r: 45,
+                    g: 45,
+                    b: 55,
+                })
+                .fg(Color::Rgb {
+                    r: 230,
+                    g: 180,
+                    b: 120,
+                }),
+            conceal_code_span: true,
+            strikethrough_style: Style::new().strikethrough().dim().fg(Color::Rgb {
+                r: 140,
+                g: 140,
+                b: 160,
+            }),
+            conceal_strikethrough: true,
+        }
+    }
+}
+
+/// Box-drawing characters for table borders
+#[derive(Debug, Clone)]
+pub struct BoxDrawingChars {
+    pub top_left: char,
+    pub top_right: char,
+    pub bottom_left: char,
+    pub bottom_right: char,
+    pub horizontal: char,
+    pub vertical: char,
+    pub cross: char,
+    pub top_tee: char,
+    pub bottom_tee: char,
+    pub left_tee: char,
+    pub right_tee: char,
+}
+
+impl Default for BoxDrawingChars {
+    fn default() -> Self {
+        Self {
+            top_left: '┌',
+            top_right: '┐',
+            bottom_left: '└',
+            bottom_right: '┘',
+            horizontal: '─',
+            vertical: '│',
+            cross: '┼',
+            top_tee: '┬',
+            bottom_tee: '┴',
+            left_tee: '├',
+            right_tee: '┤',
+        }
+    }
+}
+
+/// Configuration for table border rendering with box-drawing characters
+#[derive(Debug, Clone)]
+pub struct TableBorderConfig {
+    /// Whether to use box-drawing characters for borders
+    pub use_box_drawing: bool,
+    /// Box-drawing character set
+    pub chars: BoxDrawingChars,
+    /// Style for border characters
+    pub style: Style,
+}
+
+impl Default for TableBorderConfig {
+    fn default() -> Self {
+        Self {
+            use_box_drawing: true, // Enabled by default for visual polish
+            chars: BoxDrawingChars::default(),
+            style: Style::new().dim().fg(Color::Rgb {
+                r: 80,
+                g: 80,
+                b: 100,
+            }),
         }
     }
 }
@@ -205,6 +301,8 @@ pub struct TableConfig {
     pub delimiter_style: Style,
     /// Style for cell borders (pipe characters)
     pub border_style: Style,
+    /// Box-drawing border configuration
+    pub borders: TableBorderConfig,
 }
 
 impl Default for TableConfig {
@@ -231,6 +329,67 @@ impl Default for TableConfig {
                 g: 80,
                 b: 100,
             }),
+            borders: TableBorderConfig::default(),
+        }
+    }
+}
+
+/// Configuration for horizontal rule rendering
+#[derive(Debug, Clone)]
+pub struct HorizontalRuleConfig {
+    /// Whether to render horizontal rule styling
+    pub enabled: bool,
+    /// Character to use for the rule (repeated to fill width)
+    pub character: char,
+    /// Style for the horizontal rule
+    pub style: Style,
+    /// Minimum width of the rule (in characters)
+    pub min_width: u16,
+}
+
+impl Default for HorizontalRuleConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            character: '─', // Box-drawing horizontal
+            style: Style::new().dim().fg(Color::Rgb {
+                r: 100,
+                g: 100,
+                b: 120,
+            }),
+            min_width: 40,
+        }
+    }
+}
+
+/// Configuration for blockquote rendering
+#[derive(Debug, Clone)]
+pub struct BlockquoteConfig {
+    /// Whether to render blockquote styling
+    pub enabled: bool,
+    /// Replacement character for > marker
+    pub marker: &'static str,
+    /// Style for the marker
+    pub marker_style: Style,
+    /// Optional background for the entire blockquote
+    pub background: Option<Style>,
+}
+
+impl Default for BlockquoteConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            marker: "│ ", // Vertical line + space
+            marker_style: Style::new().fg(Color::Rgb {
+                r: 100,
+                g: 140,
+                b: 180,
+            }),
+            background: Some(Style::new().bg(Color::Rgb {
+                r: 35,
+                g: 40,
+                b: 48,
+            })),
         }
     }
 }
@@ -250,6 +409,10 @@ pub struct MarkdownConfig {
     pub inline: InlineConfig,
     /// Table configuration
     pub tables: TableConfig,
+    /// Horizontal rule configuration
+    pub horizontal_rules: HorizontalRuleConfig,
+    /// Blockquote configuration
+    pub blockquotes: BlockquoteConfig,
     /// Show raw markdown on cursor line (even in normal mode)
     pub raw_on_cursor_line: bool,
 }
@@ -263,6 +426,8 @@ impl Default for MarkdownConfig {
             code_blocks: CodeBlockConfig::default(),
             inline: InlineConfig::default(),
             tables: TableConfig::default(),
+            horizontal_rules: HorizontalRuleConfig::default(),
+            blockquotes: BlockquoteConfig::default(),
             raw_on_cursor_line: false,
         }
     }

--- a/plugins/languages/markdown/src/decorator.rs
+++ b/plugins/languages/markdown/src/decorator.rs
@@ -134,7 +134,14 @@ impl MarkdownDecorator {
 
                     if (1..=6).contains(&level) {
                         let idx = level - 1;
+                        // Add indentation based on level (H1=0, H2=1 space, H3=2 spaces, etc.)
+                        let indent = if level > 1 {
+                            " ".repeat((level - 1) * self.config.headings.indent_per_level as usize)
+                        } else {
+                            String::new()
+                        };
                         let icon = self.config.headings.icons[idx];
+                        let replacement = format!("{indent}{icon}");
                         let style = Some(self.config.headings.styles[idx].clone());
 
                         let start = node.start_position();
@@ -147,7 +154,7 @@ impl MarkdownDecorator {
                                 end.row as u32,
                                 end.column as u32 + 1, // +1 for space after marker
                             ),
-                            icon,
+                            replacement,
                             style,
                         ));
                     }
@@ -338,12 +345,28 @@ impl MarkdownDecorator {
         let mut cursor = tree_sitter::QueryCursor::new();
         let mut matches = cursor.matches(&self.block_query, tree.root_node(), content.as_bytes());
 
+        // Track delimiter rows for box-drawing
+        let mut delimiter_rows: Vec<u32> = Vec::new();
+        let mut table_ranges: Vec<(u32, u32)> = Vec::new(); // (start_line, end_line)
+
         while let Some(match_) = matches.next() {
             for capture in match_.captures {
                 let capture_name = &self.block_query.capture_names()[capture.index as usize];
                 let node = capture.node;
 
                 match *capture_name {
+                    "decoration.table" => {
+                        let start_line = node.start_position().row as u32;
+                        // end_position is exclusive, so subtract 1 to get the actual last row
+                        // But check if the end column is 0 (meaning the node ends at start of next line)
+                        let end_pos = node.end_position();
+                        let end_line = if end_pos.column == 0 && end_pos.row > 0 {
+                            (end_pos.row - 1) as u32
+                        } else {
+                            end_pos.row as u32
+                        };
+                        table_ranges.push((start_line, end_line));
+                    }
                     "decoration.table.header" => {
                         if let Some(bg_style) = &self.config.tables.header_background {
                             let start_line = node.start_position().row as u32;
@@ -355,6 +378,7 @@ impl MarkdownDecorator {
                     }
                     "decoration.table.delimiter" => {
                         let start_line = node.start_position().row as u32;
+                        delimiter_rows.push(start_line);
                         decorations.push(Decoration::single_line_background(
                             start_line,
                             self.config.tables.delimiter_style.clone(),
@@ -365,14 +389,247 @@ impl MarkdownDecorator {
             }
         }
 
+        // Add box-drawing decorations if enabled
+        if self.config.tables.borders.use_box_drawing {
+            decorations.extend(self.render_table_borders(content, &table_ranges, &delimiter_rows));
+        }
+
         decorations
     }
 
-    /// Generate inline decorations (emphasis, links)
+    /// Analyze table structure to find column positions
+    ///
+    /// Returns the pipe positions from the delimiter row (most reliable reference)
+    /// as these define the canonical column boundaries.
+    fn analyze_table_columns(
+        &self,
+        lines: &[&str],
+        start_line: u32,
+        end_line: u32,
+        delimiter_rows: &[u32],
+    ) -> Vec<u32> {
+        // Find the delimiter row for this table to get canonical column positions
+        let delimiter_line = delimiter_rows
+            .iter()
+            .find(|&&row| row >= start_line && row <= end_line)
+            .copied();
+
+        let reference_line = if let Some(delim) = delimiter_line {
+            delim
+        } else {
+            // Fallback to header row if no delimiter found
+            start_line
+        };
+
+        let line_idx = reference_line as usize;
+        if line_idx >= lines.len() {
+            return Vec::new();
+        }
+
+        // Get pipe positions from reference line
+        lines[line_idx]
+            .char_indices()
+            .filter_map(|(idx, c)| if c == '|' { Some(idx as u32) } else { None })
+            .collect()
+    }
+
+    /// Generate box-drawing border decorations for tables
+    ///
+    /// Uses a multi-pass algorithm:
+    /// 1. Analyze table structure to find column positions and widths
+    /// 2. Generate decorations for each row type (header, delimiter, data)
+    ///
+    /// Note: Top/bottom borders (┌───┐ / └───┘) require virtual text support
+    /// which is not yet implemented in the core decoration system.
+    #[allow(clippy::cast_possible_truncation)]
+    fn render_table_borders(
+        &self,
+        content: &str,
+        table_ranges: &[(u32, u32)],
+        delimiter_rows: &[u32],
+    ) -> Vec<Decoration> {
+        let mut decorations = Vec::new();
+        let lines: Vec<&str> = content.lines().collect();
+        let chars = &self.config.tables.borders.chars;
+        let style = &self.config.tables.borders.style;
+
+        for &(start_line, end_line) in table_ranges {
+            // Pass 1: Analyze table structure
+            let canonical_pipes =
+                self.analyze_table_columns(&lines, start_line, end_line, delimiter_rows);
+
+            if canonical_pipes.is_empty() {
+                continue;
+            }
+
+            let is_delimiter = |line: u32| delimiter_rows.contains(&line);
+
+            // Pass 2: Generate decorations for each row
+            for line_num in start_line..=end_line {
+                let line_idx = line_num as usize;
+                if line_idx >= lines.len() {
+                    continue;
+                }
+                let line = lines[line_idx];
+
+                // Get actual pipe positions for this line
+                let line_pipes: Vec<u32> = line
+                    .char_indices()
+                    .filter_map(|(idx, c)| if c == '|' { Some(idx as u32) } else { None })
+                    .collect();
+
+                // Replace each pipe with appropriate box-drawing character
+                for (pipe_idx, &pipe_col) in line_pipes.iter().enumerate() {
+                    let is_first_pipe = pipe_idx == 0;
+                    let is_last_pipe = pipe_idx == line_pipes.len() - 1;
+
+                    let replacement_char = if is_delimiter(line_num) {
+                        // Delimiter row uses T-junctions and cross
+                        if is_first_pipe {
+                            chars.left_tee
+                        } else if is_last_pipe {
+                            chars.right_tee
+                        } else {
+                            chars.cross
+                        }
+                    } else {
+                        // Header and data rows use vertical bars
+                        chars.vertical
+                    };
+
+                    decorations.push(Decoration::conceal(
+                        Span::single_line(line_num, pipe_col, pipe_col + 1),
+                        replacement_char.to_string(),
+                        Some(style.clone()),
+                    ));
+                }
+
+                // Replace dashes and colons in delimiter row with horizontal lines
+                if is_delimiter(line_num) {
+                    for (char_idx, c) in line.char_indices() {
+                        if c == '-' || c == ':' {
+                            decorations.push(Decoration::conceal(
+                                Span::single_line(line_num, char_idx as u32, char_idx as u32 + 1),
+                                chars.horizontal.to_string(),
+                                Some(style.clone()),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        decorations
+    }
+
+    /// Generate horizontal rule decorations
+    #[allow(clippy::cast_possible_truncation)]
+    fn render_horizontal_rules(&self, tree: &Tree, content: &str) -> Vec<Decoration> {
+        if !self.config.horizontal_rules.enabled {
+            return Vec::new();
+        }
+
+        let mut decorations = Vec::new();
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&self.block_query, tree.root_node(), content.as_bytes());
+
+        while let Some(match_) = matches.next() {
+            for capture in match_.captures {
+                let capture_name = &self.block_query.capture_names()[capture.index as usize];
+
+                if *capture_name == "decoration.horizontal_rule" {
+                    let node = capture.node;
+                    let start = node.start_position();
+                    // Get the actual text length (--- or *** or ___)
+                    let text_len = node
+                        .utf8_text(content.as_bytes())
+                        .map(|s| s.trim_end().len())
+                        .unwrap_or(3);
+
+                    // Create the replacement string
+                    let rule_char = self.config.horizontal_rules.character;
+                    let width = self.config.horizontal_rules.min_width as usize;
+                    let replacement: String = std::iter::repeat_n(rule_char, width).collect();
+
+                    // Use single-line span to avoid multi-line issues
+                    decorations.push(Decoration::conceal(
+                        Span::single_line(
+                            start.row as u32,
+                            start.column as u32,
+                            start.column as u32 + text_len as u32,
+                        ),
+                        replacement,
+                        Some(self.config.horizontal_rules.style.clone()),
+                    ));
+                }
+            }
+        }
+
+        decorations
+    }
+
+    /// Generate blockquote decorations
+    #[allow(clippy::cast_possible_truncation)]
+    fn render_blockquotes(&self, tree: &Tree, content: &str) -> Vec<Decoration> {
+        if !self.config.blockquotes.enabled {
+            return Vec::new();
+        }
+
+        let mut decorations = Vec::new();
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&self.block_query, tree.root_node(), content.as_bytes());
+
+        while let Some(match_) = matches.next() {
+            for capture in match_.captures {
+                let capture_name = &self.block_query.capture_names()[capture.index as usize];
+                let node = capture.node;
+
+                match *capture_name {
+                    "decoration.blockquote" => {
+                        // Apply background to entire blockquote
+                        if let Some(bg_style) = &self.config.blockquotes.background {
+                            let start_line = node.start_position().row as u32;
+                            let end_line = node.end_position().row as u32;
+                            decorations.push(Decoration::line_background(
+                                start_line,
+                                end_line,
+                                bg_style.clone(),
+                            ));
+                        }
+                    }
+                    "decoration.blockquote.marker" => {
+                        let start = node.start_position();
+                        let end = node.end_position();
+
+                        decorations.push(Decoration::conceal(
+                            Span::new(
+                                start.row as u32,
+                                start.column as u32,
+                                end.row as u32,
+                                end.column as u32,
+                            ),
+                            self.config.blockquotes.marker,
+                            Some(self.config.blockquotes.marker_style.clone()),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        decorations
+    }
+
+    /// Generate inline decorations (emphasis, links, code spans, strikethrough)
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_lines)]
     fn render_inline(&self, content: &str) -> Vec<Decoration> {
-        if !self.config.inline.conceal_emphasis && !self.config.inline.conceal_links {
+        // Early return if no inline features enabled
+        if !self.config.inline.conceal_emphasis
+            && !self.config.inline.conceal_links
+            && !self.config.inline.conceal_code_span
+            && !self.config.inline.conceal_strikethrough
+        {
             return Vec::new();
         }
 
@@ -483,7 +740,11 @@ impl MarkdownDecorator {
                                         end.column as u32,
                                     ),
                                 });
-                                // Apply link style
+                                // Apply link style with optional background
+                                let mut link_style = self.config.inline.link_style.clone();
+                                if let Some(bg) = &self.config.inline.link_background {
+                                    link_style = link_style.merge(bg);
+                                }
                                 decorations.push(Decoration::inline_style(
                                     Span::new(
                                         text_start.row as u32,
@@ -491,10 +752,70 @@ impl MarkdownDecorator {
                                         text_end.row as u32,
                                         text_end.column as u32,
                                     ),
-                                    self.config.inline.link_style.clone(),
+                                    link_style,
                                 ));
                             }
                         }
+                    }
+                    "decoration.code_span" if self.config.inline.conceal_code_span => {
+                        // Hide opening backtick
+                        decorations.push(Decoration::Hide {
+                            span: Span::new(
+                                start.row as u32,
+                                start.column as u32,
+                                start.row as u32,
+                                start.column as u32 + 1,
+                            ),
+                        });
+                        // Hide closing backtick
+                        decorations.push(Decoration::Hide {
+                            span: Span::new(
+                                end.row as u32,
+                                end.column as u32 - 1,
+                                end.row as u32,
+                                end.column as u32,
+                            ),
+                        });
+                        // Apply code span style to content
+                        decorations.push(Decoration::inline_style(
+                            Span::new(
+                                start.row as u32,
+                                start.column as u32 + 1,
+                                end.row as u32,
+                                end.column as u32 - 1,
+                            ),
+                            self.config.inline.code_span_style.clone(),
+                        ));
+                    }
+                    "decoration.strikethrough" if self.config.inline.conceal_strikethrough => {
+                        // Hide opening ~~ markers
+                        decorations.push(Decoration::Hide {
+                            span: Span::new(
+                                start.row as u32,
+                                start.column as u32,
+                                start.row as u32,
+                                start.column as u32 + 2,
+                            ),
+                        });
+                        // Hide closing ~~ markers
+                        decorations.push(Decoration::Hide {
+                            span: Span::new(
+                                end.row as u32,
+                                end.column as u32 - 2,
+                                end.row as u32,
+                                end.column as u32,
+                            ),
+                        });
+                        // Apply strikethrough style
+                        decorations.push(Decoration::inline_style(
+                            Span::new(
+                                start.row as u32,
+                                start.column as u32 + 2,
+                                end.row as u32,
+                                end.column as u32 - 2,
+                            ),
+                            self.config.inline.strikethrough_style.clone(),
+                        ));
                     }
                     _ => {}
                 }
@@ -568,6 +889,8 @@ impl DecorationProvider for MarkdownDecorator {
         decorations.extend(self.render_lists(tree, content));
         decorations.extend(self.render_code_blocks(tree, content));
         decorations.extend(self.render_tables(tree, content));
+        decorations.extend(self.render_horizontal_rules(tree, content));
+        decorations.extend(self.render_blockquotes(tree, content));
         decorations.extend(self.render_inline(content));
 
         decorations
@@ -658,5 +981,118 @@ mod tests {
             .count();
 
         assert!(hide_count >= 4, "Should have at least 4 Hide decorations, got {hide_count}");
+    }
+
+    #[test]
+    fn test_decorator_generates_horizontal_rule_decorations() {
+        let mut decorator = MarkdownDecorator::new().expect("Failed to create decorator");
+        let content = "Some text.\n\n---\n\nMore text.\n";
+
+        decorator.refresh(content);
+
+        let decorations = decorator.decoration_range(content, 0, 5);
+
+        println!("Generated {} decorations:", decorations.len());
+        for d in &decorations {
+            println!("  {d:?}");
+        }
+
+        // Should have horizontal rule conceal with ─ characters
+        let has_hr = decorations.iter().any(
+            |d| matches!(d, Decoration::Conceal { replacement, .. } if replacement.contains('─')),
+        );
+        assert!(has_hr, "Should have horizontal rule decoration");
+    }
+
+    #[test]
+    fn test_decorator_generates_blockquote_decorations() {
+        let mut decorator = MarkdownDecorator::new().expect("Failed to create decorator");
+        let content = "> This is a quote.\n> Second line.\n";
+
+        decorator.refresh(content);
+
+        let decorations = decorator.decoration_range(content, 0, 2);
+
+        println!("Generated {} decorations:", decorations.len());
+        for d in &decorations {
+            println!("  {d:?}");
+        }
+
+        // Should have blockquote marker replacements (one per line)
+        let marker_count = decorations.iter().filter(|d| {
+            matches!(d, Decoration::Conceal { replacement, .. } if replacement.contains('│'))
+        }).count();
+        assert!(
+            marker_count >= 2,
+            "Should have at least 2 blockquote markers, got {marker_count}"
+        );
+    }
+
+    #[test]
+    fn test_decorator_generates_table_border_decorations() {
+        let mut decorator = MarkdownDecorator::new().expect("Failed to create decorator");
+        let content = "| A | B |\n|---|---|\n| 1 | 2 |\n";
+
+        decorator.refresh(content);
+
+        let decorations = decorator.decoration_range(content, 0, 3);
+
+        println!("Content:");
+        for (i, line) in content.lines().enumerate() {
+            println!("  row {}: {:?}", i, line);
+        }
+
+        println!("\nGenerated {} decorations:", decorations.len());
+        for d in &decorations {
+            println!("  {d:?}");
+        }
+
+        // Count vertical pipe replacements (│)
+        let vertical_count = decorations
+            .iter()
+            .filter(|d| matches!(d, Decoration::Conceal { replacement, .. } if replacement == "│"))
+            .count();
+
+        // Count T-junction replacements (├, ┤, ┼)
+        let junction_count = decorations
+            .iter()
+            .filter(|d| {
+                matches!(d, Decoration::Conceal { replacement, .. } if
+                    replacement == "├" || replacement == "┤" || replacement == "┼")
+            })
+            .count();
+
+        // Count horizontal dash replacements (─)
+        let horizontal_count = decorations
+            .iter()
+            .filter(|d| matches!(d, Decoration::Conceal { replacement, .. } if replacement == "─"))
+            .count();
+
+        println!(
+            "\nCounts: vertical={}, junction={}, horizontal={}",
+            vertical_count, junction_count, horizontal_count
+        );
+
+        // Row 0 (| A | B |): 3 pipes -> 3 │
+        // Row 1 (|---|---|): 3 pipes -> ├, ┼, ┤ (3 junctions), plus 6 dashes -> 6 ─
+        // Row 2 (| 1 | 2 |): 3 pipes -> 3 │
+        // Total: 6 │, 3 junctions, 6 ─
+        // Note: Top/bottom borders require virtual text support (not yet implemented)
+
+        assert!(
+            vertical_count >= 6,
+            "Should have at least 6 vertical pipes (│), got {}",
+            vertical_count
+        );
+        assert!(
+            junction_count >= 3,
+            "Should have at least 3 junctions (├/┼/┤), got {}",
+            junction_count
+        );
+        assert!(
+            horizontal_count >= 6,
+            "Should have at least 6 horizontal dashes (─), got {}",
+            horizontal_count
+        );
     }
 }

--- a/plugins/languages/markdown/src/lib.rs
+++ b/plugins/languages/markdown/src/lib.rs
@@ -23,7 +23,7 @@ use {
     reovim_plugin_treesitter::{LanguageSupport, RegisterLanguage, TreesitterPlugin},
 };
 
-use factory::MarkdownDecorationFactory;
+use {factory::MarkdownDecorationFactory, stage::MarkdownTableBorderStage};
 
 /// Markdown language support
 pub struct MarkdownLanguage;
@@ -104,8 +104,9 @@ impl Plugin for MarkdownPlugin {
         vec![TypeId::of::<TreesitterPlugin>()]
     }
 
-    fn build(&self, _ctx: &mut PluginContext) {
-        // No commands to register
+    fn build(&self, ctx: &mut PluginContext) {
+        // Register render stage for table borders (virtual lines)
+        ctx.register_render_stage(Arc::new(MarkdownTableBorderStage::new()));
     }
 
     fn init_state(&self, registry: &PluginStateRegistry) {

--- a/plugins/languages/markdown/src/queries/decorations.scm
+++ b/plugins/languages/markdown/src/queries/decorations.scm
@@ -36,5 +36,14 @@
 (pipe_table_header) @decoration.table.header
 (pipe_table_delimiter_row) @decoration.table.delimiter
 
+; Horizontal rules (thematic breaks) for visual enhancement
+(thematic_break) @decoration.horizontal_rule
+
+; Blockquotes for styling
+(block_quote) @decoration.blockquote
+(block_quote_marker) @decoration.blockquote.marker
+; Continuation markers on subsequent lines of blockquotes (only inside block_quote)
+(block_quote (paragraph (inline (block_continuation) @decoration.blockquote.marker)))
+
 ; NOTE: Inline elements (emphasis, strong_emphasis, inline_link) are in
 ; INLINE_LANGUAGE, not LANGUAGE. See treesitter/grammar.rs for dual-grammar support.

--- a/plugins/languages/markdown/src/stage.rs
+++ b/plugins/languages/markdown/src/stage.rs
@@ -3,10 +3,16 @@
 use reovim_core::{
     component::RenderContext,
     decoration::DecorationStore,
-    render::{Decoration, DecorationKind, RenderData, RenderStage},
+    highlight::{Color, Style},
+    render::{
+        Decoration, DecorationKind, RenderData, RenderStage, VirtualLineEntry, VirtualLinePosition,
+    },
 };
 
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
 
 /// Markdown render stage - populates decorations (conceals, backgrounds)
 ///
@@ -20,6 +26,378 @@ impl MarkdownRenderStage {
     /// Create new markdown render stage
     pub fn new(decoration_store: Arc<RwLock<DecorationStore>>) -> Self {
         Self { decoration_store }
+    }
+}
+
+/// Markdown table border render stage - adds virtual lines for table borders
+///
+/// This stage detects markdown tables and adds virtual lines for top/bottom borders.
+/// It doesn't need DecorationStore - it works directly on the input lines.
+pub struct MarkdownTableBorderStage;
+
+impl MarkdownTableBorderStage {
+    /// Create new table border stage
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Detect table ranges in the content
+    ///
+    /// Returns (start_line, end_line, delimiter_line) tuples
+    fn detect_tables(lines: &[String]) -> Vec<(usize, usize, Option<usize>)> {
+        let mut tables = Vec::new();
+        let mut i = 0;
+
+        while i < lines.len() {
+            // Check if this line starts a table (contains | and non-trivial content)
+            if Self::is_table_line(&lines[i]) {
+                let start = i;
+                let mut end = i;
+                let mut delimiter = None;
+
+                // Find table extent
+                while end < lines.len() && Self::is_table_line(&lines[end]) {
+                    // Check if this is a delimiter row (|---|)
+                    if delimiter.is_none() && Self::is_delimiter_row(&lines[end]) {
+                        delimiter = Some(end);
+                    }
+                    end += 1;
+                }
+
+                // Only add if we have at least a header and delimiter
+                if end > start && delimiter.is_some() {
+                    tables.push((start, end - 1, delimiter));
+                }
+
+                i = end;
+            } else {
+                i += 1;
+            }
+        }
+
+        tables
+    }
+
+    /// Check if a line looks like a table row
+    fn is_table_line(line: &str) -> bool {
+        let trimmed = line.trim();
+        trimmed.contains('|') && !trimmed.is_empty()
+    }
+
+    /// Check if a line is a delimiter row (|---|---|)
+    fn is_delimiter_row(line: &str) -> bool {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            return false;
+        }
+        // Should contain mostly dashes, pipes, colons, and spaces
+        trimmed
+            .chars()
+            .all(|c| c == '|' || c == '-' || c == ':' || c == ' ')
+            && trimmed.contains('-')
+    }
+
+    /// Parse cells from a table row (content between pipes)
+    fn parse_cells(line: &str) -> Vec<String> {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') || !trimmed.ends_with('|') {
+            return Vec::new();
+        }
+        // Split by | and get cell content, skip first/last empty
+        trimmed[1..trimmed.len() - 1]
+            .split('|')
+            .map(|s| s.trim().to_string())
+            .collect()
+    }
+
+    /// Get column widths from a line (character count between pipes, excluding padding)
+    fn get_column_widths(line: &str) -> Vec<usize> {
+        Self::parse_cells(line)
+            .iter()
+            .map(|cell| cell.chars().count())
+            .collect()
+    }
+
+    /// Calculate max column widths across all rows in a table
+    fn calculate_max_column_widths(lines: &[String], start: usize, end: usize) -> Vec<usize> {
+        let mut max_widths: Vec<usize> = Vec::new();
+
+        for line in lines.iter().take(end + 1).skip(start) {
+            // Skip delimiter rows for width calculation (they only have dashes)
+            if Self::is_delimiter_row(line) {
+                continue;
+            }
+
+            let widths = Self::get_column_widths(line);
+            for (i, w) in widths.into_iter().enumerate() {
+                if i >= max_widths.len() {
+                    max_widths.push(w);
+                } else if w > max_widths[i] {
+                    max_widths[i] = w;
+                }
+            }
+        }
+
+        max_widths
+    }
+
+    /// Generate border from column widths
+    fn generate_border_from_widths(
+        widths: &[usize],
+        start_char: char,
+        mid_char: char,
+        end_char: char,
+    ) -> String {
+        if widths.is_empty() {
+            return String::new();
+        }
+
+        let mut result = String::new();
+        result.push(start_char);
+
+        for (i, &w) in widths.iter().enumerate() {
+            // Add 2 for padding (space on each side)
+            for _ in 0..(w + 2) {
+                result.push('─');
+            }
+            if i < widths.len() - 1 {
+                result.push(mid_char);
+            }
+        }
+
+        result.push(end_char);
+        result
+    }
+
+    /// Build column mapping for cursor position (buffer_col → visual_col)
+    ///
+    /// Maps each byte position in the original line to the corresponding
+    /// visual position in the expanded table row.
+    fn build_column_mapping(original: &str, max_widths: &[usize]) -> Vec<u16> {
+        let orig_len = original.len();
+        if orig_len == 0 || max_widths.is_empty() {
+            return Vec::new();
+        }
+
+        // Find pipe byte positions in original
+        let orig_pipes: Vec<usize> = original
+            .bytes()
+            .enumerate()
+            .filter(|(_, b)| *b == b'|')
+            .map(|(i, _)| i)
+            .collect();
+
+        if orig_pipes.len() < 2 {
+            return (0..orig_len as u16).collect();
+        }
+
+        // Calculate visual pipe positions
+        // Pattern: │ + " content " + │ + ...
+        // Each cell takes: (max_width + 2) chars for content, then │
+        // pipe[i] = pipe[i-1] + width[i-1] + 3
+        let mut visual_pipes = vec![0u16];
+        for &width in max_widths {
+            let prev = *visual_pipes.last().unwrap();
+            visual_pipes.push(prev + (width as u16) + 3);
+        }
+
+        // Build mapping for each buffer position
+        (0..orig_len)
+            .map(|buf_col| Self::map_to_visual(buf_col, &orig_pipes, &visual_pipes))
+            .collect()
+    }
+
+    /// Map a buffer column to visual column using pipe positions
+    ///
+    /// This mapping ensures cursor NEVER appears in padding areas:
+    /// - Pipe positions map exactly to visual pipe positions
+    /// - Leading space maps to visual leading space
+    /// - Content characters map at same offset from cell start
+    /// - Trailing space maps to visual trailing space (skipping padding)
+    fn map_to_visual(buf_col: usize, orig_pipes: &[usize], visual_pipes: &[u16]) -> u16 {
+        // Exact pipe match
+        if let Some(idx) = orig_pipes.iter().position(|&p| p == buf_col) {
+            return visual_pipes.get(idx).copied().unwrap_or(buf_col as u16);
+        }
+
+        // Find which segment (between pipes) we're in
+        let seg = orig_pipes
+            .iter()
+            .position(|&p| p > buf_col)
+            .unwrap_or(orig_pipes.len());
+
+        if seg == 0 || seg > orig_pipes.len() {
+            return buf_col as u16;
+        }
+
+        // We're in the cell between orig_pipes[seg-1] and orig_pipes[seg]
+        let buf_cell_start = orig_pipes[seg - 1] + 1;
+        let buf_cell_end = orig_pipes[seg];
+        let buf_cell_len = buf_cell_end - buf_cell_start;
+
+        let vis_cell_start = visual_pipes[seg - 1] + 1;
+        let vis_cell_end = visual_pipes[seg];
+
+        let pos_in_buf_cell = buf_col - buf_cell_start;
+
+        // Map based on position type:
+        // - pos 0: leading space → visual leading space
+        // - last pos (buf_cell_len-1): trailing space → visual trailing space (skips padding)
+        // - middle positions: content → same offset, clamped to content area
+        if pos_in_buf_cell == 0 {
+            // Leading space
+            vis_cell_start
+        } else if pos_in_buf_cell >= buf_cell_len.saturating_sub(1) {
+            // Trailing space - map to position right before next pipe (skips padding)
+            vis_cell_end.saturating_sub(1)
+        } else {
+            // Content - same offset from cell start, but clamped to content area
+            // Content area ends 1 before trailing space (which is 1 before pipe)
+            let max_content_pos = vis_cell_end.saturating_sub(2);
+            (vis_cell_start + pos_in_buf_cell as u16).min(max_content_pos)
+        }
+    }
+
+    /// Build expanded row with proper alignment
+    /// - Header rows: centered
+    /// - Data rows: left-aligned
+    fn build_expanded_row(line: &str, max_widths: &[usize], is_header: bool) -> String {
+        let cells = Self::parse_cells(line);
+        if cells.is_empty() {
+            return line.to_string();
+        }
+
+        let mut result = String::from("│");
+
+        for (i, cell) in cells.iter().enumerate() {
+            let width = max_widths.get(i).copied().unwrap_or(cell.chars().count());
+            let cell_len = cell.chars().count();
+
+            let padded = if is_header {
+                // CENTER align for headers
+                let total_pad = width.saturating_sub(cell_len);
+                let left_pad = total_pad / 2;
+                let right_pad = total_pad - left_pad;
+                format!(" {}{}{} ", " ".repeat(left_pad), cell, " ".repeat(right_pad))
+            } else {
+                // LEFT align for data rows
+                format!(" {:width$} ", cell, width = width)
+            };
+            result.push_str(&padded);
+            result.push('│');
+        }
+
+        result
+    }
+
+    /// Populate virtual lines for table borders and full-line conceals for all rows
+    /// Lines in `skip_lines` will not receive decorations (insert mode cursor, visual selection)
+    fn populate_table_borders(&self, input: &mut RenderData, skip_lines: &HashSet<usize>) {
+        let tables = Self::detect_tables(&input.lines);
+
+        // Default style for borders (dim gray)
+        let border_style = Style::new().fg(Color::Rgb {
+            r: 100,
+            g: 100,
+            b: 100,
+        });
+
+        for (start, end, delimiter) in tables {
+            let Some(delim_idx) = delimiter else {
+                continue;
+            };
+
+            // Calculate max column widths across ALL rows
+            let max_widths = Self::calculate_max_column_widths(&input.lines, start, end);
+            if max_widths.is_empty() {
+                continue;
+            }
+
+            // Generate top border from max widths
+            let top_border = Self::generate_border_from_widths(&max_widths, '┌', '┬', '┐');
+            if !top_border.is_empty() {
+                input.virtual_lines.insert(
+                    (start, VirtualLinePosition::Before),
+                    VirtualLineEntry {
+                        text: top_border,
+                        style: border_style.clone(),
+                        priority: 100,
+                    },
+                );
+            }
+
+            // Generate bottom border from max widths
+            let bottom_border = Self::generate_border_from_widths(&max_widths, '└', '┴', '┘');
+            if !bottom_border.is_empty() {
+                input.virtual_lines.insert(
+                    (end, VirtualLinePosition::After),
+                    VirtualLineEntry {
+                        text: bottom_border,
+                        style: border_style.clone(),
+                        priority: 100,
+                    },
+                );
+            }
+
+            // Apply full-line conceals for ALL table rows
+            for line_idx in start..=end {
+                if line_idx >= input.decorations.len() || line_idx >= input.lines.len() {
+                    continue;
+                }
+
+                // Skip decorations on lines marked for skipping (insert mode, visual selection)
+                if skip_lines.contains(&line_idx) {
+                    continue;
+                }
+
+                let line = &input.lines[line_idx];
+
+                let (replacement, col_mapping) = if line_idx == delim_idx {
+                    // Delimiter row → middle border (no cursor mapping needed)
+                    (Self::generate_border_from_widths(&max_widths, '├', '┼', '┤'), None)
+                } else if line_idx < delim_idx {
+                    // Header row → centered content
+                    let mapping = Self::build_column_mapping(line, &max_widths);
+                    (Self::build_expanded_row(line, &max_widths, true), Some(mapping))
+                } else {
+                    // Data row → left-aligned content
+                    let mapping = Self::build_column_mapping(line, &max_widths);
+                    (Self::build_expanded_row(line, &max_widths, false), Some(mapping))
+                };
+
+                if !replacement.is_empty() {
+                    // Clear existing decorations and add our full-line replacement
+                    input.decorations[line_idx].clear();
+                    input.decorations[line_idx].push(Decoration {
+                        start_col: 0,
+                        end_col: line.len(),
+                        kind: DecorationKind::Conceal {
+                            replacement: Some(replacement),
+                            col_mapping,
+                        },
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl Default for MarkdownTableBorderStage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderStage for MarkdownTableBorderStage {
+    fn transform(&self, mut input: RenderData, _ctx: &RenderContext<'_>) -> RenderData {
+        // Clone skip_decoration_lines to avoid borrow conflict
+        let skip_lines = input.skip_decoration_lines.clone();
+        self.populate_table_borders(&mut input, &skip_lines);
+        input
+    }
+
+    fn name(&self) -> &'static str {
+        "markdown-table-borders"
     }
 }
 
@@ -52,10 +430,14 @@ impl RenderStage for MarkdownRenderStage {
                             style,
                         } if span.start_line == line_num => {
                             let kind = if replacement.is_empty() {
-                                DecorationKind::Conceal { replacement: None }
+                                DecorationKind::Conceal {
+                                    replacement: None,
+                                    col_mapping: None,
+                                }
                             } else {
                                 DecorationKind::Conceal {
                                     replacement: Some(replacement.clone()),
+                                    col_mapping: None,
                                 }
                             };
 
@@ -71,7 +453,10 @@ impl RenderStage for MarkdownRenderStage {
                             Some(Decoration {
                                 start_col: span.start_col as usize,
                                 end_col: span.end_col as usize,
-                                kind: DecorationKind::Conceal { replacement: None },
+                                kind: DecorationKind::Conceal {
+                                    replacement: None,
+                                    col_mapping: None,
+                                },
                             })
                         }
                         reovim_core::decoration::Decoration::InlineStyle { span, style }
@@ -97,5 +482,421 @@ impl RenderStage for MarkdownRenderStage {
 
     fn name(&self) -> &'static str {
         "markdown"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_tables() {
+        let lines = vec![
+            "Some text".to_string(),
+            "| A | B |".to_string(),
+            "|---|---|".to_string(),
+            "| 1 | 2 |".to_string(),
+            "More text".to_string(),
+        ];
+
+        let tables = MarkdownTableBorderStage::detect_tables(&lines);
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0], (1, 3, Some(2))); // start=1, end=3, delimiter=2
+    }
+
+    #[test]
+    fn test_parse_cells() {
+        let cells = MarkdownTableBorderStage::parse_cells("| A | B |");
+        assert_eq!(cells, vec!["A", "B"]);
+
+        let cells = MarkdownTableBorderStage::parse_cells("| Long content | x |");
+        assert_eq!(cells, vec!["Long content", "x"]);
+    }
+
+    #[test]
+    fn test_get_column_widths() {
+        let widths = MarkdownTableBorderStage::get_column_widths("| A | B |");
+        assert_eq!(widths, vec![1, 1]);
+
+        let widths = MarkdownTableBorderStage::get_column_widths("| Long | x |");
+        assert_eq!(widths, vec![4, 1]);
+    }
+
+    #[test]
+    fn test_calculate_max_column_widths() {
+        let lines = vec![
+            "| h1 | h2 |".to_string(),
+            "|---|---|".to_string(),
+            "| Long content | x |".to_string(),
+        ];
+        let max_widths = MarkdownTableBorderStage::calculate_max_column_widths(&lines, 0, 2);
+        assert_eq!(max_widths, vec![12, 2]); // "Long content" = 12, "h2" = 2
+    }
+
+    #[test]
+    fn test_generate_border_from_widths() {
+        let widths = vec![1, 1];
+        let top = MarkdownTableBorderStage::generate_border_from_widths(&widths, '┌', '┬', '┐');
+        assert_eq!(top, "┌───┬───┐"); // width 1 + 2 padding = 3
+
+        let widths = vec![4, 2];
+        let middle = MarkdownTableBorderStage::generate_border_from_widths(&widths, '├', '┼', '┤');
+        assert_eq!(middle, "├──────┼────┤"); // 4+2=6, 2+2=4
+    }
+
+    #[test]
+    fn test_build_expanded_row_header_centered() {
+        let max_widths = vec![10, 4];
+        let row = MarkdownTableBorderStage::build_expanded_row("| h1 | h2 |", &max_widths, true);
+        // "h1" (2 chars) centered in 10 → 4 left pad, 4 right pad
+        // "h2" (2 chars) centered in 4 → 1 left pad, 1 right pad
+        assert_eq!(row, "│     h1     │  h2  │");
+    }
+
+    #[test]
+    fn test_build_expanded_row_data_left_aligned() {
+        let max_widths = vec![10, 4];
+        let row = MarkdownTableBorderStage::build_expanded_row("| data | x |", &max_widths, false);
+        // "data" (4 chars) left-aligned in 10 → 6 right pad
+        // "x" (1 char) left-aligned in 4 → 3 right pad
+        assert_eq!(row, "│ data       │ x    │");
+    }
+
+    #[test]
+    fn test_is_delimiter_row() {
+        assert!(MarkdownTableBorderStage::is_delimiter_row("|---|---|"));
+        assert!(MarkdownTableBorderStage::is_delimiter_row("| --- | --- |"));
+        assert!(MarkdownTableBorderStage::is_delimiter_row("|:---|---:|"));
+        assert!(!MarkdownTableBorderStage::is_delimiter_row("| A | B |"));
+        assert!(!MarkdownTableBorderStage::is_delimiter_row("no pipes"));
+    }
+
+    #[test]
+    fn test_populate_table_borders() {
+        use reovim_core::render::{Bounds, LineVisibility};
+
+        let stage = MarkdownTableBorderStage::new();
+
+        let mut input = RenderData {
+            lines: vec![
+                "| A | B |".to_string(),
+                "|---|---|".to_string(),
+                "| 1 | 2 |".to_string(),
+            ],
+            visibility: vec![LineVisibility::Visible; 3],
+            highlights: vec![Vec::new(); 3],
+            decorations: vec![Vec::new(); 3],
+            signs: vec![None; 3],
+            virtual_texts: vec![None; 3],
+            virtual_lines: std::collections::BTreeMap::new(),
+            buffer_id: 1,
+            window_id: 1,
+            window_bounds: Bounds {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            cursor: (0, 0),
+            skip_decoration_lines: HashSet::new(),
+        };
+
+        stage.populate_table_borders(&mut input, &HashSet::new());
+
+        // Should have top border before line 0
+        assert!(
+            input
+                .virtual_lines
+                .contains_key(&(0, VirtualLinePosition::Before))
+        );
+        let top = input
+            .virtual_lines
+            .get(&(0, VirtualLinePosition::Before))
+            .unwrap();
+        assert_eq!(top.text, "┌───┬───┐");
+
+        // Should have bottom border after line 2
+        assert!(
+            input
+                .virtual_lines
+                .contains_key(&(2, VirtualLinePosition::After))
+        );
+        let bottom = input
+            .virtual_lines
+            .get(&(2, VirtualLinePosition::After))
+            .unwrap();
+        assert_eq!(bottom.text, "└───┴───┘");
+
+        // Header row should have centered content with box drawing pipes
+        let header_deco = &input.decorations[0][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(header),
+            ..
+        } = &header_deco.kind
+        {
+            assert_eq!(header, "│ A │ B │");
+        } else {
+            panic!("Expected Conceal decoration with replacement for header");
+        }
+
+        // Delimiter row should have middle border
+        let delim_deco = &input.decorations[1][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(middle),
+            ..
+        } = &delim_deco.kind
+        {
+            assert_eq!(middle, "├───┼───┤");
+        } else {
+            panic!("Expected Conceal decoration with replacement for delimiter");
+        }
+
+        // Data row should have left-aligned content with box drawing pipes
+        let data_deco = &input.decorations[2][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(data),
+            ..
+        } = &data_deco.kind
+        {
+            assert_eq!(data, "│ 1 │ 2 │");
+        } else {
+            panic!("Expected Conceal decoration with replacement for data");
+        }
+    }
+
+    #[test]
+    fn test_populate_table_borders_unbalanced() {
+        use reovim_core::render::{Bounds, LineVisibility};
+
+        let stage = MarkdownTableBorderStage::new();
+
+        // Unbalanced table - data row is wider than header
+        // Max widths: ["Abcdeffase" = 11, "dfsfs" = 5, "dffdf" = 5]
+        let mut input = RenderData {
+            lines: vec![
+                "| h1 | h2 | h3 |".to_string(),
+                "|----|----|----|".to_string(),
+                "| Abcdeffase | dfsfs | dffdf |".to_string(),
+            ],
+            visibility: vec![LineVisibility::Visible; 3],
+            highlights: vec![Vec::new(); 3],
+            decorations: vec![Vec::new(); 3],
+            signs: vec![None; 3],
+            virtual_texts: vec![None; 3],
+            virtual_lines: std::collections::BTreeMap::new(),
+            buffer_id: 1,
+            window_id: 1,
+            window_bounds: Bounds {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            cursor: (0, 0),
+            skip_decoration_lines: HashSet::new(),
+        };
+
+        stage.populate_table_borders(&mut input, &HashSet::new());
+
+        // Borders now use MAX column widths: [10, 5, 5]
+        // "Abcdeffase" = 10 chars, "dfsfs" = 5 chars, "dffdf" = 5 chars
+        // Border width = content_width + 2 (for padding)
+
+        // Top border from max widths: 10+2=12, 5+2=7, 5+2=7
+        let top = input
+            .virtual_lines
+            .get(&(0, VirtualLinePosition::Before))
+            .unwrap();
+        assert_eq!(top.text, "┌────────────┬───────┬───────┐");
+
+        // Bottom border from max widths
+        let bottom = input
+            .virtual_lines
+            .get(&(2, VirtualLinePosition::After))
+            .unwrap();
+        assert_eq!(bottom.text, "└────────────┴───────┴───────┘");
+
+        // Middle border from max widths
+        let delim_decoration = &input.decorations[1][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(middle),
+            ..
+        } = &delim_decoration.kind
+        {
+            assert_eq!(middle, "├────────────┼───────┼───────┤");
+        } else {
+            panic!("Expected Conceal decoration with replacement");
+        }
+
+        // Header row should be centered within expanded widths
+        let header_decoration = &input.decorations[0][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(header),
+            ..
+        } = &header_decoration.kind
+        {
+            // "h1" (2 chars) centered in 10: pad = (10-2)=8, left=4, right=4
+            // format " {left_pad}{cell}{right_pad} " → " ____h1____ " (12 chars)
+            // "h2" (2 chars) centered in 5: pad = (5-2)=3, left=1, right=2
+            // format " {left_pad}{cell}{right_pad} " → "  h2   " (7 chars)
+            assert_eq!(header, "│     h1     │  h2   │  h3   │");
+        } else {
+            panic!("Expected Conceal decoration with replacement for header");
+        }
+
+        // Data row should be left-aligned within expanded widths
+        let data_decoration = &input.decorations[2][0];
+        if let DecorationKind::Conceal {
+            replacement: Some(data),
+            ..
+        } = &data_decoration.kind
+        {
+            assert_eq!(data, "│ Abcdeffase │ dfsfs │ dffdf │");
+        } else {
+            panic!("Expected Conceal decoration with replacement for data");
+        }
+    }
+
+    #[test]
+    fn test_build_column_mapping() {
+        // Simple table: | A | B |
+        // Original pipes at: 0, 4, 8
+        // max_widths = [1, 1]
+        // Visual:  │ A │ B │
+        // Visual pipes at: 0, 4, 8 (same as original for equal widths)
+        let mapping = MarkdownTableBorderStage::build_column_mapping("| A | B |", &[1, 1]);
+        assert_eq!(mapping[0], 0); // First pipe
+        assert_eq!(mapping[4], 4); // Second pipe
+        assert_eq!(mapping[8], 8); // Third pipe
+    }
+
+    #[test]
+    fn test_build_column_mapping_expanded() {
+        // Table with expanded widths
+        // Original: | h1 | h2 |
+        // Pipes at byte positions: 0, 5, 10
+        // max_widths = [4, 2]
+        // Visual: │ h1 │ h2 │  (padded to widths)
+        // Visual pipes: [0, 7, 12]
+        // pipe[0] = 0
+        // pipe[1] = 0 + 4 + 3 = 7
+        // pipe[2] = 7 + 2 + 3 = 12
+        let mapping = MarkdownTableBorderStage::build_column_mapping("| h1 | h2 |", &[4, 2]);
+
+        // Original: | h 1   |   h 2   |
+        // Position: 0 1 2 3 4 5 6 7 8 9 10
+        // Pipes at 0, 5, 10
+        assert_eq!(mapping[0], 0); // First pipe → 0
+        assert_eq!(mapping[5], 7); // Second pipe → 7
+        assert_eq!(mapping[10], 12); // Third pipe → 12
+    }
+
+    #[test]
+    fn test_column_mapping_in_decoration() {
+        use reovim_core::render::{Bounds, LineVisibility};
+
+        let stage = MarkdownTableBorderStage::new();
+
+        let mut input = RenderData {
+            lines: vec![
+                "| A | B |".to_string(),
+                "|---|---|".to_string(),
+                "| 1 | 2 |".to_string(),
+            ],
+            visibility: vec![LineVisibility::Visible; 3],
+            highlights: vec![Vec::new(); 3],
+            decorations: vec![Vec::new(); 3],
+            signs: vec![None; 3],
+            virtual_texts: vec![None; 3],
+            virtual_lines: std::collections::BTreeMap::new(),
+            buffer_id: 1,
+            window_id: 1,
+            window_bounds: Bounds {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            cursor: (0, 0),
+            skip_decoration_lines: HashSet::new(),
+        };
+
+        stage.populate_table_borders(&mut input, &HashSet::new());
+
+        // Header row should have column mapping
+        let header_deco = &input.decorations[0][0];
+        if let DecorationKind::Conceal { col_mapping, .. } = &header_deco.kind {
+            assert!(col_mapping.is_some(), "Header should have column mapping");
+            let mapping = col_mapping.as_ref().unwrap();
+            // Original: | A | B |
+            // Pipes at: 0, 4, 8
+            assert_eq!(mapping[0], 0); // First pipe
+            assert_eq!(mapping[4], 4); // Second pipe
+            assert_eq!(mapping[8], 8); // Third pipe
+        } else {
+            panic!("Expected Conceal decoration for header");
+        }
+
+        // Delimiter row should NOT have column mapping
+        let delim_deco = &input.decorations[1][0];
+        if let DecorationKind::Conceal { col_mapping, .. } = &delim_deco.kind {
+            assert!(col_mapping.is_none(), "Delimiter should not have column mapping");
+        }
+
+        // Data row should have column mapping
+        let data_deco = &input.decorations[2][0];
+        if let DecorationKind::Conceal { col_mapping, .. } = &data_deco.kind {
+            assert!(col_mapping.is_some(), "Data row should have column mapping");
+        }
+    }
+
+    #[test]
+    fn test_column_mapping_skips_padding() {
+        // Test that trailing space in buffer maps to visual trailing space, NOT padding
+        // Original: | foo | (7 chars)
+        // Pipes at: 0, 6
+        // Cell content: " foo " (positions 1-5)
+        // max_widths = [10] (expanded)
+        // Visual: │ foo          │ (14 chars)
+        // Visual pipes: [0, 13]
+        // Visual cell: positions 1-12
+        //   - Leading space: 1
+        //   - Content "foo": 2-4
+        //   - Padding: 5-11
+        //   - Trailing space: 12
+        let mapping = MarkdownTableBorderStage::build_column_mapping("| foo |", &[10]);
+
+        // Pipes map exactly
+        assert_eq!(mapping[0], 0, "First pipe should map to 0");
+        assert_eq!(mapping[6], 13, "Last pipe should map to 13");
+
+        // Leading space
+        assert_eq!(mapping[1], 1, "Leading space should map to 1");
+
+        // Content "foo"
+        assert_eq!(mapping[2], 2, "f should map to 2");
+        assert_eq!(mapping[3], 3, "o should map to 3");
+        assert_eq!(mapping[4], 4, "o should map to 4");
+
+        // Trailing space - should skip padding and map to position 12
+        assert_eq!(mapping[5], 12, "Trailing space should skip padding and map to 12");
+    }
+
+    #[test]
+    fn test_column_mapping_no_padding_overlap() {
+        // Test that no buffer position maps to padding area (positions 5-11 in visual)
+        let mapping = MarkdownTableBorderStage::build_column_mapping("| foo |", &[10]);
+
+        // Collect all mapped visual positions
+        let visual_positions: Vec<u16> = mapping.to_vec();
+
+        // Padding area is 5-11 - no buffer position should map there
+        for pos in &visual_positions {
+            assert!(
+                *pos < 5 || *pos > 11,
+                "Buffer position should not map to padding area (5-11), got {}",
+                pos
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Completes **Epic #89** (Enhanced Markdown Decorations) with all three phases, bringing markdown rendering to neovim-level visual experience.

---

## Phase 1: Heading Decorations (#90)

- **Heading indentation** by level (H1=0, H2=1 space, H3=2 spaces, etc.)
- **Inline code background** styling with backtick concealment
- **Link background** styling for distinct link appearance
- **Strikethrough** styling with `~~` marker concealment

## Phase 2: Horizontal Rules and Blockquotes (#91)

- **Horizontal rules**: `---`/`***`/`___` → full-width `────────────────` line
- **Blockquotes**: `>` → `│ ` vertical bar with background color

## Phase 3: Table Border Decorations (#92)

```
Before:                          After:
| Metric | v0.5.0 | v0.6.0 |    ┌────────┬────────┬────────┐
|--------|--------|--------|    │ Metric │ v0.5.0 │ v0.6.0 │
| RTT    | 55 µs  | 108 µs |    ├────────┼────────┼────────┤
| Render | 14 µs  | 62 µs  |    │ RTT    │ 55 µs  │ 108 µs │
                                │ Render │ 14 µs  │ 62 µs  │
                                └────────┴────────┴────────┘
```

- **Virtual lines system** for top/bottom table borders
- **MarkdownTableBorderStage** with unicode box-drawing characters
- **Cell expansion** to uniform width with proper padding

---

## Additional Fixes

- **Cursor positioning**: Added `col_mapping` to `DecorationKind::Conceal` - cursor no longer moves into blank padding areas
- **Visual mode**: Added `skip_decoration_lines` - visual selection now shows raw markdown (like insert mode)

---

## Test Plan

- [x] `./scripts/check.sh` passes (format, build, clippy, all tests)
- [x] Visual testing: heading indentation works
- [x] Visual testing: inline code/links/strikethrough styled correctly
- [x] Visual testing: horizontal rules render as full-width lines
- [x] Visual testing: blockquotes have vertical bar and background
- [x] Visual testing: table borders render with unicode box-drawing chars
- [x] Visual testing: cursor doesn't move into padding areas
- [x] Visual testing: visual mode disables decorations on selected lines

---

Closes #89, closes #90, closes #91, closes #92