### PR TITLE
feat(kernel): implement ipc/ inter-process communication module (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 2.2: IPC Module** (Issue #160) - Kernel ipc/ subsystem
+  - `Event` trait - Minimal requirements for IPC events (priority, batchable)
+  - `DynEvent` - Type-erased event wrapper with TypeId-based downcasting
+  - `EventResult` - Handler return type (Handled, Consumed, NotHandled)
+  - `EventBus` - Type-erased pub/sub dispatch with ArcSwap lock-free reads
+    - `subscribe<E, F>(priority, handler)` - Register typed handler with priority
+    - `emit<E>(event)` - Synchronous dispatch to all handlers
+    - `emit_async<E>(event)` - Queue for deferred processing
+    - `emit_scoped<E>(event, scope)` - Emit with lifecycle tracking
+    - `process_queue()` - Drain async queue
+  - `EventScope` - GC-like synchronization for event lifecycle
+    - Atomic counter with Condvar-based waiting
+    - `wait()` / `wait_timeout()` for blocking synchronization
+    - `DEFAULT_TIMEOUT = 3s` (production-proven value)
+  - `Subscription` - RAII handle with automatic unsubscribe on drop
+  - Channel abstractions (std::sync::mpsc wrappers):
+    - `channel<T>()` - Unbounded MPSC
+    - `bounded<T>(capacity)` - Bounded MPSC with backpressure
+    - `oneshot<T>()` - Single-use request/response
+  - 85 IPC unit tests + 24 doctests
+
 - **Phase 2.1: Memory Management Module** (Issue #159) - Kernel mm/ subsystem
   - `BufferId` - Unique buffer identifier with atomic counter generation
   - `Position` - Text position with `line` and `column` fields (0-indexed, usize)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,10 @@ dependencies = [
 name = "reovim-kernel"
 version = "0.9.0-dev"
 dependencies = [
+ "arc-swap",
+ "parking_lot",
  "reovim-arch",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/kernel/Cargo.toml
+++ b/lib/kernel/Cargo.toml
@@ -15,3 +15,12 @@ workspace = true
 [dependencies]
 # Only depends on arch layer
 reovim-arch = { path = "../arch", version = "0.9.0-dev" }
+
+# Lock-free data structures for hot paths
+arc-swap = "1.8"
+
+# Faster synchronization primitives
+parking_lot = "0.12.3"
+
+# Logging/tracing
+tracing.workspace = true

--- a/lib/kernel/src/ipc/channel.rs
+++ b/lib/kernel/src/ipc/channel.rs
@@ -1,0 +1,642 @@
+//! Channel abstractions for inter-subsystem communication.
+//!
+//! This module provides thin wrappers around `std::sync::mpsc` channels,
+//! keeping the kernel runtime-agnostic (no tokio dependency).
+//!
+//! # Design Philosophy
+//!
+//! Following the "mechanisms not policy" principle:
+//! - Provides basic channel primitives
+//! - No opinion on how they should be used
+//! - Runtime integration is left to higher layers
+//!
+//! # Channel Types
+//!
+//! - **Unbounded MPSC**: Multiple producers, single consumer, unlimited buffer
+//! - **Bounded MPSC**: Multiple producers, single consumer, fixed capacity
+//! - **Oneshot**: Single-use channel for request-response patterns
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::ipc::{channel, bounded, oneshot};
+//!
+//! // Unbounded channel
+//! let (tx, rx) = channel::<i32>();
+//! tx.send(42).unwrap();
+//! assert_eq!(rx.recv().unwrap(), 42);
+//!
+//! // Bounded channel with capacity 2
+//! let (tx, rx) = bounded::<i32>(2);
+//! tx.send(1).unwrap();
+//! tx.send(2).unwrap();
+//! // tx.send(3) would block until space is available
+//!
+//! // Oneshot for request-response
+//! let (tx, rx) = oneshot::<String>();
+//! tx.send("response".to_string()).unwrap();
+//! assert_eq!(rx.recv().unwrap(), "response");
+//! ```
+
+use std::{sync::mpsc, time::Duration};
+
+use parking_lot::Mutex;
+
+// ============================================================================
+// Unbounded Channel
+// ============================================================================
+
+/// Sender for unbounded MPSC channel.
+///
+/// Cloning creates a new sender to the same channel.
+#[derive(Clone)]
+pub struct Sender<T>(mpsc::Sender<T>);
+
+/// Receiver for unbounded MPSC channel.
+///
+/// Only one receiver exists per channel.
+pub struct Receiver<T>(mpsc::Receiver<T>);
+
+/// Error returned when sending fails because the receiver was dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendError<T>(pub T);
+
+impl<T> std::fmt::Display for SendError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "sending on a closed channel")
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for SendError<T> {}
+
+/// Error returned when receiving fails because the channel is empty and closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecvError;
+
+impl std::fmt::Display for RecvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "receiving on a closed channel")
+    }
+}
+
+impl std::error::Error for RecvError {}
+
+/// Error returned when `try_recv` fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TryRecvError {
+    /// No message available.
+    Empty,
+    /// Channel is closed.
+    Disconnected,
+}
+
+impl std::fmt::Display for TryRecvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "channel is empty"),
+            Self::Disconnected => write!(f, "channel is disconnected"),
+        }
+    }
+}
+
+impl std::error::Error for TryRecvError {}
+
+impl<T> Sender<T> {
+    /// Send a value through the channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(SendError(value))` if the receiver has been dropped.
+    pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        self.0.send(value).map_err(|e| SendError(e.0))
+    }
+}
+
+impl<T> std::fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sender").finish_non_exhaustive()
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Block until a value is received.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` if the channel is closed.
+    pub fn recv(&self) -> Result<T, RecvError> {
+        self.0.recv().map_err(|_| RecvError)
+    }
+
+    /// Try to receive without blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TryRecvError::Empty)` if no message is available,
+    /// or `Err(TryRecvError::Disconnected)` if the channel is closed.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        self.0.try_recv().map_err(|e| match e {
+            mpsc::TryRecvError::Empty => TryRecvError::Empty,
+            mpsc::TryRecvError::Disconnected => TryRecvError::Disconnected,
+        })
+    }
+
+    /// Block until a value is received or timeout expires.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` on timeout or if channel is closed.
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvError> {
+        self.0.recv_timeout(timeout).map_err(|_| RecvError)
+    }
+
+    /// Create an iterator over received values.
+    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.0.iter()
+    }
+
+    /// Try to receive all available values without blocking.
+    pub fn try_iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.0.try_iter()
+    }
+}
+
+impl<T> std::fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Receiver").finish_non_exhaustive()
+    }
+}
+
+/// Create an unbounded MPSC channel.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::ipc::channel;
+///
+/// let (tx, rx) = channel::<i32>();
+/// tx.send(42).unwrap();
+/// assert_eq!(rx.recv().unwrap(), 42);
+/// ```
+#[must_use]
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (tx, rx) = mpsc::channel();
+    (Sender(tx), Receiver(rx))
+}
+
+// ============================================================================
+// Bounded Channel
+// ============================================================================
+
+/// Sender for bounded MPSC channel.
+#[derive(Clone)]
+pub struct BoundedSender<T>(mpsc::SyncSender<T>);
+
+/// Receiver for bounded MPSC channel (same as unbounded).
+pub struct BoundedReceiver<T>(mpsc::Receiver<T>);
+
+/// Error returned when `try_send` fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrySendError<T> {
+    /// Channel is full.
+    Full(T),
+    /// Channel is closed.
+    Disconnected(T),
+}
+
+impl<T> std::fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Full(_) => write!(f, "channel is full"),
+            Self::Disconnected(_) => write!(f, "channel is disconnected"),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for TrySendError<T> {}
+
+impl<T> BoundedSender<T> {
+    /// Send a value, blocking if the channel is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(SendError(value))` if the receiver has been dropped.
+    pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        self.0.send(value).map_err(|e| SendError(e.0))
+    }
+
+    /// Try to send without blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TrySendError::Full(value))` if the channel is full,
+    /// or `Err(TrySendError::Disconnected(value))` if the receiver was dropped.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        self.0.try_send(value).map_err(|e| match e {
+            mpsc::TrySendError::Full(v) => TrySendError::Full(v),
+            mpsc::TrySendError::Disconnected(v) => TrySendError::Disconnected(v),
+        })
+    }
+}
+
+impl<T> std::fmt::Debug for BoundedSender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundedSender").finish_non_exhaustive()
+    }
+}
+
+impl<T> BoundedReceiver<T> {
+    /// Block until a value is received.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` if the channel is closed.
+    pub fn recv(&self) -> Result<T, RecvError> {
+        self.0.recv().map_err(|_| RecvError)
+    }
+
+    /// Try to receive without blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TryRecvError::Empty)` if no message is available,
+    /// or `Err(TryRecvError::Disconnected)` if the channel is closed.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        self.0.try_recv().map_err(|e| match e {
+            mpsc::TryRecvError::Empty => TryRecvError::Empty,
+            mpsc::TryRecvError::Disconnected => TryRecvError::Disconnected,
+        })
+    }
+
+    /// Block until a value is received or timeout expires.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` on timeout or if the channel is closed.
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvError> {
+        self.0.recv_timeout(timeout).map_err(|_| RecvError)
+    }
+
+    /// Create an iterator over received values.
+    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.0.iter()
+    }
+
+    /// Try to receive all available values without blocking.
+    pub fn try_iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.0.try_iter()
+    }
+}
+
+impl<T> std::fmt::Debug for BoundedReceiver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundedReceiver").finish_non_exhaustive()
+    }
+}
+
+/// Create a bounded MPSC channel with the specified capacity.
+///
+/// Senders will block when the channel is full.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::ipc::bounded;
+///
+/// let (tx, rx) = bounded::<i32>(2);
+/// tx.send(1).unwrap();
+/// tx.send(2).unwrap();
+/// // tx.send(3) would block until space is available
+///
+/// assert_eq!(rx.recv().unwrap(), 1);
+/// assert_eq!(rx.recv().unwrap(), 2);
+/// ```
+#[must_use]
+pub fn bounded<T>(capacity: usize) -> (BoundedSender<T>, BoundedReceiver<T>) {
+    let (tx, rx) = mpsc::sync_channel(capacity);
+    (BoundedSender(tx), BoundedReceiver(rx))
+}
+
+// ============================================================================
+// Oneshot Channel
+// ============================================================================
+
+/// Sender for oneshot channel.
+///
+/// Can only send a single value.
+pub struct OneshotSender<T> {
+    inner: Mutex<Option<mpsc::SyncSender<T>>>,
+}
+
+/// Receiver for oneshot channel.
+///
+/// Can only receive a single value.
+pub struct OneshotReceiver<T>(mpsc::Receiver<T>);
+
+impl<T> OneshotSender<T> {
+    /// Send the value, consuming the sender.
+    ///
+    /// This can only be called once.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(value)` if the receiver has been dropped.
+    pub fn send(self, value: T) -> Result<(), T> {
+        let sender = self.inner.lock().take();
+        match sender {
+            Some(tx) => tx.send(value).map_err(|e| e.0),
+            None => Err(value),
+        }
+    }
+
+    /// Check if the receiver is still waiting.
+    #[must_use]
+    pub fn is_connected(&self) -> bool {
+        self.inner.lock().is_some()
+    }
+}
+
+impl<T> std::fmt::Debug for OneshotSender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OneshotSender")
+            .field("connected", &self.is_connected())
+            .finish()
+    }
+}
+
+impl<T> OneshotReceiver<T> {
+    /// Block until the value is received.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` if the sender was dropped without sending.
+    pub fn recv(self) -> Result<T, RecvError> {
+        self.0.recv().map_err(|_| RecvError)
+    }
+
+    /// Try to receive without blocking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TryRecvError::Empty)` if no value is available yet,
+    /// or `Err(TryRecvError::Disconnected)` if the sender was dropped.
+    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+        self.0.try_recv().map_err(|e| match e {
+            mpsc::TryRecvError::Empty => TryRecvError::Empty,
+            mpsc::TryRecvError::Disconnected => TryRecvError::Disconnected,
+        })
+    }
+
+    /// Block until received or timeout expires.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RecvError)` on timeout or if the sender was dropped.
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvError> {
+        self.0.recv_timeout(timeout).map_err(|_| RecvError)
+    }
+}
+
+impl<T> std::fmt::Debug for OneshotReceiver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OneshotReceiver").finish_non_exhaustive()
+    }
+}
+
+/// Create a oneshot channel for single-value communication.
+///
+/// Useful for request-response patterns where exactly one response is expected.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::ipc::oneshot;
+/// use std::thread;
+///
+/// let (tx, rx) = oneshot::<String>();
+///
+/// thread::spawn(move || {
+///     tx.send("response".to_string()).unwrap();
+/// });
+///
+/// assert_eq!(rx.recv().unwrap(), "response");
+/// ```
+#[must_use]
+pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
+    let (tx, rx) = mpsc::sync_channel(1);
+    (
+        OneshotSender {
+            inner: Mutex::new(Some(tx)),
+        },
+        OneshotReceiver(rx),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::thread};
+
+    // ========== Unbounded channel tests ==========
+
+    #[test]
+    fn test_channel_send_recv() {
+        let (tx, rx) = channel::<i32>();
+        tx.send(42).unwrap();
+        assert_eq!(rx.recv().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_channel_multiple_sends() {
+        let (tx, rx) = channel::<i32>();
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        tx.send(3).unwrap();
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert_eq!(rx.recv().unwrap(), 2);
+        assert_eq!(rx.recv().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_channel_clone_sender() {
+        let (tx, rx) = channel::<i32>();
+        let tx2 = tx.clone();
+        tx.send(1).unwrap();
+        tx2.send(2).unwrap();
+        let mut values = vec![rx.recv().unwrap(), rx.recv().unwrap()];
+        values.sort_unstable();
+        assert_eq!(values, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_channel_try_recv_empty() {
+        let (tx, rx) = channel::<i32>();
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        tx.send(42).unwrap();
+        assert_eq!(rx.try_recv(), Ok(42));
+    }
+
+    #[test]
+    fn test_channel_recv_disconnected() {
+        let (tx, rx) = channel::<i32>();
+        drop(tx);
+        assert_eq!(rx.recv(), Err(RecvError));
+    }
+
+    #[test]
+    fn test_channel_send_disconnected() {
+        let (tx, rx) = channel::<i32>();
+        drop(rx);
+        assert_eq!(tx.send(42), Err(SendError(42)));
+    }
+
+    #[test]
+    fn test_channel_recv_timeout() {
+        let (tx, rx) = channel::<i32>();
+        let start = std::time::Instant::now();
+        let result = rx.recv_timeout(Duration::from_millis(10));
+        assert!(result.is_err());
+        assert!(start.elapsed() >= Duration::from_millis(10));
+
+        tx.send(42).unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(1)).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_channel_try_iter() {
+        let (tx, rx) = channel::<i32>();
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        tx.send(3).unwrap();
+        let values: Vec<_> = rx.try_iter().collect();
+        assert_eq!(values, vec![1, 2, 3]);
+    }
+
+    // ========== Bounded channel tests ==========
+
+    #[test]
+    fn test_bounded_send_recv() {
+        let (tx, rx) = bounded::<i32>(2);
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert_eq!(rx.recv().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_bounded_try_send_full() {
+        let (tx, rx) = bounded::<i32>(1);
+        tx.send(1).unwrap();
+        assert!(matches!(tx.try_send(2), Err(TrySendError::Full(2))));
+
+        rx.recv().unwrap();
+        tx.try_send(2).unwrap();
+    }
+
+    #[test]
+    fn test_bounded_try_send_disconnected() {
+        let (tx, rx) = bounded::<i32>(1);
+        drop(rx);
+        assert!(matches!(tx.try_send(42), Err(TrySendError::Disconnected(42))));
+    }
+
+    #[test]
+    fn test_bounded_clone_sender() {
+        let (tx, rx) = bounded::<i32>(2);
+        let tx2 = tx.clone();
+        tx.send(1).unwrap();
+        tx2.send(2).unwrap();
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert_eq!(rx.recv().unwrap(), 2);
+    }
+
+    // ========== Oneshot channel tests ==========
+
+    #[test]
+    fn test_oneshot_send_recv() {
+        let (tx, rx) = oneshot::<String>();
+        tx.send("hello".to_string()).unwrap();
+        assert_eq!(rx.recv().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_oneshot_receiver_dropped() {
+        let (tx, rx) = oneshot::<i32>();
+        drop(rx);
+        assert_eq!(tx.send(42), Err(42));
+    }
+
+    #[test]
+    fn test_oneshot_sender_dropped() {
+        let (tx, rx) = oneshot::<i32>();
+        drop(tx);
+        assert_eq!(rx.recv(), Err(RecvError));
+    }
+
+    #[test]
+    fn test_oneshot_try_recv() {
+        let (tx, rx) = oneshot::<i32>();
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        tx.send(42).unwrap();
+        assert_eq!(rx.try_recv(), Ok(42));
+    }
+
+    #[test]
+    fn test_oneshot_is_connected() {
+        let (tx, rx) = oneshot::<i32>();
+        assert!(tx.is_connected());
+        drop(rx);
+        // Note: is_connected doesn't detect receiver drop before send
+        // (limitation of mpsc::SyncSender)
+        let _ = tx; // Silence unused variable warning
+    }
+
+    #[test]
+    fn test_oneshot_thread() {
+        let (tx, rx) = oneshot::<String>();
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            tx.send("done".to_string()).unwrap();
+        });
+
+        assert_eq!(rx.recv().unwrap(), "done");
+        handle.join().unwrap();
+    }
+
+    // ========== Error display tests ==========
+
+    #[test]
+    fn test_error_display() {
+        assert!(SendError(42).to_string().contains("closed"));
+        assert!(RecvError.to_string().contains("closed"));
+        assert!(TryRecvError::Empty.to_string().contains("empty"));
+        assert!(
+            TryRecvError::Disconnected
+                .to_string()
+                .contains("disconnected")
+        );
+        assert!(TrySendError::Full(42).to_string().contains("full"));
+        assert!(
+            TrySendError::Disconnected(42)
+                .to_string()
+                .contains("disconnected")
+        );
+    }
+
+    // ========== Debug tests ==========
+
+    #[test]
+    fn test_debug_impls() {
+        let (tx, rx) = channel::<i32>();
+        let _ = format!("{tx:?}");
+        let _ = format!("{rx:?}");
+
+        let (tx, rx) = bounded::<i32>(1);
+        let _ = format!("{tx:?}");
+        let _ = format!("{rx:?}");
+
+        let (tx, rx) = oneshot::<i32>();
+        let _ = format!("{tx:?}");
+        let _ = format!("{rx:?}");
+    }
+}

--- a/lib/kernel/src/ipc/event.rs
+++ b/lib/kernel/src/ipc/event.rs
@@ -1,0 +1,557 @@
+//! Event trait and type-erased event wrapper.
+//!
+//! This module provides the foundational `Event` trait that all IPC events must implement,
+//! along with `DynEvent` for type-erased event dispatch.
+//!
+//! # Design Philosophy
+//!
+//! Following the Linux kernel "mechanism, not policy" principle:
+//! - Event trait defines minimal requirements
+//! - `DynEvent` provides type-erased storage and dispatch
+//! - `EventResult` signals handler outcomes without error semantics
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::ipc::{Event, DynEvent, EventResult};
+//!
+//! #[derive(Debug)]
+//! struct BufferChanged {
+//!     buffer_id: u64,
+//! }
+//!
+//! impl Event for BufferChanged {
+//!     fn priority(&self) -> u32 { 50 } // Core priority
+//! }
+//!
+//! let event = BufferChanged { buffer_id: 1 };
+//! let dyn_event = DynEvent::new(event);
+//!
+//! // Type-safe downcasting
+//! if let Some(bc) = dyn_event.downcast_ref::<BufferChanged>() {
+//!     assert_eq!(bc.buffer_id, 1);
+//! }
+//! ```
+
+use std::{
+    any::{Any, TypeId},
+    fmt::Debug,
+};
+
+use super::scope::EventScope;
+
+/// Trait for all IPC events.
+///
+/// Events are the primary communication mechanism between kernel subsystems,
+/// drivers, and modules. All events must be:
+/// - `Send + Sync` for cross-thread dispatch
+/// - `Debug` for logging and diagnostics
+/// - `'static` for type-erased storage
+///
+/// # Priority System
+///
+/// Events have a priority that affects handler dispatch order:
+/// - **0-50**: Core/critical handlers (run first)
+/// - **100**: Default priority
+/// - **200+**: Low priority (cleanup, logging)
+///
+/// Lower priority numbers mean earlier dispatch.
+///
+/// # Batching
+///
+/// Events can opt into batching for future optimization. When `batchable()`
+/// returns `true`, the event bus may combine multiple events of the same type
+/// into a single dispatch when under load.
+pub trait Event: Send + Sync + Debug + 'static {
+    /// Priority for handler dispatch ordering.
+    ///
+    /// Lower values = earlier dispatch. Default is 100 (normal priority).
+    ///
+    /// Convention:
+    /// - 0-50: Core handlers
+    /// - 100: Default/plugin handlers
+    /// - 200+: Low priority (logging, cleanup)
+    fn priority(&self) -> u32 {
+        100
+    }
+
+    /// Whether this event can be batched with similar events.
+    ///
+    /// Default is `false`. When `true`, the event bus may combine multiple
+    /// events of the same type into a single dispatch for efficiency.
+    fn batchable(&self) -> bool {
+        false
+    }
+}
+
+/// Result of handling an event.
+///
+/// Unlike `Result<T, E>`, this enum has no error variant. Event handling follows
+/// a fire-and-forget philosophy where handlers must not fail - they either
+/// handle the event or pass it on.
+///
+/// # Handler Behavior
+///
+/// - `Handled`: Continue to next handler (most common)
+/// - `Consumed`: Stop propagation to remaining handlers
+/// - `NotHandled`: Handler didn't process this event (continue dispatch)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EventResult {
+    /// Event was handled, continue to next handler.
+    Handled,
+
+    /// Event was consumed, stop propagation.
+    Consumed,
+
+    /// Handler did not process this event.
+    #[default]
+    NotHandled,
+}
+
+impl EventResult {
+    /// Returns `true` if the event was consumed (propagation should stop).
+    #[inline]
+    #[must_use]
+    pub const fn is_consumed(&self) -> bool {
+        matches!(self, Self::Consumed)
+    }
+
+    /// Returns `true` if the event was handled (but not consumed).
+    #[inline]
+    #[must_use]
+    pub const fn is_handled(&self) -> bool {
+        matches!(self, Self::Handled)
+    }
+
+    /// Returns `true` if the handler did not process the event.
+    #[inline]
+    #[must_use]
+    pub const fn is_not_handled(&self) -> bool {
+        matches!(self, Self::NotHandled)
+    }
+}
+
+/// Type-erased event wrapper for dynamic dispatch.
+///
+/// `DynEvent` wraps any type implementing `Event` and provides:
+/// - Type-safe downcasting via `TypeId`
+/// - Priority and metadata access
+/// - Optional scope attachment for lifecycle tracking
+///
+/// # Type Safety
+///
+/// Despite being type-erased, `DynEvent` maintains full type safety through
+/// `TypeId`-based downcasting. Incorrect type casts return `None` rather than
+/// undefined behavior.
+///
+/// # Memory Layout
+///
+/// ```text
+/// DynEvent
+/// ├── type_id: TypeId (16 bytes)
+/// ├── type_name: &'static str (16 bytes)
+/// ├── priority: u32 (4 bytes)
+/// ├── payload: Box<dyn Any + Send + Sync> (heap-allocated)
+/// └── scope: Option<EventScope> (optional lifecycle tracking)
+/// ```
+pub struct DynEvent {
+    /// `TypeId` for runtime type checking.
+    type_id: TypeId,
+
+    /// Type name for debugging/logging.
+    type_name: &'static str,
+
+    /// Event priority (cached from `Event::priority()`).
+    priority: u32,
+
+    /// Type-erased event payload
+    payload: Box<dyn Any + Send + Sync>,
+
+    /// Optional scope for lifecycle tracking
+    scope: Option<EventScope>,
+}
+
+impl DynEvent {
+    /// Create a new `DynEvent` from any type implementing `Event`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{Event, DynEvent};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent;
+    /// impl Event for MyEvent {}
+    ///
+    /// let dyn_event = DynEvent::new(MyEvent);
+    /// assert!(dyn_event.type_name().contains("MyEvent"));
+    /// ```
+    pub fn new<E: Event>(event: E) -> Self {
+        Self {
+            type_id: TypeId::of::<E>(),
+            type_name: std::any::type_name::<E>(),
+            priority: event.priority(),
+            payload: Box::new(event),
+            scope: None,
+        }
+    }
+
+    /// Attach an `EventScope` for lifecycle tracking.
+    ///
+    /// Returns `self` for method chaining.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{DynEvent, Event, EventScope};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent;
+    /// impl Event for MyEvent {}
+    ///
+    /// let scope = EventScope::new();
+    /// let event = DynEvent::new(MyEvent).with_scope(scope);
+    /// assert!(event.scope().is_some());
+    /// ```
+    #[must_use]
+    pub fn with_scope(mut self, scope: EventScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Get the `TypeId` of the wrapped event.
+    #[inline]
+    #[must_use]
+    pub const fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    /// Get the type name of the wrapped event (for debugging).
+    #[inline]
+    #[must_use]
+    pub const fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+
+    /// Get the event's priority.
+    #[inline]
+    #[must_use]
+    pub const fn priority(&self) -> u32 {
+        self.priority
+    }
+
+    /// Get a reference to the attached scope, if any.
+    #[inline]
+    #[must_use]
+    pub const fn scope(&self) -> Option<&EventScope> {
+        self.scope.as_ref()
+    }
+
+    /// Take the attached scope, leaving `None` in its place.
+    #[inline]
+    #[allow(clippy::missing_const_for_fn)] // Option::take() is not const
+    pub fn take_scope(&mut self) -> Option<EventScope> {
+        self.scope.take()
+    }
+
+    /// Check if this event is of type `E`.
+    #[inline]
+    #[must_use]
+    pub fn is<E: Event>(&self) -> bool {
+        self.type_id == TypeId::of::<E>()
+    }
+
+    /// Attempt to downcast to a reference of type `E`.
+    ///
+    /// Returns `None` if the event is not of type `E`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{DynEvent, Event};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent { value: i32 }
+    /// impl Event for MyEvent {}
+    ///
+    /// let event = DynEvent::new(MyEvent { value: 42 });
+    ///
+    /// if let Some(my_event) = event.downcast_ref::<MyEvent>() {
+    ///     assert_eq!(my_event.value, 42);
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn downcast_ref<E: Event>(&self) -> Option<&E> {
+        if self.type_id == TypeId::of::<E>() {
+            self.payload.downcast_ref()
+        } else {
+            None
+        }
+    }
+
+    /// Attempt to downcast to a mutable reference of type `E`.
+    ///
+    /// Returns `None` if the event is not of type `E`.
+    #[inline]
+    #[must_use]
+    pub fn downcast_mut<E: Event>(&mut self) -> Option<&mut E> {
+        if self.type_id == TypeId::of::<E>() {
+            self.payload.downcast_mut()
+        } else {
+            None
+        }
+    }
+
+    /// Consume the `DynEvent` and attempt to extract the inner event.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)` if the event is not of type `E`.
+    ///
+    /// # Panics
+    ///
+    /// This function will not panic under normal operation. The internal
+    /// `unwrap()` is guarded by a `TypeId` check that ensures type safety.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{DynEvent, Event};
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct MyEvent { value: i32 }
+    /// impl Event for MyEvent {}
+    ///
+    /// let event = DynEvent::new(MyEvent { value: 42 });
+    ///
+    /// match event.into_inner::<MyEvent>() {
+    ///     Ok(my_event) => assert_eq!(my_event.value, 42),
+    ///     Err(_) => panic!("unexpected type"),
+    /// }
+    /// ```
+    pub fn into_inner<E: Event>(self) -> Result<E, Self> {
+        if self.type_id == TypeId::of::<E>() {
+            // SAFETY: We verified the type matches via TypeId
+            Ok(*self.payload.downcast::<E>().unwrap())
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl Debug for DynEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DynEvent")
+            .field("type_name", &self.type_name)
+            .field("priority", &self.priority)
+            .field("has_scope", &self.scope.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+// DynEvent is automatically Send + Sync because:
+// - payload is Box<dyn Any + Send + Sync>
+// - EventScope is Arc-based and thread-safe
+// - All other fields are Copy or 'static references
+//
+// No manual unsafe impl needed - Rust derives these automatically.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct TestEvent {
+        value: i32,
+    }
+
+    impl Event for TestEvent {
+        fn priority(&self) -> u32 {
+            50
+        }
+    }
+
+    #[derive(Debug)]
+    struct HighPriorityEvent;
+
+    impl Event for HighPriorityEvent {
+        fn priority(&self) -> u32 {
+            0
+        }
+
+        fn batchable(&self) -> bool {
+            true
+        }
+    }
+
+    #[derive(Debug)]
+    struct DefaultEvent;
+    impl Event for DefaultEvent {}
+
+    #[derive(Debug)]
+    struct OtherEvent;
+    impl Event for OtherEvent {}
+
+    // ========== Event trait tests ==========
+
+    #[test]
+    fn test_event_default_priority() {
+        let event = DefaultEvent;
+        assert_eq!(event.priority(), 100);
+    }
+
+    #[test]
+    fn test_event_custom_priority() {
+        let event = TestEvent { value: 42 };
+        assert_eq!(event.priority(), 50);
+    }
+
+    #[test]
+    fn test_event_high_priority() {
+        let event = HighPriorityEvent;
+        assert_eq!(event.priority(), 0);
+    }
+
+    #[test]
+    fn test_event_default_batchable() {
+        let event = DefaultEvent;
+        assert!(!event.batchable());
+    }
+
+    #[test]
+    fn test_event_custom_batchable() {
+        let event = HighPriorityEvent;
+        assert!(event.batchable());
+    }
+
+    // ========== EventResult tests ==========
+
+    #[test]
+    fn test_event_result_is_consumed() {
+        assert!(EventResult::Consumed.is_consumed());
+        assert!(!EventResult::Handled.is_consumed());
+        assert!(!EventResult::NotHandled.is_consumed());
+    }
+
+    #[test]
+    fn test_event_result_is_handled() {
+        assert!(!EventResult::Consumed.is_handled());
+        assert!(EventResult::Handled.is_handled());
+        assert!(!EventResult::NotHandled.is_handled());
+    }
+
+    #[test]
+    fn test_event_result_is_not_handled() {
+        assert!(!EventResult::Consumed.is_not_handled());
+        assert!(!EventResult::Handled.is_not_handled());
+        assert!(EventResult::NotHandled.is_not_handled());
+    }
+
+    #[test]
+    fn test_event_result_default() {
+        assert_eq!(EventResult::default(), EventResult::NotHandled);
+    }
+
+    // ========== DynEvent tests ==========
+
+    #[test]
+    fn test_dyn_event_new() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        assert!(event.type_name().contains("TestEvent"));
+        assert_eq!(event.priority(), 50);
+        assert!(event.scope().is_none());
+    }
+
+    #[test]
+    fn test_dyn_event_type_id() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        assert_eq!(event.type_id(), TypeId::of::<TestEvent>());
+    }
+
+    #[test]
+    fn test_dyn_event_is() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        assert!(event.is::<TestEvent>());
+        assert!(!event.is::<OtherEvent>());
+    }
+
+    #[test]
+    fn test_dyn_event_downcast_ref() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        let downcasted = event.downcast_ref::<TestEvent>();
+        assert!(downcasted.is_some());
+        assert_eq!(downcasted.unwrap().value, 42);
+    }
+
+    #[test]
+    fn test_dyn_event_downcast_ref_wrong_type() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        let downcasted = event.downcast_ref::<OtherEvent>();
+        assert!(downcasted.is_none());
+    }
+
+    #[test]
+    fn test_dyn_event_downcast_mut() {
+        let mut event = DynEvent::new(TestEvent { value: 42 });
+        if let Some(inner) = event.downcast_mut::<TestEvent>() {
+            inner.value = 100;
+        }
+        assert_eq!(event.downcast_ref::<TestEvent>().unwrap().value, 100);
+    }
+
+    #[test]
+    fn test_dyn_event_downcast_mut_wrong_type() {
+        let mut event = DynEvent::new(TestEvent { value: 42 });
+        let downcasted = event.downcast_mut::<OtherEvent>();
+        assert!(downcasted.is_none());
+    }
+
+    #[test]
+    fn test_dyn_event_into_inner() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        let inner = event.into_inner::<TestEvent>();
+        assert!(inner.is_ok());
+        assert_eq!(inner.unwrap(), TestEvent { value: 42 });
+    }
+
+    #[test]
+    fn test_dyn_event_into_inner_wrong_type() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        let result = event.into_inner::<OtherEvent>();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dyn_event_with_scope() {
+        let scope = EventScope::new();
+        let event = DynEvent::new(TestEvent { value: 42 }).with_scope(scope.clone());
+        assert!(event.scope().is_some());
+        assert_eq!(event.scope().unwrap().id(), scope.id());
+    }
+
+    #[test]
+    fn test_dyn_event_take_scope() {
+        let scope = EventScope::new();
+        let mut event = DynEvent::new(TestEvent { value: 42 }).with_scope(scope);
+
+        let taken = event.take_scope();
+        assert!(taken.is_some());
+        assert!(event.scope().is_none());
+    }
+
+    #[test]
+    fn test_dyn_event_debug() {
+        let event = DynEvent::new(TestEvent { value: 42 });
+        let debug_str = format!("{event:?}");
+        assert!(debug_str.contains("DynEvent"));
+        assert!(debug_str.contains("TestEvent"));
+        assert!(debug_str.contains("50"));
+    }
+
+    #[test]
+    fn test_dyn_event_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DynEvent>();
+    }
+}

--- a/lib/kernel/src/ipc/event_bus.rs
+++ b/lib/kernel/src/ipc/event_bus.rs
@@ -1,0 +1,758 @@
+//! Event bus for type-erased event dispatch.
+//!
+//! The `EventBus` is the central hub for event-driven communication between
+//! kernel subsystems, drivers, and modules. It provides:
+//!
+//! - **Type-erased dispatch**: Single bus handles all event types
+//! - **Lock-free hot path**: Dispatch uses `ArcSwap` for zero-lock reads
+//! - **Priority ordering**: Handlers execute in priority order (lower = first)
+//! - **RAII subscriptions**: Handlers auto-unsubscribe when dropped
+//! - **Scoped events**: Track event lifecycle for synchronization
+//!
+//! # Design Philosophy
+//!
+//! Following the proven patterns from `lib/core`:
+//! - **Lock-free dispatch**: `ArcSwap::load()` for handler lookup
+//! - **RCU for subscriptions**: Copy-on-write via `ArcSwap::rcu()`
+//! - **Fire-and-forget**: Handlers return `EventResult`, not `Result<T, E>`
+//!
+//! # Performance
+//!
+//! - Dispatch latency: ~100ns (0 handlers) to ~1µs (10 handlers)
+//! - Subscription: ~1µs (RCU clone + sort)
+//! - Handler lookup: O(1) `HashMap` + O(n) handler iteration
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::ipc::{EventBus, Event, EventResult};
+//!
+//! #[derive(Debug)]
+//! struct BufferChanged { buffer_id: u64 }
+//! impl Event for BufferChanged {}
+//!
+//! let bus = EventBus::new();
+//!
+//! // Subscribe with priority 100 (default)
+//! let _sub = bus.subscribe::<BufferChanged, _>(100, |event| {
+//!     println!("Buffer {} changed", event.buffer_id);
+//!     EventResult::Handled
+//! });
+//!
+//! // Emit event - handler is called synchronously
+//! bus.emit(BufferChanged { buffer_id: 1 });
+//! ```
+
+use std::{any::TypeId, collections::HashMap, sync::Arc};
+
+use {arc_swap::ArcSwap, parking_lot::Mutex};
+
+use super::{
+    event::{DynEvent, Event, EventResult},
+    scope::EventScope,
+    subscription::{Subscription, SubscriptionId},
+};
+
+/// Handler function type for event dispatch.
+///
+/// Handlers receive a reference to the `DynEvent` and return an `EventResult`.
+/// The handler must downcast to the specific event type internally.
+type HandlerFn = Arc<dyn Fn(&DynEvent) -> EventResult + Send + Sync>;
+
+/// Registered handler with metadata.
+struct RegisteredHandler {
+    /// Unique subscription ID.
+    id: SubscriptionId,
+
+    /// Handler priority (lower = earlier dispatch).
+    priority: u32,
+
+    /// The handler function.
+    handler: HandlerFn,
+}
+
+/// Internal state for `EventBus`.
+struct EventBusInner {
+    /// Handler storage: `TypeId` -> sorted Vec of handlers.
+    /// Uses `ArcSwap` for lock-free reads.
+    handlers: ArcSwap<HashMap<TypeId, Vec<RegisteredHandler>>>,
+
+    /// Async event queue for `emit_async()`.
+    queue: Mutex<Vec<DynEvent>>,
+}
+
+/// Type-erased event bus for pub/sub communication.
+///
+/// The `EventBus` routes events to registered handlers based on event type.
+/// It uses lock-free data structures for the hot dispatch path and
+/// copy-on-write for subscription updates.
+///
+/// # Thread Safety
+///
+/// `EventBus` is `Clone`, `Send`, and `Sync`. Cloning creates a new handle
+/// to the same underlying bus. Multiple threads can dispatch events
+/// concurrently without blocking.
+///
+/// # Handler Ordering
+///
+/// Handlers are called in priority order (lower priority number = earlier).
+/// For handlers with the same priority, registration order is preserved.
+#[derive(Clone)]
+pub struct EventBus {
+    inner: Arc<EventBusInner>,
+}
+
+impl EventBus {
+    /// Create a new empty event bus.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(EventBusInner {
+                handlers: ArcSwap::from_pointee(HashMap::new()),
+                queue: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Subscribe a handler for events of type `E`.
+    ///
+    /// Returns a `Subscription` handle that unsubscribes when dropped.
+    ///
+    /// # Arguments
+    ///
+    /// * `priority` - Handler priority (lower = called earlier). Convention:
+    ///   - 0-50: Core/critical handlers
+    ///   - 100: Default priority
+    ///   - 200+: Low priority (cleanup, logging)
+    /// * `handler` - Function called for each event of type `E`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent { value: i32 }
+    /// impl Event for MyEvent {}
+    ///
+    /// let bus = EventBus::new();
+    ///
+    /// let sub = bus.subscribe::<MyEvent, _>(100, |event| {
+    ///     println!("Received: {:?}", event.value);
+    ///     EventResult::Handled
+    /// });
+    ///
+    /// // Handler is active while `sub` is alive
+    /// bus.emit(MyEvent { value: 42 });
+    ///
+    /// // Dropping `sub` removes the handler
+    /// drop(sub);
+    /// ```
+    pub fn subscribe<E, F>(&self, priority: u32, handler: F) -> Subscription
+    where
+        E: Event,
+        F: Fn(&E) -> EventResult + Send + Sync + 'static,
+    {
+        let type_id = TypeId::of::<E>();
+        let sub_id = SubscriptionId::new();
+
+        // Wrap handler to downcast from DynEvent
+        let wrapped_handler: HandlerFn = Arc::new(move |dyn_event: &DynEvent| {
+            dyn_event
+                .downcast_ref::<E>()
+                .map_or(EventResult::NotHandled, &handler)
+        });
+
+        let registered = RegisteredHandler {
+            id: sub_id,
+            priority,
+            handler: wrapped_handler,
+        };
+
+        // RCU update: clone, modify, swap
+        // Note: rcu takes FnMut, so we need to clone registered
+        self.inner.handlers.rcu(|current| {
+            let mut new_map = (**current).clone();
+            let handlers = new_map.entry(type_id).or_default();
+            handlers.push(registered.clone());
+            // Sort by priority (stable sort preserves registration order for same priority)
+            handlers.sort_by_key(|h| h.priority);
+            new_map
+        });
+
+        // Create unsubscribe closure that captures the inner Arc
+        let inner = Arc::clone(&self.inner);
+        let unsubscribe = move || {
+            inner.handlers.rcu(|current| {
+                let mut new_map = (**current).clone();
+                if let Some(handlers) = new_map.get_mut(&type_id) {
+                    handlers.retain(|h| h.id != sub_id);
+                    if handlers.is_empty() {
+                        new_map.remove(&type_id);
+                    }
+                }
+                new_map
+            });
+        };
+
+        Subscription::new::<E>(sub_id, unsubscribe)
+    }
+
+    /// Emit an event synchronously.
+    ///
+    /// Dispatches the event to all registered handlers in priority order.
+    /// Returns the combined result of all handlers.
+    ///
+    /// # Handler Behavior
+    ///
+    /// - Handlers are called in priority order (lower = first)
+    /// - If any handler returns `Consumed`, dispatch stops
+    /// - Otherwise continues until all handlers have been called
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent;
+    /// impl Event for MyEvent {}
+    ///
+    /// let bus = EventBus::new();
+    /// let result = bus.emit(MyEvent);
+    /// assert!(result.is_not_handled()); // No handlers registered
+    /// ```
+    pub fn emit<E: Event>(&self, event: E) -> EventResult {
+        let dyn_event = DynEvent::new(event);
+        self.dispatch(&dyn_event)
+    }
+
+    /// Emit an event with scope tracking.
+    ///
+    /// The scope's counter is incremented before dispatch and decremented
+    /// after all handlers complete. This allows callers to wait for all
+    /// effects of the event to complete.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{EventBus, Event, EventResult, EventScope};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent;
+    /// impl Event for MyEvent {}
+    ///
+    /// let bus = EventBus::new();
+    /// let scope = EventScope::new();
+    ///
+    /// scope.increment(); // Manually increment before emit_scoped
+    /// let result = bus.emit_scoped(MyEvent, &scope);
+    /// // Scope counter is now decremented
+    /// ```
+    pub fn emit_scoped<E: Event>(&self, event: E, scope: &EventScope) -> EventResult {
+        let dyn_event = DynEvent::new(event).with_scope(scope.clone());
+        let result = self.dispatch(&dyn_event);
+
+        // Decrement scope after dispatch completes
+        scope.decrement();
+
+        result
+    }
+
+    /// Queue an event for later processing.
+    ///
+    /// The event is stored in an internal queue and processed when
+    /// `process_queue()` is called. This is useful for deferring
+    /// event dispatch to avoid reentrancy issues.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    ///
+    /// #[derive(Debug)]
+    /// struct MyEvent;
+    /// impl Event for MyEvent {}
+    ///
+    /// let bus = EventBus::new();
+    ///
+    /// bus.emit_async(MyEvent);
+    /// bus.emit_async(MyEvent);
+    ///
+    /// // Events are queued but not dispatched yet
+    /// let count = bus.process_queue();
+    /// assert_eq!(count, 2);
+    /// ```
+    pub fn emit_async<E: Event>(&self, event: E) {
+        let dyn_event = DynEvent::new(event);
+        self.inner.queue.lock().push(dyn_event);
+    }
+
+    /// Queue an event with scope tracking for later processing.
+    ///
+    /// Like `emit_async`, but attaches a scope for lifecycle tracking.
+    /// The scope is incremented when queued and decremented after dispatch.
+    pub fn emit_async_scoped<E: Event>(&self, event: E, scope: &EventScope) {
+        scope.increment();
+        let dyn_event = DynEvent::new(event).with_scope(scope.clone());
+        self.inner.queue.lock().push(dyn_event);
+    }
+
+    /// Process all queued events.
+    ///
+    /// Drains the queue and dispatches each event synchronously.
+    /// Returns the number of events processed.
+    ///
+    /// # Scope Handling
+    ///
+    /// For events with attached scopes, the scope is decremented after
+    /// each event is dispatched.
+    #[must_use]
+    pub fn process_queue(&self) -> usize {
+        let events: Vec<_> = {
+            let mut queue = self.inner.queue.lock();
+            std::mem::take(&mut *queue)
+        };
+
+        let count = events.len();
+
+        for mut event in events {
+            let scope = event.take_scope();
+            let result = self.dispatch(&event);
+            tracing::trace!(event_type = event.type_name(), ?result, "processed queued event");
+            if let Some(scope) = scope {
+                scope.decrement();
+            }
+        }
+
+        count
+    }
+
+    /// Dispatch a type-erased event to registered handlers.
+    ///
+    /// This is the core dispatch logic, used by both `emit` and `process_queue`.
+    #[must_use]
+    pub fn dispatch(&self, event: &DynEvent) -> EventResult {
+        // Lock-free read of handlers
+        let handlers = self.inner.handlers.load();
+        let type_id = event.type_id();
+
+        let Some(handlers) = handlers.get(&type_id) else {
+            return EventResult::NotHandled;
+        };
+
+        let mut result = EventResult::NotHandled;
+
+        for handler in handlers {
+            let handler_result = (handler.handler)(event);
+
+            match handler_result {
+                EventResult::Consumed => {
+                    return EventResult::Consumed;
+                }
+                EventResult::Handled => {
+                    result = EventResult::Handled;
+                }
+                EventResult::NotHandled => {
+                    // Continue to next handler
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Get the number of handlers registered for a specific event type.
+    ///
+    /// Useful for debugging and testing.
+    #[must_use]
+    pub fn handler_count<E: Event>(&self) -> usize {
+        let handlers = self.inner.handlers.load();
+        handlers.get(&TypeId::of::<E>()).map_or(0, Vec::len)
+    }
+
+    /// Get the total number of handlers registered across all event types.
+    #[must_use]
+    pub fn total_handler_count(&self) -> usize {
+        let handlers = self.inner.handlers.load();
+        handlers.values().map(Vec::len).sum()
+    }
+
+    /// Get the number of events in the async queue.
+    #[must_use]
+    pub fn queue_len(&self) -> usize {
+        self.inner.queue.lock().len()
+    }
+
+    /// Check if the async queue is empty.
+    #[must_use]
+    pub fn queue_is_empty(&self) -> bool {
+        self.inner.queue.lock().is_empty()
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for EventBus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let handlers = self.inner.handlers.load();
+        f.debug_struct("EventBus")
+            .field("event_types", &handlers.len())
+            .field("total_handlers", &self.total_handler_count())
+            .field("queue_len", &self.queue_len())
+            .finish()
+    }
+}
+
+// Clone the handlers map for RegisteredHandler
+impl Clone for RegisteredHandler {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            priority: self.priority,
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{
+            sync::atomic::{AtomicI32, AtomicU32, Ordering},
+            thread,
+        },
+    };
+
+    #[derive(Debug)]
+    struct TestEvent {
+        value: i32,
+    }
+
+    impl Event for TestEvent {
+        fn priority(&self) -> u32 {
+            50
+        }
+    }
+
+    #[derive(Debug)]
+    struct OtherEvent;
+    impl Event for OtherEvent {}
+
+    // ========== Basic tests ==========
+
+    #[test]
+    fn test_event_bus_new() {
+        let bus = EventBus::new();
+        assert_eq!(bus.total_handler_count(), 0);
+        assert!(bus.queue_is_empty());
+    }
+
+    #[test]
+    fn test_event_bus_subscribe() {
+        let bus = EventBus::new();
+        let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+        assert_eq!(bus.handler_count::<TestEvent>(), 1);
+    }
+
+    #[test]
+    fn test_event_bus_unsubscribe_on_drop() {
+        let bus = EventBus::new();
+        {
+            let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+            assert_eq!(bus.handler_count::<TestEvent>(), 1);
+        }
+        assert_eq!(bus.handler_count::<TestEvent>(), 0);
+    }
+
+    #[test]
+    fn test_event_bus_emit() {
+        let bus = EventBus::new();
+        let received = Arc::new(AtomicI32::new(0));
+        let received2 = received.clone();
+
+        let _sub = bus.subscribe::<TestEvent, _>(100, move |event| {
+            received2.store(event.value, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let result = bus.emit(TestEvent { value: 42 });
+        assert!(result.is_handled());
+        assert_eq!(received.load(Ordering::SeqCst), 42);
+    }
+
+    #[test]
+    fn test_event_bus_emit_no_handlers() {
+        let bus = EventBus::new();
+        let result = bus.emit(TestEvent { value: 42 });
+        assert!(result.is_not_handled());
+    }
+
+    #[test]
+    fn test_event_bus_emit_wrong_type() {
+        let bus = EventBus::new();
+        let called = Arc::new(AtomicU32::new(0));
+        let called2 = called.clone();
+
+        let _sub = bus.subscribe::<TestEvent, _>(100, move |_| {
+            called2.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        // Emit different event type
+        bus.emit(OtherEvent);
+        assert_eq!(called.load(Ordering::SeqCst), 0);
+    }
+
+    // ========== Priority ordering tests ==========
+
+    #[test]
+    fn test_event_bus_priority_ordering() {
+        let bus = EventBus::new();
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let order1 = order.clone();
+        let _sub1 = bus.subscribe::<TestEvent, _>(200, move |_| {
+            order1.lock().push(200);
+            EventResult::Handled
+        });
+
+        let order2 = order.clone();
+        let _sub2 = bus.subscribe::<TestEvent, _>(50, move |_| {
+            order2.lock().push(50);
+            EventResult::Handled
+        });
+
+        let order3 = order.clone();
+        let _sub3 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            order3.lock().push(100);
+            EventResult::Handled
+        });
+
+        bus.emit(TestEvent { value: 1 });
+
+        let order_result = order.lock().clone();
+        assert_eq!(order_result, vec![50, 100, 200]);
+    }
+
+    // ========== Consumed stops propagation ==========
+
+    #[test]
+    fn test_event_bus_consumed_stops_propagation() {
+        let bus = EventBus::new();
+        let call_count = Arc::new(AtomicU32::new(0));
+
+        let count1 = call_count.clone();
+        let _sub1 = bus.subscribe::<TestEvent, _>(50, move |_| {
+            count1.fetch_add(1, Ordering::SeqCst);
+            EventResult::Consumed // Stop propagation
+        });
+
+        let count2 = call_count.clone();
+        let _sub2 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count2.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let result = bus.emit(TestEvent { value: 1 });
+        assert!(result.is_consumed());
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    // ========== Async queue tests ==========
+
+    #[test]
+    fn test_event_bus_emit_async() {
+        let bus = EventBus::new();
+
+        bus.emit_async(TestEvent { value: 1 });
+        bus.emit_async(TestEvent { value: 2 });
+
+        assert_eq!(bus.queue_len(), 2);
+    }
+
+    #[test]
+    fn test_event_bus_process_queue() {
+        let bus = EventBus::new();
+        let sum = Arc::new(AtomicI32::new(0));
+        let sum2 = sum.clone();
+
+        let _sub = bus.subscribe::<TestEvent, _>(100, move |event| {
+            sum2.fetch_add(event.value, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        bus.emit_async(TestEvent { value: 10 });
+        bus.emit_async(TestEvent { value: 20 });
+        bus.emit_async(TestEvent { value: 30 });
+
+        assert_eq!(sum.load(Ordering::SeqCst), 0); // Not processed yet
+
+        let count = bus.process_queue();
+        assert_eq!(count, 3);
+        assert_eq!(sum.load(Ordering::SeqCst), 60);
+        assert!(bus.queue_is_empty());
+    }
+
+    // ========== Scoped event tests ==========
+
+    #[test]
+    fn test_event_bus_emit_scoped() {
+        let bus = EventBus::new();
+        let scope = EventScope::new();
+
+        scope.increment();
+        assert_eq!(scope.in_flight(), 1);
+
+        bus.emit_scoped(TestEvent { value: 1 }, &scope);
+        assert_eq!(scope.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_event_bus_emit_async_scoped() {
+        let bus = EventBus::new();
+        let scope = EventScope::new();
+
+        bus.emit_async_scoped(TestEvent { value: 1 }, &scope);
+        assert_eq!(scope.in_flight(), 1);
+
+        let count = bus.process_queue();
+        assert_eq!(count, 1);
+        assert_eq!(scope.in_flight(), 0);
+    }
+
+    // ========== Multiple subscriptions ==========
+
+    #[test]
+    fn test_event_bus_multiple_subscriptions() {
+        let bus = EventBus::new();
+        let count = Arc::new(AtomicU32::new(0));
+
+        let count1 = count.clone();
+        let _sub1 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count1.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let count2 = count.clone();
+        let _sub2 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count2.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        bus.emit(TestEvent { value: 1 });
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_event_bus_partial_unsubscribe() {
+        let bus = EventBus::new();
+        let count = Arc::new(AtomicU32::new(0));
+
+        let count1 = count.clone();
+        let sub1 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count1.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let count2 = count.clone();
+        let _sub2 = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count2.fetch_add(10, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        bus.emit(TestEvent { value: 1 });
+        assert_eq!(count.load(Ordering::SeqCst), 11);
+
+        drop(sub1);
+
+        count.store(0, Ordering::SeqCst);
+        bus.emit(TestEvent { value: 1 });
+        assert_eq!(count.load(Ordering::SeqCst), 10);
+    }
+
+    // ========== Thread safety tests ==========
+
+    #[test]
+    fn test_event_bus_concurrent_emit() {
+        let bus = Arc::new(EventBus::new());
+        let count = Arc::new(AtomicU32::new(0));
+
+        let count_handler = count.clone();
+        let _sub = bus.subscribe::<TestEvent, _>(100, move |_| {
+            count_handler.fetch_add(1, Ordering::SeqCst);
+            EventResult::Handled
+        });
+
+        let mut handles = vec![];
+        for i in 0..10 {
+            let bus = bus.clone();
+            handles.push(thread::spawn(move || {
+                bus.emit(TestEvent { value: i });
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(count.load(Ordering::SeqCst), 10);
+    }
+
+    #[test]
+    fn test_event_bus_concurrent_subscribe_emit() {
+        let bus = Arc::new(EventBus::new());
+
+        let mut handles = vec![];
+
+        // Subscribe from multiple threads
+        for _ in 0..5 {
+            let bus = bus.clone();
+            handles.push(thread::spawn(move || {
+                let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+                // Keep subscription alive briefly
+                thread::sleep(std::time::Duration::from_millis(10));
+            }));
+        }
+
+        // Emit from multiple threads
+        for i in 0..5 {
+            let bus = bus.clone();
+            handles.push(thread::spawn(move || {
+                bus.emit(TestEvent { value: i });
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    // ========== Debug and Default tests ==========
+
+    #[test]
+    fn test_event_bus_debug() {
+        let bus = EventBus::new();
+        let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+        let debug_str = format!("{bus:?}");
+        assert!(debug_str.contains("EventBus"));
+        assert!(debug_str.contains("total_handlers"));
+    }
+
+    #[test]
+    fn test_event_bus_default() {
+        let bus = EventBus::default();
+        assert_eq!(bus.total_handler_count(), 0);
+    }
+
+    #[test]
+    fn test_event_bus_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EventBus>();
+    }
+}

--- a/lib/kernel/src/ipc/mod.rs
+++ b/lib/kernel/src/ipc/mod.rs
@@ -2,6 +2,100 @@
 //!
 //! Linux equivalent: `ipc/`
 //!
-//! Provides event bus, channels, and synchronization primitives.
+//! This module provides the event system for kernel-driver-module communication.
+//! It includes:
+//!
+//! - **Event Bus**: Type-erased pub/sub event dispatch
+//! - **`EventScope`**: GC-like synchronization for event lifecycle tracking
+//! - **Channels**: MPSC and oneshot channels for direct communication
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                        EventBus                              │
+//! │                                                              │
+//! │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐   │
+//! │  │ Subscription │    │ Subscription │    │ Subscription │   │
+//! │  │   Handler A  │    │   Handler B  │    │   Handler C  │   │
+//! │  └──────────────┘    └──────────────┘    └──────────────┘   │
+//! │         │                   │                   │           │
+//! │         └───────────────────┼───────────────────┘           │
+//! │                             │                                │
+//! │                    ┌────────┴────────┐                       │
+//! │                    │    DynEvent     │                       │
+//! │                    │  (type-erased)  │                       │
+//! │                    └────────┬────────┘                       │
+//! │                             │                                │
+//! │                    ┌────────┴────────┐                       │
+//! │                    │   EventScope    │                       │
+//! │                    │ (lifecycle sync)│                       │
+//! │                    └─────────────────┘                       │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Design Philosophy
+//!
+//! Following Linux kernel "mechanism, not policy":
+//! - Provides communication primitives
+//! - No opinion on message routing strategy
+//! - Runtime integration is left to higher layers
+//!
+//! # Performance Characteristics
+//!
+//! - **Lock-free dispatch**: Handler lookup uses `ArcSwap` for O(1) reads
+//! - **RCU subscriptions**: Copy-on-write prevents blocking dispatch
+//! - **Fire-and-forget**: No error propagation from handlers
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::ipc::{EventBus, Event, EventResult, EventScope};
+//!
+//! // Define an event
+//! #[derive(Debug)]
+//! struct BufferChanged { buffer_id: u64 }
+//! impl Event for BufferChanged {}
+//!
+//! // Create event bus
+//! let bus = EventBus::new();
+//!
+//! // Subscribe handler
+//! let _sub = bus.subscribe::<BufferChanged, _>(100, |event| {
+//!     println!("Buffer {} changed", event.buffer_id);
+//!     EventResult::Handled
+//! });
+//!
+//! // Emit event
+//! bus.emit(BufferChanged { buffer_id: 1 });
+//!
+//! // With scope tracking
+//! let scope = EventScope::new();
+//! scope.increment();
+//! bus.emit_scoped(BufferChanged { buffer_id: 2 }, &scope);
+//! assert!(scope.is_complete());
+//! ```
 
-// Placeholder - EventBus, Channel, Scope, Signal will be added in Phase 2
+mod channel;
+mod event;
+mod event_bus;
+mod scope;
+mod subscription;
+
+// Re-export channel types
+pub use channel::{
+    BoundedReceiver, BoundedSender, OneshotReceiver, OneshotSender, Receiver, RecvError, SendError,
+    Sender, TryRecvError, TrySendError, bounded, channel, oneshot,
+};
+
+// Re-export event types
+pub use event::{DynEvent, Event, EventResult};
+
+// Re-export event bus
+pub use event_bus::EventBus;
+
+// Re-export scope types
+pub use scope::{DEFAULT_TIMEOUT, EventScope, ScopeId};
+
+// Re-export subscription types
+pub use subscription::{Subscription, SubscriptionId};

--- a/lib/kernel/src/ipc/scope.rs
+++ b/lib/kernel/src/ipc/scope.rs
@@ -1,0 +1,531 @@
+//! Event scope for lifecycle tracking.
+//!
+//! `EventScope` provides GC-like synchronization for tracking event lifecycles.
+//! It enables callers to wait until all events dispatched within a scope have
+//! been fully processed.
+//!
+//! # Design Philosophy
+//!
+//! This is the **only** synchronization mechanism for event lifecycle tracking.
+//! It uses a simple reference-counting pattern:
+//! - `increment()` when an event is emitted
+//! - `decrement()` when event dispatch completes
+//! - `wait()` blocks until counter reaches zero
+//!
+//! # Use Case
+//!
+//! The primary use case is RPC key injection, where the caller needs to wait
+//! for all effects of injected keys to complete before returning a response.
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::ipc::EventScope;
+//! use std::time::Duration;
+//!
+//! let scope = EventScope::new();
+//!
+//! // Simulate emitting events
+//! scope.increment();
+//! scope.increment();
+//! assert_eq!(scope.in_flight(), 2);
+//!
+//! // Simulate event completion
+//! scope.decrement();
+//! scope.decrement();
+//! assert!(scope.is_complete());
+//!
+//! // wait() returns immediately when counter is 0
+//! scope.wait();
+//! ```
+
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use parking_lot::{Condvar, Mutex};
+
+/// Unique identifier for an `EventScope`.
+///
+/// Used for debugging and tracing to distinguish between concurrent scopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ScopeId(u64);
+
+impl ScopeId {
+    /// Create a new unique `ScopeId`.
+    fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        Self(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw ID value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for ScopeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "scope-{}", self.0)
+    }
+}
+
+/// Internal state shared between `EventScope` clones.
+struct ScopeInner {
+    /// Unique identifier for this scope.
+    id: ScopeId,
+
+    /// Count of in-flight events.
+    in_flight: AtomicUsize,
+
+    /// Condition variable for waiting.
+    /// The Mutex holds a dummy value; we only need the condvar.
+    condvar: (Mutex<()>, Condvar),
+}
+
+/// GC-like synchronization for event lifecycle tracking.
+///
+/// `EventScope` tracks in-flight events and allows callers to wait until
+/// all events within the scope have been fully processed.
+///
+/// # Thread Safety
+///
+/// `EventScope` is `Clone`, `Send`, and `Sync`. Cloning creates a new handle
+/// to the same underlying scope - all clones share the same counter.
+///
+/// # Timeout Behavior
+///
+/// The proven production timeout is **3 seconds** (see `DEFAULT_TIMEOUT`).
+/// This is long enough to handle slow handlers while preventing deadlocks.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::ipc::EventScope;
+/// use std::thread;
+/// use std::time::Duration;
+///
+/// let scope = EventScope::new();
+/// let scope2 = scope.clone(); // Same underlying scope
+///
+/// // Simulate async event processing
+/// scope.increment();
+///
+/// let handle = thread::spawn(move || {
+///     thread::sleep(Duration::from_millis(10));
+///     scope2.decrement(); // Signal completion
+/// });
+///
+/// // Wait for all events to complete
+/// let completed = scope.wait_timeout(Duration::from_secs(1));
+/// assert!(completed);
+///
+/// handle.join().unwrap();
+/// ```
+#[derive(Clone)]
+pub struct EventScope {
+    inner: Arc<ScopeInner>,
+}
+
+/// Default timeout for scope waiting (3 seconds).
+///
+/// This is the proven production value, long enough for slow handlers
+/// (like tree-sitter compilation) while preventing infinite waits.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
+
+impl EventScope {
+    /// Create a new `EventScope` with counter initialized to 0.
+    ///
+    /// The scope is considered complete when `in_flight() == 0`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(ScopeInner {
+                id: ScopeId::new(),
+                in_flight: AtomicUsize::new(0),
+                condvar: (Mutex::new(()), Condvar::new()),
+            }),
+        }
+    }
+
+    /// Get the unique ID of this scope.
+    #[inline]
+    #[must_use]
+    pub fn id(&self) -> ScopeId {
+        self.inner.id
+    }
+
+    /// Increment the in-flight counter.
+    ///
+    /// Call this when emitting an event within the scope.
+    #[inline]
+    pub fn increment(&self) {
+        self.inner.in_flight.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Decrement the in-flight counter.
+    ///
+    /// Call this when event dispatch completes. If the counter reaches 0,
+    /// all waiters are notified.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug mode if called when counter is already 0.
+    #[inline]
+    pub fn decrement(&self) {
+        let prev = self.inner.in_flight.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(prev > 0, "EventScope::decrement called when counter is 0");
+
+        // Notify waiters if we just reached 0
+        if prev == 1 {
+            let (_lock, condvar) = &self.inner.condvar;
+            condvar.notify_all();
+        }
+    }
+
+    /// Get the current in-flight count.
+    #[inline]
+    #[must_use]
+    pub fn in_flight(&self) -> usize {
+        self.inner.in_flight.load(Ordering::SeqCst)
+    }
+
+    /// Check if the scope is complete (no in-flight events).
+    #[inline]
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.in_flight() == 0
+    }
+
+    /// Block until the in-flight counter reaches 0.
+    ///
+    /// If the counter is already 0, returns immediately.
+    ///
+    /// # Warning
+    ///
+    /// This can block indefinitely if events are never decremented.
+    /// Prefer `wait_timeout()` in production code.
+    pub fn wait(&self) {
+        let (mutex, condvar) = &self.inner.condvar;
+        let mut guard = mutex.lock();
+
+        while self.in_flight() > 0 {
+            condvar.wait(&mut guard);
+        }
+    }
+
+    /// Block until the in-flight counter reaches 0, with timeout.
+    ///
+    /// Returns `true` if the scope completed, `false` if the timeout elapsed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::ipc::EventScope;
+    /// use std::time::Duration;
+    ///
+    /// let scope = EventScope::new();
+    ///
+    /// // Already complete - returns immediately
+    /// assert!(scope.wait_timeout(Duration::from_millis(100)));
+    ///
+    /// // With in-flight event that never completes
+    /// scope.increment();
+    /// assert!(!scope.wait_timeout(Duration::from_millis(10)));
+    /// ```
+    #[must_use]
+    #[allow(clippy::significant_drop_tightening)] // Guard must be held for the wait loop
+    pub fn wait_timeout(&self, timeout: Duration) -> bool {
+        let (mutex, condvar) = &self.inner.condvar;
+        let mut guard = mutex.lock();
+
+        let deadline = std::time::Instant::now() + timeout;
+
+        while self.in_flight() > 0 {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let result = condvar.wait_for(&mut guard, remaining);
+            if result.timed_out() && self.in_flight() > 0 {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Block until complete, with default timeout and warning logging.
+    ///
+    /// Uses `DEFAULT_TIMEOUT` (3 seconds). Returns `true` if completed,
+    /// `false` if timed out.
+    ///
+    /// In production, this logs a warning if the timeout is reached.
+    /// For kernel-level code, we just return the result.
+    #[must_use]
+    pub fn wait_with_default_timeout(&self) -> bool {
+        self.wait_timeout(DEFAULT_TIMEOUT)
+    }
+}
+
+impl Default for EventScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for EventScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventScope")
+            .field("id", &self.inner.id)
+            .field("in_flight", &self.in_flight())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::thread};
+
+    // ========== ScopeId tests ==========
+
+    #[test]
+    fn test_scope_id_unique() {
+        let id1 = ScopeId::new();
+        let id2 = ScopeId::new();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_scope_id_display() {
+        let id = ScopeId::new();
+        let display = format!("{id}");
+        assert!(display.starts_with("scope-"));
+    }
+
+    #[test]
+    fn test_scope_id_as_u64() {
+        let id = ScopeId::new();
+        assert!(id.as_u64() > 0);
+    }
+
+    // ========== EventScope basic tests ==========
+
+    #[test]
+    fn test_event_scope_new() {
+        let scope = EventScope::new();
+        assert_eq!(scope.in_flight(), 0);
+        assert!(scope.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_increment_decrement() {
+        let scope = EventScope::new();
+
+        scope.increment();
+        assert_eq!(scope.in_flight(), 1);
+        assert!(!scope.is_complete());
+
+        scope.increment();
+        assert_eq!(scope.in_flight(), 2);
+
+        scope.decrement();
+        assert_eq!(scope.in_flight(), 1);
+
+        scope.decrement();
+        assert_eq!(scope.in_flight(), 0);
+        assert!(scope.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_clone_shares_state() {
+        let scope1 = EventScope::new();
+        let scope2 = scope1.clone();
+
+        scope1.increment();
+        assert_eq!(scope2.in_flight(), 1);
+
+        scope2.increment();
+        assert_eq!(scope1.in_flight(), 2);
+
+        scope1.decrement();
+        scope1.decrement();
+        assert!(scope2.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_unique_ids() {
+        let scope1 = EventScope::new();
+        let scope2 = EventScope::new();
+        assert_ne!(scope1.id(), scope2.id());
+    }
+
+    #[test]
+    fn test_event_scope_clone_same_id() {
+        let scope1 = EventScope::new();
+        let scope2 = scope1.clone();
+        assert_eq!(scope1.id(), scope2.id());
+    }
+
+    // ========== EventScope wait tests ==========
+
+    #[test]
+    fn test_event_scope_wait_immediate() {
+        let scope = EventScope::new();
+        // Already complete - should return immediately
+        scope.wait();
+        assert!(scope.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_wait_timeout_immediate() {
+        let scope = EventScope::new();
+        let completed = scope.wait_timeout(Duration::from_millis(100));
+        assert!(completed);
+    }
+
+    #[test]
+    fn test_event_scope_wait_timeout_expires() {
+        let scope = EventScope::new();
+        scope.increment();
+
+        let completed = scope.wait_timeout(Duration::from_millis(10));
+        assert!(!completed);
+        assert_eq!(scope.in_flight(), 1);
+    }
+
+    #[test]
+    fn test_event_scope_wait_timeout_completes() {
+        let scope = EventScope::new();
+        let scope2 = scope.clone();
+
+        scope.increment();
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            scope2.decrement();
+        });
+
+        let completed = scope.wait_timeout(Duration::from_secs(1));
+        assert!(completed);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_event_scope_wait_with_thread() {
+        let scope = EventScope::new();
+        let scope2 = scope.clone();
+
+        scope.increment();
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(5));
+            scope2.decrement();
+        });
+
+        scope.wait();
+        assert!(scope.is_complete());
+        handle.join().unwrap();
+    }
+
+    // ========== EventScope concurrent tests ==========
+
+    #[test]
+    fn test_event_scope_concurrent_increments() {
+        let scope = EventScope::new();
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let s = scope.clone();
+            handles.push(thread::spawn(move || {
+                s.increment();
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(scope.in_flight(), 10);
+    }
+
+    #[test]
+    fn test_event_scope_concurrent_increment_decrement() {
+        let scope = EventScope::new();
+        let mut handles = vec![];
+
+        // First, increment 10 times
+        for _ in 0..10 {
+            scope.increment();
+        }
+
+        // Then decrement from multiple threads
+        for _ in 0..10 {
+            let s = scope.clone();
+            handles.push(thread::spawn(move || {
+                s.decrement();
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(scope.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_multiple_waiters() {
+        let scope = EventScope::new();
+        scope.increment();
+
+        let mut handles = vec![];
+
+        // Start multiple waiters
+        for _ in 0..3 {
+            let s = scope.clone();
+            handles.push(thread::spawn(move || {
+                let completed = s.wait_timeout(Duration::from_secs(1));
+                assert!(completed);
+            }));
+        }
+
+        // Small delay then decrement
+        thread::sleep(Duration::from_millis(10));
+        scope.decrement();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    // ========== Debug and Default tests ==========
+
+    #[test]
+    fn test_event_scope_debug() {
+        let scope = EventScope::new();
+        scope.increment();
+        let debug_str = format!("{scope:?}");
+        assert!(debug_str.contains("EventScope"));
+        assert!(debug_str.contains("in_flight: 1"));
+    }
+
+    #[test]
+    fn test_event_scope_default() {
+        let scope = EventScope::default();
+        assert!(scope.is_complete());
+    }
+
+    #[test]
+    fn test_event_scope_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EventScope>();
+    }
+}

--- a/lib/kernel/src/ipc/subscription.rs
+++ b/lib/kernel/src/ipc/subscription.rs
@@ -1,0 +1,348 @@
+//! Subscription handle for event bus unsubscription.
+//!
+//! `Subscription` is an RAII handle that automatically unsubscribes from the
+//! event bus when dropped. This ensures handlers are properly cleaned up even
+//! in the presence of panics or early returns.
+//!
+//! # Design Philosophy
+//!
+//! Following Rust's RAII pattern:
+//! - Subscription creation is tied to handler registration
+//! - Dropping the subscription removes the handler
+//! - Explicit `cancel()` available for early unsubscription
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_kernel::ipc::{EventBus, Event, Subscription};
+//!
+//! #[derive(Debug)]
+//! struct MyEvent;
+//! impl Event for MyEvent {}
+//!
+//! let bus = EventBus::new();
+//!
+//! // Subscription returned from subscribe
+//! let sub = bus.subscribe::<MyEvent, _>(100, |_event| {
+//!     println!("Event received!");
+//!     EventResult::Handled
+//! });
+//!
+//! // Handler is active while `sub` is alive
+//! bus.emit(MyEvent);
+//!
+//! // Drop `sub` to unsubscribe
+//! drop(sub);
+//! ```
+
+use std::{
+    any::TypeId,
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use parking_lot::Mutex;
+
+/// Unique identifier for a subscription.
+///
+/// Each subscription gets a unique ID for identification and debugging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriptionId(u64);
+
+impl SubscriptionId {
+    /// Create a new unique `SubscriptionId`.
+    pub(crate) fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        Self(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw ID value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SubscriptionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sub-{}", self.0)
+    }
+}
+
+/// Callback type for unsubscription.
+type UnsubscribeFn = Box<dyn FnOnce() + Send + Sync>;
+
+/// RAII handle for event subscriptions.
+///
+/// When a `Subscription` is dropped, the associated handler is automatically
+/// removed from the event bus. This ensures proper cleanup even when code
+/// panics or returns early.
+///
+/// # Thread Safety
+///
+/// `Subscription` is `Send + Sync`, allowing it to be moved between threads
+/// and shared (though sharing is unusual since drop triggers unsubscription).
+///
+/// # Example
+///
+/// ```ignore
+/// // Subscription automatically unsubscribes when dropped
+/// {
+///     let sub = bus.subscribe::<MyEvent, _>(100, handler);
+///     // Handler is active here
+/// } // Handler is removed here
+/// ```
+pub struct Subscription {
+    /// Unique identifier for this subscription.
+    id: SubscriptionId,
+
+    /// `TypeId` of the event type (for debugging).
+    type_id: TypeId,
+
+    /// Type name of the event (for debugging).
+    type_name: &'static str,
+
+    /// Unsubscribe callback, called on drop.
+    /// Wrapped in `Arc<Mutex>` to allow the callback to capture &self references
+    /// from the `EventBus`.
+    unsubscribe_fn: Arc<Mutex<Option<UnsubscribeFn>>>,
+}
+
+impl Subscription {
+    /// Create a new subscription.
+    ///
+    /// This is called internally by `EventBus::subscribe()`.
+    pub(crate) fn new<E: 'static>(
+        id: SubscriptionId,
+        unsubscribe_fn: impl FnOnce() + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            id,
+            type_id: TypeId::of::<E>(),
+            type_name: std::any::type_name::<E>(),
+            unsubscribe_fn: Arc::new(Mutex::new(Some(Box::new(unsubscribe_fn)))),
+        }
+    }
+
+    /// Get the subscription ID.
+    #[inline]
+    #[must_use]
+    pub const fn id(&self) -> SubscriptionId {
+        self.id
+    }
+
+    /// Get the `TypeId` of the subscribed event type.
+    #[inline]
+    #[must_use]
+    pub const fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    /// Get the type name of the subscribed event type.
+    #[inline]
+    #[must_use]
+    pub const fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+
+    /// Check if the subscription is still active.
+    ///
+    /// Returns `false` after `cancel()` has been called.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.unsubscribe_fn.lock().is_some()
+    }
+
+    /// Explicitly cancel the subscription.
+    ///
+    /// This is equivalent to dropping the subscription, but allows for
+    /// explicit control over when unsubscription occurs.
+    ///
+    /// Calling `cancel()` multiple times is safe and idempotent.
+    pub fn cancel(&self) {
+        let unsub = self.unsubscribe_fn.lock().take();
+        if let Some(callback) = unsub {
+            callback();
+        }
+    }
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+impl fmt::Debug for Subscription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Subscription")
+            .field("id", &self.id)
+            .field("type_name", &self.type_name)
+            .field("active", &self.is_active())
+            .finish_non_exhaustive()
+    }
+}
+
+// Subscription is automatically Send + Sync because:
+// - SubscriptionId is Copy
+// - TypeId and &'static str are Send + Sync
+// - UnsubscribeFn is Box<dyn FnOnce() + Send + Sync>
+// - Arc<Mutex<...>> is Send + Sync
+//
+// No manual unsafe impl needed - Rust derives these automatically.
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::sync::atomic::AtomicBool};
+
+    // ========== SubscriptionId tests ==========
+
+    #[test]
+    fn test_subscription_id_unique() {
+        let id1 = SubscriptionId::new();
+        let id2 = SubscriptionId::new();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_subscription_id_display() {
+        let id = SubscriptionId::new();
+        let display = format!("{id}");
+        assert!(display.starts_with("sub-"));
+    }
+
+    #[test]
+    fn test_subscription_id_as_u64() {
+        let id = SubscriptionId::new();
+        assert!(id.as_u64() > 0);
+    }
+
+    // ========== Subscription tests ==========
+
+    #[test]
+    fn test_subscription_new() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        let sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+            called2.store(true, Ordering::SeqCst);
+        });
+
+        assert!(sub.is_active());
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_subscription_id() {
+        let id = SubscriptionId::new();
+        let sub = Subscription::new::<i32>(id, || {});
+        assert_eq!(sub.id(), id);
+    }
+
+    #[test]
+    fn test_subscription_type_info() {
+        let sub = Subscription::new::<String>(SubscriptionId::new(), || {});
+        assert_eq!(sub.type_id(), TypeId::of::<String>());
+        assert!(sub.type_name().contains("String"));
+    }
+
+    #[test]
+    fn test_subscription_cancel() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        let sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+            called2.store(true, Ordering::SeqCst);
+        });
+
+        assert!(sub.is_active());
+        sub.cancel();
+        assert!(!sub.is_active());
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_subscription_cancel_idempotent() {
+        let call_count = Arc::new(AtomicU64::new(0));
+        let call_count2 = call_count.clone();
+
+        let sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+            call_count2.fetch_add(1, Ordering::SeqCst);
+        });
+
+        sub.cancel();
+        sub.cancel();
+        sub.cancel();
+
+        // Should only be called once
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_subscription_drop_calls_unsubscribe() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        {
+            let _sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+                called2.store(true, Ordering::SeqCst);
+            });
+            assert!(!called.load(Ordering::SeqCst));
+        } // Dropped here
+
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_subscription_cancel_then_drop() {
+        let call_count = Arc::new(AtomicU64::new(0));
+        let call_count2 = call_count.clone();
+
+        {
+            let sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+                call_count2.fetch_add(1, Ordering::SeqCst);
+            });
+
+            sub.cancel(); // Called once here
+        } // Drop should not call again
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_subscription_debug() {
+        let sub = Subscription::new::<String>(SubscriptionId::new(), || {});
+        let debug_str = format!("{sub:?}");
+        assert!(debug_str.contains("Subscription"));
+        assert!(debug_str.contains("String"));
+        assert!(debug_str.contains("active: true"));
+    }
+
+    #[test]
+    fn test_subscription_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Subscription>();
+    }
+
+    #[test]
+    fn test_subscription_move_between_threads() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        let sub = Subscription::new::<i32>(SubscriptionId::new(), move || {
+            called2.store(true, Ordering::SeqCst);
+        });
+
+        std::thread::spawn(move || {
+            drop(sub);
+        })
+        .join()
+        .unwrap();
+
+        assert!(called.load(Ordering::SeqCst));
+    }
+}

--- a/lib/kernel/src/mm/mod.rs
+++ b/lib/kernel/src/mm/mod.rs
@@ -53,7 +53,9 @@ mod position;
 #[cfg(test)]
 mod tests;
 
-pub use buffer::Buffer;
-pub use buffer_id::BufferId;
-pub use edit::Edit;
-pub use position::{Cursor, Position};
+pub use {
+    buffer::Buffer,
+    buffer_id::BufferId,
+    edit::Edit,
+    position::{Cursor, Position},
+};

--- a/lib/kernel/src/mm/tests.rs
+++ b/lib/kernel/src/mm/tests.rs
@@ -35,7 +35,7 @@ mod buffer_id_tests {
     #[test]
     fn test_display() {
         let id = BufferId::from_raw(123);
-        assert_eq!(format!("{}", id), "Buffer(123)");
+        assert_eq!(format!("{id}"), "Buffer(123)");
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod position_tests {
     fn test_display() {
         let pos = Position::new(0, 5);
         // Display uses 1-indexed for human readability
-        assert_eq!(format!("{}", pos), "1:6");
+        assert_eq!(format!("{pos}"), "1:6");
     }
 
     #[test]
@@ -472,7 +472,7 @@ mod buffer_tests {
                 let pos = Position::new(line, col);
                 let byte = buf.position_to_byte(pos);
                 let back = buf.byte_to_position(byte);
-                assert_eq!(pos, back, "Roundtrip failed for {:?}", pos);
+                assert_eq!(pos, back, "Roundtrip failed for {pos:?}");
             }
         }
     }


### PR DESCRIPTION
Add the IPC subsystem for kernel-driver-module communication:

- Event trait and DynEvent type-erased wrapper with TypeId downcasting
- EventBus with ArcSwap lock-free dispatch and priority ordering
- EventScope for GC-like event lifecycle synchronization
- Subscription RAII handle with automatic unsubscribe on drop
- Channel abstractions: unbounded, bounded, and oneshot

Design follows Linux kernel "mechanism, not policy" philosophy:
- Sync-first (no tokio dependency)
- Lock-free hot path via ArcSwap
- Fire-and-forget handlers (EventResult, no errors)

152 unit tests + 24 doctests covering all functionality.

Closes #160