### PR TITLE
feat(kernel): implement mm/ memory management module (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 2.1: Memory Management Module** (Issue #159) - Kernel mm/ subsystem
+  - `BufferId` - Unique buffer identifier with atomic counter generation
+  - `Position` - Text position with `line` and `column` fields (0-indexed, usize)
+  - `Cursor` - Cursor state with position, selection anchor, and preferred column
+  - `Edit` - Insert/Delete operations with position for undo/redo support
+  - `Buffer` - Line-based text storage with Vec<String> backend
+    - Constructors: `new()`, `from_string()`, `with_id()`
+    - Line access: `line()`, `line_count()`, `line_len()`, `lines()`, `content()`
+    - Edit operations: `insert()`, `insert_at()`, `delete()`, `delete_at()`, `delete_range()`
+    - Position conversion: `position_to_byte()`, `byte_to_position()` (for tree-sitter)
+  - 59 unit tests + 6 doctests covering all functionality
+
 - **Phase 1: Platform Traits and Unix Backend** (Issue #156) - Architecture layer implementation
   - Defined platform-agnostic traits in `lib/arch/src/traits.rs`:
     - `Terminal` trait - terminal I/O abstraction (size, raw mode, cursor, screen, mouse)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,10 @@ For any changes, Claude should create a proposal file at `tmp/<feature-name>-com
 - Verification checklist
 - Git commands for user to run
 
+### Pull Requests
+
+When creating PRs with `gh pr create`, do NOT add promotional footers like "Generated with Claude Code" or similar. Keep the PR body clean and professional with only relevant technical content.
+
 ### Ready-to-Take-Off & Request-for-Landing
 
 **Ready-to-Take-Off (Start of Work):**

--- a/lib/kernel/src/mm/buffer.rs
+++ b/lib/kernel/src/mm/buffer.rs
@@ -1,0 +1,463 @@
+//! Buffer data structure for text storage.
+//!
+//! The buffer is the core abstraction for text editing. It stores
+//! text as lines and provides efficient operations for insertion,
+//! deletion, and navigation.
+
+use super::{BufferId, Cursor, Edit, Position};
+
+/// A text buffer with line-based storage.
+///
+/// The buffer stores text as a vector of lines, where each line is a String
+/// without the trailing newline character. This provides efficient line-based
+/// access while maintaining a simple implementation.
+///
+/// # Invariants
+///
+/// - An empty buffer has zero lines (not one empty line)
+/// - Lines do not contain newline characters
+/// - Positions are clamped to valid ranges on access
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::mm::{Buffer, Position};
+///
+/// let mut buf = Buffer::from_string("Hello\nWorld");
+/// assert_eq!(buf.line_count(), 2);
+/// assert_eq!(buf.line(0), Some("Hello"));
+///
+/// buf.set_position(Position::new(0, 5));
+/// buf.insert("!");
+/// assert_eq!(buf.line(0), Some("Hello!"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct Buffer {
+    /// Unique identifier for this buffer.
+    id: BufferId,
+    /// Text content stored as lines.
+    lines: Vec<String>,
+    /// Cursor state.
+    cursor: Cursor,
+    /// Whether the buffer has unsaved modifications.
+    modified: bool,
+}
+
+impl Buffer {
+    /// Create a new empty buffer.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: BufferId::new(),
+            lines: Vec::new(),
+            cursor: Cursor::origin(),
+            modified: false,
+        }
+    }
+
+    /// Create a buffer with a specific ID.
+    ///
+    /// This is primarily useful for testing.
+    #[must_use]
+    pub const fn with_id(id: BufferId) -> Self {
+        Self {
+            id,
+            lines: Vec::new(),
+            cursor: Cursor::origin(),
+            modified: false,
+        }
+    }
+
+    /// Create a buffer from a string.
+    ///
+    /// The string is split by newlines into lines.
+    /// An empty string results in a buffer with zero lines.
+    #[must_use]
+    pub fn from_string(content: &str) -> Self {
+        let lines = if content.is_empty() {
+            Vec::new()
+        } else {
+            content.lines().map(String::from).collect()
+        };
+        Self {
+            id: BufferId::new(),
+            lines,
+            cursor: Cursor::origin(),
+            modified: false,
+        }
+    }
+
+    // === Accessors ===
+
+    /// Get the buffer ID.
+    #[must_use]
+    pub const fn id(&self) -> BufferId {
+        self.id
+    }
+
+    /// Get the cursor.
+    #[must_use]
+    pub const fn cursor(&self) -> &Cursor {
+        &self.cursor
+    }
+
+    /// Get a mutable reference to the cursor.
+    pub const fn cursor_mut(&mut self) -> &mut Cursor {
+        &mut self.cursor
+    }
+
+    /// Get the cursor position.
+    #[must_use]
+    pub const fn position(&self) -> Position {
+        self.cursor.position
+    }
+
+    /// Set the cursor position.
+    ///
+    /// The position is clamped to valid buffer coordinates.
+    pub fn set_position(&mut self, pos: Position) {
+        self.cursor.position = self.clamp_position(pos);
+    }
+
+    /// Check if the buffer has unsaved modifications.
+    #[must_use]
+    pub const fn is_modified(&self) -> bool {
+        self.modified
+    }
+
+    /// Mark the buffer as modified or unmodified.
+    pub const fn set_modified(&mut self, modified: bool) {
+        self.modified = modified;
+    }
+
+    // === Line Access ===
+
+    /// Get the number of lines in the buffer.
+    #[must_use]
+    pub const fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Check if the buffer is empty (has no lines).
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+
+    /// Get a specific line by index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    #[must_use]
+    pub fn line(&self, index: usize) -> Option<&str> {
+        self.lines.get(index).map(String::as_str)
+    }
+
+    /// Get the length of a specific line in characters.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    #[must_use]
+    pub fn line_len(&self, index: usize) -> Option<usize> {
+        self.lines.get(index).map(|l| l.chars().count())
+    }
+
+    /// Get all lines as a slice.
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
+    /// Get the full content as a string (lines joined with newlines).
+    #[must_use]
+    pub fn content(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    /// Set the full content from a string.
+    ///
+    /// This replaces all existing content and resets the cursor.
+    pub fn set_content(&mut self, content: &str) {
+        self.lines = if content.is_empty() {
+            Vec::new()
+        } else {
+            content.lines().map(String::from).collect()
+        };
+        self.cursor = Cursor::origin();
+        self.modified = true;
+    }
+
+    // === Edit Operations ===
+
+    /// Insert text at the current cursor position.
+    ///
+    /// Returns an [`Edit`] that can be used for undo support.
+    /// The cursor is moved to the end of the inserted text.
+    pub fn insert(&mut self, text: &str) -> Edit {
+        let pos = self.cursor.position;
+        self.insert_at(pos, text);
+        Edit::insert(pos, text)
+    }
+
+    /// Insert text at a specific position.
+    ///
+    /// The cursor is moved to the end of the inserted text.
+    pub fn insert_at(&mut self, pos: Position, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+
+        // Ensure we have at least one line
+        if self.lines.is_empty() {
+            self.lines.push(String::new());
+        }
+
+        let pos = self.clamp_position(pos);
+        let line_idx = pos.line;
+        let col = pos.column;
+
+        // Get the current line and split at insertion point
+        let current_line = &self.lines[line_idx];
+        let byte_offset = char_to_byte_offset(current_line, col);
+        let (before, after) = current_line.split_at(byte_offset);
+        let before = before.to_string();
+        let after = after.to_string();
+
+        // Handle single-line vs multi-line insertion
+        let insert_lines: Vec<&str> = text.split('\n').collect();
+
+        if insert_lines.len() == 1 {
+            // Single line: just insert in place
+            self.lines[line_idx] = format!("{before}{text}{after}");
+            self.cursor.position = Position::new(line_idx, col + text.chars().count());
+        } else {
+            // Multi-line: split and insert
+            // First line gets before + first insert part
+            let first_insert = insert_lines[0];
+            self.lines[line_idx] = format!("{before}{first_insert}");
+
+            // Last line gets last insert part + after
+            let last_insert = insert_lines[insert_lines.len() - 1];
+            let last_line = format!("{last_insert}{after}");
+
+            // Insert middle lines and last line
+            let insert_pos = line_idx + 1;
+            self.lines.splice(
+                insert_pos..insert_pos,
+                insert_lines[1..insert_lines.len() - 1]
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .chain(std::iter::once(last_line)),
+            );
+
+            // Update cursor to end of inserted text
+            let new_line_idx = line_idx + insert_lines.len() - 1;
+            self.cursor.position = Position::new(new_line_idx, last_insert.chars().count());
+        }
+
+        self.modified = true;
+    }
+
+    /// Delete text from the current cursor position.
+    ///
+    /// Deletes `count` characters forward.
+    /// Returns an [`Edit`] containing the deleted text for undo support.
+    pub fn delete(&mut self, count: usize) -> Edit {
+        let pos = self.cursor.position;
+        let text = self.delete_at(pos, count);
+        Edit::delete(pos, text)
+    }
+
+    /// Delete text at a specific position.
+    ///
+    /// Returns the deleted text.
+    pub fn delete_at(&mut self, pos: Position, count: usize) -> String {
+        if count == 0 || self.lines.is_empty() {
+            return String::new();
+        }
+
+        let pos = self.clamp_position(pos);
+        let mut deleted = String::new();
+        let mut remaining = count;
+        let current_line = pos.line;
+        let current_col = pos.column;
+
+        while remaining > 0 && current_line < self.lines.len() {
+            let line = &self.lines[current_line];
+            let chars: Vec<char> = line.chars().collect();
+            let chars_in_line = chars.len();
+
+            if current_col >= chars_in_line {
+                // At end of line, delete the newline (merge with next line)
+                if current_line + 1 < self.lines.len() {
+                    deleted.push('\n');
+                    let next_line = self.lines.remove(current_line + 1);
+                    self.lines[current_line].push_str(&next_line);
+                    remaining -= 1;
+                } else {
+                    // Nothing more to delete
+                    break;
+                }
+            } else {
+                // Delete characters in current line
+                let chars_to_delete = remaining.min(chars_in_line - current_col);
+                let delete_chars: String = chars[current_col..current_col + chars_to_delete]
+                    .iter()
+                    .collect();
+                deleted.push_str(&delete_chars);
+
+                // Rebuild the line without deleted chars
+                let new_line: String = chars[..current_col]
+                    .iter()
+                    .chain(chars[current_col + chars_to_delete..].iter())
+                    .collect();
+                self.lines[current_line] = new_line;
+
+                remaining -= chars_to_delete;
+            }
+        }
+
+        // Update cursor position to deletion start
+        self.cursor.position = self.clamp_position(pos);
+
+        if !deleted.is_empty() {
+            self.modified = true;
+        }
+
+        deleted
+    }
+
+    /// Delete a range of text.
+    ///
+    /// Returns the deleted text.
+    pub fn delete_range(&mut self, start: Position, end: Position) -> String {
+        let (start, end) = if start <= end {
+            (start, end)
+        } else {
+            (end, start)
+        };
+
+        let start = self.clamp_position(start);
+        let end = self.clamp_position(end);
+
+        // Calculate character count between positions
+        let count = self.char_count_between(start, end);
+        self.delete_at(start, count)
+    }
+
+    // === Position Conversion ===
+
+    /// Convert a position to a byte offset in the full content.
+    ///
+    /// This is useful for tree-sitter and other byte-based APIs.
+    #[must_use]
+    pub fn position_to_byte(&self, pos: Position) -> usize {
+        let pos = self.clamp_position(pos);
+        let mut offset = 0;
+
+        for (i, line) in self.lines.iter().enumerate() {
+            if i < pos.line {
+                offset += line.len() + 1; // +1 for newline
+            } else if i == pos.line {
+                // Add bytes up to column
+                offset += char_to_byte_offset(line, pos.column);
+                break;
+            }
+        }
+
+        offset
+    }
+
+    /// Convert a byte offset to a position.
+    #[must_use]
+    pub fn byte_to_position(&self, byte_offset: usize) -> Position {
+        let mut remaining = byte_offset;
+
+        for (line_idx, line) in self.lines.iter().enumerate() {
+            let line_bytes = line.len();
+            let line_total = line_bytes + 1; // +1 for newline
+
+            if remaining <= line_bytes {
+                // Position is within this line
+                let col = byte_to_char_offset(line, remaining);
+                return Position::new(line_idx, col);
+            } else if remaining < line_total {
+                // Position is at end of line (on the newline)
+                return Position::new(line_idx, line.chars().count());
+            }
+
+            remaining -= line_total;
+        }
+
+        // Past end of buffer
+        let last_line = self.lines.len().saturating_sub(1);
+        let last_col = self.lines.last().map_or(0, |l| l.chars().count());
+        Position::new(last_line, last_col)
+    }
+
+    // === Helper Methods ===
+
+    /// Clamp a position to valid buffer coordinates.
+    #[must_use]
+    fn clamp_position(&self, pos: Position) -> Position {
+        if self.lines.is_empty() {
+            return Position::origin();
+        }
+
+        let line = pos.line.min(self.lines.len() - 1);
+        let max_col = self.lines[line].chars().count();
+        let column = pos.column.min(max_col);
+
+        Position::new(line, column)
+    }
+
+    /// Count characters between two positions.
+    fn char_count_between(&self, start: Position, end: Position) -> usize {
+        if start >= end {
+            return 0;
+        }
+
+        if start.line == end.line {
+            return end.column.saturating_sub(start.column);
+        }
+
+        let mut count = 0;
+
+        // Characters from start to end of first line + newline
+        if let Some(first_line) = self.lines.get(start.line) {
+            count += first_line.chars().count() - start.column + 1; // +1 for newline
+        }
+
+        // Full lines in between
+        for line_idx in start.line + 1..end.line {
+            if let Some(line) = self.lines.get(line_idx) {
+                count += line.chars().count() + 1; // +1 for newline
+            }
+        }
+
+        // Characters in last line
+        count += end.column;
+
+        count
+    }
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// === Helper Functions ===
+
+/// Convert a character offset to a byte offset within a line.
+fn char_to_byte_offset(line: &str, char_offset: usize) -> usize {
+    line.char_indices()
+        .nth(char_offset)
+        .map_or(line.len(), |(byte_idx, _)| byte_idx)
+}
+
+/// Convert a byte offset to a character offset within a line.
+fn byte_to_char_offset(line: &str, byte_offset: usize) -> usize {
+    line.char_indices()
+        .take_while(|(byte_idx, _)| *byte_idx < byte_offset)
+        .count()
+}

--- a/lib/kernel/src/mm/buffer_id.rs
+++ b/lib/kernel/src/mm/buffer_id.rs
@@ -1,0 +1,69 @@
+//! Buffer identification.
+//!
+//! Provides unique, monotonically increasing identifiers for buffers.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Global counter for buffer IDs.
+static NEXT_BUFFER_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// Unique identifier for a buffer.
+///
+/// Buffer IDs are monotonically increasing and never reused within a session.
+/// This ensures that buffer references remain unambiguous even after buffers
+/// are closed.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::mm::BufferId;
+///
+/// let id1 = BufferId::new();
+/// let id2 = BufferId::new();
+/// assert_ne!(id1, id2);
+/// assert!(id1 < id2);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BufferId(usize);
+
+impl BufferId {
+    /// Create a new unique buffer ID.
+    ///
+    /// Each call returns a distinct ID, guaranteed to be unique within
+    /// the current process lifetime.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(NEXT_BUFFER_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw numeric value.
+    #[must_use]
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+
+    /// Create a `BufferId` from a raw value.
+    ///
+    /// This is primarily useful for testing or deserialization.
+    ///
+    /// # Warning
+    ///
+    /// Using this incorrectly may create duplicate IDs. Prefer [`BufferId::new`]
+    /// for normal usage.
+    #[must_use]
+    pub const fn from_raw(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl Default for BufferId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for BufferId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Buffer({})", self.0)
+    }
+}

--- a/lib/kernel/src/mm/edit.rs
+++ b/lib/kernel/src/mm/edit.rs
@@ -1,0 +1,121 @@
+//! Edit operations for undo/redo support.
+//!
+//! This module defines atomic edit operations that can be recorded
+//! and inverted for undo/redo functionality.
+
+use super::Position;
+
+/// A single atomic edit operation.
+///
+/// Edits are self-contained and can be inverted for undo/redo.
+/// Each edit records the position where it occurred and the text involved.
+///
+/// # Undo/Redo
+///
+/// Use [`Edit::inverse`] to get the operation that undoes this edit:
+/// - `Insert` becomes `Delete`
+/// - `Delete` becomes `Insert`
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::mm::{Edit, Position};
+///
+/// let insert = Edit::insert(Position::new(0, 5), "Hello");
+/// assert!(insert.is_insert());
+/// assert_eq!(insert.text(), "Hello");
+///
+/// // Get the inverse for undo
+/// let undo = insert.inverse();
+/// assert!(undo.is_delete());
+/// assert_eq!(undo.position(), Position::new(0, 5));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Edit {
+    /// Text was inserted at a position.
+    Insert {
+        /// Position where text was inserted.
+        position: Position,
+        /// The inserted text.
+        text: String,
+    },
+    /// Text was deleted at a position.
+    Delete {
+        /// Position where deletion started.
+        position: Position,
+        /// The deleted text.
+        text: String,
+    },
+}
+
+impl Edit {
+    /// Create an insert edit.
+    #[must_use]
+    pub fn insert(position: Position, text: impl Into<String>) -> Self {
+        Self::Insert {
+            position,
+            text: text.into(),
+        }
+    }
+
+    /// Create a delete edit.
+    #[must_use]
+    pub fn delete(position: Position, text: impl Into<String>) -> Self {
+        Self::Delete {
+            position,
+            text: text.into(),
+        }
+    }
+
+    /// Get the inverse of this edit (for undo).
+    ///
+    /// Insert becomes Delete and vice versa. The position and text
+    /// are preserved.
+    #[must_use]
+    pub fn inverse(&self) -> Self {
+        match self {
+            Self::Insert { position, text } => Self::Delete {
+                position: *position,
+                text: text.clone(),
+            },
+            Self::Delete { position, text } => Self::Insert {
+                position: *position,
+                text: text.clone(),
+            },
+        }
+    }
+
+    /// Get the position where this edit occurred.
+    #[must_use]
+    pub const fn position(&self) -> Position {
+        match self {
+            Self::Insert { position, .. } | Self::Delete { position, .. } => *position,
+        }
+    }
+
+    /// Get the text involved in this edit.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        match self {
+            Self::Insert { text, .. } | Self::Delete { text, .. } => text,
+        }
+    }
+
+    /// Check if this edit is an insertion.
+    #[must_use]
+    pub const fn is_insert(&self) -> bool {
+        matches!(self, Self::Insert { .. })
+    }
+
+    /// Check if this edit is a deletion.
+    #[must_use]
+    pub const fn is_delete(&self) -> bool {
+        matches!(self, Self::Delete { .. })
+    }
+
+    /// Check if this edit has no effect (empty text).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.text().is_empty()
+    }
+}

--- a/lib/kernel/src/mm/mod.rs
+++ b/lib/kernel/src/mm/mod.rs
@@ -2,6 +2,58 @@
 //!
 //! Linux equivalent: `mm/`
 //!
-//! Provides buffer storage, rope data structures, and memory pooling.
+//! This module provides the foundational data structures for text editing:
+//! buffer storage, position types, and edit operations. It serves as the
+//! foundation upon which all other kernel modules are built.
+//!
+//! # Module Structure
+//!
+//! - [`buffer_id`]: Unique buffer identifiers with atomic generation
+//! - [`position`]: Position and cursor types for text navigation
+//! - [`edit`]: Edit operations for undo/redo support
+//! - [`buffer`]: Core buffer data structure with line-based storage
+//!
+//! # Design Philosophy
+//!
+//! This module follows the Linux kernel's memory management principles:
+//! - Simple, efficient data structures
+//! - Clear ownership semantics
+//! - No external dependencies (pure Rust)
+//! - Extensible foundation for advanced features
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::mm::{Buffer, Position, Edit};
+//!
+//! // Create a buffer from text
+//! let mut buf = Buffer::from_string("Hello\nWorld");
+//! assert_eq!(buf.line_count(), 2);
+//! assert_eq!(buf.line(0), Some("Hello"));
+//!
+//! // Edit the buffer
+//! buf.set_position(Position::new(0, 5));
+//! let edit = buf.insert("!");
+//! assert_eq!(buf.line(0), Some("Hello!"));
+//!
+//! // Edits are self-contained for undo
+//! assert!(edit.is_insert());
+//! assert_eq!(edit.text(), "!");
+//!
+//! // Get inverse for undo
+//! let undo = edit.inverse();
+//! assert!(undo.is_delete());
+//! ```
 
-// Placeholder - Buffer, Rope, Cache, Pool will be added in Phase 2
+mod buffer;
+mod buffer_id;
+mod edit;
+mod position;
+
+#[cfg(test)]
+mod tests;
+
+pub use buffer::Buffer;
+pub use buffer_id::BufferId;
+pub use edit::Edit;
+pub use position::{Cursor, Position};

--- a/lib/kernel/src/mm/position.rs
+++ b/lib/kernel/src/mm/position.rs
@@ -1,0 +1,190 @@
+//! Position and cursor types for text navigation.
+//!
+//! This module provides the fundamental types for representing locations
+//! within a text buffer and tracking cursor state.
+
+/// A position within a text buffer.
+///
+/// Positions are 0-indexed for both line and column.
+/// Column counts Unicode scalar values (chars), not bytes or graphemes.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::mm::Position;
+///
+/// let pos = Position::new(5, 10);
+/// assert_eq!(pos.line, 5);
+/// assert_eq!(pos.column, 10);
+///
+/// // Positions are ordered by line first, then column
+/// assert!(Position::new(0, 5) < Position::new(1, 0));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Position {
+    /// Line number (0-indexed).
+    pub line: usize,
+    /// Column number (0-indexed, counting chars).
+    pub column: usize,
+}
+
+impl Position {
+    /// Create a new position.
+    #[must_use]
+    pub const fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+
+    /// Create a position at the start of the buffer (0, 0).
+    #[must_use]
+    pub const fn origin() -> Self {
+        Self { line: 0, column: 0 }
+    }
+
+    /// Create a position at the start of a specific line.
+    #[must_use]
+    pub const fn line_start(line: usize) -> Self {
+        Self { line, column: 0 }
+    }
+}
+
+impl PartialOrd for Position {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Position {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.line.cmp(&other.line) {
+            std::cmp::Ordering::Equal => self.column.cmp(&other.column),
+            ord => ord,
+        }
+    }
+}
+
+impl std::fmt::Display for Position {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.line + 1, self.column + 1)
+    }
+}
+
+/// Cursor state within a buffer.
+///
+/// The cursor tracks the current position, an optional selection anchor,
+/// and a preferred column for vertical movement.
+///
+/// # Selection
+///
+/// When `anchor` is `Some`, a selection extends from `anchor` to `position`.
+/// The selection can be in either direction (anchor before or after position).
+///
+/// # Preferred Column
+///
+/// When moving vertically through lines of varying lengths, the cursor
+/// attempts to maintain its horizontal position. The `preferred_column`
+/// stores this target column.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::mm::{Cursor, Position};
+///
+/// let mut cursor = Cursor::new(Position::new(0, 5));
+///
+/// // Start a selection
+/// cursor.start_selection();
+/// cursor.position = Position::new(0, 10);
+///
+/// // Get normalized bounds (start before end)
+/// let (start, end) = cursor.selection_bounds().unwrap();
+/// assert_eq!(start, Position::new(0, 5));
+/// assert_eq!(end, Position::new(0, 10));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Cursor {
+    /// Current cursor position.
+    pub position: Position,
+    /// Selection anchor (if selection is active).
+    ///
+    /// When `Some`, a selection extends from `anchor` to `position`.
+    pub anchor: Option<Position>,
+    /// Preferred column for vertical movement (j/k).
+    ///
+    /// This preserves horizontal position when navigating through lines
+    /// of varying lengths.
+    pub preferred_column: Option<usize>,
+}
+
+impl Cursor {
+    /// Create a new cursor at the given position.
+    #[must_use]
+    pub const fn new(position: Position) -> Self {
+        Self {
+            position,
+            anchor: None,
+            preferred_column: None,
+        }
+    }
+
+    /// Create a cursor at the origin (0, 0).
+    #[must_use]
+    pub const fn origin() -> Self {
+        Self::new(Position::origin())
+    }
+
+    /// Start a selection at the current position.
+    pub const fn start_selection(&mut self) {
+        self.anchor = Some(self.position);
+    }
+
+    /// Clear the current selection.
+    pub const fn clear_selection(&mut self) {
+        self.anchor = None;
+    }
+
+    /// Check if a selection is active.
+    #[must_use]
+    pub const fn has_selection(&self) -> bool {
+        self.anchor.is_some()
+    }
+
+    /// Get the selection bounds (start, end) in document order.
+    ///
+    /// Returns `None` if no selection is active.
+    /// The returned positions are always ordered (start <= end).
+    #[must_use]
+    pub fn selection_bounds(&self) -> Option<(Position, Position)> {
+        self.anchor.map(|anchor| {
+            if anchor <= self.position {
+                (anchor, self.position)
+            } else {
+                (self.position, anchor)
+            }
+        })
+    }
+
+    /// Set preferred column to current column.
+    ///
+    /// Call this after horizontal movements to update the target column
+    /// for subsequent vertical movements.
+    pub const fn update_preferred_column(&mut self) {
+        self.preferred_column = Some(self.position.column);
+    }
+
+    /// Clear preferred column.
+    ///
+    /// Call this after horizontal movements that should reset
+    /// the vertical movement target.
+    pub const fn clear_preferred_column(&mut self) {
+        self.preferred_column = None;
+    }
+
+    /// Get the effective column for vertical movement.
+    ///
+    /// Returns the preferred column if set, otherwise the current column.
+    #[must_use]
+    pub fn effective_column(&self) -> usize {
+        self.preferred_column.unwrap_or(self.position.column)
+    }
+}

--- a/lib/kernel/src/mm/tests.rs
+++ b/lib/kernel/src/mm/tests.rs
@@ -1,0 +1,562 @@
+//! Tests for the mm module.
+
+use super::*;
+
+// === BufferId Tests ===
+
+mod buffer_id_tests {
+    use super::*;
+
+    #[test]
+    fn test_unique_ids() {
+        let id1 = BufferId::new();
+        let id2 = BufferId::new();
+        let id3 = BufferId::new();
+
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let id1 = BufferId::new();
+        let id2 = BufferId::new();
+
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_from_raw() {
+        let id = BufferId::from_raw(42);
+        assert_eq!(id.as_usize(), 42);
+    }
+
+    #[test]
+    fn test_display() {
+        let id = BufferId::from_raw(123);
+        assert_eq!(format!("{}", id), "Buffer(123)");
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+
+        let id1 = BufferId::new();
+        let id2 = BufferId::new();
+
+        let mut set = HashSet::new();
+        set.insert(id1);
+        set.insert(id2);
+        set.insert(id1); // Duplicate
+
+        assert_eq!(set.len(), 2);
+    }
+}
+
+// === Position Tests ===
+
+mod position_tests {
+    use super::*;
+
+    #[test]
+    fn test_origin() {
+        let pos = Position::origin();
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 0);
+    }
+
+    #[test]
+    fn test_new() {
+        let pos = Position::new(5, 10);
+        assert_eq!(pos.line, 5);
+        assert_eq!(pos.column, 10);
+    }
+
+    #[test]
+    fn test_line_start() {
+        let pos = Position::line_start(3);
+        assert_eq!(pos.line, 3);
+        assert_eq!(pos.column, 0);
+    }
+
+    #[test]
+    fn test_ordering() {
+        assert!(Position::new(0, 0) < Position::new(0, 1));
+        assert!(Position::new(0, 1) < Position::new(1, 0));
+        assert!(Position::new(1, 5) < Position::new(2, 0));
+        assert_eq!(Position::new(1, 1), Position::new(1, 1));
+    }
+
+    #[test]
+    fn test_ordering_same_line() {
+        assert!(Position::new(5, 0) < Position::new(5, 1));
+        assert!(Position::new(5, 1) < Position::new(5, 10));
+    }
+
+    #[test]
+    fn test_display() {
+        let pos = Position::new(0, 5);
+        // Display uses 1-indexed for human readability
+        assert_eq!(format!("{}", pos), "1:6");
+    }
+
+    #[test]
+    fn test_default() {
+        let pos = Position::default();
+        assert_eq!(pos, Position::origin());
+    }
+}
+
+// === Cursor Tests ===
+
+mod cursor_tests {
+    use super::*;
+
+    #[test]
+    fn test_origin() {
+        let cursor = Cursor::origin();
+        assert_eq!(cursor.position, Position::origin());
+        assert!(cursor.anchor.is_none());
+        assert!(cursor.preferred_column.is_none());
+    }
+
+    #[test]
+    fn test_new() {
+        let cursor = Cursor::new(Position::new(5, 10));
+        assert_eq!(cursor.position, Position::new(5, 10));
+        assert!(!cursor.has_selection());
+    }
+
+    #[test]
+    fn test_selection() {
+        let mut cursor = Cursor::new(Position::new(0, 5));
+        assert!(!cursor.has_selection());
+
+        cursor.start_selection();
+        assert!(cursor.has_selection());
+        assert_eq!(cursor.anchor, Some(Position::new(0, 5)));
+
+        cursor.clear_selection();
+        assert!(!cursor.has_selection());
+    }
+
+    #[test]
+    fn test_selection_bounds() {
+        let mut cursor = Cursor::new(Position::new(0, 0));
+        cursor.start_selection();
+        cursor.position = Position::new(0, 5);
+
+        let bounds = cursor.selection_bounds();
+        assert_eq!(bounds, Some((Position::new(0, 0), Position::new(0, 5))));
+    }
+
+    #[test]
+    fn test_selection_bounds_backward() {
+        let mut cursor = Cursor::new(Position::new(0, 5));
+        cursor.start_selection();
+        cursor.position = Position::new(0, 0);
+
+        let bounds = cursor.selection_bounds();
+        // Should normalize to (start, end)
+        assert_eq!(bounds, Some((Position::new(0, 0), Position::new(0, 5))));
+    }
+
+    #[test]
+    fn test_selection_bounds_multiline() {
+        let mut cursor = Cursor::new(Position::new(0, 5));
+        cursor.start_selection();
+        cursor.position = Position::new(2, 3);
+
+        let bounds = cursor.selection_bounds();
+        assert_eq!(bounds, Some((Position::new(0, 5), Position::new(2, 3))));
+    }
+
+    #[test]
+    fn test_preferred_column() {
+        let mut cursor = Cursor::new(Position::new(0, 10));
+        assert!(cursor.preferred_column.is_none());
+        assert_eq!(cursor.effective_column(), 10);
+
+        cursor.update_preferred_column();
+        assert_eq!(cursor.preferred_column, Some(10));
+        assert_eq!(cursor.effective_column(), 10);
+
+        // Change position but preferred_column stays
+        cursor.position = Position::new(1, 5);
+        assert_eq!(cursor.effective_column(), 10); // Still uses preferred
+
+        cursor.clear_preferred_column();
+        assert!(cursor.preferred_column.is_none());
+        assert_eq!(cursor.effective_column(), 5); // Now uses actual
+    }
+}
+
+// === Edit Tests ===
+
+mod edit_tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_edit() {
+        let edit = Edit::insert(Position::new(0, 0), "Hello");
+        assert!(edit.is_insert());
+        assert!(!edit.is_delete());
+        assert_eq!(edit.position(), Position::new(0, 0));
+        assert_eq!(edit.text(), "Hello");
+    }
+
+    #[test]
+    fn test_delete_edit() {
+        let edit = Edit::delete(Position::new(1, 5), "World");
+        assert!(!edit.is_insert());
+        assert!(edit.is_delete());
+        assert_eq!(edit.position(), Position::new(1, 5));
+        assert_eq!(edit.text(), "World");
+    }
+
+    #[test]
+    fn test_inverse() {
+        let insert = Edit::insert(Position::new(0, 0), "Test");
+        let inverse = insert.inverse();
+
+        assert!(inverse.is_delete());
+        assert_eq!(inverse.position(), Position::new(0, 0));
+        assert_eq!(inverse.text(), "Test");
+
+        // Double inverse returns to original
+        let double = inverse.inverse();
+        assert_eq!(double, insert);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let empty_insert = Edit::insert(Position::origin(), "");
+        assert!(empty_insert.is_empty());
+
+        let non_empty = Edit::insert(Position::origin(), "x");
+        assert!(!non_empty.is_empty());
+    }
+}
+
+// === Buffer Tests ===
+
+mod buffer_tests {
+    use super::*;
+
+    #[test]
+    fn test_new_buffer() {
+        let buf = Buffer::new();
+        assert_eq!(buf.line_count(), 0);
+        assert!(buf.is_empty());
+        assert!(!buf.is_modified());
+    }
+
+    #[test]
+    fn test_from_string() {
+        let buf = Buffer::from_string("Hello\nWorld");
+        assert_eq!(buf.line_count(), 2);
+        assert_eq!(buf.line(0), Some("Hello"));
+        assert_eq!(buf.line(1), Some("World"));
+    }
+
+    #[test]
+    fn test_from_empty_string() {
+        let buf = Buffer::from_string("");
+        assert_eq!(buf.line_count(), 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_from_single_line() {
+        let buf = Buffer::from_string("Hello");
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("Hello"));
+    }
+
+    #[test]
+    fn test_from_trailing_newline() {
+        // Note: lines() doesn't include empty trailing line
+        let buf = Buffer::from_string("Hello\n");
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("Hello"));
+    }
+
+    #[test]
+    fn test_line_len() {
+        let buf = Buffer::from_string("Hello\nWorld!");
+        assert_eq!(buf.line_len(0), Some(5));
+        assert_eq!(buf.line_len(1), Some(6));
+        assert_eq!(buf.line_len(2), None);
+    }
+
+    #[test]
+    fn test_content() {
+        let buf = Buffer::from_string("Hello\nWorld");
+        assert_eq!(buf.content(), "Hello\nWorld");
+    }
+
+    #[test]
+    fn test_set_content() {
+        let mut buf = Buffer::new();
+        buf.set_content("New\nContent");
+        assert_eq!(buf.line_count(), 2);
+        assert_eq!(buf.line(0), Some("New"));
+        assert!(buf.is_modified());
+    }
+
+    #[test]
+    fn test_insert_single_char() {
+        let mut buf = Buffer::from_string("Hello");
+        buf.set_position(Position::new(0, 5));
+        buf.insert("!");
+        assert_eq!(buf.line(0), Some("Hello!"));
+        assert_eq!(buf.position(), Position::new(0, 6));
+    }
+
+    #[test]
+    fn test_insert_at_beginning() {
+        let mut buf = Buffer::from_string("World");
+        buf.set_position(Position::new(0, 0));
+        buf.insert("Hello ");
+        assert_eq!(buf.line(0), Some("Hello World"));
+    }
+
+    #[test]
+    fn test_insert_middle() {
+        let mut buf = Buffer::from_string("Hllo");
+        buf.set_position(Position::new(0, 1));
+        buf.insert("e");
+        assert_eq!(buf.line(0), Some("Hello"));
+    }
+
+    #[test]
+    fn test_insert_newline() {
+        let mut buf = Buffer::from_string("HelloWorld");
+        buf.set_position(Position::new(0, 5));
+        buf.insert("\n");
+        assert_eq!(buf.line_count(), 2);
+        assert_eq!(buf.line(0), Some("Hello"));
+        assert_eq!(buf.line(1), Some("World"));
+    }
+
+    #[test]
+    fn test_insert_multiline() {
+        let mut buf = Buffer::from_string("AC");
+        buf.set_position(Position::new(0, 1));
+        buf.insert("X\nY\nZ");
+        assert_eq!(buf.line_count(), 3);
+        assert_eq!(buf.line(0), Some("AX"));
+        assert_eq!(buf.line(1), Some("Y"));
+        assert_eq!(buf.line(2), Some("ZC"));
+    }
+
+    #[test]
+    fn test_insert_into_empty() {
+        let mut buf = Buffer::new();
+        buf.insert("Hello");
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("Hello"));
+    }
+
+    #[test]
+    fn test_insert_empty_string() {
+        let mut buf = Buffer::from_string("Hello");
+        buf.set_position(Position::new(0, 2));
+        buf.insert("");
+        assert_eq!(buf.line(0), Some("Hello"));
+        assert_eq!(buf.position(), Position::new(0, 2)); // Position unchanged
+    }
+
+    #[test]
+    fn test_delete_single_char() {
+        let mut buf = Buffer::from_string("Hello");
+        buf.set_position(Position::new(0, 0));
+        let edit = buf.delete(1);
+        assert_eq!(buf.line(0), Some("ello"));
+        assert_eq!(edit.text(), "H");
+    }
+
+    #[test]
+    fn test_delete_multiple_chars() {
+        let mut buf = Buffer::from_string("Hello World");
+        buf.set_position(Position::new(0, 0));
+        buf.delete(6);
+        assert_eq!(buf.line(0), Some("World"));
+    }
+
+    #[test]
+    fn test_delete_newline() {
+        let mut buf = Buffer::from_string("Hello\nWorld");
+        buf.set_position(Position::new(0, 5));
+        buf.delete(1);
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("HelloWorld"));
+    }
+
+    #[test]
+    fn test_delete_across_lines() {
+        let mut buf = Buffer::from_string("Hello\nWorld");
+        buf.set_position(Position::new(0, 3));
+        buf.delete(5); // "lo\nWo"
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("Helrld"));
+    }
+
+    #[test]
+    fn test_delete_nothing() {
+        let mut buf = Buffer::from_string("Hello");
+        buf.set_position(Position::new(0, 2));
+        let edit = buf.delete(0);
+        assert_eq!(buf.line(0), Some("Hello"));
+        assert!(edit.is_empty());
+    }
+
+    #[test]
+    fn test_delete_past_end() {
+        let mut buf = Buffer::from_string("Hi");
+        buf.set_position(Position::new(0, 0));
+        let edit = buf.delete(100);
+        assert_eq!(edit.text(), "Hi");
+        assert_eq!(buf.line(0), Some(""));
+    }
+
+    #[test]
+    fn test_delete_range() {
+        let mut buf = Buffer::from_string("Hello World");
+        let deleted = buf.delete_range(Position::new(0, 0), Position::new(0, 5));
+        assert_eq!(deleted, "Hello");
+        assert_eq!(buf.line(0), Some(" World"));
+    }
+
+    #[test]
+    fn test_delete_range_reversed() {
+        let mut buf = Buffer::from_string("Hello World");
+        // Passing end before start should still work
+        let deleted = buf.delete_range(Position::new(0, 5), Position::new(0, 0));
+        assert_eq!(deleted, "Hello");
+    }
+
+    #[test]
+    fn test_delete_range_multiline() {
+        let mut buf = Buffer::from_string("Hello\nBeautiful\nWorld");
+        let deleted = buf.delete_range(Position::new(0, 3), Position::new(2, 2));
+        assert_eq!(deleted, "lo\nBeautiful\nWo");
+        assert_eq!(buf.line_count(), 1);
+        assert_eq!(buf.line(0), Some("Helrld"));
+    }
+
+    #[test]
+    fn test_position_to_byte() {
+        let buf = Buffer::from_string("Hello\nWorld");
+        assert_eq!(buf.position_to_byte(Position::new(0, 0)), 0);
+        assert_eq!(buf.position_to_byte(Position::new(0, 5)), 5);
+        assert_eq!(buf.position_to_byte(Position::new(1, 0)), 6);
+        assert_eq!(buf.position_to_byte(Position::new(1, 5)), 11);
+    }
+
+    #[test]
+    fn test_byte_to_position() {
+        let buf = Buffer::from_string("Hello\nWorld");
+        assert_eq!(buf.byte_to_position(0), Position::new(0, 0));
+        assert_eq!(buf.byte_to_position(5), Position::new(0, 5));
+        assert_eq!(buf.byte_to_position(6), Position::new(1, 0));
+        assert_eq!(buf.byte_to_position(11), Position::new(1, 5));
+    }
+
+    #[test]
+    fn test_byte_position_roundtrip() {
+        let buf = Buffer::from_string("Hello\nWorld\nTest");
+        for line in 0..buf.line_count() {
+            for col in 0..=buf.line_len(line).unwrap() {
+                let pos = Position::new(line, col);
+                let byte = buf.position_to_byte(pos);
+                let back = buf.byte_to_position(byte);
+                assert_eq!(pos, back, "Roundtrip failed for {:?}", pos);
+            }
+        }
+    }
+
+    #[test]
+    fn test_unicode_handling() {
+        // Test with unicode: "Héllo" (H + é + l + l + o)
+        let buf = Buffer::from_string("Héllo");
+        // "Héllo" has 5 chars (unicode scalar values)
+        assert_eq!(buf.line_len(0), Some(5));
+        // Byte positions: H=0, é=1-2 (2 bytes), l=3, l=4, o=5
+        assert_eq!(buf.position_to_byte(Position::new(0, 0)), 0); // H starts at 0
+        assert_eq!(buf.position_to_byte(Position::new(0, 1)), 1); // é starts at 1
+        assert_eq!(buf.position_to_byte(Position::new(0, 2)), 3); // first l starts at 3 (after 2-byte é)
+        assert_eq!(buf.position_to_byte(Position::new(0, 5)), 6); // end of string
+    }
+
+    #[test]
+    fn test_unicode_insert() {
+        let mut buf = Buffer::from_string("Héllo");
+        buf.set_position(Position::new(0, 5)); // After "Héllo"
+        buf.insert(" World");
+        assert_eq!(buf.line(0), Some("Héllo World"));
+    }
+
+    #[test]
+    fn test_position_clamping() {
+        let mut buf = Buffer::from_string("Hi");
+        buf.set_position(Position::new(100, 100));
+        // Should clamp to end of buffer
+        assert_eq!(buf.position(), Position::new(0, 2));
+    }
+
+    #[test]
+    fn test_position_clamping_empty() {
+        let mut buf = Buffer::new();
+        buf.set_position(Position::new(5, 5));
+        assert_eq!(buf.position(), Position::origin());
+    }
+
+    #[test]
+    fn test_modified_flag() {
+        let mut buf = Buffer::from_string("Hello");
+        assert!(!buf.is_modified());
+
+        buf.insert("!");
+        assert!(buf.is_modified());
+
+        buf.set_modified(false);
+        assert!(!buf.is_modified());
+    }
+
+    #[test]
+    fn test_buffer_id_unique() {
+        let buf1 = Buffer::new();
+        let buf2 = Buffer::new();
+        assert_ne!(buf1.id(), buf2.id());
+    }
+
+    #[test]
+    fn test_with_id() {
+        let id = BufferId::from_raw(42);
+        let buf = Buffer::with_id(id);
+        assert_eq!(buf.id(), id);
+    }
+
+    #[test]
+    fn test_lines_accessor() {
+        let buf = Buffer::from_string("Line1\nLine2\nLine3");
+        let lines = buf.lines();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "Line1");
+        assert_eq!(lines[1], "Line2");
+        assert_eq!(lines[2], "Line3");
+    }
+
+    #[test]
+    fn test_cursor_accessors() {
+        let mut buf = Buffer::from_string("Hello");
+        buf.set_position(Position::new(0, 3));
+
+        assert_eq!(buf.cursor().position, Position::new(0, 3));
+
+        buf.cursor_mut().start_selection();
+        assert!(buf.cursor().has_selection());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement Phase 2.1 of the Linux-inspired architecture overhaul
- Add foundational memory management module (`lib/kernel/src/mm/`)
- Provide data structures that all other kernel modules depend on

## Types Implemented

| Type | Description |
|------|-------------|
| `BufferId` | Unique buffer identifier with atomic counter |
| `Position` | Text position with `line`, `column` (0-indexed, usize) |
| `Cursor` | Position + selection anchor + preferred column |
| `Edit` | Insert/Delete operations for undo/redo |
| `Buffer` | Line-based text storage with `Vec<String>` |

## Buffer API

- **Constructors**: `new()`, `from_string()`, `with_id()`
- **Line access**: `line()`, `line_count()`, `line_len()`, `content()`
- **Editing**: `insert()`, `delete()`, `delete_range()`
- **Position conversion**: `position_to_byte()`, `byte_to_position()`

## Design Decisions

- Use `(line, column)` naming instead of `(x, y)` for clarity
- Use `usize` for indices to handle large files
- Self-contained `Edit` with position for undo support
- Simple `Vec<String>` storage (Rope optimization can come later)

## Test Plan

- [x] `cargo build -p reovim-kernel` succeeds
- [x] `cargo clippy -p reovim-kernel -- -D warnings` passes (zero warnings)
- [x] `cargo test -p reovim-kernel` passes (59 unit tests + 6 doctests)
- [x] No external dependencies added (pure Rust)

## Closes

Closes #159