### PR TITLE
feat(arch): implement platform traits and Unix backend (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ All notable changes to Reovim will be documented in this file.
 
 ### Added
 
+- **Phase 1: Platform Traits and Unix Backend** (Issue #156) - Architecture layer implementation
+  - Defined platform-agnostic traits in `lib/arch/src/traits.rs`:
+    - `Terminal` trait - terminal I/O abstraction (size, raw mode, cursor, screen, mouse)
+    - `InputSource` trait - input event polling and reading
+    - `SignalHandler` trait - signal registration (resize, interrupt, suspend)
+  - Platform-agnostic types: `TerminalSize`, `KeyEvent`, `KeyCode`, `Modifiers`, `MouseEvent`, `InputEvent`, `ClearType`, `RawModeGuard`
+  - Unix backend (`lib/arch/src/unix/`) using crossterm:
+    - `UnixTerminal` - full Terminal trait implementation
+    - `UnixInputSource` - event polling and reading
+    - `UnixSignalHandler` - signal handler placeholder (crossterm handles signals internally)
+    - Type conversion functions from crossterm types
+  - Windows stubs (`lib/arch/src/windows/`) - all methods return `todo!()`
+  - Platform-specific type aliases: `PlatformTerminal`, `PlatformInputSource`, `PlatformSignalHandler`
+
 - **Phase 0: Architecture Skeleton** (Issue #152) - Foundation for Linux-inspired architecture
   - Created `lib/arch/` - Platform abstraction layer (no dependencies)
   - Created `lib/kernel/` - Core mechanisms layer (depends only on arch)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,9 @@ dependencies = [
 [[package]]
 name = "reovim-arch"
 version = "0.8.0"
+dependencies = [
+ "crossterm",
+]
 
 [[package]]
 name = "reovim-bench"

--- a/lib/arch/Cargo.toml
+++ b/lib/arch/Cargo.toml
@@ -12,5 +12,9 @@ categories.workspace = true
 [lints]
 workspace = true
 
-# NO DEPENDENCIES - this layer depends only on std
+# Traits have no dependencies (std only)
+# Platform implementations use crossterm
 [dependencies]
+
+[target.'cfg(unix)'.dependencies]
+crossterm.workspace = true

--- a/lib/arch/src/lib.rs
+++ b/lib/arch/src/lib.rs
@@ -3,21 +3,54 @@
 //! Linux equivalent: `arch/`
 //!
 //! This crate provides platform-agnostic traits for terminal I/O,
-//! signal handling, and memory operations. All code above this layer
+//! signal handling, and input events. All code above this layer
 //! is platform-independent.
 //!
 //! # Architecture
 //!
-//! - `traits`: Platform-agnostic trait definitions
+//! - `traits`: Platform-agnostic trait definitions and types
 //! - `error`: Error types for arch operations
-//! - `unix`: Unix/Linux implementation (cfg(unix))
-//! - `windows`: Windows implementation (cfg(windows))
+//! - `unix`: Unix/Linux implementation using crossterm (cfg(unix))
+//! - `windows`: Windows implementation stubs (cfg(windows))
+//!
+//! # Usage
+//!
+//! The crate provides platform-specific type aliases for convenience:
+//!
+//! ```ignore
+//! use reovim_arch::{PlatformTerminal, PlatformInputSource, Terminal, InputSource};
+//!
+//! let mut term = PlatformTerminal::new();
+//! let size = term.size()?;
+//! println!("Terminal size: {}x{}", size.cols, size.rows);
+//! ```
+//!
+//! # Platform Support
+//!
+//! - **Unix/Linux/macOS**: Full support via crossterm
+//! - **Windows**: Stub implementation (todo!() for all methods)
 
 pub mod error;
 pub mod traits;
+
+// Re-export all public types from traits
+pub use traits::*;
 
 #[cfg(unix)]
 pub mod unix;
 
 #[cfg(windows)]
 pub mod windows;
+
+// Platform-specific type aliases for convenience
+#[cfg(unix)]
+pub use unix::{
+    UnixInputSource as PlatformInputSource, UnixSignalHandler as PlatformSignalHandler,
+    UnixTerminal as PlatformTerminal,
+};
+
+#[cfg(windows)]
+pub use windows::{
+    WindowsInputSource as PlatformInputSource, WindowsSignalHandler as PlatformSignalHandler,
+    WindowsTerminal as PlatformTerminal,
+};

--- a/lib/arch/src/traits.rs
+++ b/lib/arch/src/traits.rs
@@ -2,12 +2,603 @@
 //!
 //! These traits define the interface between the kernel and platform-specific
 //! implementations. Linux equivalent: platform-independent kernel headers.
+//!
+//! All types defined here have NO external dependencies (std only).
 
-// Placeholder for Terminal trait
-// pub trait Terminal: Send + Sync { ... }
+use std::io;
+use std::time::Duration;
 
-// Placeholder for InputSource trait
-// pub trait InputSource: Send + Sync { ... }
+// =============================================================================
+// Terminal Size
+// =============================================================================
 
-// Placeholder for SignalHandler trait
-// pub trait SignalHandler: Send + Sync { ... }
+/// Terminal size with pixel dimensions for advanced rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TerminalSize {
+    /// Number of columns (characters).
+    pub cols: u16,
+    /// Number of rows (characters).
+    pub rows: u16,
+    /// Pixel width (if available, 0 otherwise).
+    pub pixel_width: u16,
+    /// Pixel height (if available, 0 otherwise).
+    pub pixel_height: u16,
+}
+
+impl TerminalSize {
+    /// Create a new terminal size.
+    #[must_use]
+    pub const fn new(cols: u16, rows: u16) -> Self {
+        Self {
+            cols,
+            rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
+    /// Create a new terminal size with pixel dimensions.
+    #[must_use]
+    pub const fn with_pixels(cols: u16, rows: u16, pixel_width: u16, pixel_height: u16) -> Self {
+        Self {
+            cols,
+            rows,
+            pixel_width,
+            pixel_height,
+        }
+    }
+}
+
+// =============================================================================
+// Key Modifiers
+// =============================================================================
+
+/// Key modifiers (bitflags-style, no external dependencies).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Modifiers(u8);
+
+impl Modifiers {
+    /// No modifiers.
+    pub const NONE: Self = Self(0);
+    /// Shift key.
+    pub const SHIFT: Self = Self(1 << 0);
+    /// Control key.
+    pub const CTRL: Self = Self(1 << 1);
+    /// Alt/Option key.
+    pub const ALT: Self = Self(1 << 2);
+    /// Super/Meta/Command key.
+    pub const SUPER: Self = Self(1 << 3);
+    /// Hyper key (rare).
+    pub const HYPER: Self = Self(1 << 4);
+    /// Meta key (rare, distinct from Super on some systems).
+    pub const META: Self = Self(1 << 5);
+
+    /// Check if a modifier is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Combine two modifier sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Check if no modifiers are set.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Get the raw bits.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// Create from raw bits.
+    #[must_use]
+    pub const fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+}
+
+impl std::ops::BitOr for Modifiers {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl std::ops::BitOrAssign for Modifiers {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+// =============================================================================
+// Key Codes
+// =============================================================================
+
+/// Platform-agnostic key codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyCode {
+    /// A character key.
+    Char(char),
+    /// Function key (F1-F12, or higher on some terminals).
+    F(u8),
+    /// Backspace key.
+    Backspace,
+    /// Enter/Return key.
+    Enter,
+    /// Tab key.
+    Tab,
+    /// Backspace in some terminals.
+    BackTab,
+    /// Escape key.
+    Escape,
+    /// Arrow keys.
+    Up,
+    Down,
+    Left,
+    Right,
+    /// Navigation keys.
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    /// Editing keys.
+    Insert,
+    Delete,
+    /// Null character (Ctrl+@).
+    Null,
+    /// Caps lock (if reported).
+    CapsLock,
+    /// Scroll lock (if reported).
+    ScrollLock,
+    /// Num lock (if reported).
+    NumLock,
+    /// Print screen (if reported).
+    PrintScreen,
+    /// Pause key (if reported).
+    Pause,
+    /// Menu key (if reported).
+    Menu,
+    /// Keypad begin (center key on keypad).
+    KeypadBegin,
+    /// Media keys.
+    MediaPlay,
+    MediaPause,
+    MediaPlayPause,
+    MediaStop,
+    MediaReverse,
+    MediaFastForward,
+    MediaRewind,
+    MediaNext,
+    MediaPrevious,
+    MediaRecord,
+    MediaLowerVolume,
+    MediaRaiseVolume,
+    MediaMuteVolume,
+    /// Modifier keys (if reported as separate events).
+    LeftShift,
+    RightShift,
+    LeftCtrl,
+    RightCtrl,
+    LeftAlt,
+    RightAlt,
+    LeftSuper,
+    RightSuper,
+    LeftHyper,
+    RightHyper,
+    LeftMeta,
+    RightMeta,
+    IsoLevel3Shift,
+    IsoLevel5Shift,
+}
+
+/// Key event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum KeyEventKind {
+    /// Key was pressed.
+    #[default]
+    Press,
+    /// Key is being held (repeat).
+    Repeat,
+    /// Key was released.
+    Release,
+}
+
+/// Key event state (for enhanced keyboard protocols).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct KeyEventState(u8);
+
+impl KeyEventState {
+    /// No state.
+    pub const NONE: Self = Self(0);
+    /// Key is from keypad.
+    pub const KEYPAD: Self = Self(1 << 0);
+    /// Caps lock is active.
+    pub const CAPS_LOCK: Self = Self(1 << 1);
+    /// Num lock is active.
+    pub const NUM_LOCK: Self = Self(1 << 2);
+
+    /// Check if a state flag is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Combine two state sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Check if no state flags are set.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+/// Key event with modifiers and kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyEvent {
+    /// The key code.
+    pub code: KeyCode,
+    /// Active modifiers.
+    pub modifiers: Modifiers,
+    /// Event kind (press, repeat, release).
+    pub kind: KeyEventKind,
+    /// Additional state (keypad, caps lock, etc.).
+    pub state: KeyEventState,
+}
+
+impl KeyEvent {
+    /// Create a new key event with just a key code.
+    #[must_use]
+    pub const fn new(code: KeyCode) -> Self {
+        Self {
+            code,
+            modifiers: Modifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    /// Create a key event with modifiers.
+    #[must_use]
+    pub const fn with_modifiers(code: KeyCode, modifiers: Modifiers) -> Self {
+        Self {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+}
+
+// =============================================================================
+// Mouse Events
+// =============================================================================
+
+/// Mouse button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// Left mouse button.
+    Left,
+    /// Right mouse button.
+    Right,
+    /// Middle mouse button (wheel click).
+    Middle,
+}
+
+/// Mouse event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseEventKind {
+    /// Button pressed down.
+    Down(MouseButton),
+    /// Button released.
+    Up(MouseButton),
+    /// Mouse dragged with button held.
+    Drag(MouseButton),
+    /// Mouse moved (without button).
+    Moved,
+    /// Scroll up.
+    ScrollUp,
+    /// Scroll down.
+    ScrollDown,
+    /// Scroll left (horizontal).
+    ScrollLeft,
+    /// Scroll right (horizontal).
+    ScrollRight,
+}
+
+/// Mouse event with position and modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    /// The event kind.
+    pub kind: MouseEventKind,
+    /// Column (0-based).
+    pub column: u16,
+    /// Row (0-based).
+    pub row: u16,
+    /// Active modifiers.
+    pub modifiers: Modifiers,
+}
+
+// =============================================================================
+// Input Events
+// =============================================================================
+
+/// Union of all input events from the terminal.
+#[derive(Debug, Clone)]
+pub enum InputEvent {
+    /// Keyboard event.
+    Key(KeyEvent),
+    /// Mouse event.
+    Mouse(MouseEvent),
+    /// Terminal resize event.
+    Resize(TerminalSize),
+    /// Terminal gained focus.
+    FocusGained,
+    /// Terminal lost focus.
+    FocusLost,
+    /// Bracketed paste content.
+    Paste(String),
+}
+
+// =============================================================================
+// Clear Type
+// =============================================================================
+
+/// Terminal clear type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClearType {
+    /// Clear entire screen.
+    All,
+    /// Clear from cursor to end of screen.
+    FromCursorDown,
+    /// Clear from cursor to start of screen.
+    FromCursorUp,
+    /// Clear current line.
+    CurrentLine,
+    /// Clear from cursor to end of line.
+    UntilNewLine,
+    /// Purge scrollback buffer (if supported).
+    Purge,
+}
+
+// =============================================================================
+// Raw Mode Guard
+// =============================================================================
+
+/// RAII guard for raw mode - restores terminal on drop.
+///
+/// When this guard is dropped, it automatically restores the terminal
+/// to its previous state (typically cooked mode).
+pub struct RawModeGuard {
+    restore_fn: Option<Box<dyn FnOnce() -> io::Result<()> + Send>>,
+}
+
+impl RawModeGuard {
+    /// Create a new raw mode guard with a restore function.
+    pub fn new<F>(restore_fn: F) -> Self
+    where
+        F: FnOnce() -> io::Result<()> + Send + 'static,
+    {
+        Self {
+            restore_fn: Some(Box::new(restore_fn)),
+        }
+    }
+
+    /// Create a disabled guard that does nothing on drop.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self { restore_fn: None }
+    }
+
+    /// Take the restore function without running it.
+    ///
+    /// After calling this, the guard will not restore on drop.
+    pub fn take(&mut self) -> Option<Box<dyn FnOnce() -> io::Result<()> + Send>> {
+        self.restore_fn.take()
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if let Some(f) = self.restore_fn.take() {
+            // Ignore errors in drop - can't propagate them
+            let _ = f();
+        }
+    }
+}
+
+// =============================================================================
+// Terminal Trait
+// =============================================================================
+
+/// Terminal backend abstraction.
+///
+/// Provides size queries, raw mode control, cursor manipulation, and screen management.
+/// This trait is the primary interface for terminal I/O operations.
+#[allow(clippy::missing_errors_doc)]
+pub trait Terminal: Send + Sync {
+    /// Get terminal dimensions.
+    ///
+    /// Returns the current terminal size in characters and optionally pixels.
+    fn size(&self) -> io::Result<TerminalSize>;
+
+    /// Enable raw mode.
+    ///
+    /// In raw mode:
+    /// - Input is not line-buffered
+    /// - Echo is disabled
+    /// - Special key combinations are passed through (Ctrl+C, etc.)
+    ///
+    /// Returns a guard that restores the terminal on drop.
+    fn enable_raw_mode(&mut self) -> io::Result<RawModeGuard>;
+
+    /// Check if keyboard enhancement protocol is supported.
+    ///
+    /// The keyboard enhancement protocol (kitty keyboard protocol) allows
+    /// distinguishing keys like Ctrl+I from Tab.
+    fn supports_keyboard_enhancement(&self) -> bool;
+
+    /// Enable keyboard enhancement protocol if supported.
+    fn enable_keyboard_enhancement(&mut self) -> io::Result<()>;
+
+    /// Disable keyboard enhancement protocol.
+    fn disable_keyboard_enhancement(&mut self) -> io::Result<()>;
+
+    /// Enter alternate screen buffer.
+    ///
+    /// The alternate screen isolates the editor UI from the shell.
+    fn enter_alternate_screen(&mut self) -> io::Result<()>;
+
+    /// Leave alternate screen buffer.
+    ///
+    /// Restores the original shell content.
+    fn leave_alternate_screen(&mut self) -> io::Result<()>;
+
+    /// Hide the cursor.
+    fn hide_cursor(&mut self) -> io::Result<()>;
+
+    /// Show the cursor.
+    fn show_cursor(&mut self) -> io::Result<()>;
+
+    /// Move cursor to position (0-based).
+    fn move_cursor(&mut self, col: u16, row: u16) -> io::Result<()>;
+
+    /// Clear terminal.
+    fn clear(&mut self, clear_type: ClearType) -> io::Result<()>;
+
+    /// Enable mouse capture.
+    ///
+    /// Mouse events will be reported as [`InputEvent::Mouse`].
+    fn enable_mouse_capture(&mut self) -> io::Result<()>;
+
+    /// Disable mouse capture.
+    fn disable_mouse_capture(&mut self) -> io::Result<()>;
+
+    /// Write bytes to the terminal.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize>;
+
+    /// Write a string to the terminal.
+    fn write_str(&mut self, s: &str) -> io::Result<()> {
+        self.write(s.as_bytes())?;
+        Ok(())
+    }
+
+    /// Flush output buffer.
+    fn flush(&mut self) -> io::Result<()>;
+}
+
+// =============================================================================
+// Input Source Trait
+// =============================================================================
+
+/// Input source abstraction.
+///
+/// Provides a blocking API for reading terminal input events.
+/// This is the low-level interface; higher layers may wrap this with async.
+#[allow(clippy::missing_errors_doc)]
+pub trait InputSource: Send {
+    /// Poll for input with timeout.
+    ///
+    /// Returns `true` if an event is available, `false` if timeout elapsed.
+    fn poll(&mut self, timeout: Duration) -> io::Result<bool>;
+
+    /// Read next input event.
+    ///
+    /// This is a blocking call. Use `poll` first to check for availability.
+    fn read_event(&mut self) -> io::Result<InputEvent>;
+
+    /// Drain all pending events.
+    ///
+    /// Returns a vector of all currently queued events.
+    fn drain(&mut self) -> Vec<InputEvent> {
+        let mut events = Vec::new();
+        while self.poll(Duration::ZERO).unwrap_or(false) {
+            if let Ok(event) = self.read_event() {
+                events.push(event);
+            }
+        }
+        events
+    }
+}
+
+// =============================================================================
+// Signal Handler Trait
+// =============================================================================
+
+/// Signal handler abstraction.
+///
+/// Provides callbacks for OS signals. Note that on Unix with crossterm,
+/// resize signals (SIGWINCH) are typically delivered as [`InputEvent::Resize`]
+/// through the input source rather than through this handler.
+pub trait SignalHandler: Send + Sync {
+    /// Register handler for terminal resize.
+    ///
+    /// Note: On most platforms with crossterm, resize is delivered via
+    /// [`InputEvent::Resize`] instead of through this handler.
+    fn on_resize(&mut self, handler: Box<dyn Fn(TerminalSize) + Send + Sync>);
+
+    /// Register handler for interrupt (Ctrl+C / SIGINT).
+    fn on_interrupt(&mut self, handler: Box<dyn Fn() + Send + Sync>);
+
+    /// Register handler for suspend (Ctrl+Z / SIGTSTP).
+    fn on_suspend(&mut self, handler: Box<dyn Fn() + Send + Sync>);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_modifiers_operations() {
+        let shift = Modifiers::SHIFT;
+        let ctrl = Modifiers::CTRL;
+        let combined = shift | ctrl;
+
+        assert!(combined.contains(Modifiers::SHIFT));
+        assert!(combined.contains(Modifiers::CTRL));
+        assert!(!combined.contains(Modifiers::ALT));
+        assert!(!combined.is_empty());
+        assert!(Modifiers::NONE.is_empty());
+    }
+
+    #[test]
+    fn test_terminal_size() {
+        let size = TerminalSize::new(80, 24);
+        assert_eq!(size.cols, 80);
+        assert_eq!(size.rows, 24);
+        assert_eq!(size.pixel_width, 0);
+        assert_eq!(size.pixel_height, 0);
+
+        let size_with_pixels = TerminalSize::with_pixels(80, 24, 800, 480);
+        assert_eq!(size_with_pixels.pixel_width, 800);
+        assert_eq!(size_with_pixels.pixel_height, 480);
+    }
+
+    #[test]
+    fn test_key_event_creation() {
+        let key = KeyEvent::new(KeyCode::Char('a'));
+        assert_eq!(key.code, KeyCode::Char('a'));
+        assert_eq!(key.modifiers, Modifiers::NONE);
+        assert_eq!(key.kind, KeyEventKind::Press);
+
+        let ctrl_a = KeyEvent::with_modifiers(KeyCode::Char('a'), Modifiers::CTRL);
+        assert!(ctrl_a.modifiers.contains(Modifiers::CTRL));
+    }
+
+    #[test]
+    fn test_raw_mode_guard_disabled() {
+        let guard = RawModeGuard::disabled();
+        drop(guard); // Should not panic
+    }
+}

--- a/lib/arch/src/unix/convert.rs
+++ b/lib/arch/src/unix/convert.rs
@@ -1,0 +1,256 @@
+//! Type conversions from crossterm types to our platform-agnostic types.
+
+use crate::traits::{
+    ClearType, InputEvent, KeyCode, KeyEvent, KeyEventKind, KeyEventState, Modifiers, MouseButton,
+    MouseEvent, MouseEventKind, TerminalSize,
+};
+use crossterm::event::{self as ct_event, Event as CtEvent};
+
+/// Convert a crossterm event to our `InputEvent`.
+#[must_use]
+pub fn convert_event(event: CtEvent) -> InputEvent {
+    match event {
+        CtEvent::Key(k) => InputEvent::Key(convert_key_event(k)),
+        CtEvent::Mouse(m) => InputEvent::Mouse(convert_mouse_event(m)),
+        CtEvent::Resize(cols, rows) => InputEvent::Resize(TerminalSize::new(cols, rows)),
+        CtEvent::FocusGained => InputEvent::FocusGained,
+        CtEvent::FocusLost => InputEvent::FocusLost,
+        CtEvent::Paste(s) => InputEvent::Paste(s),
+    }
+}
+
+/// Convert a crossterm `KeyEvent` to our `KeyEvent`.
+#[must_use]
+pub fn convert_key_event(k: ct_event::KeyEvent) -> KeyEvent {
+    KeyEvent {
+        code: convert_key_code(k.code),
+        modifiers: convert_modifiers(k.modifiers),
+        kind: convert_key_kind(k.kind),
+        state: convert_key_state(k.state),
+    }
+}
+
+/// Convert crossterm `KeyCode` to our `KeyCode`.
+#[must_use]
+pub const fn convert_key_code(code: ct_event::KeyCode) -> KeyCode {
+    use ct_event::KeyCode as Ct;
+    match code {
+        Ct::Char(c) => KeyCode::Char(c),
+        Ct::F(n) => KeyCode::F(n),
+        Ct::Backspace => KeyCode::Backspace,
+        Ct::Enter => KeyCode::Enter,
+        Ct::Tab => KeyCode::Tab,
+        Ct::BackTab => KeyCode::BackTab,
+        Ct::Esc => KeyCode::Escape,
+        Ct::Up => KeyCode::Up,
+        Ct::Down => KeyCode::Down,
+        Ct::Left => KeyCode::Left,
+        Ct::Right => KeyCode::Right,
+        Ct::Home => KeyCode::Home,
+        Ct::End => KeyCode::End,
+        Ct::PageUp => KeyCode::PageUp,
+        Ct::PageDown => KeyCode::PageDown,
+        Ct::Insert => KeyCode::Insert,
+        Ct::Delete => KeyCode::Delete,
+        Ct::Null => KeyCode::Null,
+        Ct::CapsLock => KeyCode::CapsLock,
+        Ct::ScrollLock => KeyCode::ScrollLock,
+        Ct::NumLock => KeyCode::NumLock,
+        Ct::PrintScreen => KeyCode::PrintScreen,
+        Ct::Pause => KeyCode::Pause,
+        Ct::Menu => KeyCode::Menu,
+        Ct::KeypadBegin => KeyCode::KeypadBegin,
+        Ct::Media(media) => convert_media_key(media),
+        Ct::Modifier(modifier) => convert_modifier_key(modifier),
+    }
+}
+
+/// Convert crossterm `MediaKeyCode` to our `KeyCode`.
+const fn convert_media_key(media: ct_event::MediaKeyCode) -> KeyCode {
+    use ct_event::MediaKeyCode as Ct;
+    match media {
+        Ct::Play => KeyCode::MediaPlay,
+        Ct::Pause => KeyCode::MediaPause,
+        Ct::PlayPause => KeyCode::MediaPlayPause,
+        Ct::Stop => KeyCode::MediaStop,
+        Ct::Reverse => KeyCode::MediaReverse,
+        Ct::FastForward => KeyCode::MediaFastForward,
+        Ct::Rewind => KeyCode::MediaRewind,
+        Ct::TrackNext => KeyCode::MediaNext,
+        Ct::TrackPrevious => KeyCode::MediaPrevious,
+        Ct::Record => KeyCode::MediaRecord,
+        Ct::LowerVolume => KeyCode::MediaLowerVolume,
+        Ct::RaiseVolume => KeyCode::MediaRaiseVolume,
+        Ct::MuteVolume => KeyCode::MediaMuteVolume,
+    }
+}
+
+/// Convert crossterm `ModifierKeyCode` to our `KeyCode`.
+const fn convert_modifier_key(modifier: ct_event::ModifierKeyCode) -> KeyCode {
+    use ct_event::ModifierKeyCode as Ct;
+    match modifier {
+        Ct::LeftShift => KeyCode::LeftShift,
+        Ct::RightShift => KeyCode::RightShift,
+        Ct::LeftControl => KeyCode::LeftCtrl,
+        Ct::RightControl => KeyCode::RightCtrl,
+        Ct::LeftAlt => KeyCode::LeftAlt,
+        Ct::RightAlt => KeyCode::RightAlt,
+        Ct::LeftSuper => KeyCode::LeftSuper,
+        Ct::RightSuper => KeyCode::RightSuper,
+        Ct::LeftHyper => KeyCode::LeftHyper,
+        Ct::RightHyper => KeyCode::RightHyper,
+        Ct::LeftMeta => KeyCode::LeftMeta,
+        Ct::RightMeta => KeyCode::RightMeta,
+        Ct::IsoLevel3Shift => KeyCode::IsoLevel3Shift,
+        Ct::IsoLevel5Shift => KeyCode::IsoLevel5Shift,
+    }
+}
+
+/// Convert crossterm `KeyModifiers` to our `Modifiers`.
+#[must_use]
+pub fn convert_modifiers(mods: ct_event::KeyModifiers) -> Modifiers {
+    let mut result = Modifiers::NONE;
+    if mods.contains(ct_event::KeyModifiers::SHIFT) {
+        result |= Modifiers::SHIFT;
+    }
+    if mods.contains(ct_event::KeyModifiers::CONTROL) {
+        result |= Modifiers::CTRL;
+    }
+    if mods.contains(ct_event::KeyModifiers::ALT) {
+        result |= Modifiers::ALT;
+    }
+    if mods.contains(ct_event::KeyModifiers::SUPER) {
+        result |= Modifiers::SUPER;
+    }
+    if mods.contains(ct_event::KeyModifiers::HYPER) {
+        result |= Modifiers::HYPER;
+    }
+    if mods.contains(ct_event::KeyModifiers::META) {
+        result |= Modifiers::META;
+    }
+    result
+}
+
+/// Convert crossterm `KeyEventKind` to our `KeyEventKind`.
+pub const fn convert_key_kind(kind: ct_event::KeyEventKind) -> KeyEventKind {
+    match kind {
+        ct_event::KeyEventKind::Press => KeyEventKind::Press,
+        ct_event::KeyEventKind::Repeat => KeyEventKind::Repeat,
+        ct_event::KeyEventKind::Release => KeyEventKind::Release,
+    }
+}
+
+/// Convert crossterm `KeyEventState` to our `KeyEventState`.
+#[allow(clippy::missing_const_for_fn)] // bitflags contains() isn't const
+pub fn convert_key_state(state: ct_event::KeyEventState) -> KeyEventState {
+    let mut result = KeyEventState::NONE;
+    if state.contains(ct_event::KeyEventState::KEYPAD) {
+        result = result.union(KeyEventState::KEYPAD);
+    }
+    if state.contains(ct_event::KeyEventState::CAPS_LOCK) {
+        result = result.union(KeyEventState::CAPS_LOCK);
+    }
+    if state.contains(ct_event::KeyEventState::NUM_LOCK) {
+        result = result.union(KeyEventState::NUM_LOCK);
+    }
+    result
+}
+
+/// Convert a crossterm `MouseEvent` to our `MouseEvent`.
+pub fn convert_mouse_event(m: ct_event::MouseEvent) -> MouseEvent {
+    MouseEvent {
+        kind: convert_mouse_kind(m.kind),
+        column: m.column,
+        row: m.row,
+        modifiers: convert_modifiers(m.modifiers),
+    }
+}
+
+/// Convert crossterm `MouseEventKind` to our `MouseEventKind`.
+const fn convert_mouse_kind(kind: ct_event::MouseEventKind) -> MouseEventKind {
+    use ct_event::MouseEventKind as Ct;
+    match kind {
+        Ct::Down(btn) => MouseEventKind::Down(convert_mouse_button(btn)),
+        Ct::Up(btn) => MouseEventKind::Up(convert_mouse_button(btn)),
+        Ct::Drag(btn) => MouseEventKind::Drag(convert_mouse_button(btn)),
+        Ct::Moved => MouseEventKind::Moved,
+        Ct::ScrollUp => MouseEventKind::ScrollUp,
+        Ct::ScrollDown => MouseEventKind::ScrollDown,
+        Ct::ScrollLeft => MouseEventKind::ScrollLeft,
+        Ct::ScrollRight => MouseEventKind::ScrollRight,
+    }
+}
+
+/// Convert crossterm `MouseButton` to our `MouseButton`.
+const fn convert_mouse_button(btn: ct_event::MouseButton) -> MouseButton {
+    match btn {
+        ct_event::MouseButton::Left => MouseButton::Left,
+        ct_event::MouseButton::Right => MouseButton::Right,
+        ct_event::MouseButton::Middle => MouseButton::Middle,
+    }
+}
+
+/// Convert our `ClearType` to crossterm `ClearType`.
+pub const fn convert_clear_type(ct: ClearType) -> crossterm::terminal::ClearType {
+    use crossterm::terminal::ClearType as CtClear;
+    match ct {
+        ClearType::All => CtClear::All,
+        ClearType::FromCursorDown => CtClear::FromCursorDown,
+        ClearType::FromCursorUp => CtClear::FromCursorUp,
+        ClearType::CurrentLine => CtClear::CurrentLine,
+        ClearType::UntilNewLine => CtClear::UntilNewLine,
+        ClearType::Purge => CtClear::Purge,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_key_code_char() {
+        let ct_code = ct_event::KeyCode::Char('a');
+        let our_code = convert_key_code(ct_code);
+        assert_eq!(our_code, KeyCode::Char('a'));
+    }
+
+    #[test]
+    fn test_convert_modifiers() {
+        let ct_mods = ct_event::KeyModifiers::CONTROL | ct_event::KeyModifiers::SHIFT;
+        let our_mods = convert_modifiers(ct_mods);
+        assert!(our_mods.contains(Modifiers::CTRL));
+        assert!(our_mods.contains(Modifiers::SHIFT));
+        assert!(!our_mods.contains(Modifiers::ALT));
+    }
+
+    #[test]
+    fn test_convert_key_event() {
+        let ct_event = ct_event::KeyEvent::new(ct_event::KeyCode::Esc, ct_event::KeyModifiers::NONE);
+        let our_event = convert_key_event(ct_event);
+        assert_eq!(our_event.code, KeyCode::Escape);
+        assert_eq!(our_event.modifiers, Modifiers::NONE);
+        assert_eq!(our_event.kind, KeyEventKind::Press);
+    }
+
+    #[test]
+    fn test_convert_mouse_event() {
+        let ct_mouse = ct_event::MouseEvent {
+            kind: ct_event::MouseEventKind::Down(ct_event::MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: ct_event::KeyModifiers::NONE,
+        };
+        let our_mouse = convert_mouse_event(ct_mouse);
+        assert!(matches!(our_mouse.kind, MouseEventKind::Down(MouseButton::Left)));
+        assert_eq!(our_mouse.column, 10);
+        assert_eq!(our_mouse.row, 5);
+    }
+
+    #[test]
+    fn test_convert_clear_type() {
+        assert!(matches!(
+            convert_clear_type(ClearType::All),
+            crossterm::terminal::ClearType::All
+        ));
+    }
+}

--- a/lib/arch/src/unix/input.rs
+++ b/lib/arch/src/unix/input.rs
@@ -1,0 +1,57 @@
+//! Unix input source implementation using crossterm.
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::event;
+
+use crate::traits::{InputEvent, InputSource};
+use super::convert::convert_event;
+
+/// Unix input source implementation wrapping crossterm's event system.
+pub struct UnixInputSource;
+
+impl UnixInputSource {
+    /// Create a new Unix input source.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UnixInputSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InputSource for UnixInputSource {
+    fn poll(&mut self, timeout: Duration) -> io::Result<bool> {
+        event::poll(timeout)
+    }
+
+    fn read_event(&mut self) -> io::Result<InputEvent> {
+        let ct_event = event::read()?;
+        Ok(convert_event(ct_event))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_source_creation() {
+        let _source = UnixInputSource::new();
+    }
+
+    #[test]
+    fn test_poll_no_input() {
+        let mut source = UnixInputSource::new();
+        // Should return false immediately with zero timeout (no input available)
+        let result = source.poll(Duration::ZERO);
+        // In a TTY environment this should work; in CI it may fail
+        // but should not panic
+        let _ = result;
+    }
+}

--- a/lib/arch/src/unix/mod.rs
+++ b/lib/arch/src/unix/mod.rs
@@ -1,5 +1,16 @@
 //! Unix/Linux platform implementation.
 //!
 //! Linux equivalent: `arch/x86/`, `arch/arm64/`, etc.
+//!
+//! This module provides Unix-specific implementations of the platform traits
+//! using crossterm as the underlying terminal library.
 
-// Placeholder module - implementations will be added in Phase 1
+mod convert;
+mod input;
+mod signal;
+mod terminal;
+
+pub use convert::{convert_event, convert_key_code, convert_key_event, convert_modifiers};
+pub use input::UnixInputSource;
+pub use signal::UnixSignalHandler;
+pub use terminal::UnixTerminal;

--- a/lib/arch/src/unix/signal.rs
+++ b/lib/arch/src/unix/signal.rs
@@ -1,0 +1,97 @@
+//! Unix signal handler implementation.
+//!
+//! Note: crossterm handles SIGWINCH through resize events in the event stream,
+//! not through traditional signal handlers. This implementation provides the
+//! trait interface but defers actual signal handling to the input source.
+
+use crate::traits::{SignalHandler, TerminalSize};
+
+/// Unix signal handler implementation.
+///
+/// On Unix with crossterm:
+/// - Resize (SIGWINCH) is delivered via [`InputEvent::Resize`] through the input source
+/// - Interrupt (SIGINT) is typically delivered as Ctrl+C key event in raw mode
+/// - Suspend (SIGTSTP) is typically delivered as Ctrl+Z key event in raw mode
+///
+/// This struct provides a placeholder for future signal handling needs
+/// or for platforms that require explicit signal registration.
+#[allow(clippy::struct_field_names)]
+pub struct UnixSignalHandler {
+    // Handlers are stored but not used with crossterm since it handles
+    // signals internally through the event stream
+    #[allow(dead_code)]
+    resize_handler: Option<Box<dyn Fn(TerminalSize) + Send + Sync>>,
+    #[allow(dead_code)]
+    interrupt_handler: Option<Box<dyn Fn() + Send + Sync>>,
+    #[allow(dead_code)]
+    suspend_handler: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl UnixSignalHandler {
+    /// Create a new Unix signal handler.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            resize_handler: None,
+            interrupt_handler: None,
+            suspend_handler: None,
+        }
+    }
+}
+
+impl Default for UnixSignalHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SignalHandler for UnixSignalHandler {
+    fn on_resize(&mut self, handler: Box<dyn Fn(TerminalSize) + Send + Sync>) {
+        // Note: With crossterm, resize events are delivered through the
+        // event stream as InputEvent::Resize, not through signal handlers.
+        // We store the handler for compatibility but it won't be called
+        // in the current implementation.
+        self.resize_handler = Some(handler);
+    }
+
+    fn on_interrupt(&mut self, handler: Box<dyn Fn() + Send + Sync>) {
+        // Note: In raw mode, Ctrl+C is delivered as a key event.
+        // We store the handler for compatibility.
+        self.interrupt_handler = Some(handler);
+    }
+
+    fn on_suspend(&mut self, handler: Box<dyn Fn() + Send + Sync>) {
+        // Note: In raw mode, Ctrl+Z is delivered as a key event.
+        // We store the handler for compatibility.
+        self.suspend_handler = Some(handler);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signal_handler_creation() {
+        let _handler = UnixSignalHandler::new();
+    }
+
+    #[test]
+    fn test_register_handlers() {
+        let mut handler = UnixSignalHandler::new();
+
+        handler.on_resize(Box::new(|_size| {
+            // Resize callback
+        }));
+
+        handler.on_interrupt(Box::new(|| {
+            // Interrupt callback
+        }));
+
+        handler.on_suspend(Box::new(|| {
+            // Suspend callback
+        }));
+
+        // Handlers are registered (even if not actively used with crossterm)
+    }
+}

--- a/lib/arch/src/unix/terminal.rs
+++ b/lib/arch/src/unix/terminal.rs
@@ -1,0 +1,138 @@
+//! Unix terminal implementation using crossterm.
+
+use std::io::{self, Stdout, Write};
+
+use crossterm::{
+    cursor,
+    event::{DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    execute,
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+};
+
+use crate::traits::{ClearType, RawModeGuard, Terminal, TerminalSize};
+use super::convert::convert_clear_type;
+
+/// Unix terminal implementation wrapping crossterm.
+pub struct UnixTerminal {
+    stdout: Stdout,
+    keyboard_enhancement_enabled: bool,
+}
+
+impl UnixTerminal {
+    /// Create a new Unix terminal.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stdout: io::stdout(),
+            keyboard_enhancement_enabled: false,
+        }
+    }
+}
+
+impl Default for UnixTerminal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Terminal for UnixTerminal {
+    fn size(&self) -> io::Result<TerminalSize> {
+        let (cols, rows) = terminal::size()?;
+        Ok(TerminalSize::new(cols, rows))
+    }
+
+    fn enable_raw_mode(&mut self) -> io::Result<RawModeGuard> {
+        terminal::enable_raw_mode()?;
+        Ok(RawModeGuard::new(terminal::disable_raw_mode))
+    }
+
+    fn supports_keyboard_enhancement(&self) -> bool {
+        terminal::supports_keyboard_enhancement().unwrap_or(false)
+    }
+
+    fn enable_keyboard_enhancement(&mut self) -> io::Result<()> {
+        if self.supports_keyboard_enhancement() && !self.keyboard_enhancement_enabled {
+            execute!(
+                self.stdout,
+                PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+            )?;
+            self.keyboard_enhancement_enabled = true;
+        }
+        Ok(())
+    }
+
+    fn disable_keyboard_enhancement(&mut self) -> io::Result<()> {
+        if self.keyboard_enhancement_enabled {
+            execute!(self.stdout, PopKeyboardEnhancementFlags)?;
+            self.keyboard_enhancement_enabled = false;
+        }
+        Ok(())
+    }
+
+    fn enter_alternate_screen(&mut self) -> io::Result<()> {
+        execute!(self.stdout, EnterAlternateScreen)
+    }
+
+    fn leave_alternate_screen(&mut self) -> io::Result<()> {
+        execute!(self.stdout, LeaveAlternateScreen)
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        execute!(self.stdout, cursor::Hide)
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        execute!(self.stdout, cursor::Show)
+    }
+
+    fn move_cursor(&mut self, col: u16, row: u16) -> io::Result<()> {
+        execute!(self.stdout, cursor::MoveTo(col, row))
+    }
+
+    fn clear(&mut self, clear_type: ClearType) -> io::Result<()> {
+        let ct_clear = convert_clear_type(clear_type);
+        execute!(self.stdout, terminal::Clear(ct_clear))
+    }
+
+    fn enable_mouse_capture(&mut self) -> io::Result<()> {
+        execute!(self.stdout, EnableMouseCapture)
+    }
+
+    fn disable_mouse_capture(&mut self) -> io::Result<()> {
+        execute!(self.stdout, DisableMouseCapture)
+    }
+
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.stdout.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stdout.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_terminal_creation() {
+        let _term = UnixTerminal::new();
+        // Just verify it can be created
+    }
+
+    #[test]
+    fn test_terminal_size() {
+        let term = UnixTerminal::new();
+        // In a CI environment without a TTY, this may fail
+        // but it should at least not panic
+        let _ = term.size();
+    }
+
+    #[test]
+    fn test_supports_keyboard_enhancement() {
+        let term = UnixTerminal::new();
+        // Just verify the method can be called
+        let _ = term.supports_keyboard_enhancement();
+    }
+}

--- a/lib/arch/src/windows/input.rs
+++ b/lib/arch/src/windows/input.rs
@@ -1,0 +1,41 @@
+//! Windows input source stub implementation.
+//!
+//! This is a placeholder for future Windows support.
+
+use std::io;
+use std::time::Duration;
+
+use crate::traits::{InputEvent, InputSource};
+
+/// Windows input source stub.
+///
+/// This is a placeholder implementation that will panic if used.
+/// Full Windows support will be implemented in a future phase.
+pub struct WindowsInputSource;
+
+impl WindowsInputSource {
+    /// Create a new Windows input source.
+    ///
+    /// # Panics
+    ///
+    /// Panics because Windows support is not yet implemented.
+    pub fn new() -> io::Result<Self> {
+        todo!("Windows input source support not yet implemented")
+    }
+}
+
+impl Default for WindowsInputSource {
+    fn default() -> Self {
+        todo!("Windows input source support not yet implemented")
+    }
+}
+
+impl InputSource for WindowsInputSource {
+    fn poll(&mut self, _timeout: Duration) -> io::Result<bool> {
+        todo!("Windows input source support not yet implemented")
+    }
+
+    fn read_event(&mut self) -> io::Result<InputEvent> {
+        todo!("Windows input source support not yet implemented")
+    }
+}

--- a/lib/arch/src/windows/mod.rs
+++ b/lib/arch/src/windows/mod.rs
@@ -1,5 +1,14 @@
 //! Windows platform implementation.
 //!
 //! Provides Windows Console API integration.
+//!
+//! **Note:** This is a stub implementation. Full Windows support will be
+//! implemented in a future phase.
 
-// Placeholder module - implementations will be added in Phase 1
+mod input;
+mod signal;
+mod terminal;
+
+pub use input::WindowsInputSource;
+pub use signal::WindowsSignalHandler;
+pub use terminal::WindowsTerminal;

--- a/lib/arch/src/windows/signal.rs
+++ b/lib/arch/src/windows/signal.rs
@@ -1,0 +1,42 @@
+//! Windows signal handler stub implementation.
+//!
+//! This is a placeholder for future Windows support.
+
+use crate::traits::{SignalHandler, TerminalSize};
+
+/// Windows signal handler stub.
+///
+/// This is a placeholder implementation that will panic if used.
+/// Full Windows support will be implemented in a future phase.
+pub struct WindowsSignalHandler;
+
+impl WindowsSignalHandler {
+    /// Create a new Windows signal handler.
+    ///
+    /// # Panics
+    ///
+    /// Panics because Windows support is not yet implemented.
+    pub fn new() -> Self {
+        todo!("Windows signal handler support not yet implemented")
+    }
+}
+
+impl Default for WindowsSignalHandler {
+    fn default() -> Self {
+        todo!("Windows signal handler support not yet implemented")
+    }
+}
+
+impl SignalHandler for WindowsSignalHandler {
+    fn on_resize(&mut self, _handler: Box<dyn Fn(TerminalSize) + Send + Sync>) {
+        todo!("Windows signal handler support not yet implemented")
+    }
+
+    fn on_interrupt(&mut self, _handler: Box<dyn Fn() + Send + Sync>) {
+        todo!("Windows signal handler support not yet implemented")
+    }
+
+    fn on_suspend(&mut self, _handler: Box<dyn Fn() + Send + Sync>) {
+        todo!("Windows signal handler support not yet implemented")
+    }
+}

--- a/lib/arch/src/windows/terminal.rs
+++ b/lib/arch/src/windows/terminal.rs
@@ -1,0 +1,92 @@
+//! Windows terminal stub implementation.
+//!
+//! This is a placeholder for future Windows support.
+
+use std::io;
+
+use crate::traits::{ClearType, RawModeGuard, Terminal, TerminalSize};
+
+/// Windows terminal stub.
+///
+/// This is a placeholder implementation that will panic if used.
+/// Full Windows support will be implemented in a future phase.
+pub struct WindowsTerminal;
+
+impl WindowsTerminal {
+    /// Create a new Windows terminal.
+    ///
+    /// # Panics
+    ///
+    /// Panics because Windows support is not yet implemented.
+    pub fn new() -> io::Result<Self> {
+        todo!("Windows terminal support not yet implemented")
+    }
+}
+
+impl Default for WindowsTerminal {
+    fn default() -> Self {
+        todo!("Windows terminal support not yet implemented")
+    }
+}
+
+impl Terminal for WindowsTerminal {
+    fn size(&self) -> io::Result<TerminalSize> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn enable_raw_mode(&mut self) -> io::Result<RawModeGuard> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn supports_keyboard_enhancement(&self) -> bool {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn enable_keyboard_enhancement(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn disable_keyboard_enhancement(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn enter_alternate_screen(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn leave_alternate_screen(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn move_cursor(&mut self, _col: u16, _row: u16) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn clear(&mut self, _clear_type: ClearType) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn enable_mouse_capture(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn disable_mouse_capture(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        todo!("Windows terminal support not yet implemented")
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        todo!("Windows terminal support not yet implemented")
+    }
+}


### PR DESCRIPTION
Phase 1 of the Linux-inspired architecture (Epic #150).

Platform-agnostic traits:
- Terminal: size, raw mode, cursor, screen, mouse capture
- InputSource: event polling and reading
- SignalHandler: resize, interrupt, suspend handlers
- Types: TerminalSize, KeyEvent, KeyCode, Modifiers, MouseEvent, InputEvent, ClearType, RawModeGuard

Unix backend (lib/arch/src/unix/):
- UnixTerminal: full Terminal trait implementation using crossterm
- UnixInputSource: blocking event poll/read
- UnixSignalHandler: placeholder (crossterm handles signals internally)
- Type conversion functions from crossterm types

Windows stubs (lib/arch/src/windows/):
- All implementations return todo!()
- Proper structure for future Windows support

Platform aliases:
- PlatformTerminal, PlatformInputSource, PlatformSignalHandler

Closes #156