### PR TITLE
feat(kernel): implement core/ primitives module (#161)

### DIFF
--- a/docs/architecture/clean-architecture-proposal.md
+++ b/docs/architecture/clean-architecture-proposal.md
@@ -1377,6 +1377,30 @@ impl TextObjectEngine {
 }
 ```
 
+**Design Note: Virtual Text / Decoration Compatibility**
+
+The `core/` module operates exclusively on **buffer positions** (actual text content), not
+visual/screen positions. This is intentional:
+
+```
+Buffer:     let x = 5;
+Visual:     let x: i32 = 5;   // ": i32" is virtual text (type hint)
+                ^^^^^ not in buffer, handled by render Stage 4
+```
+
+- **MotionEngine**: Calculates positions in actual buffer content
+- **TextObjectEngine**: Finds ranges in actual buffer content
+- **Virtual text**: Handled in render pipeline (Stage 4: Decorations)
+
+This separation ensures:
+1. Motions operate on real text (`w` jumps to next real word, not virtual text)
+2. Text objects select real content (operators act on buffer, not decorations)
+3. The kernel provides "mechanisms"; rendering provides "visual policies"
+
+Position mapping between buffer and visual coordinates is handled by the display
+driver (`lib/drivers/display/`), not the kernel. See Stage 4 in the rendering
+pipeline (section 5.3) for decoration/virtual text application.
+
 #### 4.2.6 Kernel API (`api/`)
 
 **Linux Equivalent:** `include/linux/` (stable interfaces)

--- a/lib/kernel/src/core/direction.rs
+++ b/lib/kernel/src/core/direction.rs
@@ -1,0 +1,162 @@
+//! Direction and boundary types for motion calculations.
+//!
+//! This module provides the foundational enums used by both
+//! motion calculations and text object handling.
+
+/// Direction of cursor movement.
+///
+/// Used by character, line, word, paragraph, and find-char motions.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::Direction;
+///
+/// let forward = Direction::Forward;  // h, j, w, }, f
+/// let backward = Direction::Backward; // l, k, b, {, F
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    /// Move forward (right for chars, down for lines)
+    Forward,
+    /// Move backward (left for chars, up for lines)
+    Backward,
+}
+
+impl Direction {
+    /// Check if direction is forward.
+    #[must_use]
+    pub const fn is_forward(&self) -> bool {
+        matches!(self, Self::Forward)
+    }
+
+    /// Check if direction is backward.
+    #[must_use]
+    pub const fn is_backward(&self) -> bool {
+        matches!(self, Self::Backward)
+    }
+
+    /// Get the opposite direction.
+    #[must_use]
+    pub const fn opposite(&self) -> Self {
+        match self {
+            Self::Forward => Self::Backward,
+            Self::Backward => Self::Forward,
+        }
+    }
+}
+
+/// Word boundary type for word motions.
+///
+/// Vim distinguishes between "words" and "WORDS":
+/// - **Word**: Sequences of alphanumeric characters or underscores,
+///   separated by other non-whitespace characters or whitespace.
+/// - **`BigWord` (WORD)**: Sequences of non-whitespace characters,
+///   separated only by whitespace.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::WordBoundary;
+///
+/// // Given text: "hello-world foo"
+/// // Word boundaries: hello | - | world | foo
+/// // BigWord boundaries: hello-world | foo
+///
+/// let word = WordBoundary::Word;       // w, b, e, ge
+/// let big_word = WordBoundary::BigWord; // W, B, E, gE
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WordBoundary {
+    /// Word: alphanumeric + underscore sequences (w/b/e)
+    Word,
+    /// WORD: non-whitespace sequences (W/B/E)
+    BigWord,
+}
+
+impl WordBoundary {
+    /// Check if a character is a word character for this boundary type.
+    #[must_use]
+    pub fn is_word_char(&self, c: char) -> bool {
+        match self {
+            Self::Word => c.is_alphanumeric() || c == '_',
+            Self::BigWord => !c.is_whitespace(),
+        }
+    }
+}
+
+/// Line position types for line-based motions.
+///
+/// These correspond to vim's 0, ^, $, and g_ commands.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::LinePosition;
+///
+/// // Given line: "  hello world  "
+/// //             ^  ^          ^ ^
+/// //             |  |          | |
+/// //             |  FirstNonBlank|
+/// //             Start           End
+/// //                         LastNonBlank
+///
+/// let start = LinePosition::Start;           // 0
+/// let first = LinePosition::FirstNonBlank;   // ^
+/// let end = LinePosition::End;               // $
+/// let last = LinePosition::LastNonBlank;     // g_
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LinePosition {
+    /// Start of line, column 0 (vim: 0)
+    Start,
+    /// First non-blank character (vim: ^)
+    FirstNonBlank,
+    /// End of line, last character (vim: $)
+    End,
+    /// Last non-blank character (vim: g_)
+    LastNonBlank,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_direction_opposite() {
+        assert_eq!(Direction::Forward.opposite(), Direction::Backward);
+        assert_eq!(Direction::Backward.opposite(), Direction::Forward);
+    }
+
+    #[test]
+    fn test_direction_is_forward_backward() {
+        assert!(Direction::Forward.is_forward());
+        assert!(!Direction::Forward.is_backward());
+        assert!(!Direction::Backward.is_forward());
+        assert!(Direction::Backward.is_backward());
+    }
+
+    #[test]
+    fn test_word_boundary_word() {
+        let boundary = WordBoundary::Word;
+        assert!(boundary.is_word_char('a'));
+        assert!(boundary.is_word_char('Z'));
+        assert!(boundary.is_word_char('0'));
+        assert!(boundary.is_word_char('_'));
+        assert!(!boundary.is_word_char('-'));
+        assert!(!boundary.is_word_char(' '));
+        assert!(!boundary.is_word_char('.'));
+    }
+
+    #[test]
+    fn test_word_boundary_big_word() {
+        let boundary = WordBoundary::BigWord;
+        assert!(boundary.is_word_char('a'));
+        assert!(boundary.is_word_char('-'));
+        assert!(boundary.is_word_char('.'));
+        assert!(boundary.is_word_char('_'));
+        assert!(!boundary.is_word_char(' '));
+        assert!(!boundary.is_word_char('\t'));
+        assert!(!boundary.is_word_char('\n'));
+    }
+}

--- a/lib/kernel/src/core/mark.rs
+++ b/lib/kernel/src/core/mark.rs
@@ -1,0 +1,443 @@
+//! Mark storage for bookmark operations.
+//!
+//! Marks allow jumping to saved positions within buffers.
+//!
+//! # Vim Mark Types
+//!
+//! - `'a` to `'z` - Buffer-local marks
+//! - `'A` to `'Z` - Global marks (across buffers)
+//! - `''` - Last jump position
+//! - `'.` - Last edit position
+//! - `'^` - Last insert position
+
+use std::collections::HashMap;
+
+use crate::mm::{BufferId, Position};
+
+/// A bookmark position with optional buffer association.
+///
+/// For global marks, both `position` and `buffer_id` are significant.
+/// For buffer-local marks, only `position` is used (buffer is implicit).
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::Mark;
+/// use reovim_kernel::mm::{BufferId, Position};
+///
+/// let mark = Mark {
+///     position: Position::new(10, 5),
+///     buffer_id: BufferId::new(),
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mark {
+    /// Position within the buffer.
+    pub position: Position,
+    /// Buffer this mark belongs to (for global marks).
+    pub buffer_id: BufferId,
+}
+
+impl Mark {
+    /// Create a new mark at the given position and buffer.
+    #[must_use]
+    pub const fn new(position: Position, buffer_id: BufferId) -> Self {
+        Self {
+            position,
+            buffer_id,
+        }
+    }
+}
+
+/// Special mark types for automatic bookmarks.
+///
+/// These marks are automatically maintained by the editor.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::SpecialMark;
+///
+/// // Jump to last position before current jump
+/// let last_jump = SpecialMark::LastJump; // ''
+///
+/// // Jump to last edit location
+/// let last_edit = SpecialMark::LastEdit; // '.
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpecialMark {
+    /// Position before last jump (vim: `''` or backtick-backtick)
+    LastJump,
+    /// Position of last edit (`'.`)
+    LastEdit,
+    /// Position of last insert (`'^`)
+    LastInsert,
+    /// Start of last visual selection (`'<`)
+    VisualStart,
+    /// End of last visual selection (`'>`)
+    VisualEnd,
+    /// Position where last exited insert mode
+    LastExitInsert,
+}
+
+/// Mark storage for all mark types.
+///
+/// Manages buffer-local marks, global marks, and special marks.
+///
+/// # Mark Types
+///
+/// - **Local marks** (`'a`-`'z`): Stored per-buffer, only position is tracked
+/// - **Global marks** (`'A`-`'Z`): Stored globally, includes buffer ID
+/// - **Special marks**: Automatically maintained editor positions
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{MarkBank, Mark, SpecialMark};
+/// use reovim_kernel::mm::{BufferId, Position};
+///
+/// let mut marks = MarkBank::new();
+///
+/// // Set local mark
+/// marks.set_local('a', Position::new(10, 0));
+///
+/// // Set global mark
+/// let buffer_id = BufferId::new();
+/// marks.set_global('A', Mark::new(Position::new(5, 0), buffer_id));
+///
+/// // Set special mark (usually done automatically)
+/// marks.set_special(SpecialMark::LastJump, Mark::new(Position::new(0, 0), buffer_id));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct MarkBank {
+    /// Buffer-local marks ('a'-'z).
+    ///
+    /// These are positions within a single buffer.
+    /// The buffer context is provided externally when accessing.
+    local: HashMap<char, Position>,
+
+    /// Global marks ('A'-'Z).
+    ///
+    /// These include buffer ID for cross-buffer jumps.
+    global: HashMap<char, Mark>,
+
+    /// Special marks maintained by the editor.
+    special: HashMap<SpecialMark, Mark>,
+}
+
+impl MarkBank {
+    /// Create a new empty mark bank.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            local: HashMap::new(),
+            global: HashMap::new(),
+            special: HashMap::new(),
+        }
+    }
+
+    // === Local Marks ===
+
+    /// Set a local mark ('a'-'z').
+    ///
+    /// Returns `true` if successful, `false` if the mark name is invalid.
+    pub fn set_local(&mut self, name: char, position: Position) -> bool {
+        if name.is_ascii_lowercase() {
+            self.local.insert(name, position);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get a local mark ('a'-'z').
+    ///
+    /// Returns `None` if the mark doesn't exist or name is invalid.
+    #[must_use]
+    pub fn get_local(&self, name: char) -> Option<Position> {
+        if name.is_ascii_lowercase() {
+            self.local.get(&name).copied()
+        } else {
+            None
+        }
+    }
+
+    /// Delete a local mark.
+    ///
+    /// Returns `true` if the mark existed and was deleted.
+    pub fn delete_local(&mut self, name: char) -> bool {
+        if name.is_ascii_lowercase() {
+            self.local.remove(&name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// List all local marks.
+    #[must_use]
+    pub fn list_local(&self) -> Vec<(char, Position)> {
+        let mut marks: Vec<_> = self.local.iter().map(|(&c, &p)| (c, p)).collect();
+        marks.sort_by_key(|(c, _)| *c);
+        marks
+    }
+
+    // === Global Marks ===
+
+    /// Set a global mark ('A'-'Z').
+    ///
+    /// Returns `true` if successful, `false` if the mark name is invalid.
+    pub fn set_global(&mut self, name: char, mark: Mark) -> bool {
+        if name.is_ascii_uppercase() {
+            self.global.insert(name, mark);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get a global mark ('A'-'Z').
+    ///
+    /// Returns `None` if the mark doesn't exist or name is invalid.
+    #[must_use]
+    pub fn get_global(&self, name: char) -> Option<&Mark> {
+        if name.is_ascii_uppercase() {
+            self.global.get(&name)
+        } else {
+            None
+        }
+    }
+
+    /// Delete a global mark.
+    ///
+    /// Returns `true` if the mark existed and was deleted.
+    pub fn delete_global(&mut self, name: char) -> bool {
+        if name.is_ascii_uppercase() {
+            self.global.remove(&name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// List all global marks.
+    #[must_use]
+    pub fn list_global(&self) -> Vec<(char, &Mark)> {
+        let mut marks: Vec<_> = self.global.iter().map(|(&c, m)| (c, m)).collect();
+        marks.sort_by_key(|(c, _)| *c);
+        marks
+    }
+
+    // === Special Marks ===
+
+    /// Set a special mark.
+    pub fn set_special(&mut self, mark: SpecialMark, value: Mark) {
+        self.special.insert(mark, value);
+    }
+
+    /// Get a special mark.
+    #[must_use]
+    pub fn get_special(&self, mark: SpecialMark) -> Option<&Mark> {
+        self.special.get(&mark)
+    }
+
+    /// Clear a special mark.
+    pub fn clear_special(&mut self, mark: SpecialMark) {
+        self.special.remove(&mark);
+    }
+
+    // === Combined Operations ===
+
+    /// Get mark by character (local, global, or special shorthand).
+    ///
+    /// - `'a'`-`'z'` - Local marks (returns `None` for position, needs buffer context)
+    /// - `'A'`-`'Z'` - Global marks
+    /// - `'\''` or `` '`' `` - Last jump
+    /// - `'.'` - Last edit
+    /// - `'^'` - Last insert
+    /// - `'<'` - Visual start
+    /// - `'>'` - Visual end
+    #[must_use]
+    pub fn get_by_char(&self, c: char) -> Option<MarkResult<'_>> {
+        match c {
+            'a'..='z' => self.local.get(&c).map(|&p| MarkResult::Local(p)),
+            'A'..='Z' => self.global.get(&c).map(MarkResult::Global),
+            '\'' | '`' => self
+                .special
+                .get(&SpecialMark::LastJump)
+                .map(MarkResult::Global),
+            '.' => self
+                .special
+                .get(&SpecialMark::LastEdit)
+                .map(MarkResult::Global),
+            '^' => self
+                .special
+                .get(&SpecialMark::LastInsert)
+                .map(MarkResult::Global),
+            '<' => self
+                .special
+                .get(&SpecialMark::VisualStart)
+                .map(MarkResult::Global),
+            '>' => self
+                .special
+                .get(&SpecialMark::VisualEnd)
+                .map(MarkResult::Global),
+            _ => None,
+        }
+    }
+
+    /// Clear all local marks (for when buffer is closed).
+    pub fn clear_local(&mut self) {
+        self.local.clear();
+    }
+
+    /// Clear all marks.
+    pub fn clear_all(&mut self) {
+        self.local.clear();
+        self.global.clear();
+        self.special.clear();
+    }
+}
+
+/// Result of a mark lookup.
+#[derive(Debug, Clone, Copy)]
+pub enum MarkResult<'a> {
+    /// Local mark - position within current buffer.
+    Local(Position),
+    /// Global mark - includes buffer ID.
+    Global(&'a Mark),
+}
+
+impl MarkResult<'_> {
+    /// Get the position from either mark type.
+    #[must_use]
+    pub const fn position(&self) -> Position {
+        match self {
+            Self::Local(pos) => *pos,
+            Self::Global(mark) => mark.position,
+        }
+    }
+
+    /// Get buffer ID if this is a global mark.
+    #[must_use]
+    pub const fn buffer_id(&self) -> Option<BufferId> {
+        match self {
+            Self::Local(_) => None,
+            Self::Global(mark) => Some(mark.buffer_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_buffer_id() -> BufferId {
+        BufferId::new()
+    }
+
+    #[test]
+    fn test_mark_new() {
+        let buf_id = test_buffer_id();
+        let mark = Mark::new(Position::new(10, 5), buf_id);
+        assert_eq!(mark.position, Position::new(10, 5));
+        assert_eq!(mark.buffer_id, buf_id);
+    }
+
+    #[test]
+    fn test_local_marks() {
+        let mut bank = MarkBank::new();
+
+        assert!(bank.set_local('a', Position::new(10, 0)));
+        assert_eq!(bank.get_local('a'), Some(Position::new(10, 0)));
+
+        // Invalid mark name
+        assert!(!bank.set_local('A', Position::new(0, 0)));
+        assert!(bank.get_local('A').is_none());
+    }
+
+    #[test]
+    fn test_global_marks() {
+        let mut bank = MarkBank::new();
+        let buf_id = test_buffer_id();
+
+        assert!(bank.set_global('A', Mark::new(Position::new(5, 0), buf_id)));
+        let mark = bank.get_global('A').unwrap();
+        assert_eq!(mark.position, Position::new(5, 0));
+        assert_eq!(mark.buffer_id, buf_id);
+
+        // Invalid mark name
+        assert!(!bank.set_global('a', Mark::new(Position::new(0, 0), buf_id)));
+    }
+
+    #[test]
+    fn test_special_marks() {
+        let mut bank = MarkBank::new();
+        let buf_id = test_buffer_id();
+
+        bank.set_special(SpecialMark::LastJump, Mark::new(Position::new(15, 3), buf_id));
+        let mark = bank.get_special(SpecialMark::LastJump).unwrap();
+        assert_eq!(mark.position, Position::new(15, 3));
+    }
+
+    #[test]
+    fn test_get_by_char() {
+        let mut bank = MarkBank::new();
+        let buf_id = test_buffer_id();
+
+        bank.set_local('x', Position::new(1, 0));
+        bank.set_global('X', Mark::new(Position::new(2, 0), buf_id));
+        bank.set_special(SpecialMark::LastJump, Mark::new(Position::new(3, 0), buf_id));
+
+        // Local
+        let result = bank.get_by_char('x').unwrap();
+        assert_eq!(result.position(), Position::new(1, 0));
+        assert!(result.buffer_id().is_none());
+
+        // Global
+        let result = bank.get_by_char('X').unwrap();
+        assert_eq!(result.position(), Position::new(2, 0));
+        assert!(result.buffer_id().is_some());
+
+        // Special (last jump via ')
+        let result = bank.get_by_char('\'').unwrap();
+        assert_eq!(result.position(), Position::new(3, 0));
+    }
+
+    #[test]
+    fn test_list_marks() {
+        let mut bank = MarkBank::new();
+        let buf_id = test_buffer_id();
+
+        bank.set_local('c', Position::new(3, 0));
+        bank.set_local('a', Position::new(1, 0));
+        bank.set_local('b', Position::new(2, 0));
+
+        let list = bank.list_local();
+        assert_eq!(list.len(), 3);
+        assert_eq!(list[0], ('a', Position::new(1, 0)));
+        assert_eq!(list[1], ('b', Position::new(2, 0)));
+        assert_eq!(list[2], ('c', Position::new(3, 0)));
+
+        bank.set_global('Z', Mark::new(Position::new(1, 0), buf_id));
+        bank.set_global('A', Mark::new(Position::new(2, 0), buf_id));
+
+        let list = bank.list_global();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].0, 'A');
+        assert_eq!(list[1].0, 'Z');
+    }
+
+    #[test]
+    fn test_delete_marks() {
+        let mut bank = MarkBank::new();
+        let buf_id = test_buffer_id();
+
+        bank.set_local('a', Position::new(1, 0));
+        assert!(bank.delete_local('a'));
+        assert!(bank.get_local('a').is_none());
+        assert!(!bank.delete_local('a')); // Already deleted
+
+        bank.set_global('A', Mark::new(Position::new(1, 0), buf_id));
+        assert!(bank.delete_global('A'));
+        assert!(bank.get_global('A').is_none());
+    }
+}

--- a/lib/kernel/src/core/mod.rs
+++ b/lib/kernel/src/core/mod.rs
@@ -1,5 +1,64 @@
-//! Core primitives.
+//! Core primitives for the kernel.
 //!
-//! Provides motion calculations, text object handling, and command dispatch.
+//! Linux equivalent: Core kernel functionality
+//!
+//! This module provides the foundational abstractions for editor operations:
+//!
+//! - **Motion**: Pure cursor movement calculations
+//! - **`TextObject`**: Text object range calculations for operators
+//! - **Register**: Yank/paste storage (without clipboard integration)
+//! - **Mark**: Bookmark operations
+//!
+//! # Design Philosophy
+//!
+//! Following Linux kernel "mechanism, not policy":
+//! - Kernel provides *how* to calculate motions (mechanisms)
+//! - Modules decide *what* keys trigger which motions (policies)
+//!
+//! All calculations are pure functions with no side effects.
+//! The buffer is never modified by these operations.
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::core::{Motion, Direction, MotionEngine};
+//! use reovim_kernel::mm::{Buffer, Cursor, Position};
+//!
+//! let buffer = Buffer::from_string("hello world");
+//! let cursor = Cursor::new(Position::new(0, 0));
+//!
+//! // Calculate where 'w' motion would land
+//! let new_pos = MotionEngine::calculate(
+//!     &buffer,
+//!     &cursor,
+//!     Motion::Word {
+//!         direction: Direction::Forward,
+//!         boundary: reovim_kernel::core::WordBoundary::Word,
+//!         end: false,
+//!     },
+//!     1,
+//! );
+//!
+//! assert_eq!(new_pos, Some(Position::new(0, 6)));
+//! ```
 
-// Placeholder - Motion, TextObject, Command will be added in Phase 2
+mod direction;
+mod mark;
+mod motion;
+mod register;
+mod textobj;
+
+// Re-export direction types
+pub use direction::{Direction, LinePosition, WordBoundary};
+
+// Re-export mark types
+pub use mark::{Mark, MarkBank, MarkResult, SpecialMark};
+
+// Re-export motion types
+pub use motion::{Motion, MotionEngine};
+
+// Re-export register types
+pub use register::{RegisterBank, RegisterContent, YankType};
+
+// Re-export text object types
+pub use textobj::{TextObject, TextObjectEngine};

--- a/lib/kernel/src/core/motion.rs
+++ b/lib/kernel/src/core/motion.rs
@@ -1,0 +1,1179 @@
+//! Motion calculations for cursor movement.
+//!
+//! This module provides pure motion calculations without any side effects.
+//! The `MotionEngine` calculates target positions given a buffer, cursor, and motion.
+//!
+//! # Design Philosophy
+//!
+//! This follows the Linux kernel "mechanism, not policy" principle:
+//! - The kernel provides *how* to calculate motions (mechanisms)
+//! - Modules decide *what* keys trigger which motions (policies)
+
+use crate::mm::{Buffer, Cursor, Position};
+
+use super::direction::{Direction, LinePosition, WordBoundary};
+
+/// Supported bracket pairs for % motion.
+const BRACKET_PAIRS: [(char, char); 3] = [('(', ')'), ('[', ']'), ('{', '}')];
+
+/// Motion types for cursor movement.
+///
+/// Each variant represents a different type of cursor motion that vim supports.
+/// Motions can be used with operators (d, y, c) or on their own for navigation.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{Motion, Direction, WordBoundary, LinePosition};
+///
+/// // Character motion (h, l)
+/// let left = Motion::Char(Direction::Backward);
+/// let right = Motion::Char(Direction::Forward);
+///
+/// // Word motion (w, b, e)
+/// let word_forward = Motion::Word {
+///     direction: Direction::Forward,
+///     boundary: WordBoundary::Word,
+///     end: false,
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Motion {
+    /// Character motion (h, l)
+    Char(Direction),
+
+    /// Line motion (j, k)
+    Line(Direction),
+
+    /// Word motion (w, b, e, ge, W, B, E, gE)
+    Word {
+        /// Direction of movement
+        direction: Direction,
+        /// Word boundary type (word vs WORD)
+        boundary: WordBoundary,
+        /// If true, move to end of word (e/E/ge/gE), else to start (w/W/b/B)
+        end: bool,
+    },
+
+    /// Line position (0, ^, $, g_)
+    LinePosition(LinePosition),
+
+    /// Paragraph motion ({, })
+    Paragraph(Direction),
+
+    /// Find character on line (f, F, t, T)
+    FindChar {
+        /// Character to find
+        char: char,
+        /// Direction to search
+        direction: Direction,
+        /// If true, stop before the character (t/T), else on it (f/F)
+        till: bool,
+    },
+
+    /// Jump to line (G, gg)
+    ///
+    /// - `None` - jump to last line (G) or first line (gg)
+    /// - `Some(n)` - jump to line n (1-indexed in vim, 0-indexed internally)
+    JumpLine(Option<usize>),
+
+    /// Match bracket (%)
+    MatchBracket,
+}
+
+impl Motion {
+    /// Check if this motion is linewise.
+    ///
+    /// Linewise motions operate on whole lines rather than character ranges.
+    /// This affects how operators (d, y, c) interpret the motion.
+    ///
+    /// # Example
+    ///
+    /// - `dj` deletes current line and next line (linewise)
+    /// - `dw` deletes to start of next word (characterwise)
+    #[must_use]
+    pub const fn is_linewise(&self) -> bool {
+        matches!(self, Self::Line(_) | Self::JumpLine(_) | Self::Paragraph(_))
+    }
+
+    /// Check if this motion is inclusive.
+    ///
+    /// Inclusive motions include the character at the target position.
+    /// This affects operators like delete and yank.
+    ///
+    /// # Example
+    ///
+    /// - `d$` deletes to end of line including the last character (inclusive)
+    /// - `dw` deletes to start of next word excluding the first character (exclusive)
+    #[must_use]
+    pub const fn is_inclusive(&self) -> bool {
+        matches!(
+            self,
+            Self::LinePosition(LinePosition::End | LinePosition::LastNonBlank)
+                | Self::Word { end: true, .. }
+                | Self::MatchBracket
+                | Self::FindChar { till: false, .. }
+        )
+    }
+}
+
+/// Motion calculation engine.
+///
+/// Provides pure calculations for cursor positions without modifying any state.
+/// This is the "mechanism" that modules use to implement motion commands.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{MotionEngine, Motion, Direction};
+/// use reovim_kernel::mm::{Buffer, Cursor, Position};
+///
+/// let buffer = Buffer::from_string("hello world");
+/// let cursor = Cursor::new(Position::new(0, 0));
+///
+/// let new_pos = MotionEngine::calculate(
+///     &buffer,
+///     &cursor,
+///     Motion::Char(Direction::Forward),
+///     1,
+/// );
+///
+/// assert_eq!(new_pos, Some(Position::new(0, 1)));
+/// ```
+pub struct MotionEngine;
+
+impl MotionEngine {
+    /// Calculate new position after applying a motion.
+    ///
+    /// Returns `None` if the motion is invalid or impossible.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - The buffer to calculate motion in
+    /// * `cursor` - Current cursor state (includes position and preferred column)
+    /// * `motion` - The motion to apply
+    /// * `count` - Number of times to apply the motion (minimum 1)
+    #[must_use]
+    pub fn calculate(
+        buffer: &Buffer,
+        cursor: &Cursor,
+        motion: Motion,
+        count: usize,
+    ) -> Option<Position> {
+        let count = count.max(1);
+
+        match motion {
+            Motion::Char(dir) => Self::char_motion(buffer, cursor.position, dir, count),
+            Motion::Line(dir) => Self::line_motion(buffer, cursor, dir, count),
+            Motion::Word {
+                direction,
+                boundary,
+                end,
+            } => Self::word_motion(buffer, cursor.position, direction, boundary, end, count),
+            Motion::LinePosition(pos) => Self::line_position(buffer, cursor.position, pos),
+            Motion::Paragraph(dir) => Self::paragraph_motion(buffer, cursor.position, dir, count),
+            Motion::FindChar {
+                char,
+                direction,
+                till,
+            } => Self::find_char(buffer, cursor.position, char, direction, till, count),
+            Motion::JumpLine(line) => Self::jump_line(buffer, cursor, line),
+            Motion::MatchBracket => Self::match_bracket(buffer, cursor.position),
+        }
+    }
+
+    /// Calculate new position and desired column after applying a motion.
+    ///
+    /// This variant is useful for vertical motions where the cursor should
+    /// try to maintain its horizontal position across lines of different lengths.
+    ///
+    /// Returns `(new_position, new_desired_column)`
+    #[must_use]
+    pub fn calculate_with_desired_col(
+        buffer: &Buffer,
+        cursor: &Cursor,
+        motion: Motion,
+        count: usize,
+    ) -> (Option<Position>, Option<usize>) {
+        let count = count.max(1);
+
+        if matches!(motion, Motion::Line(_)) {
+            // For vertical motions, preserve or establish desired column
+            let desired_col = cursor.preferred_column.unwrap_or(cursor.position.column);
+            let new_pos = Self::calculate(buffer, cursor, motion, count);
+            (new_pos, Some(desired_col))
+        } else {
+            // Horizontal motions clear the desired column
+            let new_pos = Self::calculate(buffer, cursor, motion, count);
+            (new_pos, None)
+        }
+    }
+
+    // === Private Implementation ===
+
+    fn char_motion(
+        buffer: &Buffer,
+        pos: Position,
+        direction: Direction,
+        count: usize,
+    ) -> Option<Position> {
+        let line_len = buffer.line_len(pos.line)?;
+
+        match direction {
+            Direction::Forward => {
+                // Move right, clamped to line length minus 1 (stay on last char)
+                let max_col = line_len.saturating_sub(1);
+                let new_col = pos.column.saturating_add(count).min(max_col);
+                Some(Position::new(pos.line, new_col))
+            }
+            Direction::Backward => {
+                // Move left, clamped to 0
+                let new_col = pos.column.saturating_sub(count);
+                Some(Position::new(pos.line, new_col))
+            }
+        }
+    }
+
+    fn line_motion(
+        buffer: &Buffer,
+        cursor: &Cursor,
+        direction: Direction,
+        count: usize,
+    ) -> Option<Position> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        let new_line = match direction {
+            Direction::Forward => {
+                // Move down
+                let target = cursor.position.line.saturating_add(count);
+                target.min(line_count.saturating_sub(1))
+            }
+            Direction::Backward => {
+                // Move up
+                cursor.position.line.saturating_sub(count)
+            }
+        };
+
+        // Use preferred column if set, otherwise current column
+        let target_col = cursor.effective_column();
+        let line_len = buffer.line_len(new_line)?;
+        let max_col = if line_len == 0 {
+            0
+        } else {
+            line_len.saturating_sub(1)
+        };
+        let new_col = target_col.min(max_col);
+
+        Some(Position::new(new_line, new_col))
+    }
+
+    fn word_motion(
+        buffer: &Buffer,
+        pos: Position,
+        direction: Direction,
+        boundary: WordBoundary,
+        end: bool,
+        count: usize,
+    ) -> Option<Position> {
+        let mut current = pos;
+
+        for _ in 0..count {
+            current = match (direction, end) {
+                (Direction::Forward, false) => Self::word_forward(buffer, current, boundary)?,
+                (Direction::Forward, true) => Self::word_end(buffer, current, boundary)?,
+                (Direction::Backward, false) => Self::word_backward(buffer, current, boundary)?,
+                (Direction::Backward, true) => Self::word_end_backward(buffer, current, boundary)?,
+            };
+        }
+
+        Some(current)
+    }
+
+    fn word_forward(
+        buffer: &Buffer,
+        mut pos: Position,
+        boundary: WordBoundary,
+    ) -> Option<Position> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return Some(pos);
+        }
+
+        loop {
+            if pos.line >= line_count {
+                pos.line = line_count.saturating_sub(1);
+                pos.column = buffer.line_len(pos.line).unwrap_or(0).saturating_sub(1);
+                break;
+            }
+
+            let line = buffer.line(pos.line)?;
+            let chars: Vec<char> = line.chars().collect();
+            let mut x = pos.column;
+
+            // Skip current word (non-whitespace for BigWord, word chars or punctuation for Word)
+            if boundary == WordBoundary::Word {
+                // For small word, we need to handle word chars and punctuation separately
+                if let Some(&c) = chars.get(x) {
+                    if c.is_alphanumeric() || c == '_' {
+                        // Skip word characters
+                        while x < chars.len() && (chars[x].is_alphanumeric() || chars[x] == '_') {
+                            x += 1;
+                        }
+                    } else if !c.is_whitespace() {
+                        // Skip punctuation
+                        while x < chars.len()
+                            && !chars[x].is_whitespace()
+                            && !chars[x].is_alphanumeric()
+                            && chars[x] != '_'
+                        {
+                            x += 1;
+                        }
+                    }
+                }
+            } else {
+                // BigWord: skip non-whitespace
+                while x < chars.len() && !chars[x].is_whitespace() {
+                    x += 1;
+                }
+            }
+
+            // Skip whitespace
+            while x < chars.len() && chars[x].is_whitespace() {
+                x += 1;
+            }
+
+            if x < chars.len() {
+                pos.column = x;
+                break;
+            }
+
+            // Reached end of line, try next line
+            if pos.line + 1 < line_count {
+                pos.line += 1;
+                pos.column = 0;
+
+                // Skip leading whitespace on new line
+                if let Some(next_line) = buffer.line(pos.line) {
+                    let next_chars: Vec<char> = next_line.chars().collect();
+                    let mut nx = 0;
+                    while nx < next_chars.len() && next_chars[nx].is_whitespace() {
+                        nx += 1;
+                    }
+                    if nx < next_chars.len() {
+                        pos.column = nx;
+                        break;
+                    }
+                }
+            } else {
+                pos.column = chars.len().saturating_sub(1);
+                break;
+            }
+        }
+
+        Some(pos)
+    }
+
+    fn word_end(buffer: &Buffer, mut pos: Position, boundary: WordBoundary) -> Option<Position> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return Some(pos);
+        }
+
+        // First, move forward one position
+        let line_len = buffer.line_len(pos.line)?;
+        if pos.column + 1 < line_len {
+            pos.column += 1;
+        } else if pos.line + 1 < line_count {
+            pos.line += 1;
+            pos.column = 0;
+        }
+
+        loop {
+            if pos.line >= line_count {
+                pos.line = line_count.saturating_sub(1);
+                pos.column = buffer.line_len(pos.line).unwrap_or(0).saturating_sub(1);
+                break;
+            }
+
+            let line = buffer.line(pos.line)?;
+            let chars: Vec<char> = line.chars().collect();
+            let mut x = pos.column;
+
+            // Skip whitespace
+            while x < chars.len() && chars[x].is_whitespace() {
+                x += 1;
+            }
+
+            if x >= chars.len() {
+                // End of line, try next
+                if pos.line + 1 < line_count {
+                    pos.line += 1;
+                    pos.column = 0;
+                    continue;
+                }
+                pos.column = chars.len().saturating_sub(1);
+                break;
+            }
+
+            // Find end of word
+            if boundary == WordBoundary::Word {
+                let is_word_char = chars[x].is_alphanumeric() || chars[x] == '_';
+                if is_word_char {
+                    while x + 1 < chars.len()
+                        && (chars[x + 1].is_alphanumeric() || chars[x + 1] == '_')
+                    {
+                        x += 1;
+                    }
+                } else {
+                    while x + 1 < chars.len()
+                        && !chars[x + 1].is_whitespace()
+                        && !chars[x + 1].is_alphanumeric()
+                        && chars[x + 1] != '_'
+                    {
+                        x += 1;
+                    }
+                }
+            } else {
+                // BigWord: find end of non-whitespace
+                while x + 1 < chars.len() && !chars[x + 1].is_whitespace() {
+                    x += 1;
+                }
+            }
+
+            pos.column = x;
+            break;
+        }
+
+        Some(pos)
+    }
+
+    fn word_backward(
+        buffer: &Buffer,
+        mut pos: Position,
+        boundary: WordBoundary,
+    ) -> Option<Position> {
+        if buffer.is_empty() {
+            return Some(pos);
+        }
+
+        loop {
+            let line = buffer.line(pos.line)?;
+            let chars: Vec<char> = line.chars().collect();
+
+            // If at start of line, go to previous line
+            if pos.column == 0 {
+                if pos.line > 0 {
+                    pos.line -= 1;
+                    pos.column = buffer.line_len(pos.line).unwrap_or(0);
+                    continue;
+                }
+                break;
+            }
+
+            let mut x = pos.column.saturating_sub(1);
+
+            // Skip whitespace backward
+            while x > 0 && chars.get(x).is_some_and(|c| c.is_whitespace()) {
+                x -= 1;
+            }
+
+            // Handle case where we hit start of line while skipping whitespace
+            if x == 0 && chars.first().is_some_and(|c| c.is_whitespace()) {
+                if pos.line > 0 {
+                    pos.line -= 1;
+                    pos.column = buffer.line_len(pos.line).unwrap_or(0);
+                    continue;
+                }
+                pos.column = 0;
+                break;
+            }
+
+            // Find start of word
+            if boundary == WordBoundary::Word {
+                if let Some(&c) = chars.get(x) {
+                    if c.is_alphanumeric() || c == '_' {
+                        while x > 0
+                            && chars
+                                .get(x - 1)
+                                .is_some_and(|c| c.is_alphanumeric() || *c == '_')
+                        {
+                            x -= 1;
+                        }
+                    } else if !c.is_whitespace() {
+                        while x > 0
+                            && chars.get(x - 1).is_some_and(|c| {
+                                !c.is_whitespace() && !c.is_alphanumeric() && *c != '_'
+                            })
+                        {
+                            x -= 1;
+                        }
+                    }
+                }
+            } else {
+                // BigWord: find start of non-whitespace
+                while x > 0 && chars.get(x - 1).is_some_and(|c| !c.is_whitespace()) {
+                    x -= 1;
+                }
+            }
+
+            pos.column = x;
+            break;
+        }
+
+        Some(pos)
+    }
+
+    fn word_end_backward(
+        buffer: &Buffer,
+        mut pos: Position,
+        _boundary: WordBoundary,
+    ) -> Option<Position> {
+        // ge/gE: Move backward to end of previous word
+        // Note: For ge/gE, the boundary distinction mainly affects where we stop,
+        // but the basic algorithm of finding end of previous word is similar.
+        // TODO: Implement full word/BigWord distinction if needed.
+        if buffer.is_empty() {
+            return Some(pos);
+        }
+
+        // First move back one position
+        if pos.column > 0 {
+            pos.column -= 1;
+        } else if pos.line > 0 {
+            pos.line -= 1;
+            pos.column = buffer.line_len(pos.line).unwrap_or(0).saturating_sub(1);
+        }
+
+        loop {
+            let line = buffer.line(pos.line)?;
+            let chars: Vec<char> = line.chars().collect();
+
+            if chars.is_empty() {
+                if pos.line > 0 {
+                    pos.line -= 1;
+                    pos.column = buffer.line_len(pos.line).unwrap_or(0).saturating_sub(1);
+                    continue;
+                }
+                break;
+            }
+
+            let mut x = pos.column.min(chars.len().saturating_sub(1));
+
+            // Skip whitespace backward
+            while x > 0 && chars.get(x).is_some_and(|c| c.is_whitespace()) {
+                x -= 1;
+            }
+
+            if chars.get(x).is_some_and(|c| c.is_whitespace()) {
+                // Still on whitespace, go to previous line
+                if pos.line > 0 {
+                    pos.line -= 1;
+                    pos.column = buffer.line_len(pos.line).unwrap_or(0).saturating_sub(1);
+                    continue;
+                }
+                pos.column = 0;
+                break;
+            }
+
+            // Now at end of a word
+            pos.column = x;
+            break;
+        }
+
+        Some(pos)
+    }
+
+    fn line_position(buffer: &Buffer, pos: Position, line_pos: LinePosition) -> Option<Position> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+        let line_len = chars.len();
+
+        let new_col = match line_pos {
+            LinePosition::Start => 0,
+            LinePosition::FirstNonBlank => {
+                chars.iter().position(|c| !c.is_whitespace()).unwrap_or(0)
+            }
+            LinePosition::End => line_len.saturating_sub(1),
+            LinePosition::LastNonBlank => chars
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, c)| !c.is_whitespace())
+                .map_or(0, |(i, _)| i),
+        };
+
+        Some(Position::new(pos.line, new_col))
+    }
+
+    fn paragraph_motion(
+        buffer: &Buffer,
+        pos: Position,
+        direction: Direction,
+        count: usize,
+    ) -> Option<Position> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        let mut current_line = pos.line;
+        let mut found = 0;
+
+        match direction {
+            Direction::Forward => {
+                // Skip current paragraph (non-empty lines)
+                while current_line < line_count {
+                    let line = buffer.line(current_line)?;
+                    if line.trim().is_empty() {
+                        break;
+                    }
+                    current_line += 1;
+                }
+
+                // Find next paragraphs
+                while current_line < line_count && found < count {
+                    // Skip empty lines
+                    while current_line < line_count {
+                        let line = buffer.line(current_line)?;
+                        if !line.trim().is_empty() {
+                            break;
+                        }
+                        current_line += 1;
+                    }
+
+                    if current_line >= line_count {
+                        break;
+                    }
+
+                    found += 1;
+                    if found >= count {
+                        break;
+                    }
+
+                    // Skip non-empty lines
+                    while current_line < line_count {
+                        let line = buffer.line(current_line)?;
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                        current_line += 1;
+                    }
+                }
+            }
+            Direction::Backward => {
+                // Skip current paragraph
+                while current_line > 0 {
+                    let line = buffer.line(current_line)?;
+                    if line.trim().is_empty() {
+                        break;
+                    }
+                    current_line -= 1;
+                }
+
+                // Find previous paragraphs
+                while current_line > 0 && found < count {
+                    // Skip empty lines
+                    while current_line > 0 {
+                        let line = buffer.line(current_line)?;
+                        if !line.trim().is_empty() {
+                            break;
+                        }
+                        current_line -= 1;
+                    }
+
+                    if current_line == 0 {
+                        let line = buffer.line(0)?;
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                    }
+
+                    found += 1;
+                    if found >= count {
+                        // Find start of this paragraph
+                        while current_line > 0 {
+                            let prev = buffer.line(current_line - 1)?;
+                            if prev.trim().is_empty() {
+                                break;
+                            }
+                            current_line -= 1;
+                        }
+                        break;
+                    }
+
+                    // Skip non-empty lines
+                    while current_line > 0 {
+                        let line = buffer.line(current_line)?;
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                        current_line -= 1;
+                    }
+                }
+            }
+        }
+
+        Some(Position::new(current_line.min(line_count.saturating_sub(1)), 0))
+    }
+
+    fn find_char(
+        buffer: &Buffer,
+        pos: Position,
+        target: char,
+        direction: Direction,
+        till: bool,
+        count: usize,
+    ) -> Option<Position> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+
+        let mut found_count = 0;
+        let mut found_pos = None;
+
+        match direction {
+            Direction::Forward => {
+                for (i, &c) in chars.iter().enumerate().skip(pos.column + 1) {
+                    if c == target {
+                        found_count += 1;
+                        if found_count == count {
+                            found_pos = Some(i);
+                            break;
+                        }
+                    }
+                }
+            }
+            Direction::Backward => {
+                for i in (0..pos.column).rev() {
+                    if chars.get(i) == Some(&target) {
+                        found_count += 1;
+                        if found_count == count {
+                            found_pos = Some(i);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        found_pos.map(|col| {
+            let adjusted_col = if till {
+                match direction {
+                    Direction::Forward => col.saturating_sub(1).max(pos.column),
+                    Direction::Backward => col.saturating_add(1).min(chars.len().saturating_sub(1)),
+                }
+            } else {
+                col
+            };
+            Position::new(pos.line, adjusted_col)
+        })
+    }
+
+    fn jump_line(buffer: &Buffer, _cursor: &Cursor, target: Option<usize>) -> Option<Position> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        // G without count goes to last line, with count goes to that line
+        let max_line = line_count.saturating_sub(1);
+        let new_line = target.map_or(max_line, |line| line.min(max_line));
+
+        // Jump to first non-blank on target line
+        let line_content = buffer.line(new_line)?;
+        let first_non_blank = line_content
+            .chars()
+            .position(|c| !c.is_whitespace())
+            .unwrap_or(0);
+
+        Some(Position::new(new_line, first_non_blank))
+    }
+
+    fn match_bracket(buffer: &Buffer, pos: Position) -> Option<Position> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+        let cursor_char = chars.get(pos.column).copied();
+
+        // If cursor is on a bracket, find its match
+        if let Some(ch) = cursor_char {
+            for (open, close) in BRACKET_PAIRS {
+                if ch == open {
+                    return Self::find_forward_bracket(buffer, pos, open, close);
+                } else if ch == close {
+                    return Self::find_backward_bracket(buffer, pos, open, close);
+                }
+            }
+        }
+
+        // Search forward on current line for a bracket
+        for (offset, &ch) in chars.iter().enumerate().skip(pos.column + 1) {
+            for (open, close) in BRACKET_PAIRS {
+                if ch == open {
+                    let search_pos = Position::new(pos.line, offset);
+                    return Self::find_forward_bracket(buffer, search_pos, open, close);
+                } else if ch == close {
+                    let search_pos = Position::new(pos.line, offset);
+                    return Self::find_backward_bracket(buffer, search_pos, open, close);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn find_forward_bracket(
+        buffer: &Buffer,
+        start: Position,
+        open: char,
+        close: char,
+    ) -> Option<Position> {
+        let mut depth = 1;
+        let mut line_idx = start.line;
+        let mut col = start.column + 1;
+
+        while line_idx < buffer.line_count() {
+            let line = buffer.line(line_idx)?;
+            let chars: Vec<char> = line.chars().collect();
+
+            while col < chars.len() {
+                let ch = chars[col];
+                if ch == open {
+                    depth += 1;
+                } else if ch == close {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(Position::new(line_idx, col));
+                    }
+                }
+                col += 1;
+            }
+
+            line_idx += 1;
+            col = 0;
+        }
+
+        None
+    }
+
+    fn find_backward_bracket(
+        buffer: &Buffer,
+        start: Position,
+        open: char,
+        close: char,
+    ) -> Option<Position> {
+        let mut depth = 1;
+        let mut line_idx = start.line;
+
+        // Handle first line specially
+        if let Some(line) = buffer.line(line_idx) {
+            let chars: Vec<char> = line.chars().collect();
+            if start.column > 0 {
+                for col in (0..start.column).rev() {
+                    let ch = chars[col];
+                    if ch == close {
+                        depth += 1;
+                    } else if ch == open {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(Position::new(line_idx, col));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Continue scanning previous lines
+        while line_idx > 0 {
+            line_idx -= 1;
+            let line = buffer.line(line_idx)?;
+            let chars: Vec<char> = line.chars().collect();
+
+            for col in (0..chars.len()).rev() {
+                let ch = chars[col];
+                if ch == close {
+                    depth += 1;
+                } else if ch == open {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(Position::new(line_idx, col));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_buffer(content: &str) -> Buffer {
+        Buffer::from_string(content)
+    }
+
+    fn make_cursor(line: usize, column: usize) -> Cursor {
+        Cursor::new(Position::new(line, column))
+    }
+
+    #[test]
+    fn test_motion_is_linewise() {
+        assert!(Motion::Line(Direction::Forward).is_linewise());
+        assert!(Motion::Line(Direction::Backward).is_linewise());
+        assert!(Motion::JumpLine(None).is_linewise());
+        assert!(Motion::Paragraph(Direction::Forward).is_linewise());
+
+        assert!(!Motion::Char(Direction::Forward).is_linewise());
+        assert!(
+            !Motion::Word {
+                direction: Direction::Forward,
+                boundary: WordBoundary::Word,
+                end: false
+            }
+            .is_linewise()
+        );
+    }
+
+    #[test]
+    fn test_motion_is_inclusive() {
+        assert!(Motion::LinePosition(LinePosition::End).is_inclusive());
+        assert!(
+            Motion::Word {
+                direction: Direction::Forward,
+                boundary: WordBoundary::Word,
+                end: true
+            }
+            .is_inclusive()
+        );
+        assert!(Motion::MatchBracket.is_inclusive());
+
+        assert!(
+            !Motion::Word {
+                direction: Direction::Forward,
+                boundary: WordBoundary::Word,
+                end: false
+            }
+            .is_inclusive()
+        );
+        assert!(!Motion::Char(Direction::Forward).is_inclusive());
+    }
+
+    #[test]
+    fn test_char_motion_forward() {
+        let buffer = make_buffer("hello");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Char(Direction::Forward), 1);
+        assert_eq!(pos, Some(Position::new(0, 1)));
+
+        // With count
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Char(Direction::Forward), 3);
+        assert_eq!(pos, Some(Position::new(0, 3)));
+
+        // Clamped to line end
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Char(Direction::Forward), 10);
+        assert_eq!(pos, Some(Position::new(0, 4))); // "hello" has 5 chars, max column is 4
+    }
+
+    #[test]
+    fn test_char_motion_backward() {
+        let buffer = make_buffer("hello");
+        let cursor = make_cursor(0, 4);
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Char(Direction::Backward), 1);
+        assert_eq!(pos, Some(Position::new(0, 3)));
+
+        // Clamped to 0
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Char(Direction::Backward), 10);
+        assert_eq!(pos, Some(Position::new(0, 0)));
+    }
+
+    #[test]
+    fn test_line_motion() {
+        let buffer = make_buffer("line1\nline2\nline3");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Line(Direction::Forward), 1);
+        assert_eq!(pos, Some(Position::new(1, 0)));
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Line(Direction::Forward), 2);
+        assert_eq!(pos, Some(Position::new(2, 0)));
+
+        // Clamped to last line
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::Line(Direction::Forward), 10);
+        assert_eq!(pos, Some(Position::new(2, 0)));
+    }
+
+    #[test]
+    fn test_line_position() {
+        let buffer = make_buffer("  hello world  ");
+        let cursor = make_cursor(0, 5);
+
+        let pos =
+            MotionEngine::calculate(&buffer, &cursor, Motion::LinePosition(LinePosition::Start), 1);
+        assert_eq!(pos, Some(Position::new(0, 0)));
+
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::LinePosition(LinePosition::FirstNonBlank),
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 2))); // First 'h'
+
+        let pos =
+            MotionEngine::calculate(&buffer, &cursor, Motion::LinePosition(LinePosition::End), 1);
+        assert_eq!(pos, Some(Position::new(0, 14))); // Last char index
+
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::LinePosition(LinePosition::LastNonBlank),
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 12))); // Last 'd'
+    }
+
+    #[test]
+    fn test_word_forward() {
+        let buffer = make_buffer("hello world foo");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::Word {
+                direction: Direction::Forward,
+                boundary: WordBoundary::Word,
+                end: false,
+            },
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 6))); // 'w' of world
+    }
+
+    #[test]
+    fn test_word_backward() {
+        let buffer = make_buffer("hello world foo");
+        let cursor = make_cursor(0, 12);
+
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::Word {
+                direction: Direction::Backward,
+                boundary: WordBoundary::Word,
+                end: false,
+            },
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 6))); // 'w' of world
+    }
+
+    #[test]
+    fn test_word_end() {
+        let buffer = make_buffer("hello world foo");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::Word {
+                direction: Direction::Forward,
+                boundary: WordBoundary::Word,
+                end: true,
+            },
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 4))); // 'o' of hello
+    }
+
+    #[test]
+    fn test_jump_line() {
+        let buffer = make_buffer("line0\nline1\nline2");
+        let cursor = make_cursor(0, 0);
+
+        // G (no count) goes to last line
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::JumpLine(None), 1);
+        assert_eq!(pos, Some(Position::new(2, 0)));
+
+        // Jump to specific line
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::JumpLine(Some(1)), 1);
+        assert_eq!(pos, Some(Position::new(1, 0)));
+    }
+
+    #[test]
+    fn test_match_bracket() {
+        let buffer = make_buffer("(hello)");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::MatchBracket, 1);
+        assert_eq!(pos, Some(Position::new(0, 6))); // closing )
+
+        // From closing bracket
+        let cursor = make_cursor(0, 6);
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::MatchBracket, 1);
+        assert_eq!(pos, Some(Position::new(0, 0))); // opening (
+    }
+
+    #[test]
+    fn test_match_bracket_nested() {
+        let buffer = make_buffer("((inner))");
+        let cursor = make_cursor(0, 0);
+
+        let pos = MotionEngine::calculate(&buffer, &cursor, Motion::MatchBracket, 1);
+        assert_eq!(pos, Some(Position::new(0, 8))); // outermost closing )
+    }
+
+    #[test]
+    fn test_find_char() {
+        let buffer = make_buffer("hello world");
+        let cursor = make_cursor(0, 0);
+
+        // f (find forward)
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::FindChar {
+                char: 'w',
+                direction: Direction::Forward,
+                till: false,
+            },
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 6)));
+
+        // t (till forward)
+        let pos = MotionEngine::calculate(
+            &buffer,
+            &cursor,
+            Motion::FindChar {
+                char: 'w',
+                direction: Direction::Forward,
+                till: true,
+            },
+            1,
+        );
+        assert_eq!(pos, Some(Position::new(0, 5)));
+    }
+
+    #[test]
+    fn test_paragraph_motion() {
+        let buffer = make_buffer("para1\n\npara2\npara2b\n\npara3");
+        let cursor = make_cursor(0, 0);
+
+        // } (forward)
+        let pos =
+            MotionEngine::calculate(&buffer, &cursor, Motion::Paragraph(Direction::Forward), 1);
+        assert_eq!(pos.map(|p| p.line), Some(2)); // Start of para2
+
+        // { (backward) from para3
+        let cursor = make_cursor(5, 0);
+        let pos =
+            MotionEngine::calculate(&buffer, &cursor, Motion::Paragraph(Direction::Backward), 1);
+        assert_eq!(pos.map(|p| p.line), Some(2)); // Start of para2
+    }
+}

--- a/lib/kernel/src/core/register.rs
+++ b/lib/kernel/src/core/register.rs
@@ -1,0 +1,363 @@
+//! Register storage for yank/paste operations.
+//!
+//! This module provides pure register storage without any clipboard integration.
+//! System clipboard access is a driver-level concern.
+//!
+//! # Vim Register Types
+//!
+//! - `""` - Unnamed register (default for yank/delete)
+//! - `"a` to `"z` - Named registers
+//! - `"+` and `"*` - System clipboard (handled by drivers, not here)
+
+use std::collections::HashMap;
+
+/// Type of yank operation.
+///
+/// This affects how paste operations behave:
+/// - **Characterwise**: Paste at cursor position
+/// - **Linewise**: Paste below/above current line
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::YankType;
+///
+/// // yw yanks characterwise
+/// let char_yank = YankType::Characterwise;
+///
+/// // yy yanks linewise
+/// let line_yank = YankType::Linewise;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum YankType {
+    /// Characterwise yank (e.g., yw, y$, d2w)
+    #[default]
+    Characterwise,
+    /// Linewise yank (e.g., yy, yj, dd)
+    Linewise,
+}
+
+/// Content stored in a register.
+///
+/// Combines the yanked text with its yank type for proper paste behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisterContent {
+    /// The yanked text.
+    pub text: String,
+    /// How the text was yanked (affects paste behavior).
+    pub yank_type: YankType,
+}
+
+impl RegisterContent {
+    /// Create new register content with specified yank type.
+    #[must_use]
+    pub fn new(text: impl Into<String>, yank_type: YankType) -> Self {
+        Self {
+            text: text.into(),
+            yank_type,
+        }
+    }
+
+    /// Create characterwise register content.
+    #[must_use]
+    pub fn characterwise(text: impl Into<String>) -> Self {
+        Self::new(text, YankType::Characterwise)
+    }
+
+    /// Create linewise register content.
+    #[must_use]
+    pub fn linewise(text: impl Into<String>) -> Self {
+        Self::new(text, YankType::Linewise)
+    }
+
+    /// Check if content is empty.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // String::is_empty is not const
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// Check if content is characterwise.
+    #[must_use]
+    pub const fn is_characterwise(&self) -> bool {
+        matches!(self.yank_type, YankType::Characterwise)
+    }
+
+    /// Check if content is linewise.
+    #[must_use]
+    pub const fn is_linewise(&self) -> bool {
+        matches!(self.yank_type, YankType::Linewise)
+    }
+}
+
+impl Default for RegisterContent {
+    fn default() -> Self {
+        Self {
+            text: String::new(),
+            yank_type: YankType::Characterwise,
+        }
+    }
+}
+
+/// Register storage for yank/paste operations.
+///
+/// This is a pure data structure without any system clipboard integration.
+/// System clipboard access (`"+` and `"*`) is handled at the driver level.
+///
+/// # Supported Registers
+///
+/// - Unnamed register (`""`) - Default for all operations
+/// - Named registers (`"a` to `"z`) - User-specified storage
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{RegisterBank, RegisterContent, YankType};
+///
+/// let mut bank = RegisterBank::new();
+///
+/// // Set unnamed register (default yank target)
+/// bank.set(RegisterContent::characterwise("hello"));
+/// assert_eq!(bank.get().text, "hello");
+///
+/// // Use named register
+/// bank.set_named('a', RegisterContent::linewise("line content"));
+/// assert_eq!(bank.get_named('a').map(|r| r.text.as_str()), Some("line content"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegisterBank {
+    /// Unnamed register (default target).
+    unnamed: RegisterContent,
+    /// Named registers (a-z).
+    named: HashMap<char, RegisterContent>,
+}
+
+impl RegisterBank {
+    /// Create a new empty register bank.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            unnamed: RegisterContent::default(),
+            named: HashMap::new(),
+        }
+    }
+
+    /// Get the unnamed register content.
+    #[must_use]
+    pub const fn get(&self) -> &RegisterContent {
+        &self.unnamed
+    }
+
+    /// Set the unnamed register content.
+    pub fn set(&mut self, content: RegisterContent) {
+        self.unnamed = content;
+    }
+
+    /// Get a named register content ('a'-'z').
+    ///
+    /// Returns `None` if the register name is invalid or empty.
+    #[must_use]
+    pub fn get_named(&self, name: char) -> Option<&RegisterContent> {
+        if name.is_ascii_lowercase() {
+            self.named.get(&name)
+        } else {
+            None
+        }
+    }
+
+    /// Set a named register content ('a'-'z').
+    ///
+    /// Returns `true` if successful, `false` if the register name is invalid.
+    pub fn set_named(&mut self, name: char, content: RegisterContent) -> bool {
+        if name.is_ascii_lowercase() {
+            self.named.insert(name, content);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Append to a named register ('A'-'Z' appends to 'a'-'z').
+    ///
+    /// Returns `true` if successful, `false` if the register name is invalid.
+    pub fn append_named(&mut self, name: char, content: &str) -> bool {
+        if name.is_ascii_uppercase() {
+            let lower = name.to_ascii_lowercase();
+            if let Some(existing) = self.named.get_mut(&lower) {
+                existing.text.push_str(content);
+            } else {
+                self.named
+                    .insert(lower, RegisterContent::characterwise(content.to_string()));
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clear the unnamed register.
+    pub fn clear(&mut self) {
+        self.unnamed = RegisterContent::default();
+    }
+
+    /// Clear a named register.
+    ///
+    /// Returns `true` if the register existed and was cleared.
+    pub fn clear_named(&mut self, name: char) -> bool {
+        if name.is_ascii_lowercase() {
+            self.named.remove(&name).is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Clear all registers.
+    pub fn clear_all(&mut self) {
+        self.unnamed = RegisterContent::default();
+        self.named.clear();
+    }
+
+    /// Get register by name.
+    ///
+    /// - `None` or `'"'` returns the unnamed register
+    /// - `'a'`-`'z'` returns named registers
+    #[must_use]
+    pub fn get_by_name(&self, name: Option<char>) -> Option<&RegisterContent> {
+        match name {
+            None | Some('"') => Some(&self.unnamed),
+            Some(c) if c.is_ascii_lowercase() => self.named.get(&c),
+            _ => None,
+        }
+    }
+
+    /// Set register by name.
+    ///
+    /// - `None` or `'"'` sets the unnamed register
+    /// - `'a'`-`'z'` sets named registers
+    /// - `'A'`-`'Z'` appends to named registers
+    ///
+    /// Returns `true` if successful.
+    pub fn set_by_name(&mut self, name: Option<char>, content: RegisterContent) -> bool {
+        match name {
+            None | Some('"') => {
+                self.unnamed = content;
+                true
+            }
+            Some(c) if c.is_ascii_lowercase() => {
+                self.named.insert(c, content);
+                true
+            }
+            Some(c) if c.is_ascii_uppercase() => {
+                let lower = c.to_ascii_lowercase();
+                if let Some(existing) = self.named.get_mut(&lower) {
+                    existing.text.push_str(&content.text);
+                } else {
+                    self.named.insert(lower, content);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Default for RegisterBank {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_content_new() {
+        let content = RegisterContent::new("hello", YankType::Characterwise);
+        assert_eq!(content.text, "hello");
+        assert!(content.is_characterwise());
+    }
+
+    #[test]
+    fn test_register_content_characterwise() {
+        let content = RegisterContent::characterwise("test");
+        assert!(content.is_characterwise());
+        assert!(!content.is_linewise());
+    }
+
+    #[test]
+    fn test_register_content_linewise() {
+        let content = RegisterContent::linewise("test");
+        assert!(!content.is_characterwise());
+        assert!(content.is_linewise());
+    }
+
+    #[test]
+    fn test_register_bank_unnamed() {
+        let mut bank = RegisterBank::new();
+        assert!(bank.get().is_empty());
+
+        bank.set(RegisterContent::characterwise("hello"));
+        assert_eq!(bank.get().text, "hello");
+    }
+
+    #[test]
+    fn test_register_bank_named() {
+        let mut bank = RegisterBank::new();
+
+        assert!(bank.set_named('a', RegisterContent::characterwise("alpha")));
+        assert_eq!(bank.get_named('a').map(|r| r.text.as_str()), Some("alpha"));
+
+        // Invalid register name
+        assert!(!bank.set_named('1', RegisterContent::characterwise("invalid")));
+        assert!(bank.get_named('1').is_none());
+    }
+
+    #[test]
+    fn test_register_bank_append() {
+        let mut bank = RegisterBank::new();
+
+        bank.set_named('a', RegisterContent::characterwise("hello"));
+        bank.append_named('A', " world");
+
+        assert_eq!(bank.get_named('a').map(|r| r.text.as_str()), Some("hello world"));
+    }
+
+    #[test]
+    fn test_register_bank_get_by_name() {
+        let mut bank = RegisterBank::new();
+        bank.set(RegisterContent::characterwise("unnamed"));
+        bank.set_named('x', RegisterContent::characterwise("named"));
+
+        assert_eq!(bank.get_by_name(None).map(|r| r.text.as_str()), Some("unnamed"));
+        assert_eq!(bank.get_by_name(Some('"')).map(|r| r.text.as_str()), Some("unnamed"));
+        assert_eq!(bank.get_by_name(Some('x')).map(|r| r.text.as_str()), Some("named"));
+        assert!(bank.get_by_name(Some('+')).is_none()); // System clipboard not handled here
+    }
+
+    #[test]
+    fn test_register_bank_set_by_name() {
+        let mut bank = RegisterBank::new();
+
+        assert!(bank.set_by_name(None, RegisterContent::characterwise("unnamed")));
+        assert!(bank.set_by_name(Some('a'), RegisterContent::characterwise("alpha")));
+        assert!(bank.set_by_name(Some('A'), RegisterContent::characterwise(" appended")));
+
+        assert_eq!(bank.get().text, "unnamed");
+        assert_eq!(bank.get_named('a').map(|r| r.text.as_str()), Some("alpha appended"));
+    }
+
+    #[test]
+    fn test_register_bank_clear() {
+        let mut bank = RegisterBank::new();
+        bank.set(RegisterContent::characterwise("hello"));
+        bank.set_named('a', RegisterContent::characterwise("alpha"));
+
+        bank.clear();
+        assert!(bank.get().is_empty());
+        assert!(bank.get_named('a').is_some()); // Named not affected
+
+        bank.clear_all();
+        assert!(bank.get_named('a').is_none());
+    }
+}

--- a/lib/kernel/src/core/textobj.rs
+++ b/lib/kernel/src/core/textobj.rs
@@ -1,0 +1,744 @@
+//! Text object calculations for operator-pending mode.
+//!
+//! Text objects define regions of text for operators like delete (d), yank (y),
+//! and change (c). They come in two scopes:
+//! - **Inner**: The content without delimiters/whitespace (e.g., `iw`, `i(`)
+//! - **Around**: The content including delimiters/whitespace (e.g., `aw`, `a(`)
+
+use crate::mm::{Buffer, Position};
+
+use super::direction::WordBoundary;
+
+/// Text object types for operator-pending mode.
+///
+/// Text objects define regions of text that operators act upon.
+/// Each text object has inner (i) and around (a) variants.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{TextObject, WordBoundary};
+///
+/// // Delete inner word: diw
+/// let inner_word = TextObject::InnerWord(WordBoundary::Word);
+///
+/// // Yank around parentheses: ya(
+/// let around_paren = TextObject::ABracket('(');
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextObject {
+    /// Inner word (iw, iW)
+    InnerWord(WordBoundary),
+    /// A word including surrounding whitespace (aw, aW)
+    AWord(WordBoundary),
+    /// Inner paragraph (ip)
+    InnerParagraph,
+    /// A paragraph including surrounding blank lines (ap)
+    AParagraph,
+    /// Inner quotes (i", i', i\`)
+    InnerQuote(char),
+    /// Around quotes including the quote characters (a", a', a\`)
+    AQuote(char),
+    /// Inner bracket (i(, i[, i{, i<)
+    InnerBracket(char),
+    /// Around bracket including the brackets (a(, a[, a{, a<)
+    ABracket(char),
+}
+
+impl TextObject {
+    /// Check if this text object is an "inner" variant.
+    #[must_use]
+    pub const fn is_inner(&self) -> bool {
+        matches!(
+            self,
+            Self::InnerWord(_) | Self::InnerParagraph | Self::InnerQuote(_) | Self::InnerBracket(_)
+        )
+    }
+
+    /// Check if this text object is an "around" variant.
+    #[must_use]
+    pub const fn is_around(&self) -> bool {
+        !self.is_inner()
+    }
+
+    /// Parse a text object from scope character and object character.
+    ///
+    /// # Arguments
+    ///
+    /// * `scope` - 'i' for inner, 'a' for around
+    /// * `object` - The object character (w, W, (, [, {, ", ', etc.)
+    ///
+    /// # Returns
+    ///
+    /// `Some(TextObject)` if valid, `None` otherwise.
+    #[must_use]
+    pub const fn from_chars(scope: char, object: char) -> Option<Self> {
+        let is_inner = match scope {
+            'i' => true,
+            'a' => false,
+            _ => return None,
+        };
+
+        match object {
+            'w' => Some(if is_inner {
+                Self::InnerWord(WordBoundary::Word)
+            } else {
+                Self::AWord(WordBoundary::Word)
+            }),
+            'W' => Some(if is_inner {
+                Self::InnerWord(WordBoundary::BigWord)
+            } else {
+                Self::AWord(WordBoundary::BigWord)
+            }),
+            'p' => Some(if is_inner {
+                Self::InnerParagraph
+            } else {
+                Self::AParagraph
+            }),
+            '(' | ')' | 'b' => Some(if is_inner {
+                Self::InnerBracket('(')
+            } else {
+                Self::ABracket('(')
+            }),
+            '[' | ']' => Some(if is_inner {
+                Self::InnerBracket('[')
+            } else {
+                Self::ABracket('[')
+            }),
+            '{' | '}' | 'B' => Some(if is_inner {
+                Self::InnerBracket('{')
+            } else {
+                Self::ABracket('{')
+            }),
+            '<' | '>' => Some(if is_inner {
+                Self::InnerBracket('<')
+            } else {
+                Self::ABracket('<')
+            }),
+            '"' => Some(if is_inner {
+                Self::InnerQuote('"')
+            } else {
+                Self::AQuote('"')
+            }),
+            '\'' => Some(if is_inner {
+                Self::InnerQuote('\'')
+            } else {
+                Self::AQuote('\'')
+            }),
+            '`' => Some(if is_inner {
+                Self::InnerQuote('`')
+            } else {
+                Self::AQuote('`')
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Text object calculation engine.
+///
+/// Provides pure calculations for text object ranges without modifying any state.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::core::{TextObjectEngine, TextObject, WordBoundary};
+/// use reovim_kernel::mm::{Buffer, Position};
+///
+/// let buffer = Buffer::from_string("hello world");
+/// let pos = Position::new(0, 0);
+///
+/// let range = TextObjectEngine::range(
+///     &buffer,
+///     pos,
+///     TextObject::InnerWord(WordBoundary::Word),
+///     1,
+/// );
+///
+/// assert_eq!(range, Some((Position::new(0, 0), Position::new(0, 4))));
+/// ```
+pub struct TextObjectEngine;
+
+impl TextObjectEngine {
+    /// Calculate the range for a text object.
+    ///
+    /// Returns `(start, end)` positions for the text object, where both
+    /// positions are inclusive.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - The buffer to calculate in
+    /// * `position` - Current cursor position
+    /// * `text_object` - The text object to calculate
+    /// * `count` - Number of text objects (for nested brackets, etc.)
+    ///
+    /// # Returns
+    ///
+    /// `Some((start, end))` if a valid range was found, `None` otherwise.
+    #[must_use]
+    pub fn range(
+        buffer: &Buffer,
+        position: Position,
+        text_object: TextObject,
+        count: usize,
+    ) -> Option<(Position, Position)> {
+        let count = count.max(1);
+
+        match text_object {
+            TextObject::InnerWord(boundary) => Self::inner_word(buffer, position, boundary),
+            TextObject::AWord(boundary) => Self::a_word(buffer, position, boundary),
+            TextObject::InnerParagraph => Self::inner_paragraph(buffer, position),
+            TextObject::AParagraph => Self::a_paragraph(buffer, position),
+            TextObject::InnerQuote(quote) => Self::inner_quote(buffer, position, quote),
+            TextObject::AQuote(quote) => Self::a_quote(buffer, position, quote),
+            TextObject::InnerBracket(bracket) => {
+                Self::inner_bracket(buffer, position, bracket, count)
+            }
+            TextObject::ABracket(bracket) => Self::a_bracket(buffer, position, bracket, count),
+        }
+    }
+
+    // === Word Text Objects ===
+
+    fn inner_word(
+        buffer: &Buffer,
+        pos: Position,
+        boundary: WordBoundary,
+    ) -> Option<(Position, Position)> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+
+        if chars.is_empty() {
+            return Some((pos, pos));
+        }
+
+        let col = pos.column.min(chars.len().saturating_sub(1));
+        let current_char = chars.get(col)?;
+
+        // Determine what kind of "word" we're in
+        let is_word_char = boundary.is_word_char(*current_char);
+        let is_whitespace = current_char.is_whitespace();
+
+        // Find boundaries
+        let mut start = col;
+        let mut end = col;
+
+        if is_whitespace {
+            // Select whitespace run
+            while start > 0 && chars.get(start - 1).is_some_and(|c| c.is_whitespace()) {
+                start -= 1;
+            }
+            while end + 1 < chars.len() && chars.get(end + 1).is_some_and(|c| c.is_whitespace()) {
+                end += 1;
+            }
+        } else if boundary == WordBoundary::Word {
+            // For small word, separate word chars from punctuation
+            if is_word_char {
+                while start > 0
+                    && chars
+                        .get(start - 1)
+                        .is_some_and(|c| boundary.is_word_char(*c))
+                {
+                    start -= 1;
+                }
+                while end + 1 < chars.len()
+                    && chars
+                        .get(end + 1)
+                        .is_some_and(|c| boundary.is_word_char(*c))
+                {
+                    end += 1;
+                }
+            } else {
+                // Punctuation
+                while start > 0
+                    && chars
+                        .get(start - 1)
+                        .is_some_and(|c| !c.is_whitespace() && !boundary.is_word_char(*c))
+                {
+                    start -= 1;
+                }
+                while end + 1 < chars.len()
+                    && chars
+                        .get(end + 1)
+                        .is_some_and(|c| !c.is_whitespace() && !boundary.is_word_char(*c))
+                {
+                    end += 1;
+                }
+            }
+        } else {
+            // BigWord: any non-whitespace
+            while start > 0 && chars.get(start - 1).is_some_and(|c| !c.is_whitespace()) {
+                start -= 1;
+            }
+            while end + 1 < chars.len() && chars.get(end + 1).is_some_and(|c| !c.is_whitespace()) {
+                end += 1;
+            }
+        }
+
+        Some((Position::new(pos.line, start), Position::new(pos.line, end)))
+    }
+
+    fn a_word(
+        buffer: &Buffer,
+        pos: Position,
+        boundary: WordBoundary,
+    ) -> Option<(Position, Position)> {
+        let (inner_start, inner_end) = Self::inner_word(buffer, pos, boundary)?;
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+
+        let mut start = inner_start.column;
+        let mut end = inner_end.column;
+
+        // Try to include trailing whitespace first
+        let mut has_trailing = false;
+        while end + 1 < chars.len() && chars.get(end + 1).is_some_and(|c| c.is_whitespace()) {
+            end += 1;
+            has_trailing = true;
+        }
+
+        // If no trailing whitespace, include leading whitespace
+        if !has_trailing {
+            while start > 0 && chars.get(start - 1).is_some_and(|c| c.is_whitespace()) {
+                start -= 1;
+            }
+        }
+
+        Some((Position::new(pos.line, start), Position::new(pos.line, end)))
+    }
+
+    // === Paragraph Text Objects ===
+
+    fn inner_paragraph(buffer: &Buffer, pos: Position) -> Option<(Position, Position)> {
+        let line_count = buffer.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        let current_line = buffer.line(pos.line)?;
+        let is_empty_line = current_line.trim().is_empty();
+
+        let mut start = pos.line;
+        let mut end = pos.line;
+
+        // Expand selection based on whether we're on empty or non-empty lines
+        let predicate = |l: &str| {
+            if is_empty_line {
+                l.trim().is_empty()
+            } else {
+                !l.trim().is_empty()
+            }
+        };
+
+        while start > 0 && buffer.line(start - 1).is_some_and(&predicate) {
+            start -= 1;
+        }
+        while end + 1 < line_count && buffer.line(end + 1).is_some_and(&predicate) {
+            end += 1;
+        }
+
+        let end_col = buffer.line_len(end).unwrap_or(0).saturating_sub(1);
+        Some((Position::new(start, 0), Position::new(end, end_col.max(0))))
+    }
+
+    fn a_paragraph(buffer: &Buffer, pos: Position) -> Option<(Position, Position)> {
+        let (inner_start, inner_end) = Self::inner_paragraph(buffer, pos)?;
+        let line_count = buffer.line_count();
+
+        let mut start = inner_start.line;
+        let mut end = inner_end.line;
+
+        // Include trailing blank lines
+        while end + 1 < line_count && buffer.line(end + 1).is_some_and(|l| l.trim().is_empty()) {
+            end += 1;
+        }
+
+        // If no trailing blank lines, include leading blank lines
+        if end == inner_end.line {
+            while start > 0 && buffer.line(start - 1).is_some_and(|l| l.trim().is_empty()) {
+                start -= 1;
+            }
+        }
+
+        let end_col = buffer.line_len(end).unwrap_or(0).saturating_sub(1);
+        Some((Position::new(start, 0), Position::new(end, end_col.max(0))))
+    }
+
+    // === Quote Text Objects ===
+
+    fn inner_quote(buffer: &Buffer, pos: Position, quote: char) -> Option<(Position, Position)> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+
+        // Find quote boundaries on current line
+        let (open, close) = Self::find_quote_pair(&chars, pos.column, quote)?;
+
+        // Inner: exclude the quotes
+        let start = open + 1;
+        let end = close.saturating_sub(1);
+
+        if start > end {
+            // Empty quotes
+            Some((Position::new(pos.line, start), Position::new(pos.line, start)))
+        } else {
+            Some((Position::new(pos.line, start), Position::new(pos.line, end)))
+        }
+    }
+
+    fn a_quote(buffer: &Buffer, pos: Position, quote: char) -> Option<(Position, Position)> {
+        let line = buffer.line(pos.line)?;
+        let chars: Vec<char> = line.chars().collect();
+
+        let (open, close) = Self::find_quote_pair(&chars, pos.column, quote)?;
+
+        Some((Position::new(pos.line, open), Position::new(pos.line, close)))
+    }
+
+    fn find_quote_pair(chars: &[char], col: usize, quote: char) -> Option<(usize, usize)> {
+        // Find all quote positions on the line
+        let quotes: Vec<usize> = chars
+            .iter()
+            .enumerate()
+            .filter(|&(_, c)| *c == quote)
+            .map(|(i, _)| i)
+            .collect();
+
+        if quotes.len() < 2 {
+            return None;
+        }
+
+        // Find the pair that contains or is nearest to cursor
+        for pair in quotes.chunks(2) {
+            if pair.len() == 2 {
+                let (open, close) = (pair[0], pair[1]);
+                if col >= open && col <= close {
+                    return Some((open, close));
+                }
+            }
+        }
+
+        // If cursor is before first quote, use first pair
+        if col < quotes[0] && quotes.len() >= 2 {
+            return Some((quotes[0], quotes[1]));
+        }
+
+        // If cursor is after last quote, use last pair
+        if quotes.len() >= 2 && col > quotes[quotes.len() - 1] {
+            let len = quotes.len();
+            if len >= 2 {
+                return Some((quotes[len - 2], quotes[len - 1]));
+            }
+        }
+
+        None
+    }
+
+    // === Bracket Text Objects ===
+
+    fn inner_bracket(
+        buffer: &Buffer,
+        pos: Position,
+        bracket: char,
+        count: usize,
+    ) -> Option<(Position, Position)> {
+        let (open, close) = Self::get_bracket_pair(bracket)?;
+        let (open_pos, close_pos) = Self::find_bracket_pair(buffer, pos, open, close, count)?;
+
+        // Inner: exclude the brackets
+        // Move open_pos forward past the bracket
+        let start = Self::next_position(buffer, open_pos)?;
+        // Move close_pos backward before the bracket
+        let end = Self::prev_position(buffer, close_pos)?;
+
+        if start > end {
+            // Empty brackets - return position after opening bracket
+            Some((start, start))
+        } else {
+            Some((start, end))
+        }
+    }
+
+    fn a_bracket(
+        buffer: &Buffer,
+        pos: Position,
+        bracket: char,
+        count: usize,
+    ) -> Option<(Position, Position)> {
+        let (open, close) = Self::get_bracket_pair(bracket)?;
+        Self::find_bracket_pair(buffer, pos, open, close, count)
+    }
+
+    const fn get_bracket_pair(bracket: char) -> Option<(char, char)> {
+        match bracket {
+            '(' | ')' => Some(('(', ')')),
+            '[' | ']' => Some(('[', ']')),
+            '{' | '}' => Some(('{', '}')),
+            '<' | '>' => Some(('<', '>')),
+            _ => None,
+        }
+    }
+
+    fn find_bracket_pair(
+        buffer: &Buffer,
+        pos: Position,
+        open: char,
+        close: char,
+        count: usize,
+    ) -> Option<(Position, Position)> {
+        // Find the opening bracket (searching backward and at cursor)
+        let open_pos = Self::find_opening_bracket(buffer, pos, open, close, count)?;
+
+        // Find the closing bracket (searching forward from opening)
+        let close_pos = Self::find_closing_bracket(buffer, open_pos, open, close)?;
+
+        Some((open_pos, close_pos))
+    }
+
+    fn find_opening_bracket(
+        buffer: &Buffer,
+        pos: Position,
+        open: char,
+        close: char,
+        count: usize,
+    ) -> Option<Position> {
+        let mut depth: isize = 0;
+        let mut found_count = 0;
+        let mut line_idx = pos.line;
+        let mut last_open = None;
+
+        // First check at and before current position on current line
+        if let Some(line) = buffer.line(line_idx) {
+            let chars: Vec<char> = line.chars().collect();
+            let start_col = pos.column.min(chars.len().saturating_sub(1));
+
+            for col in (0..=start_col).rev() {
+                if let Some(&c) = chars.get(col) {
+                    if c == close {
+                        depth += 1;
+                    } else if c == open {
+                        if depth > 0 {
+                            depth -= 1;
+                        } else {
+                            found_count += 1;
+                            last_open = Some(Position::new(line_idx, col));
+                            if found_count >= count {
+                                return last_open;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Search previous lines
+        while line_idx > 0 {
+            line_idx -= 1;
+            if let Some(line) = buffer.line(line_idx) {
+                let chars: Vec<char> = line.chars().collect();
+                for col in (0..chars.len()).rev() {
+                    if let Some(&c) = chars.get(col) {
+                        if c == close {
+                            depth += 1;
+                        } else if c == open {
+                            if depth > 0 {
+                                depth -= 1;
+                            } else {
+                                found_count += 1;
+                                last_open = Some(Position::new(line_idx, col));
+                                if found_count >= count {
+                                    return last_open;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        last_open
+    }
+
+    fn find_closing_bracket(
+        buffer: &Buffer,
+        open_pos: Position,
+        open: char,
+        close: char,
+    ) -> Option<Position> {
+        let mut depth = 1;
+        let mut line_idx = open_pos.line;
+        let mut col = open_pos.column + 1;
+
+        while line_idx < buffer.line_count() {
+            if let Some(line) = buffer.line(line_idx) {
+                let chars: Vec<char> = line.chars().collect();
+
+                while col < chars.len() {
+                    let c = chars[col];
+                    if c == open {
+                        depth += 1;
+                    } else if c == close {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(Position::new(line_idx, col));
+                        }
+                    }
+                    col += 1;
+                }
+            }
+
+            line_idx += 1;
+            col = 0;
+        }
+
+        None
+    }
+
+    fn next_position(buffer: &Buffer, pos: Position) -> Option<Position> {
+        let line_len = buffer.line_len(pos.line)?;
+        if pos.column + 1 < line_len {
+            Some(Position::new(pos.line, pos.column + 1))
+        } else if pos.line + 1 < buffer.line_count() {
+            Some(Position::new(pos.line + 1, 0))
+        } else {
+            Some(Position::new(pos.line, pos.column))
+        }
+    }
+
+    fn prev_position(buffer: &Buffer, pos: Position) -> Option<Position> {
+        if pos.column > 0 {
+            Some(Position::new(pos.line, pos.column - 1))
+        } else if pos.line > 0 {
+            let prev_len = buffer.line_len(pos.line - 1)?;
+            Some(Position::new(pos.line - 1, prev_len.saturating_sub(1)))
+        } else {
+            Some(Position::new(0, 0))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_buffer(content: &str) -> Buffer {
+        Buffer::from_string(content)
+    }
+
+    #[test]
+    fn test_text_object_from_chars() {
+        assert_eq!(
+            TextObject::from_chars('i', 'w'),
+            Some(TextObject::InnerWord(WordBoundary::Word))
+        );
+        assert_eq!(
+            TextObject::from_chars('a', 'W'),
+            Some(TextObject::AWord(WordBoundary::BigWord))
+        );
+        assert_eq!(TextObject::from_chars('i', '('), Some(TextObject::InnerBracket('(')));
+        assert_eq!(TextObject::from_chars('a', '"'), Some(TextObject::AQuote('"')));
+        assert_eq!(TextObject::from_chars('x', 'w'), None);
+    }
+
+    #[test]
+    fn test_inner_word() {
+        let buffer = make_buffer("hello world");
+        let pos = Position::new(0, 0);
+
+        let range =
+            TextObjectEngine::range(&buffer, pos, TextObject::InnerWord(WordBoundary::Word), 1);
+
+        assert_eq!(
+            range,
+            Some((Position::new(0, 0), Position::new(0, 4))) // "hello"
+        );
+    }
+
+    #[test]
+    fn test_a_word() {
+        let buffer = make_buffer("hello world");
+        let pos = Position::new(0, 0);
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::AWord(WordBoundary::Word), 1);
+
+        // "hello " (including trailing space)
+        assert_eq!(range, Some((Position::new(0, 0), Position::new(0, 5))));
+    }
+
+    #[test]
+    fn test_inner_bracket() {
+        let buffer = make_buffer("(hello)");
+        let pos = Position::new(0, 3); // inside
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::InnerBracket('('), 1);
+
+        // "hello" without parens
+        assert_eq!(range, Some((Position::new(0, 1), Position::new(0, 5))));
+    }
+
+    #[test]
+    fn test_a_bracket() {
+        let buffer = make_buffer("(hello)");
+        let pos = Position::new(0, 3);
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::ABracket('('), 1);
+
+        // "(hello)" including parens
+        assert_eq!(range, Some((Position::new(0, 0), Position::new(0, 6))));
+    }
+
+    #[test]
+    fn test_nested_brackets() {
+        let buffer = make_buffer("((inner))");
+        let pos = Position::new(0, 4); // on 'i'
+
+        // count=1 should get inner parens
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::InnerBracket('('), 1);
+        assert_eq!(range, Some((Position::new(0, 2), Position::new(0, 6)))); // "inner"
+
+        // count=2 should get outer parens
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::InnerBracket('('), 2);
+        assert_eq!(range, Some((Position::new(0, 1), Position::new(0, 7)))); // "(inner)"
+    }
+
+    #[test]
+    fn test_inner_quote() {
+        let buffer = make_buffer("\"hello\"");
+        let pos = Position::new(0, 3);
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::InnerQuote('"'), 1);
+
+        // "hello" without quotes
+        assert_eq!(range, Some((Position::new(0, 1), Position::new(0, 5))));
+    }
+
+    #[test]
+    fn test_a_quote() {
+        let buffer = make_buffer("\"hello\"");
+        let pos = Position::new(0, 3);
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::AQuote('"'), 1);
+
+        // "\"hello\"" including quotes
+        assert_eq!(range, Some((Position::new(0, 0), Position::new(0, 6))));
+    }
+
+    #[test]
+    fn test_inner_paragraph() {
+        let buffer = make_buffer("line1\nline2\n\nline3");
+        let pos = Position::new(0, 0);
+
+        let range = TextObjectEngine::range(&buffer, pos, TextObject::InnerParagraph, 1);
+
+        // First paragraph: lines 0-1
+        assert_eq!(range, Some((Position::new(0, 0), Position::new(1, 4))));
+    }
+
+    #[test]
+    fn test_is_inner_around() {
+        assert!(TextObject::InnerWord(WordBoundary::Word).is_inner());
+        assert!(!TextObject::InnerWord(WordBoundary::Word).is_around());
+
+        assert!(!TextObject::AWord(WordBoundary::Word).is_inner());
+        assert!(TextObject::AWord(WordBoundary::Word).is_around());
+    }
+}


### PR DESCRIPTION
Implement the kernel core/ subsystem following the clean architecture proposal (section 4.2.5). This provides pure, side-effect-free mechanisms for cursor movement, text object range calculations, and storage types.

Components added:
- Direction types: Direction, WordBoundary, LinePosition enums
- Motion: Motion enum with MotionEngine for vim-style cursor movement
  - Character (h/l), Line (j/k), Word (w/W/b/B/e/E)
  - Line position (0/^/$/g_), Paragraph ({/})
  - Find char (f/F/t/T), Jump line (gg/G), Match bracket (%)
- TextObject: TextObject enum with TextObjectEngine for operator ranges
  - Word objects (iw/aw/iW/aW)
  - Bracket objects (i(/a(/i[/a[/i{/a{)
  - Quote objects (i"/a"/i'/a')
  - Paragraph objects (ip/ap)
- Register: YankType, RegisterContent, RegisterBank for yank/paste storage
  - Unnamed and named registers (a-z)
  - No clipboard integration (driver concern)
- Mark: Mark, SpecialMark, MarkBank for bookmarks
  - Local marks (a-z), Global marks (A-Z)
  - Special marks (last jump/edit/insert)

Closes: #161