### PR TITLE
feat(kernel): implement api/ stable kernel API (#164)

### DIFF
--- a/lib/kernel/Cargo.toml
+++ b/lib/kernel/Cargo.toml
@@ -12,6 +12,10 @@ categories.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+unstable-api = []
+
 [dependencies]
 # Only depends on arch layer (Rule 2: kernel/ depends only on arch/)
 reovim-arch = { path = "../arch", version = "0.9.0-dev" }

--- a/lib/kernel/src/api/buffer_manager.rs
+++ b/lib/kernel/src/api/buffer_manager.rs
@@ -1,0 +1,97 @@
+//! Buffer manager trait for kernel-driver communication.
+//!
+//! Defines the interface for buffer storage and retrieval. The kernel provides
+//! pure storage mechanisms; drivers handle I/O operations (loading, saving).
+
+use std::{fmt, sync::Arc};
+
+use reovim_arch::sync::RwLock;
+
+use crate::mm::{Buffer, BufferId};
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+/// Error type for buffer manager operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BufferError {
+    /// Buffer with the given ID was not found.
+    NotFound(BufferId),
+    /// Buffer with the given ID already exists.
+    AlreadyExists(BufferId),
+    /// Invalid operation attempted.
+    InvalidOperation(&'static str),
+}
+
+impl fmt::Display for BufferError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "buffer not found: {id:?}"),
+            Self::AlreadyExists(id) => write!(f, "buffer already exists: {id:?}"),
+            Self::InvalidOperation(msg) => write!(f, "invalid operation: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BufferError {}
+
+// ============================================================================
+// BufferManager Trait
+// ============================================================================
+
+/// Buffer manager interface for kernel-driver communication.
+///
+/// This trait defines how buffers are stored and retrieved. The kernel provides
+/// pure storage mechanisms, while drivers implement I/O operations.
+///
+/// # Design Philosophy
+///
+/// - **No I/O operations**: No `open()/save()` methods - VFS driver handles these
+/// - **No focus tracking**: Active buffer tracking is a runtime/window concern
+/// - **Thread-safe**: Uses `Arc<RwLock<Buffer>>` for concurrent access
+/// - **Kernel purity**: Pure mechanisms only, no external dependencies
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_kernel::api::v1::{BufferManager, Buffer, BufferId};
+///
+/// struct SimpleBufferManager { /* ... */ }
+///
+/// impl BufferManager for SimpleBufferManager {
+///     fn get(&self, id: BufferId) -> Option<Arc<RwLock<Buffer>>> {
+///         // Implementation
+///     }
+///     // ... other methods
+/// }
+/// ```
+pub trait BufferManager: Send + Sync {
+    /// Get buffer by ID.
+    ///
+    /// Returns `None` if the buffer does not exist.
+    fn get(&self, id: BufferId) -> Option<Arc<RwLock<Buffer>>>;
+
+    /// Create a new empty buffer.
+    ///
+    /// Returns the ID of the newly created buffer.
+    fn create(&self) -> BufferId;
+
+    /// Register an existing buffer (used by drivers after loading).
+    ///
+    /// Returns the ID assigned to the registered buffer.
+    fn register(&self, buffer: Buffer) -> BufferId;
+
+    /// Unregister buffer, returning ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(BufferError::NotFound)` if the buffer does not exist.
+    fn unregister(&self, id: BufferId) -> Result<Buffer, BufferError>;
+
+    /// List all buffer IDs.
+    fn list(&self) -> Vec<BufferId>;
+
+    /// Get count of buffers.
+    fn count(&self) -> usize;
+}

--- a/lib/kernel/src/api/context.rs
+++ b/lib/kernel/src/api/context.rs
@@ -1,0 +1,77 @@
+//! Kernel context for drivers and modules.
+//!
+//! Provides a unified context struct bundling kernel services for easy access.
+
+use std::{fmt, sync::Arc};
+
+use crate::{
+    core::{MotionEngine, TextObjectEngine},
+    ipc::EventBus,
+};
+
+use super::buffer_manager::BufferManager;
+
+// ============================================================================
+// KernelContext
+// ============================================================================
+
+/// Kernel context bundling all kernel services.
+///
+/// This struct provides drivers and modules with access to kernel services.
+/// All fields are `Arc`-wrapped for cheap cloning and safe concurrent access.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_kernel::api::v1::KernelContext;
+///
+/// fn setup_driver(ctx: KernelContext) {
+///     // Access event bus
+///     let _bus = ctx.event_bus.clone();
+///
+///     // Access buffer manager
+///     let count = ctx.buffers.count();
+///
+///     // Context is cheap to clone
+///     let ctx2 = ctx.clone();
+/// }
+/// ```
+#[derive(Clone)]
+pub struct KernelContext {
+    /// Event bus for publish/subscribe communication.
+    pub event_bus: Arc<EventBus>,
+    /// Buffer manager for buffer storage and retrieval.
+    pub buffers: Arc<dyn BufferManager>,
+    /// Motion calculation engine.
+    pub motion: Arc<MotionEngine>,
+    /// Text object calculation engine.
+    pub text_objects: Arc<TextObjectEngine>,
+}
+
+impl KernelContext {
+    /// Create a new kernel context.
+    pub fn new(
+        event_bus: Arc<EventBus>,
+        buffers: Arc<dyn BufferManager>,
+        motion: Arc<MotionEngine>,
+        text_objects: Arc<TextObjectEngine>,
+    ) -> Self {
+        Self {
+            event_bus,
+            buffers,
+            motion,
+            text_objects,
+        }
+    }
+}
+
+impl fmt::Debug for KernelContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KernelContext")
+            .field("event_bus", &"Arc<EventBus>")
+            .field("buffers", &"Arc<dyn BufferManager>")
+            .field("motion", &"Arc<MotionEngine>")
+            .field("text_objects", &"Arc<TextObjectEngine>")
+            .finish()
+    }
+}

--- a/lib/kernel/src/api/internal.rs
+++ b/lib/kernel/src/api/internal.rs
@@ -1,0 +1,14 @@
+//! Internal kernel APIs.
+//!
+//! This module contains APIs that are for kernel-internal use only.
+//! These APIs are not part of the public contract and may change without notice.
+//!
+//! # Warning
+//!
+//! Do not depend on any APIs in this module from outside the kernel crate.
+//! They are hidden from documentation and provide no stability guarantees.
+
+#![doc(hidden)]
+
+// Internal APIs will be added here as needed.
+// Currently empty - placeholder for future internal kernel APIs.

--- a/lib/kernel/src/api/mod.rs
+++ b/lib/kernel/src/api/mod.rs
@@ -2,8 +2,65 @@
 //!
 //! Linux equivalent: `include/linux/`
 //!
-//! Defines the stable interface that drivers and modules can depend on.
-//! Breaking changes require a new API version.
+//! This module defines the stable interface that drivers and modules depend on.
+//! All public APIs are accessed exclusively via the `v1` module.
+//!
+//! # Module Structure
+//!
+//! - `v1`: Stable API v1 - the primary public interface
+//! - `unstable`: Experimental APIs (feature-gated)
+//! - `internal`: Internal kernel APIs (doc hidden)
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_kernel::api::v1::*;
+//!
+//! // Check API compatibility
+//! check_api_version(Version::new(1, 0, 0))?;
+//!
+//! // Use kernel types
+//! let bus = EventBus::new();
+//! pr_info!("kernel initialized");
+//! ```
 
-/// API version for compatibility checking.
-pub const API_VERSION: (u32, u32, u32) = (0, 1, 0);
+// ============================================================================
+// Internal modules (not directly exposed)
+// ============================================================================
+
+mod buffer_manager;
+mod context;
+mod version;
+
+// ============================================================================
+// Public modules
+// ============================================================================
+
+/// Stable API v1.
+///
+/// This is the primary public interface. All stable kernel APIs are accessed
+/// through this module.
+pub mod v1;
+
+/// Experimental APIs (feature-gated).
+///
+/// APIs in this module may change without notice. Enable the `unstable-api`
+/// feature to use them.
+#[cfg(feature = "unstable-api")]
+pub mod unstable;
+
+/// Internal kernel APIs.
+///
+/// These APIs are for kernel-internal use only and are hidden from documentation.
+#[doc(hidden)]
+pub mod internal;
+
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+/// Re-export v1 at api level for convenience.
+///
+/// This allows both `use reovim_kernel::api::v1::*` and
+/// `use reovim_kernel::api::*` to work.
+pub use v1::*;

--- a/lib/kernel/src/api/unstable.rs
+++ b/lib/kernel/src/api/unstable.rs
@@ -1,0 +1,23 @@
+//! Experimental and unstable APIs.
+//!
+//! This module contains APIs that are experimental and may change without notice.
+//! These APIs are feature-gated behind the `unstable-api` feature flag.
+//!
+//! # Warning
+//!
+//! APIs in this module:
+//! - May be removed without deprecation
+//! - May have breaking changes in minor versions
+//! - Are not covered by semver guarantees
+//!
+//! # Usage
+//!
+//! To use unstable APIs, enable the feature in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! reovim-kernel = { version = "0.9", features = ["unstable-api"] }
+//! ```
+
+// Experimental APIs will be added here as needed.
+// Currently empty - placeholder for future experimental kernel APIs.

--- a/lib/kernel/src/api/v1.rs
+++ b/lib/kernel/src/api/v1.rs
@@ -1,0 +1,184 @@
+//! Stable Kernel API v1.
+//!
+//! Linux equivalent: `include/linux/`
+//!
+//! This module provides the stable public interface for drivers and modules.
+//! All types exported here are covered by semver guarantees within the v1.x series.
+//!
+//! # Stability Guarantee
+//!
+//! - Breaking changes require a new major version (v2)
+//! - New APIs may be added in minor versions
+//! - Patch versions contain only bug fixes
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_kernel::api::v1::*;
+//!
+//! // Check API compatibility
+//! check_api_version(Version::new(1, 0, 0))?;
+//!
+//! // Use kernel types
+//! let bus = EventBus::new();
+//! pr_info!("kernel initialized");
+//! ```
+
+// ============================================================================
+// Version
+// ============================================================================
+
+pub use super::version::{
+    API_VERSION, API_VERSION_STR, Version, VersionError, VersionErrorKind, check_api_version,
+    is_compatible,
+};
+
+// ============================================================================
+// Context & Manager
+// ============================================================================
+
+pub use super::{
+    buffer_manager::{BufferError, BufferManager},
+    context::KernelContext,
+};
+
+// ============================================================================
+// Memory Management (mm/)
+// ============================================================================
+
+pub use crate::mm::{Buffer, BufferId, Cursor, Edit, Position};
+
+// ============================================================================
+// IPC (ipc/)
+// ============================================================================
+
+// Event types
+pub use crate::ipc::{
+    DEFAULT_TIMEOUT, DynEvent, Event, EventBus, EventResult, EventScope, ScopeId, Subscription,
+    SubscriptionId,
+};
+
+// Channel types
+pub use crate::ipc::{
+    BoundedReceiver, BoundedSender, OneshotReceiver, OneshotSender, Receiver, RecvError, SendError,
+    Sender, TryRecvError, TrySendError, bounded, channel, oneshot,
+};
+
+// ============================================================================
+// Core Primitives (core/)
+// ============================================================================
+
+// Motion
+pub use crate::core::{Direction, LinePosition, Motion, MotionEngine, WordBoundary};
+
+// Text Objects
+pub use crate::core::{TextObject, TextObjectEngine};
+
+// Registers
+pub use crate::core::{RegisterBank, RegisterContent, YankType};
+
+// Marks
+pub use crate::core::{Mark, MarkBank, MarkResult, SpecialMark};
+
+// ============================================================================
+// Block Operations (block/)
+// ============================================================================
+
+pub use crate::block::{
+    History, HistoryEntry, Snapshot, Transaction, UndoNode, UndoResult, UndoTree,
+};
+
+// ============================================================================
+// Scheduler (sched/)
+// ============================================================================
+
+pub use crate::sched::{
+    BoxedTask,
+    // Configuration constants
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_PRIORITY_QUEUE_CAPACITY,
+    DEFAULT_WORK_QUEUE_CAPACITY,
+    Executor,
+    PRIORITY_QUEUE_DEFAULT_CAPACITY,
+    Priority,
+    PriorityQueue,
+    Runtime,
+    RuntimeCommand,
+    RuntimeConfig,
+    RuntimeState,
+    RuntimeStats,
+    Task,
+    TaskId,
+    TaskState,
+    WORK_QUEUE_DEFAULT_CAPACITY,
+    WORK_QUEUE_MAX_CAPACITY,
+    WorkQueue,
+};
+
+// ============================================================================
+// Logging (printk/)
+// ============================================================================
+
+// Types and functions
+pub use crate::printk::{
+    Level, Logger, NopLogger, ParseLevelError, Record, RecordBuilder, SetLoggerError, flush,
+    logger, set_logger,
+};
+
+// Internal function needed by macros (hidden from docs)
+#[doc(hidden)]
+pub use crate::printk::__log;
+
+// Macros (re-export from crate root for unified access)
+pub use crate::{pr_debug, pr_err, pr_info, pr_trace, pr_warn};
+
+// ============================================================================
+// Sync Primitives (from arch)
+// ============================================================================
+
+pub use reovim_arch::sync::{
+    ArcSwap, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_version() {
+        assert_eq!(API_VERSION, Version::new(1, 0, 0));
+        assert_eq!(API_VERSION_STR, "1.0.0");
+    }
+
+    #[test]
+    fn test_version_compatibility() {
+        // Same version is compatible
+        assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 0, 0)));
+        // Older minor is compatible
+        assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 1, 0)));
+        // Newer minor is NOT compatible
+        assert!(!is_compatible(Version::new(1, 2, 0), Version::new(1, 1, 0)));
+        // Different major is NOT compatible
+        assert!(!is_compatible(Version::new(2, 0, 0), Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_all_types_accessible_via_v1() {
+        // Verify key types are accessible via api::v1
+        let _: BufferId;
+        let _: Position;
+        let _: fn() -> EventBus = EventBus::new;
+        let _: fn() -> Runtime = Runtime::new;
+    }
+
+    #[test]
+    fn test_macros_accessible() {
+        // Verify printk macros work via v1
+        pr_info!("test message");
+        pr_debug!("debug: {}", 42);
+    }
+}

--- a/lib/kernel/src/api/version.rs
+++ b/lib/kernel/src/api/version.rs
@@ -1,0 +1,278 @@
+//! Version management and compatibility checking.
+//!
+//! Provides API version constants and compatibility utilities for ensuring
+//! module-kernel version compatibility.
+
+use std::fmt;
+
+// ============================================================================
+// Version Type
+// ============================================================================
+
+/// Semantic version representation.
+///
+/// Provides type-safe version handling with named fields instead of tuples.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Version {
+    /// Major version - breaking changes increment this.
+    pub major: u32,
+    /// Minor version - backwards-compatible additions increment this.
+    pub minor: u32,
+    /// Patch version - backwards-compatible fixes increment this.
+    pub patch: u32,
+}
+
+impl Version {
+    /// Create a new version.
+    #[inline]
+    #[must_use]
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+// ============================================================================
+// Version Constants
+// ============================================================================
+
+/// Current API version.
+///
+/// This is the first stable release of the kernel API.
+pub const API_VERSION: Version = Version::new(1, 0, 0);
+
+/// Current API version as a string.
+pub const API_VERSION_STR: &str = "1.0.0";
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+/// Error returned when version compatibility check fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionError {
+    /// The kind of version error.
+    pub kind: VersionErrorKind,
+    /// The version that was required.
+    pub required: Version,
+    /// The version that was provided/available.
+    pub provided: Version,
+}
+
+/// Kinds of version compatibility errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionErrorKind {
+    /// Major version mismatch (breaking change).
+    MajorMismatch,
+    /// Required minor version is newer than provided.
+    MinorTooNew,
+}
+
+impl fmt::Display for VersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            VersionErrorKind::MajorMismatch => {
+                write!(
+                    f,
+                    "API major version mismatch: required {}.x.x, provided {}.x.x",
+                    self.required.major, self.provided.major
+                )
+            }
+            VersionErrorKind::MinorTooNew => {
+                write!(
+                    f,
+                    "API minor version too new: required {}.{}.x, provided {}.{}.x",
+                    self.required.major,
+                    self.required.minor,
+                    self.provided.major,
+                    self.provided.minor
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VersionError {}
+
+// ============================================================================
+// Compatibility Functions
+// ============================================================================
+
+/// Check if the current API version is compatible with the required version.
+///
+/// Returns `Ok(())` if compatible, `Err(VersionError)` otherwise.
+///
+/// # Compatibility Rules (semver)
+///
+/// - Major version must match exactly
+/// - Module can require an older minor version than kernel provides
+/// - Patch version is ignored for compatibility
+///
+/// # Errors
+///
+/// Returns `Err(VersionError)` if:
+/// - Major version mismatch (`VersionErrorKind::MajorMismatch`)
+/// - Required minor version is newer than provided (`VersionErrorKind::MinorTooNew`)
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::{check_api_version, Version};
+///
+/// // Check if kernel provides compatible API
+/// let result = check_api_version(Version::new(1, 0, 0));
+/// assert!(result.is_ok());
+/// ```
+pub const fn check_api_version(required: Version) -> Result<(), VersionError> {
+    if is_compatible(required, API_VERSION) {
+        Ok(())
+    } else if required.major != API_VERSION.major {
+        Err(VersionError {
+            kind: VersionErrorKind::MajorMismatch,
+            required,
+            provided: API_VERSION,
+        })
+    } else {
+        Err(VersionError {
+            kind: VersionErrorKind::MinorTooNew,
+            required,
+            provided: API_VERSION,
+        })
+    }
+}
+
+/// Check if `required` version is compatible with `provided` version.
+///
+/// # Compatibility Rules
+///
+/// - Major version must match exactly
+/// - Required minor must be <= provided minor (backwards compatible)
+/// - Patch version is ignored
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::{is_compatible, Version};
+///
+/// // Same version is compatible
+/// assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 0, 0)));
+///
+/// // Older required minor is compatible
+/// assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 1, 0)));
+///
+/// // Newer required minor is NOT compatible
+/// assert!(!is_compatible(Version::new(1, 2, 0), Version::new(1, 1, 0)));
+///
+/// // Different major is NOT compatible
+/// assert!(!is_compatible(Version::new(2, 0, 0), Version::new(1, 0, 0)));
+/// ```
+#[must_use]
+pub const fn is_compatible(required: Version, provided: Version) -> bool {
+    // Major must match exactly
+    if required.major != provided.major {
+        return false;
+    }
+
+    // Required minor must be <= provided minor
+    required.minor <= provided.minor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_new() {
+        let v = Version::new(1, 2, 3);
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 2);
+        assert_eq!(v.patch, 3);
+    }
+
+    #[test]
+    fn test_version_display() {
+        let v = Version::new(1, 2, 3);
+        assert_eq!(v.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_api_version_constants() {
+        assert_eq!(API_VERSION, Version::new(1, 0, 0));
+        assert_eq!(API_VERSION_STR, "1.0.0");
+    }
+
+    #[test]
+    fn test_is_compatible_same_version() {
+        assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_is_compatible_older_minor() {
+        assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 1, 0)));
+        assert!(is_compatible(Version::new(1, 1, 0), Version::new(1, 5, 0)));
+    }
+
+    #[test]
+    fn test_is_compatible_newer_minor_not_compatible() {
+        assert!(!is_compatible(Version::new(1, 2, 0), Version::new(1, 1, 0)));
+    }
+
+    #[test]
+    fn test_is_compatible_different_major_not_compatible() {
+        assert!(!is_compatible(Version::new(2, 0, 0), Version::new(1, 0, 0)));
+        assert!(!is_compatible(Version::new(1, 0, 0), Version::new(2, 0, 0)));
+    }
+
+    #[test]
+    fn test_is_compatible_patch_ignored() {
+        assert!(is_compatible(Version::new(1, 0, 0), Version::new(1, 0, 5)));
+        assert!(is_compatible(Version::new(1, 0, 10), Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_check_api_version_compatible() {
+        assert!(check_api_version(Version::new(1, 0, 0)).is_ok());
+    }
+
+    #[test]
+    fn test_check_api_version_major_mismatch() {
+        let result = check_api_version(Version::new(2, 0, 0));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, VersionErrorKind::MajorMismatch);
+    }
+
+    #[test]
+    fn test_check_api_version_minor_too_new() {
+        let result = check_api_version(Version::new(1, 5, 0));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, VersionErrorKind::MinorTooNew);
+    }
+
+    #[test]
+    fn test_version_error_display() {
+        let err = VersionError {
+            kind: VersionErrorKind::MajorMismatch,
+            required: Version::new(2, 0, 0),
+            provided: Version::new(1, 0, 0),
+        };
+        assert!(err.to_string().contains("major version mismatch"));
+
+        let err = VersionError {
+            kind: VersionErrorKind::MinorTooNew,
+            required: Version::new(1, 5, 0),
+            provided: Version::new(1, 0, 0),
+        };
+        assert!(err.to_string().contains("minor version too new"));
+    }
+}

--- a/lib/kernel/src/block/mod.rs
+++ b/lib/kernel/src/block/mod.rs
@@ -19,8 +19,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::block::{Transaction, UndoTree};
-//! use reovim_kernel::mm::{Edit, Position};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Create an undo tree
 //! let mut tree = UndoTree::new();

--- a/lib/kernel/src/block/snapshot.rs
+++ b/lib/kernel/src/block/snapshot.rs
@@ -30,8 +30,7 @@ use {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::block::Snapshot;
-/// use reovim_kernel::mm::Buffer;
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Create a buffer with some content
 /// let mut buffer = Buffer::from_string("Hello, World!");

--- a/lib/kernel/src/block/transaction.rs
+++ b/lib/kernel/src/block/transaction.rs
@@ -13,8 +13,7 @@ use crate::mm::Edit;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::block::Transaction;
-/// use reovim_kernel::mm::{Edit, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mut txn = Transaction::new();
 /// txn.push(Edit::insert(Position::new(0, 0), "Hello"));

--- a/lib/kernel/src/core/direction.rs
+++ b/lib/kernel/src/core/direction.rs
@@ -10,7 +10,7 @@
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::Direction;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let forward = Direction::Forward;  // h, j, w, }, f
 /// let backward = Direction::Backward; // l, k, b, {, F
@@ -57,7 +57,7 @@ impl Direction {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::WordBoundary;
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Given text: "hello-world foo"
 /// // Word boundaries: hello | - | world | foo
@@ -92,7 +92,7 @@ impl WordBoundary {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::LinePosition;
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Given line: "  hello world  "
 /// //             ^  ^          ^ ^

--- a/lib/kernel/src/core/mark.rs
+++ b/lib/kernel/src/core/mark.rs
@@ -22,8 +22,7 @@ use crate::mm::{BufferId, Position};
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::Mark;
-/// use reovim_kernel::mm::{BufferId, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mark = Mark {
 ///     position: Position::new(10, 5),
@@ -56,7 +55,7 @@ impl Mark {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::SpecialMark;
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Jump to last position before current jump
 /// let last_jump = SpecialMark::LastJump; // ''
@@ -93,8 +92,7 @@ pub enum SpecialMark {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{MarkBank, Mark, SpecialMark};
-/// use reovim_kernel::mm::{BufferId, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mut marks = MarkBank::new();
 ///

--- a/lib/kernel/src/core/mod.rs
+++ b/lib/kernel/src/core/mod.rs
@@ -21,8 +21,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::core::{Motion, Direction, MotionEngine};
-//! use reovim_kernel::mm::{Buffer, Cursor, Position};
+//! use reovim_kernel::api::v1::*;
 //!
 //! let buffer = Buffer::from_string("hello world");
 //! let cursor = Cursor::new(Position::new(0, 0));
@@ -33,7 +32,7 @@
 //!     &cursor,
 //!     Motion::Word {
 //!         direction: Direction::Forward,
-//!         boundary: reovim_kernel::core::WordBoundary::Word,
+//!         boundary: WordBoundary::Word,
 //!         end: false,
 //!     },
 //!     1,

--- a/lib/kernel/src/core/motion.rs
+++ b/lib/kernel/src/core/motion.rs
@@ -24,7 +24,7 @@ const BRACKET_PAIRS: [(char, char); 3] = [('(', ')'), ('[', ']'), ('{', '}')];
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{Motion, Direction, WordBoundary, LinePosition};
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Character motion (h, l)
 /// let left = Motion::Char(Direction::Backward);
@@ -125,8 +125,7 @@ impl Motion {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{MotionEngine, Motion, Direction};
-/// use reovim_kernel::mm::{Buffer, Cursor, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let buffer = Buffer::from_string("hello world");
 /// let cursor = Cursor::new(Position::new(0, 0));

--- a/lib/kernel/src/core/register.rs
+++ b/lib/kernel/src/core/register.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::YankType;
+/// use reovim_kernel::api::v1::*;
 ///
 /// // yw yanks characterwise
 /// let char_yank = YankType::Characterwise;
@@ -112,7 +112,7 @@ impl Default for RegisterContent {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{RegisterBank, RegisterContent, YankType};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mut bank = RegisterBank::new();
 ///

--- a/lib/kernel/src/core/textobj.rs
+++ b/lib/kernel/src/core/textobj.rs
@@ -17,7 +17,7 @@ use super::direction::WordBoundary;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{TextObject, WordBoundary};
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Delete inner word: diw
 /// let inner_word = TextObject::InnerWord(WordBoundary::Word);
@@ -142,8 +142,7 @@ impl TextObject {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::core::{TextObjectEngine, TextObject, WordBoundary};
-/// use reovim_kernel::mm::{Buffer, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let buffer = Buffer::from_string("hello world");
 /// let pos = Position::new(0, 0);

--- a/lib/kernel/src/ipc/channel.rs
+++ b/lib/kernel/src/ipc/channel.rs
@@ -19,7 +19,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::ipc::{channel, bounded, oneshot};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Unbounded channel
 //! let (tx, rx) = channel::<i32>();
@@ -178,7 +178,7 @@ impl<T> std::fmt::Debug for Receiver<T> {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::ipc::channel;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let (tx, rx) = channel::<i32>();
 /// tx.send(42).unwrap();
@@ -313,7 +313,7 @@ impl<T> std::fmt::Debug for BoundedReceiver<T> {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::ipc::bounded;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let (tx, rx) = bounded::<i32>(2);
 /// tx.send(1).unwrap();
@@ -422,7 +422,7 @@ impl<T> std::fmt::Debug for OneshotReceiver<T> {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::ipc::oneshot;
+/// use reovim_kernel::api::v1::*;
 /// use std::thread;
 ///
 /// let (tx, rx) = oneshot::<String>();

--- a/lib/kernel/src/ipc/event.rs
+++ b/lib/kernel/src/ipc/event.rs
@@ -13,7 +13,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::ipc::{Event, DynEvent, EventResult};
+//! use reovim_kernel::api::v1::*;
 //!
 //! #[derive(Debug)]
 //! struct BufferChanged {
@@ -177,7 +177,7 @@ impl DynEvent {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{Event, DynEvent};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent;
@@ -203,7 +203,7 @@ impl DynEvent {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{DynEvent, Event, EventScope};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent;
@@ -268,7 +268,7 @@ impl DynEvent {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{DynEvent, Event};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent { value: i32 }
@@ -317,7 +317,7 @@ impl DynEvent {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{DynEvent, Event};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug, PartialEq)]
     /// struct MyEvent { value: i32 }

--- a/lib/kernel/src/ipc/event_bus.rs
+++ b/lib/kernel/src/ipc/event_bus.rs
@@ -25,7 +25,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::ipc::{EventBus, Event, EventResult};
+//! use reovim_kernel::api::v1::*;
 //!
 //! #[derive(Debug)]
 //! struct BufferChanged { buffer_id: u64 }
@@ -129,7 +129,7 @@ impl EventBus {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent { value: i32 }
@@ -212,7 +212,7 @@ impl EventBus {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent;
@@ -236,7 +236,7 @@ impl EventBus {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{EventBus, Event, EventResult, EventScope};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent;
@@ -268,7 +268,7 @@ impl EventBus {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::{EventBus, Event, EventResult};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// #[derive(Debug)]
     /// struct MyEvent;

--- a/lib/kernel/src/ipc/mod.rs
+++ b/lib/kernel/src/ipc/mod.rs
@@ -50,7 +50,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::ipc::{EventBus, Event, EventResult, EventScope};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Define an event
 //! #[derive(Debug)]

--- a/lib/kernel/src/ipc/scope.rs
+++ b/lib/kernel/src/ipc/scope.rs
@@ -20,7 +20,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::ipc::EventScope;
+//! use reovim_kernel::api::v1::*;
 //! use std::time::Duration;
 //!
 //! let scope = EventScope::new();
@@ -108,7 +108,7 @@ struct ScopeInner {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::ipc::EventScope;
+/// use reovim_kernel::api::v1::*;
 /// use std::thread;
 /// use std::time::Duration;
 ///
@@ -228,7 +228,7 @@ impl EventScope {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::ipc::EventScope;
+    /// use reovim_kernel::api::v1::*;
     /// use std::time::Duration;
     ///
     /// let scope = EventScope::new();

--- a/lib/kernel/src/lib.rs
+++ b/lib/kernel/src/lib.rs
@@ -5,27 +5,54 @@
 //! This crate provides pure mechanisms without I/O. Drivers and modules
 //! implement policies using these primitives.
 //!
+//! # Usage
+//!
+//! All public APIs are accessed via the `api::v1` module:
+//!
+//! ```ignore
+//! use reovim_kernel::api::v1::*;
+//!
+//! // Check API compatibility
+//! check_api_version(Version::new(1, 0, 0))?;
+//!
+//! // Use kernel types
+//! let bus = EventBus::new();
+//! pr_info!("kernel initialized");
+//! ```
+//!
 //! # Subsystems
+//!
+//! Internal subsystems (not directly accessible):
 //!
 //! - `sched`: Scheduler and runtime (Linux: `kernel/sched/`)
 //! - `mm`: Memory management / buffers (Linux: `mm/`)
 //! - `ipc`: Inter-process communication / events (Linux: `ipc/`)
 //! - `core`: Core primitives (motion, text objects, commands)
 //! - `block`: Block operations (undo, transactions)
-//! - `api`: Stable kernel API (Linux: `include/linux/`)
 //! - `printk`: Kernel logging (Linux: `kernel/printk/`)
 //! - `debug`: Tracing and metrics
 //! - `panic`: Panic handling and recovery
+//!
+//! All subsystem types are re-exported through `api::v1`.
+
+// ============================================================================
+// Public API - the ONLY public module
+// ============================================================================
 
 pub mod api;
-pub mod block;
-pub mod core;
-pub mod debug;
-pub mod ipc;
-pub mod mm;
-pub mod panic;
-pub mod printk;
-pub mod sched;
 
-// Re-export arch for convenience
-pub use reovim_arch as arch;
+// ============================================================================
+// Internal modules - NOT accessible from outside
+// ============================================================================
+
+pub(crate) mod block;
+pub(crate) mod core;
+pub(crate) mod debug;
+pub(crate) mod ipc;
+pub(crate) mod mm;
+pub(crate) mod panic;
+pub(crate) mod printk;
+pub(crate) mod sched;
+
+// Re-export arch for internal use only
+pub(crate) use reovim_arch as arch;

--- a/lib/kernel/src/mm/buffer.rs
+++ b/lib/kernel/src/mm/buffer.rs
@@ -21,7 +21,7 @@ use super::{BufferId, Cursor, Edit, Position};
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::mm::{Buffer, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mut buf = Buffer::from_string("Hello\nWorld");
 /// assert_eq!(buf.line_count(), 2);

--- a/lib/kernel/src/mm/buffer_id.rs
+++ b/lib/kernel/src/mm/buffer_id.rs
@@ -16,7 +16,7 @@ static NEXT_BUFFER_ID: AtomicUsize = AtomicUsize::new(0);
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::mm::BufferId;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let id1 = BufferId::new();
 /// let id2 = BufferId::new();

--- a/lib/kernel/src/mm/edit.rs
+++ b/lib/kernel/src/mm/edit.rs
@@ -19,7 +19,7 @@ use super::Position;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::mm::{Edit, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let insert = Edit::insert(Position::new(0, 5), "Hello");
 /// assert!(insert.is_insert());

--- a/lib/kernel/src/mm/mod.rs
+++ b/lib/kernel/src/mm/mod.rs
@@ -24,7 +24,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::mm::{Buffer, Position, Edit};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Create a buffer from text
 //! let mut buf = Buffer::from_string("Hello\nWorld");

--- a/lib/kernel/src/mm/position.rs
+++ b/lib/kernel/src/mm/position.rs
@@ -11,7 +11,7 @@
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::mm::Position;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let pos = Position::new(5, 10);
 /// assert_eq!(pos.line, 5);
@@ -88,7 +88,7 @@ impl std::fmt::Display for Position {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::mm::{Cursor, Position};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let mut cursor = Cursor::new(Position::new(0, 5));
 ///

--- a/lib/kernel/src/printk/level.rs
+++ b/lib/kernel/src/printk/level.rs
@@ -27,7 +27,7 @@ use std::{fmt, str::FromStr};
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::Level;
+/// use reovim_kernel::api::v1::*;
 /// use std::str::FromStr;
 ///
 /// let level = Level::Info;
@@ -87,7 +87,7 @@ impl Level {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::printk::Level;
+    /// use reovim_kernel::api::v1::*;
     ///
     /// assert_eq!(Level::Error.as_str(), "ERROR");
     /// assert_eq!(Level::Warn.as_str(), "WARN");
@@ -111,7 +111,7 @@ impl Level {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::printk::Level;
+    /// use reovim_kernel::api::v1::*;
     ///
     /// assert!(Level::Error.is_at_least(Level::Info));   // Error is more severe
     /// assert!(Level::Info.is_at_least(Level::Info));    // Same level
@@ -143,7 +143,7 @@ impl FromStr for Level {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::printk::Level;
+    /// use reovim_kernel::api::v1::*;
     /// use std::str::FromStr;
     ///
     /// assert_eq!(Level::from_str("error"), Ok(Level::Error));

--- a/lib/kernel/src/printk/logger.rs
+++ b/lib/kernel/src/printk/logger.rs
@@ -24,7 +24,7 @@ use super::{level::Level, record::Record};
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::{Logger, Level, Record};
+/// use reovim_kernel::api::v1::*;
 ///
 /// struct StderrLogger;
 ///
@@ -139,7 +139,7 @@ static NOP_LOGGER: NopLogger = NopLogger;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::{Logger, Level, Record, set_logger};
+/// use reovim_kernel::api::v1::*;
 ///
 /// struct MyLogger;
 ///
@@ -170,7 +170,7 @@ pub fn set_logger(logger: &'static dyn Logger) -> Result<(), SetLoggerError> {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::{logger, Level};
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Before set_logger() is called, returns NopLogger
 /// assert!(!logger().enabled(Level::Error));

--- a/lib/kernel/src/printk/macros.rs
+++ b/lib/kernel/src/printk/macros.rs
@@ -14,7 +14,7 @@
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::pr_err;
+/// use reovim_kernel::api::v1::pr_err;
 ///
 /// let buffer_id = 42;
 /// pr_err!("failed to save buffer {}", buffer_id);
@@ -23,9 +23,9 @@
 #[macro_export]
 macro_rules! pr_err {
     ($($arg:tt)*) => {
-        if $crate::printk::logger().enabled($crate::printk::Level::Error) {
-            $crate::printk::__log(
-                $crate::printk::Level::Error,
+        if $crate::api::v1::logger().enabled($crate::api::v1::Level::Error) {
+            $crate::api::v1::__log(
+                $crate::api::v1::Level::Error,
                 module_path!(),
                 file!(),
                 line!(),
@@ -43,7 +43,7 @@ macro_rules! pr_err {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::pr_warn;
+/// use reovim_kernel::api::v1::pr_warn;
 ///
 /// let path = "/tmp/file.txt";
 /// pr_warn!("file {} not found, using default", path);
@@ -52,9 +52,9 @@ macro_rules! pr_err {
 #[macro_export]
 macro_rules! pr_warn {
     ($($arg:tt)*) => {
-        if $crate::printk::logger().enabled($crate::printk::Level::Warn) {
-            $crate::printk::__log(
-                $crate::printk::Level::Warn,
+        if $crate::api::v1::logger().enabled($crate::api::v1::Level::Warn) {
+            $crate::api::v1::__log(
+                $crate::api::v1::Level::Warn,
                 module_path!(),
                 file!(),
                 line!(),
@@ -71,7 +71,7 @@ macro_rules! pr_warn {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::pr_info;
+/// use reovim_kernel::api::v1::pr_info;
 ///
 /// pr_info!("editor started");
 /// pr_info!("opened {} buffers", 3);
@@ -79,9 +79,9 @@ macro_rules! pr_warn {
 #[macro_export]
 macro_rules! pr_info {
     ($($arg:tt)*) => {
-        if $crate::printk::logger().enabled($crate::printk::Level::Info) {
-            $crate::printk::__log(
-                $crate::printk::Level::Info,
+        if $crate::api::v1::logger().enabled($crate::api::v1::Level::Info) {
+            $crate::api::v1::__log(
+                $crate::api::v1::Level::Info,
                 module_path!(),
                 file!(),
                 line!(),
@@ -99,7 +99,7 @@ macro_rules! pr_info {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::pr_debug;
+/// use reovim_kernel::api::v1::pr_debug;
 ///
 /// let cursor_pos = (10, 5);
 /// pr_debug!("cursor moved to {:?}", cursor_pos);
@@ -108,9 +108,9 @@ macro_rules! pr_info {
 #[macro_export]
 macro_rules! pr_debug {
     ($($arg:tt)*) => {
-        if $crate::printk::logger().enabled($crate::printk::Level::Debug) {
-            $crate::printk::__log(
-                $crate::printk::Level::Debug,
+        if $crate::api::v1::logger().enabled($crate::api::v1::Level::Debug) {
+            $crate::api::v1::__log(
+                $crate::api::v1::Level::Debug,
                 module_path!(),
                 file!(),
                 line!(),
@@ -128,7 +128,7 @@ macro_rules! pr_debug {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::pr_trace;
+/// use reovim_kernel::api::v1::pr_trace;
 ///
 /// pr_trace!("processing event");
 /// pr_trace!("loop iteration {}", 42);
@@ -136,9 +136,9 @@ macro_rules! pr_debug {
 #[macro_export]
 macro_rules! pr_trace {
     ($($arg:tt)*) => {
-        if $crate::printk::logger().enabled($crate::printk::Level::Trace) {
-            $crate::printk::__log(
-                $crate::printk::Level::Trace,
+        if $crate::api::v1::logger().enabled($crate::api::v1::Level::Trace) {
+            $crate::api::v1::__log(
+                $crate::api::v1::Level::Trace,
                 module_path!(),
                 file!(),
                 line!(),

--- a/lib/kernel/src/printk/mod.rs
+++ b/lib/kernel/src/printk/mod.rs
@@ -73,7 +73,7 @@
 //! ## Setting a Logger (Driver Layer)
 //!
 //! ```
-//! use reovim_kernel::printk::{Logger, Level, Record, set_logger};
+//! use reovim_kernel::api::v1::*;
 //!
 //! struct StderrLogger;
 //!

--- a/lib/kernel/src/printk/record.rs
+++ b/lib/kernel/src/printk/record.rs
@@ -16,7 +16,7 @@ use super::level::Level;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::{Level, Record};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let record = Record::builder(Level::Info)
 ///     .message("buffer opened")
@@ -44,7 +44,7 @@ impl<'a> Record<'a> {
     /// # Example
     ///
     /// ```
-    /// use reovim_kernel::printk::{Level, Record};
+    /// use reovim_kernel::api::v1::*;
     ///
     /// let record = Record::builder(Level::Error)
     ///     .message("something went wrong")
@@ -93,7 +93,7 @@ impl<'a> Record<'a> {
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::printk::{Level, Record};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let record = Record::builder(Level::Debug)
 ///     .message("entering function")

--- a/lib/kernel/src/sched/executor.rs
+++ b/lib/kernel/src/sched/executor.rs
@@ -15,7 +15,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::sched::{Executor, WorkQueue, Task};
+//! use reovim_kernel::api::v1::*;
 //! use std::sync::Arc;
 //!
 //! let queue = Arc::new(WorkQueue::new());

--- a/lib/kernel/src/sched/mod.rs
+++ b/lib/kernel/src/sched/mod.rs
@@ -32,7 +32,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::sched::{Runtime, RuntimeState, Task, Priority};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Create and boot runtime
 //! let mut runtime = Runtime::new();
@@ -63,7 +63,7 @@
 //! marked as such and counted in statistics.
 //!
 //! ```
-//! use reovim_kernel::sched::Runtime;
+//! use reovim_kernel::api::v1::*;
 //!
 //! let mut runtime = Runtime::new();
 //! runtime.boot();

--- a/lib/kernel/src/sched/runtime.rs
+++ b/lib/kernel/src/sched/runtime.rs
@@ -16,7 +16,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::sched::{Runtime, RuntimeState};
+//! use reovim_kernel::api::v1::*;
 //!
 //! let mut runtime = Runtime::new();
 //! runtime.boot();
@@ -62,7 +62,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 16;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::sched::{Runtime, RuntimeConfig};
+/// use reovim_kernel::api::v1::*;
 ///
 /// let config = RuntimeConfig {
 ///     work_queue_capacity: 2048,

--- a/lib/kernel/src/sched/state.rs
+++ b/lib/kernel/src/sched/state.rs
@@ -151,6 +151,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::clone_on_copy)] // Intentionally testing Clone impl
     fn test_clone_and_copy() {
         let state = RuntimeState::Running;
         let cloned = state.clone();

--- a/lib/kernel/src/sched/task.rs
+++ b/lib/kernel/src/sched/task.rs
@@ -9,7 +9,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::sched::{Task, Priority};
+//! use reovim_kernel::api::v1::*;
 //!
 //! // Create a task with default (normal) priority
 //! let task = Task::new(|| {
@@ -36,7 +36,7 @@ use std::{
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::sched::TaskId;
+/// use reovim_kernel::api::v1::*;
 ///
 /// let id1 = TaskId::new();
 /// let id2 = TaskId::new();
@@ -210,7 +210,7 @@ pub type BoxedTask = Box<dyn FnOnce() + Send + 'static>;
 /// # Example
 ///
 /// ```
-/// use reovim_kernel::sched::{Task, Priority, TaskState};
+/// use reovim_kernel::api::v1::*;
 ///
 /// // Create a high-priority task with a name
 /// let mut task = Task::with_priority(Priority::HIGH, || println!("Hello!"))

--- a/lib/kernel/src/sched/work_queue.rs
+++ b/lib/kernel/src/sched/work_queue.rs
@@ -15,7 +15,7 @@
 //! # Example
 //!
 //! ```
-//! use reovim_kernel::sched::{WorkQueue, Task};
+//! use reovim_kernel::api::v1::*;
 //!
 //! let queue = WorkQueue::new();
 //!


### PR DESCRIPTION
Define the stable kernel API surface following Linux `include/linux/` pattern. All public APIs are now accessed exclusively via `api::v1::*`, with internal modules hidden behind `pub(crate)`.

Key changes:
- Add Version struct for type-safe version management (API v1.0.0)
- Add BufferManager trait for kernel-driver buffer communication
- Add KernelContext struct bundling kernel services
- Create v1.rs with all stable exports (90+ types)
- Add unstable.rs (feature-gated) and internal.rs (doc-hidden) placeholders
- Update printk macros to use api::v1 paths
- Update all doctests to use api::v1 imports
- Make internal modules (mm, ipc, core, block, sched, printk) pub(crate)

Breaking change: Direct imports like `reovim_kernel::mm::Buffer` no longer work. Use `reovim_kernel::api::v1::Buffer` instead.

Closes: #164