### PR TITLE
feat(kernel): implement block/ operations module (#162)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,9 @@ dependencies = [
 name = "reovim-arch"
 version = "0.9.0-dev"
 dependencies = [
+ "arc-swap",
  "crossterm",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1670,10 +1672,7 @@ dependencies = [
 name = "reovim-kernel"
 version = "0.9.0-dev"
 dependencies = [
- "arc-swap",
- "parking_lot",
  "reovim-arch",
- "tracing",
 ]
 
 [[package]]

--- a/docs/architecture/clean-architecture-proposal.md
+++ b/docs/architecture/clean-architecture-proposal.md
@@ -138,6 +138,21 @@ Following Linux kernel philosophy:
    - Lock-free where possible
    - Cache-friendly data structures
 
+6. **Kernel Purity**
+   - Kernel uses minimal external dependencies (pure Rust where possible)
+   - Kernel provides data structures and accessors
+   - Drivers/modules handle format-specific concerns (serialization, I/O formats)
+   - Example: Kernel's `Snapshot` provides `lines()`, `cursor()` accessors;
+     driver layer handles JSON serialization for file storage
+
+7. **Linux-Aligned printk**
+   - Kernel has its own `printk/` subsystem (like Linux `kernel/printk/`)
+   - Kernel defines `Logger` trait (mechanism), drivers implement (policy)
+   - Zero external dependencies in kernel - std only
+   - External deps (tracing, etc.) belong in `drivers/log`, not kernel
+   - Arch layer provides sync primitives only, NOT logging
+   - Macros: `pr_err!()`, `pr_warn!()`, `pr_info!()`, `pr_debug!()`
+
 ---
 
 ## 3. Architecture Overview
@@ -218,12 +233,19 @@ Following Linux kernel philosophy:
 │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘        │
 │                                                                            │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
-│  │   block/    │  │    api/     │  │   debug/    │  │   panic/    │        │
+│  │   block/    │  │    api/     │  │  printk/    │  │   panic/    │        │
 │  │  ─────────  │  │  ─────────  │  │  ─────────  │  │  ─────────  │        │
-│  │  undo       │  │  stable     │  │  trace      │  │  handler    │        │
-│  │  history    │  │  versioned  │  │  metrics    │  │  recovery   │        │
-│  │  transaction│  │  compat     │  │  profiler   │  │  dump       │        │
+│  │  undo       │  │  stable     │  │  Logger     │  │  handler    │        │
+│  │  history    │  │  versioned  │  │  pr_err!    │  │  recovery   │        │
+│  │  transaction│  │  compat     │  │  pr_info!   │  │  kpanic!    │        │
 │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘        │
+│                                                                            │
+│  ┌─────────────┐                                                           │
+│  │   debug/    │                                                           │
+│  │  ─────────  │                                                           │
+│  │  metrics    │                                                           │
+│  │  profiler   │                                                           │
+│  └─────────────┘                                                           │
 └────────────────────────────────────────────────────────────────────────────┘
                                      │
                         ═════════════╪═════════════ Arch Interface
@@ -667,9 +689,15 @@ lib/kernel/
     │   ├── journal.rs         # Write-ahead log
     │   └── snapshot.rs        # Buffer snapshots
     │
-    ├── debug/                  # Debug/tracing subsystem
+    ├── printk/                 # Kernel logging (like Linux kernel/printk/)
+    │   ├── mod.rs             # Public API, re-exports
+    │   ├── level.rs           # Level enum (Error, Warn, Info, Debug, Trace)
+    │   ├── record.rs          # Record struct (level, message, file, line)
+    │   ├── logger.rs          # Logger trait, NopLogger
+    │   └── macros.rs          # pr_err!, pr_warn!, pr_info!, pr_debug!
+    │
+    ├── debug/                  # Debug utilities (separate from logging)
     │   ├── mod.rs
-    │   ├── trace.rs           # Tracing infrastructure
     │   ├── metrics.rs         # Performance metrics
     │   ├── profiler.rs        # Built-in profiler
     │   └── dump.rs            # State dumping
@@ -2897,9 +2925,14 @@ pub use unix::UnixTerminal as PlatformTerminal;
 - Define command traits
 
 **2.4 Block Operations (block/)**
-- Extract `UndoTree`
-- Extract transaction system
-- Extract history
+- Extract `UndoTree` with branching support (vim-style)
+  - Store cursor position (before/after) in each UndoNode for restore
+  - Configurable max_nodes limit (default: 10000)
+- Extract `Transaction` for grouping edits atomically
+- Extract `History` for change logging with timestamps
+- Extract `Snapshot` for buffer state capture
+  - Pure Rust accessors: `lines()`, `cursor()`, `timestamp()`
+  - Serialization handled by driver layer (kernel purity principle)
 
 **2.5 Scheduler (sched/)**
 - Extract runtime loop

--- a/lib/arch/Cargo.toml
+++ b/lib/arch/Cargo.toml
@@ -12,9 +12,13 @@ categories.workspace = true
 [lints]
 workspace = true
 
-# Traits have no dependencies (std only)
-# Platform implementations use crossterm
+# Platform-optimized primitives and abstractions
 [dependencies]
+# Lock-free data structures for hot paths
+arc-swap = "1.8"
+
+# Faster synchronization primitives
+parking_lot = "0.12.3"
 
 [target.'cfg(unix)'.dependencies]
 crossterm.workspace = true

--- a/lib/arch/src/lib.rs
+++ b/lib/arch/src/lib.rs
@@ -31,6 +31,7 @@
 //! - **Windows**: Stub implementation (todo!() for all methods)
 
 pub mod error;
+pub mod sync;
 pub mod traits;
 
 // Re-export all public types from traits

--- a/lib/arch/src/sync.rs
+++ b/lib/arch/src/sync.rs
@@ -1,0 +1,33 @@
+//! Platform-optimized synchronization primitives.
+//!
+//! This module re-exports synchronization primitives optimized for the
+//! current platform. The kernel layer uses these instead of depending
+//! directly on external crates, maintaining the dependency rule:
+//!
+//! ```text
+//! arch/ -> (platform crates)
+//! kernel/ -> arch/ only
+//! ```
+//!
+//! # Why not `std::sync`?
+//!
+//! - `parking_lot::Mutex`: No poisoning, smaller, ~2x faster
+//! - `parking_lot::Condvar`: Can wait without holding guard
+//! - `arc_swap::ArcSwap`: Lock-free reads (no std equivalent)
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_arch::sync::{Mutex, Condvar, ArcSwap};
+//!
+//! let mutex = Mutex::new(42);
+//! let guard = mutex.lock();
+//! ```
+
+// === Lock-free Primitives ===
+
+pub use arc_swap::ArcSwap;
+
+// === Synchronization Primitives ===
+
+pub use parking_lot::{Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/lib/kernel/Cargo.toml
+++ b/lib/kernel/Cargo.toml
@@ -13,14 +13,5 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-# Only depends on arch layer
+# Only depends on arch layer (Rule 2: kernel/ depends only on arch/)
 reovim-arch = { path = "../arch", version = "0.9.0-dev" }
-
-# Lock-free data structures for hot paths
-arc-swap = "1.8"
-
-# Faster synchronization primitives
-parking_lot = "0.12.3"
-
-# Logging/tracing
-tracing.workspace = true

--- a/lib/kernel/src/block/history.rs
+++ b/lib/kernel/src/block/history.rs
@@ -1,0 +1,185 @@
+//! Change history log.
+//!
+//! Provides a linear log of all changes with timestamps,
+//! useful for debugging and change tracking.
+
+use {crate::mm::Edit, std::time::Instant};
+
+/// An entry in the change history.
+#[derive(Debug, Clone)]
+pub struct HistoryEntry {
+    /// Edits that were made.
+    edits: Vec<Edit>,
+    /// When the change occurred.
+    timestamp: Instant,
+    /// Sequential change number.
+    seq_num: u64,
+}
+
+impl HistoryEntry {
+    /// Get the edits in this entry.
+    #[must_use]
+    pub fn edits(&self) -> &[Edit] {
+        &self.edits
+    }
+
+    /// Get when this change occurred.
+    #[must_use]
+    pub const fn timestamp(&self) -> Instant {
+        self.timestamp
+    }
+
+    /// Get the sequential change number.
+    #[must_use]
+    pub const fn seq_num(&self) -> u64 {
+        self.seq_num
+    }
+}
+
+/// Change history log.
+///
+/// Records all changes made to a buffer in chronological order.
+/// Unlike `UndoTree`, this is a simple linear log without branching.
+///
+/// # Use Cases
+///
+/// - Debugging: See what changes were made and when
+/// - Auditing: Track modification history
+/// - Collaboration: Synchronize changes between editors
+///
+/// # Memory Management
+///
+/// The history has a configurable maximum number of entries.
+/// When exceeded, the oldest entries are removed.
+#[derive(Debug)]
+pub struct History {
+    /// All recorded entries.
+    entries: Vec<HistoryEntry>,
+    /// Maximum number of entries to retain.
+    max_entries: usize,
+    /// Sequential change counter.
+    seq_counter: u64,
+}
+
+impl Default for History {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl History {
+    /// Default maximum number of entries.
+    pub const DEFAULT_MAX_ENTRIES: usize = 10000;
+
+    /// Create a new empty history.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_max_entries(Self::DEFAULT_MAX_ENTRIES)
+    }
+
+    /// Create a new history with custom maximum entries.
+    #[must_use]
+    pub fn with_max_entries(max_entries: usize) -> Self {
+        Self {
+            entries: Vec::new(),
+            max_entries: max_entries.max(1),
+            seq_counter: 0,
+        }
+    }
+
+    /// Record a new change.
+    pub fn record(&mut self, edits: Vec<Edit>) {
+        if edits.is_empty() {
+            return;
+        }
+
+        self.seq_counter += 1;
+
+        let entry = HistoryEntry {
+            edits,
+            timestamp: Instant::now(),
+            seq_num: self.seq_counter,
+        };
+
+        self.entries.push(entry);
+
+        // Trim if over limit
+        while self.entries.len() > self.max_entries {
+            self.entries.remove(0);
+        }
+    }
+
+    /// Get all entries in chronological order.
+    #[must_use]
+    pub fn entries(&self) -> &[HistoryEntry] {
+        &self.entries
+    }
+
+    /// Get the most recent entry.
+    #[must_use]
+    pub fn last(&self) -> Option<&HistoryEntry> {
+        self.entries.last()
+    }
+
+    /// Get an entry by index.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&HistoryEntry> {
+        self.entries.get(index)
+    }
+
+    /// Clear all history.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        // Note: seq_counter is not reset to maintain uniqueness
+    }
+
+    /// Get the number of entries.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if history is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Get the maximum entries limit.
+    #[must_use]
+    pub const fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    /// Set the maximum entries limit.
+    pub fn set_max_entries(&mut self, max: usize) {
+        self.max_entries = max.max(1);
+        while self.entries.len() > self.max_entries {
+            self.entries.remove(0);
+        }
+    }
+
+    /// Get the current sequential counter value.
+    #[must_use]
+    pub const fn seq_counter(&self) -> u64 {
+        self.seq_counter
+    }
+
+    /// Get entries since a given sequence number.
+    #[must_use]
+    pub fn since(&self, seq_num: u64) -> Vec<&HistoryEntry> {
+        self.entries
+            .iter()
+            .filter(|e| e.seq_num > seq_num)
+            .collect()
+    }
+
+    /// Get entries within a time range.
+    #[must_use]
+    pub fn between(&self, start: Instant, end: Instant) -> Vec<&HistoryEntry> {
+        self.entries
+            .iter()
+            .filter(|e| e.timestamp >= start && e.timestamp <= end)
+            .collect()
+    }
+}

--- a/lib/kernel/src/block/mod.rs
+++ b/lib/kernel/src/block/mod.rs
@@ -1,5 +1,55 @@
 //! Block operations subsystem.
 //!
 //! Provides undo tree, change history, and atomic transactions.
+//! Linux equivalent: Block device operations, journaling.
+//!
+//! # Design Principle
+//!
+//! Kernel provides mechanisms (pure Rust), drivers provide policies
+//! (serialization). Snapshot provides accessors; file I/O is handled
+//! by the driver layer.
+//!
+//! # Components
+//!
+//! - [`Transaction`]: Groups multiple edits for atomic undo/redo
+//! - [`UndoTree`]: Branching undo history with cursor position tracking
+//! - [`History`]: Change log with timestamps
+//! - [`Snapshot`]: Buffer state capture for restore
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::block::{Transaction, UndoTree};
+//! use reovim_kernel::mm::{Edit, Position};
+//!
+//! // Create an undo tree
+//! let mut tree = UndoTree::new();
+//!
+//! // Record an edit with cursor positions
+//! let edit = Edit::insert(Position::new(0, 0), "Hello");
+//! tree.push(
+//!     vec![edit],
+//!     Position::new(0, 0),  // cursor before
+//!     Position::new(0, 5),  // cursor after
+//! );
+//!
+//! // Undo returns edits to apply and cursor to restore
+//! if let Some(result) = tree.undo() {
+//!     assert_eq!(result.cursor, Position::new(0, 0));
+//! }
+//! ```
 
-// Placeholder - UndoTree, History, Transaction will be added in Phase 2
+mod history;
+mod snapshot;
+mod transaction;
+mod undo;
+
+#[cfg(test)]
+mod tests;
+
+pub use {
+    history::{History, HistoryEntry},
+    snapshot::Snapshot,
+    transaction::Transaction,
+    undo::{UndoNode, UndoResult, UndoTree},
+};

--- a/lib/kernel/src/block/snapshot.rs
+++ b/lib/kernel/src/block/snapshot.rs
@@ -1,0 +1,160 @@
+//! Buffer state capture and restore.
+//!
+//! Snapshots capture the complete state of a buffer at a point in time,
+//! enabling restore operations for recovery or checkpointing.
+//!
+//! # Design Principle
+//!
+//! Following the kernel purity principle, this module provides pure Rust
+//! data structures and accessors. File serialization (JSON, etc.) is
+//! handled by the driver layer (`lib/drivers/vfs/`).
+
+use {
+    crate::mm::{Buffer, BufferId, Position},
+    std::time::SystemTime,
+};
+
+/// A captured buffer state.
+///
+/// Snapshots are used for:
+/// - Safety checkpoints before complex operations
+/// - Crash recovery
+/// - Cursor restoration when reopening files
+///
+/// # File Storage
+///
+/// This struct provides accessors for all data needed by the driver
+/// layer to serialize/deserialize to files. The kernel does not handle
+/// serialization directly.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::block::Snapshot;
+/// use reovim_kernel::mm::Buffer;
+///
+/// // Create a buffer with some content
+/// let mut buffer = Buffer::from_string("Hello, World!");
+///
+/// // Capture state
+/// let snapshot = Snapshot::capture(&buffer);
+///
+/// // Later, restore the state
+/// snapshot.restore(&mut buffer);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    /// Lines at time of capture.
+    lines: Vec<String>,
+    /// Cursor position at time of capture.
+    cursor: Position,
+    /// Buffer ID (for validation on restore).
+    buffer_id: BufferId,
+    /// When snapshot was taken.
+    timestamp: SystemTime,
+}
+
+impl Snapshot {
+    /// Capture the current state of a buffer.
+    #[must_use]
+    pub fn capture(buffer: &Buffer) -> Self {
+        Self {
+            lines: buffer.lines().to_vec(),
+            cursor: buffer.position(),
+            buffer_id: buffer.id(),
+            timestamp: SystemTime::now(),
+        }
+    }
+
+    /// Create a snapshot from components.
+    ///
+    /// This is useful for restoring from serialized data.
+    #[must_use]
+    pub const fn from_parts(
+        lines: Vec<String>,
+        cursor: Position,
+        buffer_id: BufferId,
+        timestamp: SystemTime,
+    ) -> Self {
+        Self {
+            lines,
+            cursor,
+            buffer_id,
+            timestamp,
+        }
+    }
+
+    /// Restore a buffer to this snapshot's state.
+    ///
+    /// This replaces the buffer's content and cursor position.
+    /// The buffer ID is not changed.
+    pub fn restore(&self, buffer: &mut Buffer) {
+        // Set content from snapshot lines
+        let content = self.lines.join("\n");
+        buffer.set_content(&content);
+
+        // Restore cursor position
+        buffer.set_position(self.cursor);
+    }
+
+    /// Restore only the cursor position.
+    ///
+    /// This is useful when reopening a file that already has its
+    /// content loaded - we only need to restore the cursor.
+    pub fn restore_cursor(&self, buffer: &mut Buffer) {
+        buffer.set_position(self.cursor);
+    }
+
+    // === Accessors for driver-layer serialization ===
+
+    /// Get the captured lines.
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
+    /// Get the captured cursor position.
+    #[must_use]
+    pub const fn cursor(&self) -> Position {
+        self.cursor
+    }
+
+    /// Get the buffer ID.
+    #[must_use]
+    pub const fn buffer_id(&self) -> BufferId {
+        self.buffer_id
+    }
+
+    /// Get the timestamp when snapshot was taken.
+    #[must_use]
+    pub const fn timestamp(&self) -> SystemTime {
+        self.timestamp
+    }
+
+    // === Utility Methods ===
+
+    /// Check if this snapshot matches a buffer's ID.
+    #[must_use]
+    pub fn matches_buffer(&self, buffer: &Buffer) -> bool {
+        self.buffer_id == buffer.id()
+    }
+
+    /// Get the total number of characters in the snapshot.
+    #[must_use]
+    pub fn char_count(&self) -> usize {
+        self.lines.iter().map(|l| l.chars().count()).sum::<usize>()
+            + self.lines.len().saturating_sub(1) // newlines
+    }
+
+    /// Get the number of lines in the snapshot.
+    #[must_use]
+    pub const fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Check if the snapshot is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+}

--- a/lib/kernel/src/block/tests.rs
+++ b/lib/kernel/src/block/tests.rs
@@ -1,0 +1,569 @@
+//! Tests for block operations subsystem.
+
+use {
+    super::*,
+    crate::mm::{Buffer, BufferId, Edit, Position},
+};
+
+// === Transaction Tests ===
+
+mod transaction_tests {
+    use super::*;
+
+    #[test]
+    fn test_new_transaction_is_empty() {
+        let txn = Transaction::new();
+        assert!(txn.is_empty());
+        assert_eq!(txn.len(), 0);
+    }
+
+    #[test]
+    fn test_push_and_edits() {
+        let mut txn = Transaction::new();
+        txn.push(Edit::insert(Position::new(0, 0), "Hello"));
+        txn.push(Edit::insert(Position::new(0, 5), " World"));
+
+        assert!(!txn.is_empty());
+        assert_eq!(txn.len(), 2);
+
+        let edits = txn.edits();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].text(), "Hello");
+        assert_eq!(edits[1].text(), " World");
+    }
+
+    #[test]
+    fn test_inverse() {
+        let mut txn = Transaction::new();
+        txn.push(Edit::insert(Position::new(0, 0), "A"));
+        txn.push(Edit::insert(Position::new(0, 1), "B"));
+        txn.push(Edit::insert(Position::new(0, 2), "C"));
+
+        let inverse = txn.inverse();
+
+        // Inverse should be in reverse order
+        let edits = inverse.edits();
+        assert_eq!(edits.len(), 3);
+
+        // Edits should be inverted (insert -> delete)
+        assert!(edits[0].is_delete());
+        assert!(edits[1].is_delete());
+        assert!(edits[2].is_delete());
+
+        // Order should be reversed: C, B, A
+        assert_eq!(edits[0].text(), "C");
+        assert_eq!(edits[1].text(), "B");
+        assert_eq!(edits[2].text(), "A");
+    }
+
+    #[test]
+    fn test_from_vec() {
+        let edits = vec![
+            Edit::insert(Position::new(0, 0), "X"),
+            Edit::insert(Position::new(0, 1), "Y"),
+        ];
+
+        let txn: Transaction = edits.into();
+        assert_eq!(txn.len(), 2);
+    }
+
+    #[test]
+    fn test_from_single_edit() {
+        let edit = Edit::insert(Position::new(0, 0), "Z");
+        let txn: Transaction = edit.into();
+        assert_eq!(txn.len(), 1);
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let mut txn = Transaction::new();
+        txn.push(Edit::insert(Position::new(0, 0), "A"));
+        txn.push(Edit::insert(Position::new(0, 1), "B"));
+
+        assert_eq!(txn.into_iter().count(), 2);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut txn = Transaction::new();
+        txn.push(Edit::insert(Position::new(0, 0), "A"));
+        assert!(!txn.is_empty());
+
+        txn.clear();
+        assert!(txn.is_empty());
+    }
+}
+
+// === UndoTree Tests ===
+
+mod undo_tree_tests {
+    use super::*;
+
+    #[test]
+    fn test_new_tree_at_root() {
+        let tree = UndoTree::new();
+        assert!(!tree.can_undo());
+        assert!(!tree.can_redo());
+        assert_eq!(tree.node_count(), 1); // Root node
+    }
+
+    #[test]
+    fn test_linear_undo_redo() {
+        let mut tree = UndoTree::new();
+
+        // Push first edit
+        tree.push(
+            vec![Edit::insert(Position::new(0, 0), "Hello")],
+            Position::new(0, 0),
+            Position::new(0, 5),
+        );
+        assert!(tree.can_undo());
+        assert!(!tree.can_redo());
+
+        // Push second edit
+        tree.push(
+            vec![Edit::insert(Position::new(0, 5), " World")],
+            Position::new(0, 5),
+            Position::new(0, 11),
+        );
+
+        // Undo second edit
+        let result = tree.undo().expect("should be able to undo");
+        assert_eq!(result.cursor, Position::new(0, 5));
+        assert!(result.edits[0].is_delete());
+
+        // Now can redo
+        assert!(tree.can_undo());
+        assert!(tree.can_redo());
+
+        // Undo first edit
+        let result = tree.undo().expect("should be able to undo");
+        assert_eq!(result.cursor, Position::new(0, 0));
+
+        // At root, can't undo more
+        assert!(!tree.can_undo());
+        assert!(tree.can_redo());
+
+        // Redo first edit
+        let result = tree.redo().expect("should be able to redo");
+        assert_eq!(result.cursor, Position::new(0, 5));
+        assert!(result.edits[0].is_insert());
+
+        // Redo second edit
+        let result = tree.redo().expect("should be able to redo");
+        assert_eq!(result.cursor, Position::new(0, 11));
+    }
+
+    #[test]
+    fn test_undo_restores_cursor() {
+        let mut tree = UndoTree::new();
+
+        tree.push(
+            vec![Edit::insert(Position::new(5, 10), "text")],
+            Position::new(5, 10), // cursor before
+            Position::new(5, 14), // cursor after
+        );
+
+        let result = tree.undo().unwrap();
+        assert_eq!(result.cursor, Position::new(5, 10));
+    }
+
+    #[test]
+    fn test_redo_restores_cursor() {
+        let mut tree = UndoTree::new();
+
+        tree.push(
+            vec![Edit::insert(Position::new(3, 5), "abc")],
+            Position::new(3, 5),
+            Position::new(3, 8),
+        );
+
+        tree.undo();
+        let result = tree.redo().unwrap();
+        assert_eq!(result.cursor, Position::new(3, 8));
+    }
+
+    #[test]
+    fn test_branching_undo() {
+        let mut tree = UndoTree::new();
+
+        // Push edit A
+        tree.push(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+        );
+
+        // Push edit B
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        // Undo B, now at A
+        tree.undo();
+        assert!(tree.can_redo());
+
+        // Push edit C (creates new branch)
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "C")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        // Current tree structure:
+        // Root -> A -> B
+        //           -> C (current)
+
+        // Undo C, back to A
+        tree.undo();
+
+        // A should have 2 children (branches)
+        let branches = tree.branches();
+        assert_eq!(branches.len(), 2);
+    }
+
+    #[test]
+    fn test_switch_branch() {
+        let mut tree = UndoTree::new();
+
+        // Create branching structure
+        tree.push(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+        );
+
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        tree.undo();
+
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "C")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        tree.undo();
+
+        // At A, branches are [B-index, C-index]
+        // Default redo would go to active branch (C, since it was added last)
+        let branches = tree.branches();
+        assert_eq!(branches.len(), 2);
+
+        // Switch to first branch (B)
+        assert!(tree.switch_branch(0));
+
+        // Redo should now go to B branch
+        let result = tree.redo().unwrap();
+        assert_eq!(result.edits[0].text(), "B");
+    }
+
+    #[test]
+    fn test_max_nodes_pruning() {
+        let mut tree = UndoTree::with_max_nodes(5);
+
+        // Create branches that can be pruned
+        // Push A
+        tree.push(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+        );
+
+        // Push B, C as branches from A
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+        tree.undo(); // back to A
+
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "C")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+        tree.undo(); // back to A
+
+        // Push D, E, F, G from A (creates more branches)
+        for c in ['D', 'E', 'F', 'G'] {
+            tree.push(
+                vec![Edit::insert(Position::new(0, 1), c.to_string())],
+                Position::new(0, 1),
+                Position::new(0, 2),
+            );
+            tree.undo(); // back to A
+        }
+
+        // Now push H and stay there (this is the protected path)
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "H")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        // Tree structure: root -> A -> [B, C, D, E, F, G, H]
+        // Protected path: root -> A -> H
+        // Leaf nodes B, C, D, E, F, G can be pruned
+
+        // Should be pruned to max_nodes (5)
+        // Protected: root, A, H (3 nodes)
+        // After pruning: at most 5 nodes
+        assert!(tree.node_count() <= 5);
+
+        // Current path should still be intact
+        assert!(tree.can_undo());
+
+        // Verify we're still at H
+        let result = tree.undo().unwrap();
+        assert_eq!(result.edits[0].text(), "H");
+    }
+
+    #[test]
+    fn test_empty_edits_not_pushed() {
+        let mut tree = UndoTree::new();
+
+        tree.push(vec![], Position::new(0, 0), Position::new(0, 0));
+
+        // Should still only have root
+        assert_eq!(tree.node_count(), 1);
+        assert!(!tree.can_undo());
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut tree = UndoTree::new();
+
+        tree.push(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+        );
+
+        tree.push(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+        );
+
+        tree.clear();
+
+        assert!(!tree.can_undo());
+        assert!(!tree.can_redo());
+        assert_eq!(tree.node_count(), 1);
+    }
+}
+
+// === History Tests ===
+
+mod history_tests {
+    use super::*;
+
+    #[test]
+    fn test_new_history_is_empty() {
+        let history = History::new();
+        assert!(history.is_empty());
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn test_record_and_entries() {
+        let mut history = History::new();
+
+        history.record(vec![Edit::insert(Position::new(0, 0), "A")]);
+        history.record(vec![Edit::insert(Position::new(0, 1), "B")]);
+
+        assert!(!history.is_empty());
+        assert_eq!(history.len(), 2);
+
+        let entries = history.entries();
+        assert_eq!(entries[0].edits()[0].text(), "A");
+        assert_eq!(entries[1].edits()[0].text(), "B");
+    }
+
+    #[test]
+    fn test_max_entries() {
+        let mut history = History::with_max_entries(3);
+
+        for i in 0..5 {
+            history.record(vec![Edit::insert(Position::new(0, 0), i.to_string())]);
+        }
+
+        // Should be capped at 3
+        assert_eq!(history.len(), 3);
+
+        // Oldest entries should be removed
+        let entries = history.entries();
+        assert_eq!(entries[0].edits()[0].text(), "2");
+        assert_eq!(entries[1].edits()[0].text(), "3");
+        assert_eq!(entries[2].edits()[0].text(), "4");
+    }
+
+    #[test]
+    fn test_seq_num_increments() {
+        let mut history = History::new();
+
+        history.record(vec![Edit::insert(Position::new(0, 0), "A")]);
+        history.record(vec![Edit::insert(Position::new(0, 0), "B")]);
+
+        let entries = history.entries();
+        assert_eq!(entries[0].seq_num(), 1);
+        assert_eq!(entries[1].seq_num(), 2);
+    }
+
+    #[test]
+    fn test_empty_edits_not_recorded() {
+        let mut history = History::new();
+        history.record(vec![]);
+        assert!(history.is_empty());
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut history = History::new();
+        history.record(vec![Edit::insert(Position::new(0, 0), "A")]);
+        assert!(!history.is_empty());
+
+        history.clear();
+        assert!(history.is_empty());
+
+        // seq_counter should not reset
+        history.record(vec![Edit::insert(Position::new(0, 0), "B")]);
+        assert!(history.entries()[0].seq_num() > 1);
+    }
+
+    #[test]
+    fn test_since() {
+        let mut history = History::new();
+
+        for i in 0..5 {
+            history.record(vec![Edit::insert(Position::new(0, 0), i.to_string())]);
+        }
+
+        // Get entries since seq_num 3
+        let since = history.since(3);
+        assert_eq!(since.len(), 2);
+        assert_eq!(since[0].seq_num(), 4);
+        assert_eq!(since[1].seq_num(), 5);
+    }
+
+    #[test]
+    fn test_last() {
+        let mut history = History::new();
+        assert!(history.last().is_none());
+
+        history.record(vec![Edit::insert(Position::new(0, 0), "A")]);
+        history.record(vec![Edit::insert(Position::new(0, 0), "B")]);
+
+        assert_eq!(history.last().unwrap().edits()[0].text(), "B");
+    }
+}
+
+// === Snapshot Tests ===
+
+mod snapshot_tests {
+    use super::*;
+
+    #[test]
+    fn test_capture_and_restore() {
+        let mut buffer = Buffer::from_string("Hello\nWorld");
+        buffer.set_position(Position::new(1, 3));
+
+        let snapshot = Snapshot::capture(&buffer);
+
+        // Modify buffer
+        buffer.set_content("Something else");
+        buffer.set_position(Position::new(0, 0));
+
+        // Restore
+        snapshot.restore(&mut buffer);
+
+        assert_eq!(buffer.content(), "Hello\nWorld");
+        assert_eq!(buffer.position(), Position::new(1, 3));
+    }
+
+    #[test]
+    fn test_accessors() {
+        let mut buffer = Buffer::from_string("Test content");
+        buffer.set_position(Position::new(0, 5));
+
+        let snapshot = Snapshot::capture(&buffer);
+
+        assert_eq!(snapshot.lines(), &["Test content"]);
+        assert_eq!(snapshot.cursor(), Position::new(0, 5));
+        assert_eq!(snapshot.buffer_id(), buffer.id());
+        assert!(snapshot.timestamp() <= std::time::SystemTime::now());
+    }
+
+    #[test]
+    fn test_cursor_preserved() {
+        let mut buffer = Buffer::from_string("Line 1\nLine 2\nLine 3");
+        buffer.set_position(Position::new(2, 4));
+
+        let snapshot = Snapshot::capture(&buffer);
+        assert_eq!(snapshot.cursor(), Position::new(2, 4));
+
+        // Modify and restore cursor only
+        buffer.set_position(Position::new(0, 0));
+        snapshot.restore_cursor(&mut buffer);
+
+        assert_eq!(buffer.position(), Position::new(2, 4));
+    }
+
+    #[test]
+    fn test_from_parts() {
+        let lines = vec!["Line 1".to_string(), "Line 2".to_string()];
+        let cursor = Position::new(1, 5);
+        let buffer_id = BufferId::new();
+        let timestamp = std::time::SystemTime::now();
+
+        let snapshot = Snapshot::from_parts(lines.clone(), cursor, buffer_id, timestamp);
+
+        assert_eq!(snapshot.lines(), &lines[..]);
+        assert_eq!(snapshot.cursor(), cursor);
+        assert_eq!(snapshot.buffer_id(), buffer_id);
+    }
+
+    #[test]
+    fn test_matches_buffer() {
+        let buffer = Buffer::from_string("Test");
+        let snapshot = Snapshot::capture(&buffer);
+
+        assert!(snapshot.matches_buffer(&buffer));
+
+        let other_buffer = Buffer::from_string("Other");
+        assert!(!snapshot.matches_buffer(&other_buffer));
+    }
+
+    #[test]
+    fn test_char_count() {
+        let buffer = Buffer::from_string("Hello\nWorld");
+        let snapshot = Snapshot::capture(&buffer);
+
+        // "Hello" (5) + "\n" (1) + "World" (5) = 11
+        assert_eq!(snapshot.char_count(), 11);
+    }
+
+    #[test]
+    fn test_line_count() {
+        let buffer = Buffer::from_string("A\nB\nC");
+        let snapshot = Snapshot::capture(&buffer);
+        assert_eq!(snapshot.line_count(), 3);
+    }
+
+    #[test]
+    fn test_empty_snapshot() {
+        let buffer = Buffer::new();
+        let snapshot = Snapshot::capture(&buffer);
+
+        assert!(snapshot.is_empty());
+        assert_eq!(snapshot.line_count(), 0);
+        assert_eq!(snapshot.char_count(), 0);
+    }
+}

--- a/lib/kernel/src/block/transaction.rs
+++ b/lib/kernel/src/block/transaction.rs
@@ -1,0 +1,131 @@
+//! Transaction for grouping edits.
+//!
+//! A transaction groups multiple edits together so they can be
+//! undone/redone as a single unit.
+
+use crate::mm::Edit;
+
+/// A transaction groups multiple edits for atomic undo/redo.
+///
+/// When a transaction is undone, all its edits are reversed in reverse order.
+/// When redone, all edits are applied in original order.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::block::Transaction;
+/// use reovim_kernel::mm::{Edit, Position};
+///
+/// let mut txn = Transaction::new();
+/// txn.push(Edit::insert(Position::new(0, 0), "Hello"));
+/// txn.push(Edit::insert(Position::new(0, 5), " World"));
+///
+/// assert_eq!(txn.len(), 2);
+/// assert!(!txn.is_empty());
+///
+/// // Get inverse for undo
+/// let inverse = txn.inverse();
+/// assert_eq!(inverse.len(), 2);
+/// // Inverse edits are in reverse order
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct Transaction {
+    /// Edits in this transaction (in order applied).
+    edits: Vec<Edit>,
+}
+
+impl Transaction {
+    /// Create a new empty transaction.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { edits: Vec::new() }
+    }
+
+    /// Returns an iterator over the edits.
+    pub fn iter(&self) -> std::slice::Iter<'_, Edit> {
+        self.edits.iter()
+    }
+
+    /// Create a transaction with pre-allocated capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            edits: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Add an edit to this transaction.
+    pub fn push(&mut self, edit: Edit) {
+        self.edits.push(edit);
+    }
+
+    /// Get all edits in this transaction.
+    #[must_use]
+    pub fn edits(&self) -> &[Edit] {
+        &self.edits
+    }
+
+    /// Consume the transaction and return the edits.
+    #[must_use]
+    pub fn into_edits(self) -> Vec<Edit> {
+        self.edits
+    }
+
+    /// Check if this transaction has no edits.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.edits.is_empty()
+    }
+
+    /// Get the number of edits in this transaction.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.edits.len()
+    }
+
+    /// Create the inverse of this transaction (for undo).
+    ///
+    /// The inverse contains the inverse of each edit, in reverse order.
+    /// Applying the inverse undoes the original transaction.
+    #[must_use]
+    pub fn inverse(&self) -> Self {
+        Self {
+            edits: self.edits.iter().rev().map(Edit::inverse).collect(),
+        }
+    }
+
+    /// Clear all edits from this transaction.
+    pub fn clear(&mut self) {
+        self.edits.clear();
+    }
+}
+
+impl From<Vec<Edit>> for Transaction {
+    fn from(edits: Vec<Edit>) -> Self {
+        Self { edits }
+    }
+}
+
+impl From<Edit> for Transaction {
+    fn from(edit: Edit) -> Self {
+        Self { edits: vec![edit] }
+    }
+}
+
+impl IntoIterator for Transaction {
+    type Item = Edit;
+    type IntoIter = std::vec::IntoIter<Edit>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.edits.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Transaction {
+    type Item = &'a Edit;
+    type IntoIter = std::slice::Iter<'a, Edit>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.edits.iter()
+    }
+}

--- a/lib/kernel/src/block/undo.rs
+++ b/lib/kernel/src/block/undo.rs
@@ -1,0 +1,465 @@
+//! Undo tree with branching support.
+//!
+//! Provides vim-style branching undo history where undoing and then
+//! making new changes creates a new branch rather than losing history.
+
+use {
+    crate::mm::{Edit, Position},
+    std::time::Instant,
+};
+
+/// A node in the undo tree.
+///
+/// Each node represents a set of edits made at a point in time,
+/// along with cursor positions for proper restoration.
+#[derive(Debug, Clone)]
+pub struct UndoNode {
+    /// Edits that were made (in order applied).
+    edits: Vec<Edit>,
+    /// Cursor position before these edits were applied.
+    cursor_before: Position,
+    /// Cursor position after these edits were applied.
+    cursor_after: Position,
+    /// When this node was created.
+    timestamp: Instant,
+    /// Parent node index (None for root).
+    parent: Option<usize>,
+    /// Child node indices (branches).
+    children: Vec<usize>,
+    /// Sequential change number.
+    seq_num: u64,
+}
+
+impl UndoNode {
+    /// Get the edits in this node.
+    #[must_use]
+    pub fn edits(&self) -> &[Edit] {
+        &self.edits
+    }
+
+    /// Get cursor position before edits.
+    #[must_use]
+    pub const fn cursor_before(&self) -> Position {
+        self.cursor_before
+    }
+
+    /// Get cursor position after edits.
+    #[must_use]
+    pub const fn cursor_after(&self) -> Position {
+        self.cursor_after
+    }
+
+    /// Get timestamp when this node was created.
+    #[must_use]
+    pub const fn timestamp(&self) -> Instant {
+        self.timestamp
+    }
+
+    /// Get sequential change number.
+    #[must_use]
+    pub const fn seq_num(&self) -> u64 {
+        self.seq_num
+    }
+
+    /// Check if this is the root node.
+    #[must_use]
+    pub const fn is_root(&self) -> bool {
+        self.parent.is_none()
+    }
+
+    /// Get number of branches (children) from this node.
+    #[must_use]
+    pub const fn branch_count(&self) -> usize {
+        self.children.len()
+    }
+}
+
+/// Result from an undo or redo operation.
+///
+/// Contains the edits to apply and the cursor position to restore.
+#[derive(Debug, Clone)]
+pub struct UndoResult {
+    /// Edits to apply (already inverted for undo).
+    pub edits: Vec<Edit>,
+    /// Cursor position to restore.
+    pub cursor: Position,
+}
+
+/// Undo tree with branching support.
+///
+/// Unlike a simple undo stack, an undo tree preserves all history.
+/// When you undo and then make new changes, a new branch is created
+/// rather than discarding the undone changes.
+///
+/// # Vim Comparison
+///
+/// This is similar to vim's `:undotree` feature. The `g-` and `g+`
+/// commands traverse changes in time order (`seq_num`), while `u` and
+/// `Ctrl-R` traverse the tree structure.
+///
+/// # Memory Management
+///
+/// The tree has a configurable maximum number of nodes. When exceeded,
+/// the oldest nodes are pruned (but the path from root to current is
+/// always preserved).
+#[derive(Debug)]
+pub struct UndoTree {
+    /// All nodes in the tree.
+    nodes: Vec<UndoNode>,
+    /// Index of current position in the tree.
+    current: usize,
+    /// Sequential change counter.
+    seq_counter: u64,
+    /// Maximum number of nodes to retain.
+    max_nodes: usize,
+    /// Index of the preferred/active branch at each node.
+    /// Used to remember which branch to follow on redo.
+    active_branches: Vec<usize>,
+}
+
+impl Default for UndoTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UndoTree {
+    /// Default maximum number of nodes.
+    pub const DEFAULT_MAX_NODES: usize = 10000;
+
+    /// Create a new undo tree.
+    ///
+    /// The tree starts with a root node representing the initial state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_max_nodes(Self::DEFAULT_MAX_NODES)
+    }
+
+    /// Create a new undo tree with custom maximum nodes.
+    #[must_use]
+    pub fn with_max_nodes(max_nodes: usize) -> Self {
+        let root = UndoNode {
+            edits: Vec::new(),
+            cursor_before: Position::default(),
+            cursor_after: Position::default(),
+            timestamp: Instant::now(),
+            parent: None,
+            children: Vec::new(),
+            seq_num: 0,
+        };
+
+        Self {
+            nodes: vec![root],
+            current: 0,
+            seq_counter: 0,
+            max_nodes: max_nodes.max(1), // At least 1 node
+            active_branches: vec![0],
+        }
+    }
+
+    /// Push a new change onto the tree.
+    ///
+    /// Creates a new node as a child of the current node.
+    /// If the current node already has children (we're in the middle
+    /// of the tree after an undo), this creates a new branch.
+    pub fn push(&mut self, edits: Vec<Edit>, cursor_before: Position, cursor_after: Position) {
+        if edits.is_empty() {
+            return;
+        }
+
+        self.seq_counter += 1;
+
+        let new_node = UndoNode {
+            edits,
+            cursor_before,
+            cursor_after,
+            timestamp: Instant::now(),
+            parent: Some(self.current),
+            children: Vec::new(),
+            seq_num: self.seq_counter,
+        };
+
+        let new_idx = self.nodes.len();
+        self.nodes.push(new_node);
+
+        // Add as child of current node
+        self.nodes[self.current].children.push(new_idx);
+
+        // Update active branch for current node
+        let branch_idx = self.nodes[self.current].children.len() - 1;
+        // Extend active_branches if needed
+        while self.active_branches.len() <= self.current {
+            self.active_branches.push(0);
+        }
+        self.active_branches[self.current] = branch_idx;
+
+        // Ensure active_branches has entry for new node
+        while self.active_branches.len() <= new_idx {
+            self.active_branches.push(0);
+        }
+
+        // Move to new node
+        self.current = new_idx;
+
+        // Prune if over limit
+        self.prune_if_needed();
+    }
+
+    /// Undo the current change.
+    ///
+    /// Moves to the parent node and returns the inverse edits
+    /// along with the cursor position to restore.
+    ///
+    /// Returns `None` if at the root (nothing to undo).
+    pub fn undo(&mut self) -> Option<UndoResult> {
+        let current_node = &self.nodes[self.current];
+
+        // Can't undo past root
+        let parent_idx = current_node.parent?;
+
+        // Get inverse edits and cursor to restore
+        let result = UndoResult {
+            edits: current_node.edits.iter().rev().map(Edit::inverse).collect(),
+            cursor: current_node.cursor_before,
+        };
+
+        // Move to parent
+        self.current = parent_idx;
+
+        Some(result)
+    }
+
+    /// Redo the last undone change.
+    ///
+    /// Moves to the first child node (or the active branch) and
+    /// returns the edits along with cursor position to restore.
+    ///
+    /// Returns `None` if there's nothing to redo.
+    pub fn redo(&mut self) -> Option<UndoResult> {
+        let current_node = &self.nodes[self.current];
+
+        if current_node.children.is_empty() {
+            return None;
+        }
+
+        // Get active branch index
+        let branch_idx = self
+            .active_branches
+            .get(self.current)
+            .copied()
+            .unwrap_or(0)
+            .min(current_node.children.len() - 1);
+
+        let child_idx = current_node.children[branch_idx];
+        let child_node = &self.nodes[child_idx];
+
+        let result = UndoResult {
+            edits: child_node.edits.clone(),
+            cursor: child_node.cursor_after,
+        };
+
+        // Move to child
+        self.current = child_idx;
+
+        Some(result)
+    }
+
+    /// Redo a specific branch.
+    ///
+    /// Like `redo()` but follows a specific branch index.
+    pub fn redo_branch(&mut self, branch_idx: usize) -> Option<UndoResult> {
+        let current_node = &self.nodes[self.current];
+
+        if branch_idx >= current_node.children.len() {
+            return None;
+        }
+
+        // Update active branch
+        if self.current < self.active_branches.len() {
+            self.active_branches[self.current] = branch_idx;
+        }
+
+        let child_idx = current_node.children[branch_idx];
+        let child_node = &self.nodes[child_idx];
+
+        let result = UndoResult {
+            edits: child_node.edits.clone(),
+            cursor: child_node.cursor_after,
+        };
+
+        self.current = child_idx;
+
+        Some(result)
+    }
+
+    /// Get the available branches (children) from current node.
+    ///
+    /// Returns indices that can be passed to `redo_branch()`.
+    #[must_use]
+    pub fn branches(&self) -> &[usize] {
+        &self.nodes[self.current].children
+    }
+
+    /// Switch the active branch at current node.
+    ///
+    /// This affects which branch `redo()` will follow.
+    /// Returns `false` if the branch index is invalid.
+    pub fn switch_branch(&mut self, branch_idx: usize) -> bool {
+        let current_node = &self.nodes[self.current];
+
+        if branch_idx >= current_node.children.len() {
+            return false;
+        }
+
+        while self.active_branches.len() <= self.current {
+            self.active_branches.push(0);
+        }
+        self.active_branches[self.current] = branch_idx;
+
+        true
+    }
+
+    /// Check if undo is possible.
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        self.nodes[self.current].parent.is_some()
+    }
+
+    /// Check if redo is possible.
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        !self.nodes[self.current].children.is_empty()
+    }
+
+    /// Get the current node.
+    #[must_use]
+    pub fn current_node(&self) -> &UndoNode {
+        &self.nodes[self.current]
+    }
+
+    /// Get the current node index.
+    #[must_use]
+    pub const fn current_index(&self) -> usize {
+        self.current
+    }
+
+    /// Get total number of nodes in the tree.
+    #[must_use]
+    pub const fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Get the maximum nodes limit.
+    #[must_use]
+    pub const fn max_nodes(&self) -> usize {
+        self.max_nodes
+    }
+
+    /// Set the maximum nodes limit.
+    pub fn set_max_nodes(&mut self, max: usize) {
+        self.max_nodes = max.max(1);
+        self.prune_if_needed();
+    }
+
+    /// Get the current sequential change number.
+    #[must_use]
+    pub const fn seq_counter(&self) -> u64 {
+        self.seq_counter
+    }
+
+    /// Prune old nodes if over the limit.
+    ///
+    /// This is a simple pruning strategy that removes the oldest
+    /// nodes that are not on the path from root to current.
+    fn prune_if_needed(&mut self) {
+        if self.nodes.len() <= self.max_nodes {
+            return;
+        }
+
+        // Build set of nodes on path from root to current
+        let mut protected = vec![false; self.nodes.len()];
+        let mut idx = self.current;
+        loop {
+            protected[idx] = true;
+            match self.nodes[idx].parent {
+                Some(parent) => idx = parent,
+                None => break,
+            }
+        }
+
+        // Find nodes to remove (oldest first, not protected)
+        let to_remove = self.nodes.len() - self.max_nodes;
+        let mut removed = 0;
+        let mut remove_indices = Vec::new();
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            if removed >= to_remove {
+                break;
+            }
+            if !protected[i] && node.children.is_empty() {
+                remove_indices.push(i);
+                removed += 1;
+            }
+        }
+
+        // Actually remove nodes (in reverse order to maintain indices)
+        for &idx in remove_indices.iter().rev() {
+            self.remove_node(idx);
+        }
+    }
+
+    /// Remove a node from the tree.
+    ///
+    /// Updates parent's children list and adjusts indices.
+    fn remove_node(&mut self, idx: usize) {
+        if idx == 0 || idx == self.current {
+            return; // Never remove root or current
+        }
+
+        // Remove from parent's children
+        if let Some(parent_idx) = self.nodes[idx].parent {
+            self.nodes[parent_idx].children.retain(|&c| c != idx);
+        }
+
+        // Update indices in all nodes
+        for node in &mut self.nodes {
+            if let Some(ref mut parent) = node.parent
+                && *parent > idx
+            {
+                *parent -= 1;
+            }
+            for child in &mut node.children {
+                if *child > idx {
+                    *child -= 1;
+                }
+            }
+        }
+
+        // Update current if needed
+        if self.current > idx {
+            self.current -= 1;
+        }
+
+        // Update active_branches
+        for branch in &mut self.active_branches {
+            if *branch > idx {
+                *branch -= 1;
+            }
+        }
+
+        // Remove the node
+        self.nodes.remove(idx);
+
+        // Trim active_branches
+        while self.active_branches.len() > self.nodes.len() {
+            self.active_branches.pop();
+        }
+    }
+
+    /// Clear all history except root.
+    pub fn clear(&mut self) {
+        let root_cursor = self.nodes[0].cursor_after;
+        *self = Self::with_max_nodes(self.max_nodes);
+        self.nodes[0].cursor_after = root_cursor;
+    }
+}

--- a/lib/kernel/src/ipc/channel.rs
+++ b/lib/kernel/src/ipc/channel.rs
@@ -40,7 +40,7 @@
 
 use std::{sync::mpsc, time::Duration};
 
-use parking_lot::Mutex;
+use reovim_arch::sync::Mutex;
 
 // ============================================================================
 // Unbounded Channel

--- a/lib/kernel/src/ipc/event_bus.rs
+++ b/lib/kernel/src/ipc/event_bus.rs
@@ -45,7 +45,7 @@
 
 use std::{any::TypeId, collections::HashMap, sync::Arc};
 
-use {arc_swap::ArcSwap, parking_lot::Mutex};
+use reovim_arch::sync::{ArcSwap, Mutex};
 
 use super::{
     event::{DynEvent, Event, EventResult},
@@ -318,8 +318,9 @@ impl EventBus {
 
         for mut event in events {
             let scope = event.take_scope();
-            let result = self.dispatch(&event);
-            tracing::trace!(event_type = event.type_name(), ?result, "processed queued event");
+            let _result = self.dispatch(&event);
+            // TODO: Replace with pr_trace!() once printk is implemented
+            // pr_trace!("processed queued event: {} -> {:?}", event.type_name(), result);
             if let Some(scope) = scope {
                 scope.decrement();
             }

--- a/lib/kernel/src/ipc/scope.rs
+++ b/lib/kernel/src/ipc/scope.rs
@@ -48,7 +48,7 @@ use std::{
     time::Duration,
 };
 
-use parking_lot::{Condvar, Mutex};
+use reovim_arch::sync::{Condvar, Mutex};
 
 /// Unique identifier for an `EventScope`.
 ///

--- a/lib/kernel/src/ipc/subscription.rs
+++ b/lib/kernel/src/ipc/subscription.rs
@@ -44,7 +44,7 @@ use std::{
     },
 };
 
-use parking_lot::Mutex;
+use reovim_arch::sync::Mutex;
 
 /// Unique identifier for a subscription.
 ///


### PR DESCRIPTION
Adds undo tree and transaction system following kernel purity principle:

- Transaction: Grouped edits with inverse support
- UndoTree: Vim-style branching undo with cursor position
- History: Append-only change log with timestamps
- Snapshot: Buffer state capture with accessors for driver serialization

Also moves sync primitives to arch/ layer to maintain kernel purity:
- kernel/ now depends only on arch/, no direct external deps
- arch/sync re-exports parking_lot and arc-swap primitives

Kernel remains pure Rust with zero external dependencies.

Closes #162