### PR TITLE
feat(kernel): implement sched/ scheduler module (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
-- **Phase 2.3: Printk Module** (Issue #168) - Kernel printk/ logging subsystem
+- **Phase 2.7: Printk Module** (Issue #168) - Kernel printk/ logging subsystem
   - `Level` enum - Log severity levels (Error, Warn, Info, Debug, Trace)
     - Ordered by severity for filtering (Error < Warn < Info < Debug < Trace)
     - `FromStr` trait for parsing from strings (case-insensitive)
@@ -31,6 +31,70 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
     - Level check before `format_args!` evaluation (zero allocation when disabled)
     - Captures `module_path!()`, `file!()`, `line!()` at call site
   - 25 unit tests + 32 doctests
+
+- **Phase 2.5: Scheduler Module** (Issue #163) - Kernel sched/ subsystem
+  - `RuntimeState` - Lifecycle state machine (Booting/Running/Stopping/Emergency)
+  - `TaskId` - Unique task identifier with atomic counter generation
+  - `Priority` - Task execution priority (CRITICAL=0, HIGH=50, NORMAL=100, LOW=200, IDLE=1000)
+  - `TaskState` - Execution state enum (Pending, Running, Completed, Failed)
+  - `Task` - Deferred work unit with priority, name, and panic-safe execution
+  - `WorkQueue` - Bounded FIFO task queue with overflow detection
+    - `push(task) -> bool` - Non-blocking, returns false on overflow
+    - `try_pop()` / `drain()` - Task retrieval
+    - `dropped_count()` - Track overflow statistics
+  - `PriorityQueue` - Priority-ordered event queue using BinaryHeap
+    - Min-heap behavior (lower priority value = processed first)
+    - FIFO ordering for same-priority events via sequence number
+  - `Executor` - Synchronous task executor with `catch_unwind` panic handling
+    - `tick()` - Process batch of tasks with panic isolation
+    - `execute_task()` - Single task execution with error recovery
+  - `Runtime` - Main event loop coordinator
+    - `boot()` / `shutdown()` / `emergency_stop()` - Lifecycle control
+    - `tick() -> bool` - Single event loop iteration
+    - `schedule_work()` / `schedule_task()` - Deferred task scheduling
+    - `queue_event()` - Priority-ordered event dispatch
+    - `stats()` - Runtime statistics (executed, failed, dropped)
+  - `RuntimeConfig` - Builder pattern for runtime customization
+  - `RuntimeCommand` - External control channel (Shutdown, Emergency, ScheduleTask)
+  - 67 sched unit tests + 6 doctests
+
+- **Phase 2.4: Block Operations Module** (Issue #162) - Kernel block/ subsystem
+  - `Transaction` - Groups multiple edits for atomic undo/redo
+    - `new()`, `push()` - Create and add edits
+    - `edits()`, `is_empty()` - Accessors
+  - `UndoTree` - Branching undo history with cursor position tracking
+    - `new()`, `push()` - Create and record edits with cursor positions
+    - `undo()`, `redo()` - Navigate history
+    - `branch_count()`, `current_branch()` - Branch management
+  - `UndoResult` - Undo/redo result with edits and cursor position
+  - `UndoNode` - Node in undo tree with parent/children links
+  - `History` - Change log with timestamps
+    - `record()`, `entries()`, `clear()` - History management
+  - `HistoryEntry` - Single history entry with timestamp
+  - `Snapshot` - Buffer state capture for restore
+    - `capture()`, `restore()` - State management
+  - 32 unit tests + 4 doctests
+
+- **Phase 2.3: Core Primitives Module** (Issue #161) - Kernel core/ subsystem
+  - `Direction` enum - Forward/Backward movement direction
+  - `WordBoundary` enum - Word/BigWord boundary types
+  - `LinePosition` enum - Start/FirstNonBlank/End/LastNonBlank positions
+  - `Motion` enum - All motion types (Char, Line, Word, Paragraph, FindChar, etc.)
+  - `MotionEngine` - Pure cursor movement calculations
+    - `calculate()` - Apply motion to cursor position
+    - No side effects, returns new position
+  - `TextObject` enum - Inner/Around text objects (Word, Bracket, Quote, etc.)
+  - `TextObjectEngine` - Text object range calculations
+    - `range()` - Calculate start/end positions for text object
+  - `RegisterBank` - Yank/paste storage (without clipboard integration)
+    - Named registers (a-z), numbered registers (0-9)
+    - `get()`, `set()`, `append()` operations
+  - `RegisterContent` - Register value with yank type
+  - `YankType` - Char/Line/Block yank modes
+  - `Mark` - Single bookmark with position and metadata
+  - `MarkBank` - Mark storage with named marks (a-z, A-Z)
+  - `SpecialMark` - Special marks (LastChange, LastJump, etc.)
+  - 44 unit tests + 5 doctests
 
 - **Phase 2.2: IPC Module** (Issue #160) - Kernel ipc/ subsystem
   - `Event` trait - Minimal requirements for IPC events (priority, batchable)
@@ -86,6 +150,10 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
   - All crates are empty skeletons that compile with zero warnings
   - Dependency graph enforced: arch → kernel → drivers
   - `lib/drivers/syntax` has NO tree-sitter dependency (trait definitions only)
+
+### Fixed
+
+- **IPC Channel Clone** - Fixed `Sender<T>` and `BoundedSender<T>` Clone impl to not require `T: Clone` (matching std::sync::mpsc behavior)
 
 ---
 

--- a/lib/kernel/src/ipc/channel.rs
+++ b/lib/kernel/src/ipc/channel.rs
@@ -49,8 +49,14 @@ use reovim_arch::sync::Mutex;
 /// Sender for unbounded MPSC channel.
 ///
 /// Cloning creates a new sender to the same channel.
-#[derive(Clone)]
 pub struct Sender<T>(mpsc::Sender<T>);
+
+// Manual Clone impl because mpsc::Sender<T> is Clone without requiring T: Clone
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 /// Receiver for unbounded MPSC channel.
 ///
@@ -189,8 +195,14 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 // ============================================================================
 
 /// Sender for bounded MPSC channel.
-#[derive(Clone)]
 pub struct BoundedSender<T>(mpsc::SyncSender<T>);
+
+// Manual Clone impl because mpsc::SyncSender<T> is Clone without requiring T: Clone
+impl<T> Clone for BoundedSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 /// Receiver for bounded MPSC channel (same as unbounded).
 pub struct BoundedReceiver<T>(mpsc::Receiver<T>);

--- a/lib/kernel/src/sched/executor.rs
+++ b/lib/kernel/src/sched/executor.rs
@@ -1,0 +1,410 @@
+//! Synchronous task executor.
+//!
+//! Linux equivalent: Core scheduler in `kernel/sched/core.c`
+//!
+//! This module provides an executor for running tasks synchronously with
+//! panic handling. Tasks that panic are caught and marked as failed rather
+//! than crashing the entire runtime.
+//!
+//! # Panic Safety
+//!
+//! The executor wraps task execution in `catch_unwind`, ensuring that a
+//! panicking task doesn't bring down the entire editor. Failed tasks are
+//! marked as such and counted in statistics.
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::sched::{Executor, WorkQueue, Task};
+//! use std::sync::Arc;
+//!
+//! let queue = Arc::new(WorkQueue::new());
+//! let mut executor = Executor::new(Arc::clone(&queue));
+//!
+//! // Schedule some tasks
+//! queue.push(Task::new(|| println!("Task 1")));
+//! queue.push(Task::new(|| println!("Task 2")));
+//!
+//! // Process tasks
+//! let processed = executor.tick();
+//! assert_eq!(processed, 2);
+//! ```
+
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::Arc,
+};
+
+use super::{task::Task, work_queue::WorkQueue};
+
+/// Default batch size for processing.
+const DEFAULT_BATCH_SIZE: usize = 16;
+
+/// Task executor for synchronous task processing.
+///
+/// Provides a simple run-to-completion model where tasks are executed
+/// one at a time. Panics are caught to prevent runtime crashes.
+pub struct Executor {
+    /// Work queue for pending tasks.
+    work_queue: Arc<WorkQueue>,
+
+    /// Maximum tasks to process per tick.
+    batch_size: usize,
+
+    /// Total tasks successfully executed.
+    executed_count: u64,
+
+    /// Total tasks that failed (error or panic).
+    failed_count: u64,
+}
+
+impl Executor {
+    /// Create a new executor with a shared work queue.
+    #[must_use]
+    pub const fn new(work_queue: Arc<WorkQueue>) -> Self {
+        Self {
+            work_queue,
+            batch_size: DEFAULT_BATCH_SIZE,
+            executed_count: 0,
+            failed_count: 0,
+        }
+    }
+
+    /// Set the batch size for processing.
+    ///
+    /// The batch size limits how many tasks are processed per `tick()` call.
+    #[must_use]
+    pub fn with_batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size.max(1);
+        self
+    }
+
+    /// Process one tick (up to `batch_size` tasks).
+    ///
+    /// Returns the total number of tasks processed (successful + failed).
+    pub fn tick(&mut self) -> usize {
+        let mut processed = 0;
+
+        while processed < self.batch_size {
+            let Some(mut task) = self.work_queue.try_pop() else {
+                break;
+            };
+
+            if Self::execute_task(&mut task) {
+                self.executed_count += 1;
+            } else {
+                self.failed_count += 1;
+            }
+            processed += 1;
+        }
+
+        processed
+    }
+
+    /// Execute a single task with panic handling.
+    ///
+    /// Returns `true` if the task completed successfully, `false` if it
+    /// failed or panicked.
+    pub fn execute_task(task: &mut Task) -> bool {
+        // Wrap in catch_unwind to handle panics
+        let result = catch_unwind(AssertUnwindSafe(|| task.execute()));
+
+        match result {
+            Ok(Ok(())) => true,
+            Ok(Err(_)) => {
+                // Task returned an error
+                task.mark_failed();
+                false
+            }
+            Err(_panic) => {
+                // Task panicked
+                task.mark_failed();
+                false
+            }
+        }
+    }
+
+    /// Schedule a task for execution.
+    ///
+    /// Returns `false` if the queue is full.
+    #[must_use]
+    pub fn schedule(&self, task: Task) -> bool {
+        self.work_queue.push(task)
+    }
+
+    /// Schedule work using a closure.
+    ///
+    /// Convenience method that creates a task with normal priority.
+    pub fn spawn<F>(&self, work: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.schedule(Task::new(work))
+    }
+
+    /// Get the total number of successfully executed tasks.
+    #[inline]
+    #[must_use]
+    pub const fn executed_count(&self) -> u64 {
+        self.executed_count
+    }
+
+    /// Get the total number of failed tasks.
+    #[inline]
+    #[must_use]
+    pub const fn failed_count(&self) -> u64 {
+        self.failed_count
+    }
+
+    /// Check if there's pending work.
+    #[must_use]
+    pub fn has_pending(&self) -> bool {
+        !self.work_queue.is_empty()
+    }
+
+    /// Get the current batch size.
+    #[inline]
+    #[must_use]
+    pub const fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// Drain all pending tasks, executing each one.
+    ///
+    /// Returns the total number of tasks processed.
+    pub fn drain(&mut self) -> usize {
+        let mut total = 0;
+        while self.has_pending() {
+            total += self.tick();
+        }
+        total
+    }
+
+    /// Reset execution statistics.
+    pub const fn reset_stats(&mut self) {
+        self.executed_count = 0;
+        self.failed_count = 0;
+    }
+}
+
+impl std::fmt::Debug for Executor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Executor")
+            .field("batch_size", &self.batch_size)
+            .field("executed_count", &self.executed_count)
+            .field("failed_count", &self.failed_count)
+            .field("pending", &self.work_queue.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    fn make_executor() -> Executor {
+        Executor::new(Arc::new(WorkQueue::new()))
+    }
+
+    // === Basic tests ===
+
+    #[test]
+    fn test_new() {
+        let executor = make_executor();
+        assert_eq!(executor.batch_size(), DEFAULT_BATCH_SIZE);
+        assert_eq!(executor.executed_count(), 0);
+        assert_eq!(executor.failed_count(), 0);
+        assert!(!executor.has_pending());
+    }
+
+    #[test]
+    fn test_with_batch_size() {
+        let queue = Arc::new(WorkQueue::new());
+        let executor = Executor::new(queue).with_batch_size(5);
+        assert_eq!(executor.batch_size(), 5);
+    }
+
+    #[test]
+    fn test_batch_size_minimum() {
+        let queue = Arc::new(WorkQueue::new());
+        let executor = Executor::new(queue).with_batch_size(0);
+        assert_eq!(executor.batch_size(), 1); // Clamped to 1
+    }
+
+    // === Execution tests ===
+
+    #[test]
+    fn test_tick() {
+        let queue = Arc::new(WorkQueue::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..5 {
+            let counter_clone = Arc::clone(&counter);
+            queue.push(Task::new(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        let mut executor = Executor::new(queue);
+        let processed = executor.tick();
+
+        assert_eq!(processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(executor.executed_count(), 5);
+        assert_eq!(executor.failed_count(), 0);
+    }
+
+    #[test]
+    fn test_tick_batch_limit() {
+        let queue = Arc::new(WorkQueue::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..20 {
+            let counter_clone = Arc::clone(&counter);
+            queue.push(Task::new(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        let mut executor = Executor::new(Arc::clone(&queue)).with_batch_size(5);
+
+        // First tick processes 5
+        let processed = executor.tick();
+        assert_eq!(processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(queue.len(), 15);
+
+        // Second tick processes 5 more
+        let processed = executor.tick();
+        assert_eq!(processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+    }
+
+    #[test]
+    fn test_spawn() {
+        let queue = Arc::new(WorkQueue::new());
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let mut executor = Executor::new(Arc::clone(&queue));
+        assert!(executor.spawn(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        }));
+
+        executor.tick();
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    // === Panic handling tests ===
+
+    #[test]
+    fn test_panic_handling() {
+        let queue = Arc::new(WorkQueue::new());
+        let before_panic = Arc::new(AtomicBool::new(false));
+        let after_panic = Arc::new(AtomicBool::new(false));
+
+        let before_clone = Arc::clone(&before_panic);
+        let after_clone = Arc::clone(&after_panic);
+
+        // Task that runs before panic
+        queue.push(Task::new(move || {
+            before_clone.store(true, Ordering::SeqCst);
+        }));
+
+        // Task that panics
+        queue.push(Task::new(|| {
+            panic!("intentional panic for testing");
+        }));
+
+        // Task that runs after panic
+        queue.push(Task::new(move || {
+            after_clone.store(true, Ordering::SeqCst);
+        }));
+
+        let mut executor = Executor::new(queue);
+        let processed = executor.tick();
+
+        // All three tasks should have been processed
+        assert_eq!(processed, 3);
+        assert!(before_panic.load(Ordering::SeqCst));
+        assert!(after_panic.load(Ordering::SeqCst));
+
+        // One failed, two succeeded
+        assert_eq!(executor.executed_count(), 2);
+        assert_eq!(executor.failed_count(), 1);
+    }
+
+    #[test]
+    fn test_execute_task_success() {
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let mut task = Task::new(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+
+        assert!(Executor::execute_task(&mut task));
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_execute_task_panic() {
+        let mut task = Task::new(|| {
+            panic!("test panic");
+        });
+
+        assert!(!Executor::execute_task(&mut task));
+    }
+
+    // === Drain tests ===
+
+    #[test]
+    fn test_drain() {
+        let queue = Arc::new(WorkQueue::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..50 {
+            let counter_clone = Arc::clone(&counter);
+            queue.push(Task::new(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        let mut executor = Executor::new(queue).with_batch_size(10);
+        let total = executor.drain();
+
+        assert_eq!(total, 50);
+        assert_eq!(counter.load(Ordering::SeqCst), 50);
+        assert!(!executor.has_pending());
+    }
+
+    // === Stats tests ===
+
+    #[test]
+    fn test_reset_stats() {
+        let queue = Arc::new(WorkQueue::new());
+        queue.push(Task::new(|| {}));
+
+        let mut executor = Executor::new(queue);
+        executor.tick();
+        assert_eq!(executor.executed_count(), 1);
+
+        executor.reset_stats();
+        assert_eq!(executor.executed_count(), 0);
+        assert_eq!(executor.failed_count(), 0);
+    }
+
+    // === Debug tests ===
+
+    #[test]
+    fn test_debug() {
+        let executor = make_executor();
+        let debug_str = format!("{executor:?}");
+        assert!(debug_str.contains("Executor"));
+        assert!(debug_str.contains("batch_size"));
+        assert!(debug_str.contains("executed_count"));
+    }
+}

--- a/lib/kernel/src/sched/mod.rs
+++ b/lib/kernel/src/sched/mod.rs
@@ -2,6 +2,100 @@
 //!
 //! Linux equivalent: `kernel/sched/`
 //!
-//! Provides the main runtime loop, task execution, and work queues.
+//! This module provides the main runtime loop, task execution, and work queues.
+//! It is the heart of the editor's event coordination, managing:
+//!
+//! - **Runtime**: Central event loop coordinator
+//! - **Task**: Deferred work units with priorities
+//! - **`WorkQueue`**: Bounded task queue with overflow detection
+//! - **`PriorityQueue`**: Priority-ordered event queue
+//! - **Executor**: Synchronous task executor with panic handling
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌────────────────────────────────────────────────────────────┐
+//! │                         Runtime                            │
+//! │  ┌──────────────┐  ┌────────────┐  ┌────────────────────┐  │
+//! │  │ PriorityQueue│  │  WorkQueue │  │     Executor       │  │
+//! │  │   (events)   │  │   (tasks)  │  │ (panic handling)   │  │
+//! │  └──────┬───────┘  └──────┬─────┘  └──────────┬─────────┘  │
+//! │         │                 │                   │            │
+//! │         v                 v                   v            │
+//! │  ┌─────────────────────────────────────────────────────┐   │
+//! │  │                    EventBus                         │   │
+//! │  │              (type-erased dispatch)                 │   │
+//! │  └─────────────────────────────────────────────────────┘   │
+//! └────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::sched::{Runtime, RuntimeState, Task, Priority};
+//!
+//! // Create and boot runtime
+//! let mut runtime = Runtime::new();
+//! runtime.boot();
+//!
+//! // Schedule work
+//! runtime.schedule_work(|| println!("Hello from deferred task!"));
+//!
+//! // Schedule priority task
+//! runtime.schedule_work_with_priority(Priority::HIGH, || {
+//!     println!("High priority work!");
+//! });
+//!
+//! // Process all pending work
+//! while !runtime.is_idle() {
+//!     runtime.tick();
+//! }
+//!
+//! // Shutdown
+//! runtime.shutdown();
+//! assert_eq!(runtime.state(), RuntimeState::Stopping);
+//! ```
+//!
+//! # Panic Safety
+//!
+//! The executor wraps task execution in `catch_unwind`, ensuring that a
+//! panicking task doesn't bring down the entire editor. Failed tasks are
+//! marked as such and counted in statistics.
+//!
+//! ```
+//! use reovim_kernel::sched::Runtime;
+//!
+//! let mut runtime = Runtime::new();
+//! runtime.boot();
+//!
+//! // This panic won't crash the runtime
+//! runtime.schedule_work(|| panic!("intentional panic"));
+//!
+//! runtime.tick();
+//!
+//! let stats = runtime.stats();
+//! assert_eq!(stats.tasks_failed, 1);
+//! ```
 
-// Placeholder - Runtime, Executor, Task, WorkQueue will be added in Phase 2
+mod executor;
+mod priority;
+mod runtime;
+mod state;
+mod task;
+mod work_queue;
+
+// Re-export all public types
+pub use {
+    executor::Executor,
+    priority::{DEFAULT_CAPACITY as PRIORITY_QUEUE_DEFAULT_CAPACITY, PriorityQueue},
+    runtime::{
+        DEFAULT_BATCH_SIZE, DEFAULT_PRIORITY_QUEUE_CAPACITY, DEFAULT_WORK_QUEUE_CAPACITY, Runtime,
+        RuntimeCommand, RuntimeConfig, RuntimeStats,
+    },
+    state::RuntimeState,
+    task::{BoxedTask, Priority, Task, TaskId, TaskState},
+    work_queue::{
+        DEFAULT_CAPACITY as WORK_QUEUE_DEFAULT_CAPACITY, MAX_CAPACITY as WORK_QUEUE_MAX_CAPACITY,
+        WorkQueue,
+    },
+};

--- a/lib/kernel/src/sched/priority.rs
+++ b/lib/kernel/src/sched/priority.rs
@@ -1,0 +1,457 @@
+//! Priority queue for ordered event processing.
+//!
+//! Linux equivalent: Priority scheduling in `kernel/sched/`
+//!
+//! This module provides a priority-ordered queue for events. Events with
+//! lower priority values are processed first. Events with the same priority
+//! are processed in FIFO order.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_kernel::sched::PriorityQueue;
+//! use reovim_kernel::ipc::{DynEvent, Event};
+//!
+//! #[derive(Debug)]
+//! struct HighPriorityEvent;
+//! impl Event for HighPriorityEvent {
+//!     fn priority(&self) -> u32 { 0 }
+//! }
+//!
+//! #[derive(Debug)]
+//! struct LowPriorityEvent;
+//! impl Event for LowPriorityEvent {
+//!     fn priority(&self) -> u32 { 200 }
+//! }
+//!
+//! let queue = PriorityQueue::new();
+//!
+//! // Add events in reverse priority order
+//! queue.push(DynEvent::new(LowPriorityEvent));
+//! queue.push(DynEvent::new(HighPriorityEvent));
+//!
+//! // Pop returns highest priority (lowest value) first
+//! let event = queue.pop().unwrap();
+//! assert_eq!(event.priority(), 0); // HighPriorityEvent
+//! ```
+
+use std::{
+    cmp::Ordering,
+    collections::BinaryHeap,
+    sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
+};
+
+use crate::{arch::sync::Mutex, ipc::DynEvent};
+
+/// Default capacity for priority queue.
+pub const DEFAULT_CAPACITY: usize = 256;
+
+/// Entry in the priority queue.
+///
+/// Wraps a `DynEvent` with ordering metadata for the binary heap.
+struct PriorityEntry {
+    /// Event priority (from `Event::priority()`).
+    priority: u32,
+
+    /// Insertion sequence for FIFO ordering within same priority.
+    sequence: u64,
+
+    /// The event.
+    event: DynEvent,
+}
+
+impl PartialEq for PriorityEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority && self.sequence == other.sequence
+    }
+}
+
+impl Eq for PriorityEntry {}
+
+impl PartialOrd for PriorityEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PriorityEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is a max-heap, so we reverse the ordering:
+        // - Lower priority value = higher precedence (comes first)
+        // - For same priority, lower sequence = earlier (FIFO)
+        //
+        // We want: smaller priority → "greater" in heap terms
+        // We want: smaller sequence → "greater" in heap terms (for same priority)
+        match other.priority.cmp(&self.priority) {
+            Ordering::Equal => other.sequence.cmp(&self.sequence),
+            ord => ord,
+        }
+    }
+}
+
+/// Priority queue for events.
+///
+/// Maintains events in priority order with FIFO ordering for events
+/// of the same priority. Thread-safe via internal mutex.
+///
+/// # Ordering
+///
+/// Events are ordered by:
+/// 1. Priority (lower value = higher precedence)
+/// 2. Insertion order (earlier = higher precedence)
+///
+/// This ensures that high-priority events (like user input) are always
+/// processed before low-priority events (like render signals).
+pub struct PriorityQueue {
+    /// Heap storage.
+    heap: Mutex<BinaryHeap<PriorityEntry>>,
+
+    /// Sequence counter for FIFO ordering.
+    sequence: AtomicU64,
+
+    /// Maximum capacity (0 = unlimited).
+    capacity: usize,
+}
+
+impl PriorityQueue {
+    /// Create a new priority queue with default capacity.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Create a priority queue with specified capacity.
+    ///
+    /// A capacity of 0 means unlimited (not recommended).
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            heap: Mutex::new(BinaryHeap::with_capacity(capacity.min(4096))),
+            sequence: AtomicU64::new(0),
+            capacity,
+        }
+    }
+
+    /// Push an event onto the queue.
+    ///
+    /// Returns `false` if capacity is exceeded (event is dropped).
+    pub fn push(&self, event: DynEvent) -> bool {
+        let mut heap = self.heap.lock();
+
+        if self.capacity > 0 && heap.len() >= self.capacity {
+            return false;
+        }
+
+        let entry = PriorityEntry {
+            priority: event.priority(),
+            sequence: self.sequence.fetch_add(1, AtomicOrdering::Relaxed),
+            event,
+        };
+        heap.push(entry);
+        true
+    }
+
+    /// Pop the highest priority event.
+    ///
+    /// Returns `None` if the queue is empty.
+    #[must_use]
+    pub fn pop(&self) -> Option<DynEvent> {
+        self.heap.lock().pop().map(|e| e.event)
+    }
+
+    /// Peek at the priority of the next event without removing it.
+    ///
+    /// Returns `None` if the queue is empty.
+    #[must_use]
+    pub fn peek_priority(&self) -> Option<u32> {
+        self.heap.lock().peek().map(|e| e.priority)
+    }
+
+    /// Get the number of events in the queue.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.heap.lock().len()
+    }
+
+    /// Check if the queue is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.heap.lock().is_empty()
+    }
+
+    /// Get the queue capacity.
+    #[inline]
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Clear all events from the queue.
+    pub fn clear(&self) {
+        self.heap.lock().clear();
+    }
+
+    /// Drain all events from the queue in priority order.
+    ///
+    /// Returns events sorted by priority (highest first).
+    #[must_use]
+    pub fn drain(&self) -> Vec<DynEvent> {
+        let mut heap = self.heap.lock();
+        let mut result = Vec::with_capacity(heap.len());
+        while let Some(entry) = heap.pop() {
+            result.push(entry.event);
+        }
+        result
+    }
+}
+
+impl Default for PriorityQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for PriorityQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PriorityQueue")
+            .field("len", &self.len())
+            .field("capacity", &self.capacity)
+            .field("peek_priority", &self.peek_priority())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::ipc::Event};
+
+    // Test event types with different priorities
+    #[derive(Debug)]
+    struct CriticalEvent;
+    impl Event for CriticalEvent {
+        fn priority(&self) -> u32 {
+            0
+        }
+    }
+
+    #[derive(Debug)]
+    struct HighEvent;
+    impl Event for HighEvent {
+        fn priority(&self) -> u32 {
+            50
+        }
+    }
+
+    #[derive(Debug)]
+    struct NormalEvent(u32);
+    impl Event for NormalEvent {
+        fn priority(&self) -> u32 {
+            100
+        }
+    }
+
+    #[derive(Debug)]
+    struct LowEvent;
+    impl Event for LowEvent {
+        fn priority(&self) -> u32 {
+            200
+        }
+    }
+
+    // === Basic tests ===
+
+    #[test]
+    fn test_new() {
+        let queue = PriorityQueue::new();
+        assert_eq!(queue.capacity(), DEFAULT_CAPACITY);
+        assert!(queue.is_empty());
+        assert_eq!(queue.len(), 0);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let queue = PriorityQueue::with_capacity(100);
+        assert_eq!(queue.capacity(), 100);
+    }
+
+    #[test]
+    fn test_push_and_pop() {
+        let queue = PriorityQueue::new();
+        queue.push(DynEvent::new(NormalEvent(1)));
+        assert_eq!(queue.len(), 1);
+
+        let event = queue.pop().unwrap();
+        assert_eq!(event.priority(), 100);
+        assert!(queue.is_empty());
+    }
+
+    // === Priority ordering tests ===
+
+    #[test]
+    fn test_priority_ordering() {
+        let queue = PriorityQueue::new();
+
+        // Add events in reverse priority order
+        queue.push(DynEvent::new(LowEvent));
+        queue.push(DynEvent::new(NormalEvent(1)));
+        queue.push(DynEvent::new(HighEvent));
+        queue.push(DynEvent::new(CriticalEvent));
+
+        // Pop should return in priority order (lowest value first)
+        assert_eq!(queue.pop().unwrap().priority(), 0); // Critical
+        assert_eq!(queue.pop().unwrap().priority(), 50); // High
+        assert_eq!(queue.pop().unwrap().priority(), 100); // Normal
+        assert_eq!(queue.pop().unwrap().priority(), 200); // Low
+    }
+
+    #[test]
+    fn test_fifo_same_priority() {
+        let queue = PriorityQueue::new();
+
+        // Add multiple events with same priority
+        for i in 0..5 {
+            queue.push(DynEvent::new(NormalEvent(i)));
+        }
+
+        // Should pop in FIFO order
+        for i in 0..5 {
+            let event = queue.pop().unwrap();
+            let inner = event.downcast_ref::<NormalEvent>().unwrap();
+            assert_eq!(inner.0, i);
+        }
+    }
+
+    #[test]
+    fn test_mixed_priority_fifo() {
+        let queue = PriorityQueue::new();
+
+        // Add interleaved events
+        queue.push(DynEvent::new(NormalEvent(1)));
+        queue.push(DynEvent::new(HighEvent));
+        queue.push(DynEvent::new(NormalEvent(2)));
+        queue.push(DynEvent::new(LowEvent));
+        queue.push(DynEvent::new(NormalEvent(3)));
+
+        // High priority first
+        assert_eq!(queue.pop().unwrap().priority(), 50);
+
+        // Then normal priority in FIFO order
+        for expected in [1, 2, 3] {
+            let event = queue.pop().unwrap();
+            let inner = event.downcast_ref::<NormalEvent>().unwrap();
+            assert_eq!(inner.0, expected);
+        }
+
+        // Then low priority
+        assert_eq!(queue.pop().unwrap().priority(), 200);
+    }
+
+    // === Peek tests ===
+
+    #[test]
+    fn test_peek_priority() {
+        let queue = PriorityQueue::new();
+        assert!(queue.peek_priority().is_none());
+
+        queue.push(DynEvent::new(LowEvent));
+        assert_eq!(queue.peek_priority(), Some(200));
+
+        queue.push(DynEvent::new(HighEvent));
+        assert_eq!(queue.peek_priority(), Some(50));
+
+        // Peek shouldn't remove
+        assert_eq!(queue.len(), 2);
+    }
+
+    // === Capacity tests ===
+
+    #[test]
+    fn test_capacity_overflow() {
+        let queue = PriorityQueue::with_capacity(3);
+
+        assert!(queue.push(DynEvent::new(NormalEvent(1))));
+        assert!(queue.push(DynEvent::new(NormalEvent(2))));
+        assert!(queue.push(DynEvent::new(NormalEvent(3))));
+        assert!(!queue.push(DynEvent::new(NormalEvent(4)))); // Should fail
+
+        assert_eq!(queue.len(), 3);
+    }
+
+    // === Drain tests ===
+
+    #[test]
+    fn test_drain() {
+        let queue = PriorityQueue::new();
+
+        queue.push(DynEvent::new(LowEvent));
+        queue.push(DynEvent::new(HighEvent));
+        queue.push(DynEvent::new(NormalEvent(1)));
+
+        let events = queue.drain();
+        assert_eq!(events.len(), 3);
+        assert!(queue.is_empty());
+
+        // Should be in priority order
+        assert_eq!(events[0].priority(), 50);
+        assert_eq!(events[1].priority(), 100);
+        assert_eq!(events[2].priority(), 200);
+    }
+
+    // === Clear tests ===
+
+    #[test]
+    fn test_clear() {
+        let queue = PriorityQueue::new();
+
+        for _ in 0..5 {
+            queue.push(DynEvent::new(NormalEvent(0)));
+        }
+
+        queue.clear();
+        assert!(queue.is_empty());
+    }
+
+    // === Debug tests ===
+
+    #[test]
+    fn test_debug() {
+        let queue = PriorityQueue::with_capacity(100);
+        queue.push(DynEvent::new(NormalEvent(1)));
+        let debug_str = format!("{queue:?}");
+        assert!(debug_str.contains("PriorityQueue"));
+        assert!(debug_str.contains("len"));
+    }
+
+    // === Send + Sync tests ===
+
+    #[test]
+    fn test_priority_queue_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PriorityQueue>();
+    }
+
+    // === Concurrent tests ===
+
+    #[test]
+    fn test_concurrent_push() {
+        use std::{sync::Arc, thread};
+
+        let queue = Arc::new(PriorityQueue::with_capacity(1000));
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let queue_clone = Arc::clone(&queue);
+            handles.push(thread::spawn(move || {
+                for _ in 0..50 {
+                    queue_clone.push(DynEvent::new(NormalEvent(0)));
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(queue.len(), 500);
+    }
+}

--- a/lib/kernel/src/sched/runtime.rs
+++ b/lib/kernel/src/sched/runtime.rs
@@ -1,0 +1,800 @@
+//! Runtime event loop coordinator.
+//!
+//! Linux equivalent: Main scheduler in `kernel/sched/core.c`
+//!
+//! The [`Runtime`] is the central coordinator for event processing and task
+//! execution. It manages the event loop lifecycle, processes events from the
+//! priority queue, and executes deferred tasks.
+//!
+//! # Design Philosophy
+//!
+//! - **Pure coordination**: Runtime doesn't own business logic, just orchestrates
+//! - **Sync execution**: All processing happens synchronously (async is driver responsibility)
+//! - **Panic safety**: Tasks that panic are caught and don't crash the runtime
+//! - **Graceful shutdown**: Supports clean shutdown with work draining
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::sched::{Runtime, RuntimeState};
+//!
+//! let mut runtime = Runtime::new();
+//! runtime.boot();
+//!
+//! // Schedule some work
+//! runtime.schedule_work(|| println!("Deferred work!"));
+//!
+//! // Process pending work and check if idle
+//! runtime.tick();
+//! assert!(runtime.is_idle());
+//!
+//! // Request shutdown
+//! runtime.shutdown();
+//! assert_eq!(runtime.state(), RuntimeState::Stopping);
+//! ```
+
+use std::sync::Arc;
+
+use {
+    super::{
+        executor::Executor,
+        priority::PriorityQueue,
+        state::RuntimeState,
+        task::{Priority, Task},
+        work_queue::WorkQueue,
+    },
+    crate::ipc::{DynEvent, EventBus, EventScope, Receiver, Sender, channel},
+};
+
+/// Default work queue capacity.
+pub const DEFAULT_WORK_QUEUE_CAPACITY: usize = 1024;
+
+/// Default priority queue capacity.
+pub const DEFAULT_PRIORITY_QUEUE_CAPACITY: usize = 256;
+
+/// Default batch size for task execution.
+pub const DEFAULT_BATCH_SIZE: usize = 16;
+
+/// Runtime configuration.
+///
+/// Used with [`Runtime::with_config()`] to customize runtime behavior.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::sched::{Runtime, RuntimeConfig};
+///
+/// let config = RuntimeConfig {
+///     work_queue_capacity: 2048,
+///     priority_queue_capacity: 512,
+///     batch_size: 32,
+/// };
+///
+/// let runtime = Runtime::with_config(config);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeConfig {
+    /// Maximum tasks in the work queue.
+    pub work_queue_capacity: usize,
+
+    /// Maximum events in the priority queue.
+    pub priority_queue_capacity: usize,
+
+    /// Maximum tasks processed per tick.
+    pub batch_size: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            work_queue_capacity: DEFAULT_WORK_QUEUE_CAPACITY,
+            priority_queue_capacity: DEFAULT_PRIORITY_QUEUE_CAPACITY,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+}
+
+/// Commands that can be sent to the runtime.
+///
+/// Used for external control of the runtime lifecycle.
+#[derive(Debug)]
+pub enum RuntimeCommand {
+    /// Request graceful shutdown.
+    Shutdown,
+
+    /// Request emergency stop (panic recovery).
+    Emergency,
+
+    /// Schedule a task for execution.
+    ScheduleTask(Task),
+}
+
+/// Runtime execution statistics.
+///
+/// Provides insight into runtime operation for monitoring and debugging.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeStats {
+    /// Current runtime state.
+    pub state: RuntimeState,
+
+    /// Number of events in the priority queue.
+    pub event_queue_len: usize,
+
+    /// Number of tasks in the work queue.
+    pub work_queue_len: usize,
+
+    /// Number of tasks dropped due to overflow.
+    pub work_dropped: usize,
+
+    /// Total tasks successfully executed.
+    pub tasks_executed: u64,
+
+    /// Total tasks that failed (error or panic).
+    pub tasks_failed: u64,
+}
+
+/// Runtime event loop coordinator.
+///
+/// The `Runtime` manages the main event loop, coordinating between:
+/// - Event processing (via [`PriorityQueue`] and [`EventBus`])
+/// - Task execution (via [`WorkQueue`] and [`Executor`])
+/// - Lifecycle management (boot, run, shutdown)
+///
+/// # Thread Safety
+///
+/// The runtime itself is `Send` but not `Sync` - it should be owned by a
+/// single thread that drives the event loop. However, the command channel
+/// and work queue can be accessed from other threads for scheduling.
+///
+/// # State Transitions
+///
+/// ```text
+/// Booting → Running → Stopping
+///    ↓         ↓          ↓
+///    └─────────┴──────────┴→ Emergency
+/// ```
+pub struct Runtime {
+    /// Current lifecycle state.
+    state: RuntimeState,
+
+    /// Event bus for pub/sub communication.
+    event_bus: Arc<EventBus>,
+
+    /// Priority queue for ordered event processing.
+    event_queue: PriorityQueue,
+
+    /// Work queue for deferred tasks.
+    work_queue: Arc<WorkQueue>,
+
+    /// Task executor with panic handling.
+    executor: Executor,
+
+    /// Sender for runtime commands.
+    command_tx: Sender<RuntimeCommand>,
+
+    /// Receiver for runtime commands.
+    command_rx: Receiver<RuntimeCommand>,
+
+    /// Whether a render is pending.
+    render_pending: bool,
+
+    /// Current event scope for lifecycle tracking.
+    current_scope: Option<EventScope>,
+}
+
+impl Runtime {
+    /// Create a new runtime with default configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_config(RuntimeConfig::default())
+    }
+
+    /// Create a runtime with custom configuration.
+    #[must_use]
+    pub fn with_config(config: RuntimeConfig) -> Self {
+        let work_queue = Arc::new(WorkQueue::with_capacity(config.work_queue_capacity));
+        let executor = Executor::new(Arc::clone(&work_queue)).with_batch_size(config.batch_size);
+        let event_queue = PriorityQueue::with_capacity(config.priority_queue_capacity);
+        let (command_tx, command_rx) = channel();
+
+        Self {
+            state: RuntimeState::Booting,
+            event_bus: Arc::new(EventBus::new()),
+            event_queue,
+            work_queue,
+            executor,
+            command_tx,
+            command_rx,
+            render_pending: false,
+            current_scope: None,
+        }
+    }
+
+    /// Create a runtime with a shared event bus.
+    ///
+    /// This is useful when the event bus is shared with other subsystems.
+    #[must_use]
+    pub fn with_event_bus(mut self, event_bus: Arc<EventBus>) -> Self {
+        self.event_bus = event_bus;
+        self
+    }
+
+    /// Boot the runtime, transitioning from `Booting` to `Running`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called when not in `Booting` state.
+    pub fn boot(&mut self) {
+        assert_eq!(self.state, RuntimeState::Booting, "boot() called when not in Booting state");
+        self.state = RuntimeState::Running;
+    }
+
+    /// Get the current runtime state.
+    #[inline]
+    #[must_use]
+    pub const fn state(&self) -> RuntimeState {
+        self.state
+    }
+
+    /// Get a reference to the event bus.
+    #[inline]
+    #[must_use]
+    pub const fn event_bus(&self) -> &Arc<EventBus> {
+        &self.event_bus
+    }
+
+    /// Get a clone of the command sender.
+    ///
+    /// The sender can be used from other threads to send commands.
+    #[must_use]
+    pub fn command_sender(&self) -> Sender<RuntimeCommand> {
+        self.command_tx.clone()
+    }
+
+    /// Process one tick of the event loop.
+    ///
+    /// This method:
+    /// 1. Processes runtime commands
+    /// 2. Dispatches events from the priority queue
+    /// 3. Executes tasks from the work queue
+    /// 4. Processes queued async events
+    ///
+    /// Returns `true` if the runtime should continue, `false` if it should stop.
+    pub fn tick(&mut self) -> bool {
+        // Process commands first
+        self.process_commands();
+
+        // Check if we should stop
+        if self.state.is_terminal() {
+            // Drain remaining work before stopping (graceful shutdown)
+            if self.state == RuntimeState::Stopping {
+                self.executor.drain();
+            }
+            return false;
+        }
+
+        // Only process work when running
+        if self.state.is_running() {
+            // Dispatch events from priority queue
+            self.dispatch_events();
+
+            // Execute tasks from work queue
+            self.executor.tick();
+
+            // Process queued async events
+            let _ = self.event_bus.process_queue();
+        }
+
+        true
+    }
+
+    /// Process pending runtime commands.
+    fn process_commands(&mut self) {
+        while let Ok(command) = self.command_rx.try_recv() {
+            match command {
+                RuntimeCommand::Shutdown => {
+                    if self.state == RuntimeState::Running {
+                        self.state = RuntimeState::Stopping;
+                    }
+                }
+                RuntimeCommand::Emergency => {
+                    self.state = RuntimeState::Emergency;
+                }
+                RuntimeCommand::ScheduleTask(task) => {
+                    if self.state.can_accept_work() {
+                        self.work_queue.push(task);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Dispatch events from the priority queue to handlers.
+    fn dispatch_events(&self) {
+        while let Some(event) = self.event_queue.pop() {
+            let _result = self.event_bus.dispatch(&event);
+            // Decrement scope if present
+            if let Some(ref scope) = self.current_scope
+                && scope.in_flight() > 0
+            {
+                scope.decrement();
+            }
+        }
+    }
+
+    /// Schedule a closure for deferred execution.
+    ///
+    /// Returns `false` if the queue is full or runtime is not accepting work.
+    pub fn schedule_work<F>(&self, work: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        if !self.state.can_accept_work() {
+            return false;
+        }
+        self.work_queue.push(Task::new(work))
+    }
+
+    /// Schedule a closure with specific priority.
+    ///
+    /// Returns `false` if the queue is full or runtime is not accepting work.
+    pub fn schedule_work_with_priority<F>(&self, priority: Priority, work: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        if !self.state.can_accept_work() {
+            return false;
+        }
+        self.work_queue.push(Task::with_priority(priority, work))
+    }
+
+    /// Schedule a pre-built task for execution.
+    ///
+    /// Returns `false` if the queue is full or runtime is not accepting work.
+    pub fn schedule_task(&self, task: Task) -> bool {
+        if !self.state.can_accept_work() {
+            return false;
+        }
+        self.work_queue.push(task)
+    }
+
+    /// Queue an event for priority-ordered processing.
+    ///
+    /// Returns `false` if the queue is full.
+    pub fn queue_event(&self, event: DynEvent) -> bool {
+        self.event_queue.push(event)
+    }
+
+    /// Request a render on the next tick.
+    pub const fn request_render(&mut self) {
+        self.render_pending = true;
+    }
+
+    /// Check and clear the render pending flag.
+    ///
+    /// Returns `true` if a render was requested since the last call.
+    pub const fn take_render_pending(&mut self) -> bool {
+        let pending = self.render_pending;
+        self.render_pending = false;
+        pending
+    }
+
+    /// Check if a render is pending.
+    #[inline]
+    #[must_use]
+    pub const fn is_render_pending(&self) -> bool {
+        self.render_pending
+    }
+
+    /// Set the current event scope for lifecycle tracking.
+    pub fn set_scope(&mut self, scope: EventScope) {
+        self.current_scope = Some(scope);
+    }
+
+    /// Clear the current event scope.
+    pub fn clear_scope(&mut self) {
+        self.current_scope = None;
+    }
+
+    /// Get a reference to the current scope.
+    #[must_use]
+    pub const fn current_scope(&self) -> Option<&EventScope> {
+        self.current_scope.as_ref()
+    }
+
+    /// Request graceful shutdown.
+    ///
+    /// The runtime will finish processing current work before stopping.
+    pub fn shutdown(&mut self) {
+        if self.state == RuntimeState::Running {
+            self.state = RuntimeState::Stopping;
+        }
+    }
+
+    /// Request emergency stop.
+    ///
+    /// The runtime will stop immediately without draining work.
+    pub const fn emergency_stop(&mut self) {
+        self.state = RuntimeState::Emergency;
+    }
+
+    /// Check if the runtime is idle (no pending work).
+    #[must_use]
+    pub fn is_idle(&self) -> bool {
+        self.event_queue.is_empty() && self.work_queue.is_empty() && self.event_bus.queue_is_empty()
+    }
+
+    /// Get runtime statistics.
+    #[must_use]
+    pub fn stats(&self) -> RuntimeStats {
+        RuntimeStats {
+            state: self.state,
+            event_queue_len: self.event_queue.len(),
+            work_queue_len: self.work_queue.len(),
+            work_dropped: self.work_queue.dropped_count(),
+            tasks_executed: self.executor.executed_count(),
+            tasks_failed: self.executor.failed_count(),
+        }
+    }
+
+    /// Get a reference to the work queue.
+    ///
+    /// This allows external code to schedule tasks directly.
+    #[must_use]
+    pub const fn work_queue(&self) -> &Arc<WorkQueue> {
+        &self.work_queue
+    }
+
+    /// Run until the runtime stops.
+    ///
+    /// This is a convenience method that calls `tick()` in a loop.
+    /// For more control, use `tick()` directly.
+    pub fn run(&mut self) {
+        while self.tick() {}
+    }
+}
+
+impl Default for Runtime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Runtime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Runtime")
+            .field("state", &self.state)
+            .field("event_queue_len", &self.event_queue.len())
+            .field("work_queue_len", &self.work_queue.len())
+            .field("render_pending", &self.render_pending)
+            .field("has_scope", &self.current_scope.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    // === Basic tests ===
+
+    #[test]
+    fn test_runtime_new() {
+        let runtime = Runtime::new();
+        assert_eq!(runtime.state(), RuntimeState::Booting);
+        assert!(runtime.is_idle());
+    }
+
+    #[test]
+    fn test_runtime_with_config() {
+        let config = RuntimeConfig {
+            work_queue_capacity: 100,
+            priority_queue_capacity: 50,
+            batch_size: 8,
+        };
+        let runtime = Runtime::with_config(config);
+        assert_eq!(runtime.state(), RuntimeState::Booting);
+    }
+
+    #[test]
+    fn test_runtime_boot() {
+        let mut runtime = Runtime::new();
+        assert_eq!(runtime.state(), RuntimeState::Booting);
+
+        runtime.boot();
+        assert_eq!(runtime.state(), RuntimeState::Running);
+    }
+
+    #[test]
+    #[should_panic(expected = "boot() called when not in Booting state")]
+    fn test_runtime_boot_twice_panics() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        runtime.boot(); // Should panic
+    }
+
+    // === Shutdown tests ===
+
+    #[test]
+    fn test_runtime_shutdown() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        assert_eq!(runtime.state(), RuntimeState::Running);
+
+        runtime.shutdown();
+        assert_eq!(runtime.state(), RuntimeState::Stopping);
+    }
+
+    #[test]
+    fn test_runtime_emergency_stop() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        runtime.emergency_stop();
+        assert_eq!(runtime.state(), RuntimeState::Emergency);
+    }
+
+    #[test]
+    fn test_runtime_shutdown_via_command() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let sender = runtime.command_sender();
+        sender.send(RuntimeCommand::Shutdown).unwrap();
+
+        runtime.tick();
+        assert_eq!(runtime.state(), RuntimeState::Stopping);
+    }
+
+    // === Task scheduling tests ===
+
+    #[test]
+    fn test_runtime_schedule_work() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        assert!(runtime.schedule_work(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        }));
+
+        runtime.tick();
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_runtime_schedule_work_not_running() {
+        let runtime = Runtime::new(); // Still booting
+        assert!(!runtime.schedule_work(|| {}));
+    }
+
+    #[test]
+    fn test_runtime_schedule_task() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let task = Task::new(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+
+        assert!(runtime.schedule_task(task));
+        runtime.tick();
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_runtime_schedule_work_with_priority() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let order1 = Arc::clone(&order);
+        runtime.schedule_work_with_priority(Priority::LOW, move || {
+            order1.lock().unwrap().push("low");
+        });
+
+        let order2 = Arc::clone(&order);
+        runtime.schedule_work_with_priority(Priority::HIGH, move || {
+            order2.lock().unwrap().push("high");
+        });
+
+        // Note: WorkQueue is FIFO, not priority-ordered
+        // Priority only matters for tasks in PriorityQueue
+        runtime.tick();
+        runtime.tick();
+
+        let result = order.lock().unwrap().clone();
+        // Tasks are executed in FIFO order from WorkQueue
+        assert_eq!(result.len(), 2);
+    }
+
+    // === Render pending tests ===
+
+    #[test]
+    fn test_runtime_render_pending() {
+        let mut runtime = Runtime::new();
+
+        assert!(!runtime.is_render_pending());
+
+        runtime.request_render();
+        assert!(runtime.is_render_pending());
+
+        assert!(runtime.take_render_pending());
+        assert!(!runtime.is_render_pending());
+    }
+
+    // === Scope tests ===
+
+    #[test]
+    fn test_runtime_scope() {
+        let mut runtime = Runtime::new();
+        assert!(runtime.current_scope().is_none());
+
+        let scope = EventScope::new();
+        runtime.set_scope(scope);
+        assert!(runtime.current_scope().is_some());
+
+        runtime.clear_scope();
+        assert!(runtime.current_scope().is_none());
+    }
+
+    // === Idle tests ===
+
+    #[test]
+    fn test_runtime_is_idle() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        assert!(runtime.is_idle());
+
+        runtime.schedule_work(|| {});
+        assert!(!runtime.is_idle());
+
+        runtime.tick();
+        assert!(runtime.is_idle());
+    }
+
+    // === Stats tests ===
+
+    #[test]
+    fn test_runtime_stats() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        runtime.schedule_work(|| {});
+        runtime.schedule_work(|| panic!("intentional panic"));
+
+        let stats = runtime.stats();
+        assert_eq!(stats.state, RuntimeState::Running);
+        assert_eq!(stats.work_queue_len, 2);
+        assert_eq!(stats.tasks_executed, 0);
+
+        runtime.tick();
+
+        let stats = runtime.stats();
+        assert_eq!(stats.work_queue_len, 0);
+        // One succeeded, one failed
+        assert_eq!(stats.tasks_executed, 1);
+        assert_eq!(stats.tasks_failed, 1);
+    }
+
+    // === Tick behavior tests ===
+
+    #[test]
+    fn test_runtime_tick_returns_false_on_stop() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        assert!(runtime.tick());
+
+        runtime.shutdown();
+        assert!(!runtime.tick());
+    }
+
+    #[test]
+    fn test_runtime_tick_drains_on_shutdown() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..5 {
+            let counter_clone = Arc::clone(&counter);
+            runtime.schedule_work(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+
+        runtime.shutdown();
+        runtime.tick(); // Should drain all tasks
+
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+    }
+
+    // === Run tests ===
+
+    #[test]
+    fn test_runtime_run() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        // Schedule work that will trigger shutdown
+        runtime.schedule_work(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        // Send shutdown command
+        let sender = runtime.command_sender();
+        sender.send(RuntimeCommand::Shutdown).unwrap();
+
+        runtime.run();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert!(runtime.state().is_shutting_down());
+    }
+
+    // === Debug tests ===
+
+    #[test]
+    fn test_runtime_debug() {
+        let runtime = Runtime::new();
+        let debug_str = format!("{runtime:?}");
+        assert!(debug_str.contains("Runtime"));
+        assert!(debug_str.contains("Booting"));
+    }
+
+    // === Event bus integration ===
+
+    #[test]
+    fn test_runtime_with_event_bus() {
+        let bus = Arc::new(EventBus::new());
+        let bus_clone = Arc::clone(&bus);
+
+        let runtime = Runtime::new().with_event_bus(bus);
+
+        // Both should point to the same EventBus
+        assert!(Arc::ptr_eq(runtime.event_bus(), &bus_clone));
+    }
+
+    // === Command channel tests ===
+
+    #[test]
+    fn test_runtime_command_schedule_task() {
+        let mut runtime = Runtime::new();
+        runtime.boot();
+
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let task = Task::new(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+
+        let sender = runtime.command_sender();
+        sender.send(RuntimeCommand::ScheduleTask(task)).unwrap();
+
+        runtime.tick();
+        runtime.tick(); // Need second tick to execute the scheduled task
+
+        assert!(executed.load(Ordering::SeqCst));
+    }
+
+    // === Send test ===
+
+    #[test]
+    fn test_runtime_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Runtime>();
+    }
+}

--- a/lib/kernel/src/sched/state.rs
+++ b/lib/kernel/src/sched/state.rs
@@ -1,0 +1,172 @@
+//! Runtime lifecycle state machine.
+//!
+//! Linux equivalent: Task states in `kernel/sched/sched.h`
+//!
+//! The runtime transitions through these states during its lifecycle:
+//! - `Booting` -> `Running` -> `Stopping`
+//! - Any state can transition to `Emergency` on panic
+
+/// Runtime lifecycle state.
+///
+/// Represents the current operating mode of the scheduler runtime.
+///
+/// # State Transitions
+///
+/// ```text
+/// ┌─────────┐     ┌─────────┐     ┌──────────┐
+/// │ Booting │────>│ Running │────>│ Stopping │
+/// └─────────┘     └─────────┘     └──────────┘
+///      │               │               │
+///      └───────────────┴───────────────┘
+///                      │
+///                      v
+///               ┌───────────┐
+///               │ Emergency │
+///               └───────────┘
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum RuntimeState {
+    /// Initializing subsystems, loading modules.
+    ///
+    /// Linux equivalent: `TASK_NEW`
+    #[default]
+    Booting,
+
+    /// Normal operation, processing events.
+    ///
+    /// Linux equivalent: `TASK_RUNNING`
+    Running,
+
+    /// Graceful shutdown in progress.
+    ///
+    /// Remaining work is drained before full stop.
+    ///
+    /// Linux equivalent: `TASK_STOPPED`
+    Stopping,
+
+    /// Emergency shutdown (panic recovery mode).
+    ///
+    /// No new work accepted, cleanup only.
+    ///
+    /// Linux equivalent: Kernel oops handling
+    Emergency,
+}
+
+impl RuntimeState {
+    /// Check if runtime is in the running state.
+    ///
+    /// Only in `Running` state can new work be accepted.
+    #[inline]
+    #[must_use]
+    pub const fn is_running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    /// Check if shutdown is in progress.
+    ///
+    /// Returns `true` for both `Stopping` and `Emergency` states.
+    #[inline]
+    #[must_use]
+    pub const fn is_shutting_down(&self) -> bool {
+        matches!(self, Self::Stopping | Self::Emergency)
+    }
+
+    /// Check if runtime can accept new work.
+    ///
+    /// Equivalent to `is_running()` - only running runtime accepts work.
+    #[inline]
+    #[must_use]
+    pub const fn can_accept_work(&self) -> bool {
+        self.is_running()
+    }
+
+    /// Check if this is a terminal state.
+    ///
+    /// Terminal states indicate the runtime should stop its main loop.
+    #[inline]
+    #[must_use]
+    pub const fn is_terminal(&self) -> bool {
+        matches!(self, Self::Stopping | Self::Emergency)
+    }
+}
+
+impl std::fmt::Display for RuntimeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Booting => write!(f, "Booting"),
+            Self::Running => write!(f, "Running"),
+            Self::Stopping => write!(f, "Stopping"),
+            Self::Emergency => write!(f, "Emergency"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_state() {
+        assert_eq!(RuntimeState::default(), RuntimeState::Booting);
+    }
+
+    #[test]
+    fn test_is_running() {
+        assert!(!RuntimeState::Booting.is_running());
+        assert!(RuntimeState::Running.is_running());
+        assert!(!RuntimeState::Stopping.is_running());
+        assert!(!RuntimeState::Emergency.is_running());
+    }
+
+    #[test]
+    fn test_is_shutting_down() {
+        assert!(!RuntimeState::Booting.is_shutting_down());
+        assert!(!RuntimeState::Running.is_shutting_down());
+        assert!(RuntimeState::Stopping.is_shutting_down());
+        assert!(RuntimeState::Emergency.is_shutting_down());
+    }
+
+    #[test]
+    fn test_can_accept_work() {
+        assert!(!RuntimeState::Booting.can_accept_work());
+        assert!(RuntimeState::Running.can_accept_work());
+        assert!(!RuntimeState::Stopping.can_accept_work());
+        assert!(!RuntimeState::Emergency.can_accept_work());
+    }
+
+    #[test]
+    fn test_is_terminal() {
+        assert!(!RuntimeState::Booting.is_terminal());
+        assert!(!RuntimeState::Running.is_terminal());
+        assert!(RuntimeState::Stopping.is_terminal());
+        assert!(RuntimeState::Emergency.is_terminal());
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", RuntimeState::Booting), "Booting");
+        assert_eq!(format!("{}", RuntimeState::Running), "Running");
+        assert_eq!(format!("{}", RuntimeState::Stopping), "Stopping");
+        assert_eq!(format!("{}", RuntimeState::Emergency), "Emergency");
+    }
+
+    #[test]
+    fn test_clone_and_copy() {
+        let state = RuntimeState::Running;
+        let cloned = state.clone();
+        let copied = state;
+        assert_eq!(state, cloned);
+        assert_eq!(state, copied);
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(RuntimeState::Booting);
+        set.insert(RuntimeState::Running);
+        assert!(set.contains(&RuntimeState::Booting));
+        assert!(set.contains(&RuntimeState::Running));
+        assert!(!set.contains(&RuntimeState::Stopping));
+    }
+}

--- a/lib/kernel/src/sched/task.rs
+++ b/lib/kernel/src/sched/task.rs
@@ -1,0 +1,591 @@
+//! Task abstraction for deferred work units.
+//!
+//! Linux equivalent: `kernel/sched/core.c` `task_struct`
+//!
+//! This module provides the [`Task`] type for encapsulating units of work
+//! to be executed by the scheduler. Tasks are the fundamental unit of
+//! deferred execution in the kernel.
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::sched::{Task, Priority};
+//!
+//! // Create a task with default (normal) priority
+//! let task = Task::new(|| {
+//!     println!("Task executed!");
+//! });
+//!
+//! // Create a high-priority task
+//! let urgent = Task::with_priority(Priority::HIGH, || {
+//!     println!("Urgent work!");
+//! });
+//! ```
+
+use std::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+/// Unique task identifier.
+///
+/// Task IDs are monotonically increasing and never reused within a session.
+/// This follows the same pattern as [`BufferId`](crate::mm::BufferId) and
+/// [`ScopeId`](crate::ipc::ScopeId).
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::sched::TaskId;
+///
+/// let id1 = TaskId::new();
+/// let id2 = TaskId::new();
+/// assert_ne!(id1, id2);
+/// assert!(id2.as_u64() > id1.as_u64());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TaskId(u64);
+
+impl TaskId {
+    /// Create a new unique task ID.
+    ///
+    /// IDs start at 1 and increment monotonically.
+    #[must_use]
+    pub fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        Self(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw numeric value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Create from raw value.
+    ///
+    /// Primarily for testing and deserialization.
+    #[inline]
+    #[must_use]
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl Default for TaskId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Task({})", self.0)
+    }
+}
+
+/// Task execution priority.
+///
+/// Lower values indicate higher priority (processed sooner).
+/// This follows the convention where 0 is the highest priority.
+///
+/// # Priority Levels
+///
+/// | Level | Value | Use Case |
+/// |-------|-------|----------|
+/// | `CRITICAL` | 0 | Kernel-internal, mode changes |
+/// | `HIGH` | 50 | User input, commands |
+/// | `NORMAL` | 100 | Default for most tasks |
+/// | `LOW` | 200 | Background work |
+/// | `IDLE` | 1000 | Cleanup, logging |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Priority(pub u32);
+
+impl Priority {
+    /// Critical priority - kernel-internal operations, mode changes.
+    pub const CRITICAL: Self = Self(0);
+
+    /// High priority - user input, commands.
+    pub const HIGH: Self = Self(50);
+
+    /// Normal priority - default for most tasks.
+    pub const NORMAL: Self = Self(100);
+
+    /// Low priority - background work, render signals.
+    pub const LOW: Self = Self(200);
+
+    /// Idle priority - cleanup, logging.
+    pub const IDLE: Self = Self(1000);
+
+    /// Create a priority with a custom value.
+    #[inline]
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Get the raw priority value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for Priority {
+    fn default() -> Self {
+        Self::NORMAL
+    }
+}
+
+impl fmt::Display for Priority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::CRITICAL => write!(f, "Critical(0)"),
+            Self::HIGH => write!(f, "High(50)"),
+            Self::NORMAL => write!(f, "Normal(100)"),
+            Self::LOW => write!(f, "Low(200)"),
+            Self::IDLE => write!(f, "Idle(1000)"),
+            Self(v) => write!(f, "Priority({v})"),
+        }
+    }
+}
+
+/// Task execution state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TaskState {
+    /// Task is waiting to be executed.
+    #[default]
+    Pending,
+
+    /// Task is currently executing.
+    Running,
+
+    /// Task completed successfully.
+    Completed,
+
+    /// Task failed (error or panic).
+    Failed,
+}
+
+impl TaskState {
+    /// Check if the task is still pending.
+    #[inline]
+    #[must_use]
+    pub const fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Check if the task has finished (completed or failed).
+    #[inline]
+    #[must_use]
+    pub const fn is_finished(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
+}
+
+impl fmt::Display for TaskState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pending => write!(f, "Pending"),
+            Self::Running => write!(f, "Running"),
+            Self::Completed => write!(f, "Completed"),
+            Self::Failed => write!(f, "Failed"),
+        }
+    }
+}
+
+/// Type-erased task function.
+///
+/// A boxed closure that can be executed once. Tasks must be `Send` to allow
+/// scheduling from any thread.
+pub type BoxedTask = Box<dyn FnOnce() + Send + 'static>;
+
+/// A unit of deferred work.
+///
+/// Tasks encapsulate a closure to be executed later by the scheduler.
+/// Each task has a unique ID, priority, and execution state.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::sched::{Task, Priority, TaskState};
+///
+/// // Create a high-priority task with a name
+/// let mut task = Task::with_priority(Priority::HIGH, || println!("Hello!"))
+///     .with_name("greeting");
+///
+/// assert_eq!(task.state(), TaskState::Pending);
+/// assert_eq!(task.priority(), Priority::HIGH);
+///
+/// // Execute the task
+/// let result = task.execute();
+/// assert!(result.is_ok());
+/// assert_eq!(task.state(), TaskState::Completed);
+/// ```
+pub struct Task {
+    /// Unique identifier.
+    id: TaskId,
+
+    /// Task priority.
+    priority: Priority,
+
+    /// Current state.
+    state: TaskState,
+
+    /// The work to execute (None after execution).
+    work: Option<BoxedTask>,
+
+    /// Optional name for debugging.
+    name: Option<&'static str>,
+}
+
+impl Task {
+    /// Create a new task with normal priority.
+    #[must_use]
+    pub fn new<F>(work: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        Self::with_priority(Priority::NORMAL, work)
+    }
+
+    /// Create a task with specific priority.
+    #[must_use]
+    pub fn with_priority<F>(priority: Priority, work: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        Self {
+            id: TaskId::new(),
+            priority,
+            state: TaskState::Pending,
+            work: Some(Box::new(work)),
+            name: None,
+        }
+    }
+
+    /// Set the task name for debugging.
+    #[must_use]
+    pub const fn with_name(mut self, name: &'static str) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// Get the task ID.
+    #[inline]
+    #[must_use]
+    pub const fn id(&self) -> TaskId {
+        self.id
+    }
+
+    /// Get the task priority.
+    #[inline]
+    #[must_use]
+    pub const fn priority(&self) -> Priority {
+        self.priority
+    }
+
+    /// Get the current state.
+    #[inline]
+    #[must_use]
+    pub const fn state(&self) -> TaskState {
+        self.state
+    }
+
+    /// Get the task name (if set).
+    #[inline]
+    #[must_use]
+    pub const fn name(&self) -> Option<&'static str> {
+        self.name
+    }
+
+    /// Check if the task can still be executed.
+    #[inline]
+    #[must_use]
+    pub const fn is_executable(&self) -> bool {
+        matches!(self.state, TaskState::Pending) && self.work.is_some()
+    }
+
+    /// Execute the task.
+    ///
+    /// Consumes the work closure and transitions state to `Completed`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Task has already been executed
+    /// - Task was cancelled (work is None)
+    pub fn execute(&mut self) -> Result<(), &'static str> {
+        if self.state != TaskState::Pending {
+            return Err("task already executed or cancelled");
+        }
+
+        let work = self.work.take().ok_or("work closure missing")?;
+
+        self.state = TaskState::Running;
+        work();
+        self.state = TaskState::Completed;
+
+        Ok(())
+    }
+
+    /// Mark the task as failed.
+    ///
+    /// Used by the executor when a panic is caught during execution.
+    pub fn mark_failed(&mut self) {
+        self.work = None;
+        self.state = TaskState::Failed;
+    }
+
+    /// Cancel the task.
+    ///
+    /// Removes the work closure without executing it.
+    pub fn cancel(&mut self) {
+        self.work = None;
+        self.state = TaskState::Failed;
+    }
+}
+
+impl fmt::Debug for Task {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Task")
+            .field("id", &self.id)
+            .field("priority", &self.priority)
+            .field("state", &self.state)
+            .field("name", &self.name)
+            .field("has_work", &self.work.is_some())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::sync::{Arc, atomic::AtomicBool},
+    };
+
+    // === TaskId tests ===
+
+    #[test]
+    fn test_task_id_new() {
+        let id1 = TaskId::new();
+        let id2 = TaskId::new();
+        assert_ne!(id1, id2);
+        assert!(id2.as_u64() > id1.as_u64());
+    }
+
+    #[test]
+    fn test_task_id_from_raw() {
+        let id = TaskId::from_raw(42);
+        assert_eq!(id.as_u64(), 42);
+    }
+
+    #[test]
+    fn test_task_id_display() {
+        let id = TaskId::from_raw(123);
+        assert_eq!(format!("{id}"), "Task(123)");
+    }
+
+    #[test]
+    fn test_task_id_ordering() {
+        let id1 = TaskId::from_raw(1);
+        let id2 = TaskId::from_raw(2);
+        assert!(id1 < id2);
+    }
+
+    #[test]
+    fn test_task_id_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(TaskId::from_raw(1));
+        set.insert(TaskId::from_raw(2));
+        assert!(set.contains(&TaskId::from_raw(1)));
+        assert!(!set.contains(&TaskId::from_raw(3)));
+    }
+
+    // === Priority tests ===
+
+    #[test]
+    fn test_priority_constants() {
+        assert_eq!(Priority::CRITICAL.as_u32(), 0);
+        assert_eq!(Priority::HIGH.as_u32(), 50);
+        assert_eq!(Priority::NORMAL.as_u32(), 100);
+        assert_eq!(Priority::LOW.as_u32(), 200);
+        assert_eq!(Priority::IDLE.as_u32(), 1000);
+    }
+
+    #[test]
+    fn test_priority_default() {
+        assert_eq!(Priority::default(), Priority::NORMAL);
+    }
+
+    #[test]
+    fn test_priority_ordering() {
+        assert!(Priority::CRITICAL < Priority::HIGH);
+        assert!(Priority::HIGH < Priority::NORMAL);
+        assert!(Priority::NORMAL < Priority::LOW);
+        assert!(Priority::LOW < Priority::IDLE);
+    }
+
+    #[test]
+    fn test_priority_custom() {
+        let custom = Priority::new(75);
+        assert_eq!(custom.as_u32(), 75);
+        assert!(Priority::HIGH < custom);
+        assert!(custom < Priority::NORMAL);
+    }
+
+    #[test]
+    fn test_priority_display() {
+        assert_eq!(format!("{}", Priority::CRITICAL), "Critical(0)");
+        assert_eq!(format!("{}", Priority::HIGH), "High(50)");
+        assert_eq!(format!("{}", Priority::NORMAL), "Normal(100)");
+        assert_eq!(format!("{}", Priority::LOW), "Low(200)");
+        assert_eq!(format!("{}", Priority::IDLE), "Idle(1000)");
+        assert_eq!(format!("{}", Priority::new(75)), "Priority(75)");
+    }
+
+    // === TaskState tests ===
+
+    #[test]
+    fn test_task_state_default() {
+        assert_eq!(TaskState::default(), TaskState::Pending);
+    }
+
+    #[test]
+    fn test_task_state_is_pending() {
+        assert!(TaskState::Pending.is_pending());
+        assert!(!TaskState::Running.is_pending());
+        assert!(!TaskState::Completed.is_pending());
+        assert!(!TaskState::Failed.is_pending());
+    }
+
+    #[test]
+    fn test_task_state_is_finished() {
+        assert!(!TaskState::Pending.is_finished());
+        assert!(!TaskState::Running.is_finished());
+        assert!(TaskState::Completed.is_finished());
+        assert!(TaskState::Failed.is_finished());
+    }
+
+    #[test]
+    fn test_task_state_display() {
+        assert_eq!(format!("{}", TaskState::Pending), "Pending");
+        assert_eq!(format!("{}", TaskState::Running), "Running");
+        assert_eq!(format!("{}", TaskState::Completed), "Completed");
+        assert_eq!(format!("{}", TaskState::Failed), "Failed");
+    }
+
+    // === Task tests ===
+
+    #[test]
+    fn test_task_new() {
+        let task = Task::new(|| {});
+        assert_eq!(task.state(), TaskState::Pending);
+        assert_eq!(task.priority(), Priority::NORMAL);
+        assert!(task.name().is_none());
+        assert!(task.is_executable());
+    }
+
+    #[test]
+    fn test_task_with_priority() {
+        let task = Task::with_priority(Priority::HIGH, || {});
+        assert_eq!(task.priority(), Priority::HIGH);
+    }
+
+    #[test]
+    fn test_task_with_name() {
+        let task = Task::new(|| {}).with_name("test_task");
+        assert_eq!(task.name(), Some("test_task"));
+    }
+
+    #[test]
+    fn test_task_execute() {
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let mut task = Task::new(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+
+        assert!(task.execute().is_ok());
+        assert!(executed.load(Ordering::SeqCst));
+        assert_eq!(task.state(), TaskState::Completed);
+        assert!(!task.is_executable());
+    }
+
+    #[test]
+    fn test_task_execute_twice_fails() {
+        let mut task = Task::new(|| {});
+        assert!(task.execute().is_ok());
+        assert!(task.execute().is_err());
+    }
+
+    #[test]
+    fn test_task_cancel() {
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+
+        let mut task = Task::new(move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+
+        task.cancel();
+        assert_eq!(task.state(), TaskState::Failed);
+        assert!(!task.is_executable());
+        assert!(!executed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_task_mark_failed() {
+        let mut task = Task::new(|| {});
+        task.mark_failed();
+        assert_eq!(task.state(), TaskState::Failed);
+        assert!(!task.is_executable());
+    }
+
+    #[test]
+    fn test_task_debug() {
+        let task = Task::new(|| {}).with_name("debug_test");
+        let debug_str = format!("{task:?}");
+        assert!(debug_str.contains("Task"));
+        assert!(debug_str.contains("debug_test"));
+        assert!(debug_str.contains("Pending"));
+    }
+
+    #[test]
+    fn test_task_unique_ids() {
+        let task1 = Task::new(|| {});
+        let task2 = Task::new(|| {});
+        assert_ne!(task1.id(), task2.id());
+    }
+
+    // === Send + Sync tests ===
+
+    #[test]
+    fn test_task_id_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TaskId>();
+    }
+
+    #[test]
+    fn test_priority_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Priority>();
+    }
+
+    #[test]
+    fn test_task_state_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TaskState>();
+    }
+
+    #[test]
+    fn test_task_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Task>();
+    }
+}

--- a/lib/kernel/src/sched/work_queue.rs
+++ b/lib/kernel/src/sched/work_queue.rs
@@ -1,0 +1,407 @@
+//! Work queue for deferred task execution.
+//!
+//! Linux equivalent: `kernel/workqueue.c`
+//!
+//! This module provides a bounded, thread-safe queue for scheduling
+//! tasks to be executed later by the runtime.
+//!
+//! # Features
+//!
+//! - **Bounded capacity**: Prevents unbounded memory growth
+//! - **Overflow detection**: Tracks dropped tasks without blocking
+//! - **Thread-safe**: Can be accessed from multiple threads
+//! - **FIFO ordering**: Tasks processed in submission order
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::sched::{WorkQueue, Task};
+//!
+//! let queue = WorkQueue::new();
+//!
+//! // Push some tasks
+//! queue.push(Task::new(|| println!("Task 1")));
+//! queue.push(Task::new(|| println!("Task 2")));
+//!
+//! // Pop and execute
+//! while let Some(mut task) = queue.try_pop() {
+//!     task.execute().ok();
+//! }
+//! ```
+
+use std::{
+    collections::VecDeque,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::arch::sync::Mutex;
+
+use super::task::Task;
+
+/// Default capacity for work queue.
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+/// Maximum capacity (to prevent unbounded growth).
+pub const MAX_CAPACITY: usize = 4096;
+
+/// Work queue for deferred tasks.
+///
+/// Thread-safe, FIFO queue with bounded capacity. When the queue is full,
+/// new tasks are dropped and the overflow counter is incremented.
+///
+/// # Thread Safety
+///
+/// The queue uses a `Mutex<VecDeque<Task>>` internally, making it safe
+/// to push from multiple threads. However, heavy contention should be
+/// avoided for performance.
+pub struct WorkQueue {
+    /// Queue storage.
+    queue: Mutex<VecDeque<Task>>,
+
+    /// Maximum capacity.
+    capacity: usize,
+
+    /// Number of tasks dropped due to overflow.
+    dropped: AtomicUsize,
+}
+
+impl WorkQueue {
+    /// Create a new work queue with default capacity.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Create a work queue with specified capacity.
+    ///
+    /// Capacity is clamped to `MAX_CAPACITY`.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let capacity = capacity.min(MAX_CAPACITY);
+        Self {
+            queue: Mutex::new(VecDeque::with_capacity(capacity)),
+            capacity,
+            dropped: AtomicUsize::new(0),
+        }
+    }
+
+    /// Push a task to the queue.
+    ///
+    /// Returns `true` if the task was queued, `false` if dropped due to overflow.
+    /// This is non-blocking - overflow tasks are immediately dropped.
+    pub fn push(&self, task: Task) -> bool {
+        let mut queue = self.queue.lock();
+        if queue.len() >= self.capacity {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
+        queue.push_back(task);
+        true
+    }
+
+    /// Try to pop a task from the queue.
+    ///
+    /// Returns `None` if the queue is empty.
+    #[must_use]
+    pub fn try_pop(&self) -> Option<Task> {
+        self.queue.lock().pop_front()
+    }
+
+    /// Drain all tasks from the queue.
+    ///
+    /// Returns all pending tasks, leaving the queue empty.
+    #[must_use]
+    pub fn drain(&self) -> Vec<Task> {
+        let mut queue = self.queue.lock();
+        queue.drain(..).collect()
+    }
+
+    /// Process up to `limit` pending tasks.
+    ///
+    /// Pops and executes tasks in order. Returns the number of tasks
+    /// successfully executed. Tasks that fail or panic are counted
+    /// but not returned.
+    pub fn process_pending(&self, limit: usize) -> usize {
+        let mut processed = 0;
+        while processed < limit {
+            let Some(mut task) = self.try_pop() else {
+                break;
+            };
+            // Execute, ignoring errors (caller can use executor for panic handling)
+            let _ = task.execute();
+            processed += 1;
+        }
+        processed
+    }
+
+    /// Get the number of pending tasks.
+    ///
+    /// Note: This is a snapshot and may change immediately after returning.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.queue.lock().len()
+    }
+
+    /// Check if the queue is empty.
+    ///
+    /// Note: This is a snapshot and may change immediately after returning.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.lock().is_empty()
+    }
+
+    /// Get the queue capacity.
+    #[inline]
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Get the number of dropped tasks (overflow).
+    ///
+    /// This count accumulates over the lifetime of the queue.
+    #[must_use]
+    pub fn dropped_count(&self) -> usize {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Clear all pending tasks without executing them.
+    ///
+    /// Returns the number of tasks cleared.
+    pub fn clear(&self) -> usize {
+        let mut queue = self.queue.lock();
+        let count = queue.len();
+        queue.clear();
+        count
+    }
+}
+
+impl Default for WorkQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for WorkQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkQueue")
+            .field("len", &self.len())
+            .field("capacity", &self.capacity)
+            .field("dropped", &self.dropped_count())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::sync::{Arc, atomic::AtomicUsize},
+    };
+
+    // === Basic tests ===
+
+    #[test]
+    fn test_new() {
+        let queue = WorkQueue::new();
+        assert_eq!(queue.capacity(), DEFAULT_CAPACITY);
+        assert!(queue.is_empty());
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.dropped_count(), 0);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let queue = WorkQueue::with_capacity(100);
+        assert_eq!(queue.capacity(), 100);
+    }
+
+    #[test]
+    fn test_with_capacity_clamped() {
+        let queue = WorkQueue::with_capacity(MAX_CAPACITY + 1000);
+        assert_eq!(queue.capacity(), MAX_CAPACITY);
+    }
+
+    #[test]
+    fn test_push_and_pop() {
+        let queue = WorkQueue::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        queue.push(Task::new(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        assert_eq!(queue.len(), 1);
+        assert!(!queue.is_empty());
+
+        let mut task = queue.try_pop().unwrap();
+        assert!(task.execute().is_ok());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn test_fifo_order() {
+        let queue = WorkQueue::new();
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        for i in 0..5 {
+            let order_clone = Arc::clone(&order);
+            queue.push(Task::new(move || {
+                order_clone.lock().push(i);
+            }));
+        }
+
+        while let Some(mut task) = queue.try_pop() {
+            task.execute().ok();
+        }
+
+        let result = order.lock().clone();
+        assert_eq!(result, vec![0, 1, 2, 3, 4]);
+    }
+
+    // === Overflow tests ===
+
+    #[test]
+    fn test_overflow() {
+        let queue = WorkQueue::with_capacity(3);
+
+        assert!(queue.push(Task::new(|| {})));
+        assert!(queue.push(Task::new(|| {})));
+        assert!(queue.push(Task::new(|| {})));
+        assert!(!queue.push(Task::new(|| {}))); // Should fail
+        assert!(!queue.push(Task::new(|| {}))); // Should fail
+
+        assert_eq!(queue.len(), 3);
+        assert_eq!(queue.dropped_count(), 2);
+    }
+
+    #[test]
+    fn test_overflow_recovery() {
+        let queue = WorkQueue::with_capacity(2);
+
+        queue.push(Task::new(|| {}));
+        queue.push(Task::new(|| {}));
+        assert!(!queue.push(Task::new(|| {}))); // Overflow
+
+        let _ = queue.try_pop(); // Free up space
+        assert!(queue.push(Task::new(|| {}))); // Should succeed now
+        assert_eq!(queue.len(), 2);
+    }
+
+    // === Drain tests ===
+
+    #[test]
+    fn test_drain() {
+        let queue = WorkQueue::new();
+        for _ in 0..5 {
+            queue.push(Task::new(|| {}));
+        }
+
+        let tasks = queue.drain();
+        assert_eq!(tasks.len(), 5);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn test_drain_empty() {
+        let queue = WorkQueue::new();
+        let tasks = queue.drain();
+        assert!(tasks.is_empty());
+    }
+
+    // === Process pending tests ===
+
+    #[test]
+    fn test_process_pending() {
+        let queue = WorkQueue::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..10 {
+            let counter_clone = Arc::clone(&counter);
+            queue.push(Task::new(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        // Process only 5
+        let processed = queue.process_pending(5);
+        assert_eq!(processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(queue.len(), 5);
+
+        // Process remaining
+        let processed = queue.process_pending(10);
+        assert_eq!(processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn test_process_pending_empty() {
+        let queue = WorkQueue::new();
+        let processed = queue.process_pending(10);
+        assert_eq!(processed, 0);
+    }
+
+    // === Clear tests ===
+
+    #[test]
+    fn test_clear() {
+        let queue = WorkQueue::new();
+        for _ in 0..5 {
+            queue.push(Task::new(|| {}));
+        }
+
+        let cleared = queue.clear();
+        assert_eq!(cleared, 5);
+        assert!(queue.is_empty());
+    }
+
+    // === Debug tests ===
+
+    #[test]
+    fn test_debug() {
+        let queue = WorkQueue::with_capacity(100);
+        queue.push(Task::new(|| {}));
+        let debug_str = format!("{queue:?}");
+        assert!(debug_str.contains("WorkQueue"));
+        assert!(debug_str.contains("len"));
+        assert!(debug_str.contains("capacity"));
+    }
+
+    // === Concurrent tests ===
+
+    #[test]
+    fn test_concurrent_push() {
+        use std::thread;
+
+        let queue = Arc::new(WorkQueue::with_capacity(1000));
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let queue_clone = Arc::clone(&queue);
+            handles.push(thread::spawn(move || {
+                for _ in 0..50 {
+                    queue_clone.push(Task::new(|| {}));
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Should have 500 tasks (10 threads * 50 tasks)
+        assert_eq!(queue.len(), 500);
+    }
+
+    // === Send + Sync tests ===
+
+    #[test]
+    fn test_work_queue_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WorkQueue>();
+    }
+}


### PR DESCRIPTION
Add the scheduler subsystem providing runtime loop, task execution, and work queues. This is the heart of the editor's event coordination.

Components:
- RuntimeState: Lifecycle state machine (Booting/Running/Stopping/Emergency)
- Task: Deferred work unit with TaskId, Priority, and panic-safe execution
- WorkQueue: Bounded FIFO task queue with overflow detection
- PriorityQueue: Priority-ordered event queue using BinaryHeap
- Executor: Sync task executor with catch_unwind panic handling
- Runtime: Main event loop coordinator with EventBus integration

Key features:
- Panic safety: Tasks that panic are caught, don't crash runtime
- Priority ordering: Lower priority value = processed first
- FIFO for same priority: Sequence numbers ensure fair ordering
- Overflow detection: WorkQueue tracks dropped tasks
- Builder pattern: RuntimeConfig for customization

Also fixes IPC channel Clone impl to not require T: Clone.

CHANGELOG updated with correct phase numbers for all kernel modules:
- Phase 2.3: core/ (was missing)
- Phase 2.4: block/ (was missing)
- Phase 2.5: sched/ (this PR)
- Phase 2.7: printk/ (was incorrectly labeled as 2.3)

67 sched unit tests + 6 doctests added.

Closes #163