### PR TITLE
feat(arch): add Phase 0 skeleton structure for Linux-inspired architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Phase 0: Architecture Skeleton** (Issue #152) - Foundation for Linux-inspired architecture
+  - Created `lib/arch/` - Platform abstraction layer (no dependencies)
+  - Created `lib/kernel/` - Core mechanisms layer (depends only on arch)
+  - Created `lib/drivers/` - 6 driver crates (display, input, syntax, lsp, net, vfs)
+  - All crates are empty skeletons that compile with zero warnings
+  - Dependency graph enforced: arch → kernel → drivers
+  - `lib/drivers/syntax` has NO tree-sitter dependency (trait definitions only)
+
 - **Enhanced Markdown Decorations** (Epic #89) - Complete markdown rendering overhaul
   - **Phase 1: Heading Decorations** (#90)
     - Heading indentation by level (H1=0, H2=1 space, H3=2 spaces, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,45 +344,12 @@ Reovim is a Rust-based neovim-like text editor built with async tokio runtime an
 
 1.92 (Rust 2024 edition)
 
-### Performance (v0.6.0)
-
-v0.6.0 uses diff-based rendering via FrameBuffer, trading per-render overhead for zero flickering:
-
-| Metric | v0.5.0 | v0.6.0 |
-|--------|--------|--------|
-| Window render (10 lines) | 1.63 µs | 10.15 µs |
-| Full screen render | 14.50 µs | 62.41 µs |
-| Char insert RTT | 55 µs | 108 µs |
-| Move down RTT | 751 µs | 806 µs |
-| Throughput | ~144k/sec | ~18k/sec |
-
-**Key benefit**: Only changed cells sent to terminal, eliminating flickering.
-
 ## Release Process
 
-### Version Bump
-
-Use the bump-version script to update version across the workspace:
-
-```bash
-./scripts/bump-version.sh 0.X.Y
-```
-
-This script:
-- Updates `version` in workspace `Cargo.toml`
-- Updates `reovim-core` and `reovim-sys` dependency versions
-- Runs `cargo check` to verify
-
-### Release Checklist
-
-1. Bump version using `./scripts/bump-version.sh X.Y.Z`
-2. Update `CHANGELOG.md` with new version entry
-3. Run `cargo build` and `cargo clippy` (zero warnings required)
-4. Run `cargo test`
 
 ### Git Commits
 
-**IMPORTANT**: Claude should NEVER handle git commits. The user will manage ALL git operations. Claude must not have any "opinion" about when or how to commit - only create proposals and let the user decide.
+**IMPORTANT**: Claude should NEVER handle git commits. The user will manage ALL git operations. Claude must not have any "opinion" about when or how to commit - only create proposals and let the user decide. And Never add emoji on below
 
 **Changelog Convention**: Every feature, fix, or notable change MUST include an update to `CHANGELOG.md` under the `[Unreleased]` section before proposing a commit.
 
@@ -395,14 +362,10 @@ For any changes, Claude should create a proposal file at `tmp/<feature-name>-com
 ### Ready-to-Take-Off & Request-for-Landing
 
 **Ready-to-Take-Off (Start of Work):**
-1. Read `tmp/*` for context from previous sessions
+1. Use `gh issue` for view issues or Read `tmp/*` for context from previous sessions
 2. Check `git worktree list` for active branches
 3. Check `git status` for uncommitted work
 4. Understand the task and plan implementation
-5. **Suggest a runway (branch)** for the work:
-   - `develop` - Upstream, main development branch
-   - `feat/*` - Feature branches
-   - `fix/*` - Bug fix branches
 
 **Request-for-Landing (End of Work):**
 1. **Sync with upstream (CRUCIAL)**:
@@ -465,70 +428,3 @@ For in-depth information, see:
 - [docs/plugins/system.md](./docs/plugins/system.md) - Plugin development with unified pattern
 - [docs/guides/development.md](./docs/guides/development.md) - Development guide
 - [docs/guides/testing.md](./docs/guides/testing.md) - Testing guide
-
-### Creating Plugin Commands (Modern Pattern)
-
-When adding new plugin commands, use the unified command-event pattern:
-
-**Zero-sized commands:**
-```rust
-use reovim_core::declare_event_command;
-
-declare_event_command! {
-    MyAction,
-    id: "my_action",
-    description: "Perform my action",
-}
-```
-
-**Counted commands (with repeat count):**
-```rust
-use reovim_core::declare_counted_event_command;
-
-declare_counted_event_command! {
-    MyMove,
-    id: "my_move",
-    description: "Move by count",
-}
-```
-
-**Commands with custom data:**
-```rust
-#[derive(Debug, Clone, Copy)]
-pub struct MyInputChar {
-    pub c: char,
-}
-
-impl Event for MyInputChar {
-    fn priority(&self) -> u32 { 100 }
-}
-```
-
-See `plugins/features/explorer/src/command.rs` for a complete example with all three patterns.
-
-### Registering Plugin Settings (Extensible Settings System)
-
-Plugins can register settings to appear in the settings menu using `RegisterSettingSection` and `RegisterOption` events:
-
-```rust
-use reovim_core::option::{
-    RegisterSettingSection, RegisterOption, OptionSpec, OptionValue,
-    OptionCategory, OptionConstraint,
-};
-
-fn subscribe(&self, bus: &EventBus, _state: Arc<PluginStateRegistry>) {
-    // Register a settings section (optional - auto-created from category if omitted)
-    bus.emit(RegisterSettingSection::new("my_plugin", "My Plugin")
-        .with_description("Plugin settings")
-        .with_order(100));  // Core sections use 0-50
-
-    // Register options
-    bus.emit(RegisterOption::new(
-        OptionSpec::new("enabled", "Enable feature", OptionValue::Bool(true))
-            .with_section("My Plugin")
-            .with_display_order(10),
-    ));
-}
-```
-
-See `lib/core/src/plugin/builtin/core.rs` for a complete example of registering core settings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "reovim-arch"
+version = "0.8.0"
+
+[[package]]
 name = "reovim-bench"
 version = "0.8.0"
 dependencies = [
@@ -1615,6 +1619,55 @@ dependencies = [
  "tree-sitter-toml-ng",
  "unicode-width",
  "walkdir",
+]
+
+[[package]]
+name = "reovim-driver-display"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-driver-input"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-driver-lsp"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-driver-net"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-driver-syntax"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-driver-vfs"
+version = "0.8.0"
+dependencies = [
+ "reovim-kernel",
+]
+
+[[package]]
+name = "reovim-kernel"
+version = "0.8.0"
+dependencies = [
+ "reovim-arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,30 @@
 [workspace]
-members = ["lib/*", "runner/", "tools/*", "plugins/features/*", "plugins/languages/*"]
+members = [
+    # Existing lib crates
+    "lib/core",
+    "lib/sys",
+    "lib/lsp",
+
+    # New architecture layers
+    "lib/arch",
+    "lib/kernel",
+
+    # New driver crates
+    "lib/drivers/display",
+    "lib/drivers/input",
+    "lib/drivers/syntax",
+    "lib/drivers/lsp",
+    "lib/drivers/net",
+    "lib/drivers/vfs",
+
+    # Runner and tools
+    "runner/",
+    "tools/*",
+
+    # Plugins
+    "plugins/features/*",
+    "plugins/languages/*",
+]
 default-members = ["runner/"]
 resolver = "2"
 
@@ -50,6 +75,18 @@ chrono = "0.4"
 reovim-core = { path = "./lib/core", version = "0.8.0" }
 reovim-sys = { path = "./lib/sys", version = "0.8.0" }
 reovim-lsp = { path = "./lib/lsp", version = "0.8.0" }
+
+# new architecture crates
+reovim-arch = { path = "./lib/arch", version = "0.8.0" }
+reovim-kernel = { path = "./lib/kernel", version = "0.8.0" }
+
+# new driver crates
+reovim-driver-display = { path = "./lib/drivers/display", version = "0.8.0" }
+reovim-driver-input = { path = "./lib/drivers/input", version = "0.8.0" }
+reovim-driver-syntax = { path = "./lib/drivers/syntax", version = "0.8.0" }
+reovim-driver-lsp = { path = "./lib/drivers/lsp", version = "0.8.0" }
+reovim-driver-net = { path = "./lib/drivers/net", version = "0.8.0" }
+reovim-driver-vfs = { path = "./lib/drivers/vfs", version = "0.8.0" }
 
 # plugins
 reovim-plugin-range-finder = { path = "./plugins/features/range-finder", version = "0.8.0" }

--- a/lib/arch/Cargo.toml
+++ b/lib/arch/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "reovim-arch"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Platform abstraction layer for reovim (Linux arch/ equivalent)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+# NO DEPENDENCIES - this layer depends only on std
+[dependencies]

--- a/lib/arch/src/error.rs
+++ b/lib/arch/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for architecture layer.
+
+use std::fmt;
+
+/// Architecture layer error.
+#[derive(Debug)]
+pub enum ArchError {
+    /// I/O error from platform.
+    Io(std::io::Error),
+    /// Feature not supported on this platform.
+    NotSupported(&'static str),
+}
+
+impl fmt::Display for ArchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::NotSupported(feature) => write!(f, "Not supported: {feature}"),
+        }
+    }
+}
+
+impl std::error::Error for ArchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::NotSupported(_) => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ArchError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}

--- a/lib/arch/src/lib.rs
+++ b/lib/arch/src/lib.rs
@@ -1,0 +1,23 @@
+//! Platform abstraction layer for reovim.
+//!
+//! Linux equivalent: `arch/`
+//!
+//! This crate provides platform-agnostic traits for terminal I/O,
+//! signal handling, and memory operations. All code above this layer
+//! is platform-independent.
+//!
+//! # Architecture
+//!
+//! - `traits`: Platform-agnostic trait definitions
+//! - `error`: Error types for arch operations
+//! - `unix`: Unix/Linux implementation (cfg(unix))
+//! - `windows`: Windows implementation (cfg(windows))
+
+pub mod error;
+pub mod traits;
+
+#[cfg(unix)]
+pub mod unix;
+
+#[cfg(windows)]
+pub mod windows;

--- a/lib/arch/src/traits.rs
+++ b/lib/arch/src/traits.rs
@@ -1,0 +1,13 @@
+//! Platform-agnostic trait definitions.
+//!
+//! These traits define the interface between the kernel and platform-specific
+//! implementations. Linux equivalent: platform-independent kernel headers.
+
+// Placeholder for Terminal trait
+// pub trait Terminal: Send + Sync { ... }
+
+// Placeholder for InputSource trait
+// pub trait InputSource: Send + Sync { ... }
+
+// Placeholder for SignalHandler trait
+// pub trait SignalHandler: Send + Sync { ... }

--- a/lib/arch/src/unix/mod.rs
+++ b/lib/arch/src/unix/mod.rs
@@ -1,0 +1,5 @@
+//! Unix/Linux platform implementation.
+//!
+//! Linux equivalent: `arch/x86/`, `arch/arm64/`, etc.
+
+// Placeholder module - implementations will be added in Phase 1

--- a/lib/arch/src/windows/mod.rs
+++ b/lib/arch/src/windows/mod.rs
@@ -1,0 +1,5 @@
+//! Windows platform implementation.
+//!
+//! Provides Windows Console API integration.
+
+// Placeholder module - implementations will be added in Phase 1

--- a/lib/drivers/display/Cargo.toml
+++ b/lib/drivers/display/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-driver-display"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Display driver for reovim (frame buffer, compositor, windows)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/display/src/lib.rs
+++ b/lib/drivers/display/src/lib.rs
@@ -1,0 +1,14 @@
+//! Display driver for reovim.
+//!
+//! Linux equivalent: `drivers/video/`, `drivers/gpu/`
+//!
+//! Provides frame buffer management, layer compositing, and window management.
+//!
+//! # Components
+//!
+//! - Frame buffer (2D cell grid)
+//! - Compositor (layer blending, z-order)
+//! - Window manager (splits, tabs, layout)
+//! - Terminal renderer (ANSI output)
+
+// Placeholder - DisplayDriver trait and implementations will be added in Phase 3

--- a/lib/drivers/input/Cargo.toml
+++ b/lib/drivers/input/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-driver-input"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Input driver for reovim (keyboard, mouse, clipboard)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/input/src/lib.rs
+++ b/lib/drivers/input/src/lib.rs
@@ -1,0 +1,13 @@
+//! Input driver for reovim.
+//!
+//! Linux equivalent: `drivers/input/`
+//!
+//! Provides keyboard event handling, mouse support, and clipboard operations.
+//!
+//! # Components
+//!
+//! - Keyboard broker (key event dispatch)
+//! - Mouse broker (click, scroll, drag)
+//! - Clipboard backend (system clipboard integration)
+
+// Placeholder - InputDriver trait and implementations will be added in Phase 3

--- a/lib/drivers/lsp/Cargo.toml
+++ b/lib/drivers/lsp/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-driver-lsp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "LSP driver for reovim (Language Server Protocol client)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/lsp/src/lib.rs
+++ b/lib/drivers/lsp/src/lib.rs
@@ -1,0 +1,12 @@
+//! LSP driver for reovim.
+//!
+//! Provides Language Server Protocol client infrastructure.
+//!
+//! # Components
+//!
+//! - LSP client (server connection, message handling)
+//! - Protocol types (requests, responses, notifications)
+//! - Diagnostic cache (lock-free diagnostic storage)
+
+// Placeholder - LspDriver trait will be added in Phase 3
+// Note: Will eventually absorb functionality from lib/lsp

--- a/lib/drivers/net/Cargo.toml
+++ b/lib/drivers/net/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-driver-net"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Network driver for reovim (RPC server, transports)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/net/src/lib.rs
+++ b/lib/drivers/net/src/lib.rs
@@ -1,0 +1,14 @@
+//! Network driver for reovim.
+//!
+//! Linux equivalent: `drivers/net/`, `net/`
+//!
+//! Provides RPC server infrastructure and transport abstractions.
+//!
+//! # Components
+//!
+//! - RPC server (JSON-RPC 2.0)
+//! - Transport layer (TCP, Unix socket, stdio)
+//! - Request handlers
+
+// Placeholder - NetDriver trait will be added in Phase 3
+// Note: Will eventually absorb functionality from lib/core/src/rpc/

--- a/lib/drivers/syntax/Cargo.toml
+++ b/lib/drivers/syntax/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "reovim-driver-syntax"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Syntax highlighting driver for reovim (trait definitions only)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+# NOTE: NO tree-sitter! That's an implementation detail of language modules.
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/syntax/src/lib.rs
+++ b/lib/drivers/syntax/src/lib.rs
@@ -1,0 +1,23 @@
+//! Syntax highlighting driver for reovim.
+//!
+//! **IMPORTANT:** This crate defines ONLY the trait interface for syntax
+//! highlighting. It does NOT depend on tree-sitter or any parsing library.
+//! Those are implementation details of language modules (plugins/languages/*).
+//!
+//! # Architecture
+//!
+//! ```text
+//! lib/drivers/syntax/     <-- Trait definitions (this crate)
+//!        ^
+//!        |
+//! plugins/languages/*     <-- Implementations (tree-sitter, etc.)
+//! ```
+//!
+//! # Components
+//!
+//! - `SyntaxDriver` trait (parsing, highlighting)
+//! - `LanguageRegistry` (language discovery)
+//! - Highlight cache infrastructure
+
+// Placeholder - SyntaxDriver trait will be added in Phase 3
+// NO tree-sitter imports allowed here!

--- a/lib/drivers/vfs/Cargo.toml
+++ b/lib/drivers/vfs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-driver-vfs"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Virtual filesystem driver for reovim"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on kernel layer
+reovim-kernel = { path = "../../kernel", version = "0.8.0" }

--- a/lib/drivers/vfs/src/lib.rs
+++ b/lib/drivers/vfs/src/lib.rs
@@ -1,0 +1,13 @@
+//! Virtual filesystem driver for reovim.
+//!
+//! Linux equivalent: `fs/`
+//!
+//! Provides filesystem abstraction for file operations and watching.
+//!
+//! # Components
+//!
+//! - Local filesystem operations
+//! - File watcher integration
+//! - Path normalization
+
+// Placeholder - VfsDriver trait will be added in Phase 3

--- a/lib/kernel/Cargo.toml
+++ b/lib/kernel/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reovim-kernel"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Core kernel mechanisms for reovim (Linux kernel/ equivalent)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Only depends on arch layer
+reovim-arch = { path = "../arch", version = "0.8.0" }

--- a/lib/kernel/src/api/mod.rs
+++ b/lib/kernel/src/api/mod.rs
@@ -1,0 +1,9 @@
+//! Stable kernel API.
+//!
+//! Linux equivalent: `include/linux/`
+//!
+//! Defines the stable interface that drivers and modules can depend on.
+//! Breaking changes require a new API version.
+
+/// API version for compatibility checking.
+pub const API_VERSION: (u32, u32, u32) = (0, 1, 0);

--- a/lib/kernel/src/block/mod.rs
+++ b/lib/kernel/src/block/mod.rs
@@ -1,0 +1,5 @@
+//! Block operations subsystem.
+//!
+//! Provides undo tree, change history, and atomic transactions.
+
+// Placeholder - UndoTree, History, Transaction will be added in Phase 2

--- a/lib/kernel/src/core/mod.rs
+++ b/lib/kernel/src/core/mod.rs
@@ -1,0 +1,5 @@
+//! Core primitives.
+//!
+//! Provides motion calculations, text object handling, and command dispatch.
+
+// Placeholder - Motion, TextObject, Command will be added in Phase 2

--- a/lib/kernel/src/debug/mod.rs
+++ b/lib/kernel/src/debug/mod.rs
@@ -1,0 +1,5 @@
+//! Debug and tracing subsystem.
+//!
+//! Provides tracing infrastructure, metrics collection, and profiling.
+
+// Placeholder - Trace, Metrics, Profiler will be added in Phase 2

--- a/lib/kernel/src/ipc/mod.rs
+++ b/lib/kernel/src/ipc/mod.rs
@@ -1,0 +1,7 @@
+//! Inter-process communication subsystem.
+//!
+//! Linux equivalent: `ipc/`
+//!
+//! Provides event bus, channels, and synchronization primitives.
+
+// Placeholder - EventBus, Channel, Scope, Signal will be added in Phase 2

--- a/lib/kernel/src/lib.rs
+++ b/lib/kernel/src/lib.rs
@@ -1,0 +1,29 @@
+//! Core kernel mechanisms for reovim.
+//!
+//! Linux equivalent: `kernel/`
+//!
+//! This crate provides pure mechanisms without I/O. Drivers and modules
+//! implement policies using these primitives.
+//!
+//! # Subsystems
+//!
+//! - `sched`: Scheduler and runtime (Linux: `kernel/sched/`)
+//! - `mm`: Memory management / buffers (Linux: `mm/`)
+//! - `ipc`: Inter-process communication / events (Linux: `ipc/`)
+//! - `core`: Core primitives (motion, text objects, commands)
+//! - `block`: Block operations (undo, transactions)
+//! - `api`: Stable kernel API (Linux: `include/linux/`)
+//! - `debug`: Tracing and metrics
+//! - `panic`: Panic handling and recovery
+
+pub mod api;
+pub mod block;
+pub mod core;
+pub mod debug;
+pub mod ipc;
+pub mod mm;
+pub mod panic;
+pub mod sched;
+
+// Re-export arch for convenience
+pub use reovim_arch as arch;

--- a/lib/kernel/src/mm/mod.rs
+++ b/lib/kernel/src/mm/mod.rs
@@ -1,0 +1,7 @@
+//! Memory management subsystem.
+//!
+//! Linux equivalent: `mm/`
+//!
+//! Provides buffer storage, rope data structures, and memory pooling.
+
+// Placeholder - Buffer, Rope, Cache, Pool will be added in Phase 2

--- a/lib/kernel/src/panic/mod.rs
+++ b/lib/kernel/src/panic/mod.rs
@@ -1,0 +1,5 @@
+//! Panic handling subsystem.
+//!
+//! Provides custom panic handlers, crash recovery, and state dumping.
+
+// Placeholder - Handler, Recovery, Report will be added in Phase 2

--- a/lib/kernel/src/sched/mod.rs
+++ b/lib/kernel/src/sched/mod.rs
@@ -1,0 +1,7 @@
+//! Scheduler subsystem.
+//!
+//! Linux equivalent: `kernel/sched/`
+//!
+//! Provides the main runtime loop, task execution, and work queues.
+
+// Placeholder - Runtime, Executor, Task, WorkQueue will be added in Phase 2


### PR DESCRIPTION
Create empty crate skeleton for the new microkernel-inspired architecture.
This establishes the foundation for Phase 1+ migration without changing
existing lib/core behavior.

New crates:
- lib/arch: Platform abstraction layer (no dependencies)
- lib/kernel: Core mechanisms (depends only on arch)
- lib/drivers/display: Frame buffer, compositor, windows
- lib/drivers/input: Keyboard, mouse, clipboard
- lib/drivers/syntax: Syntax highlighting (NO tree-sitter!)
- lib/drivers/lsp: LSP client infrastructure
- lib/drivers/net: RPC server, transports
- lib/drivers/vfs: Virtual filesystem

Dependency graph enforced:
  lib/arch → no deps
  lib/kernel → only arch
  lib/drivers/* → only kernel

Closes https://github.com/ds1sqe/reovim/issues/152