### PR TITLE
feat(kernel): add ModuleId and SyntaxHighlight to api/ (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 2.8: Module & Syntax API** (Issue #173) - Kernel API extensions for Phase 3
+  - `ModuleId` struct - Unique identifier for loadable modules
+    - Convention: kebab-case names (e.g., "lang-rust", "feat-completion")
+    - `new()`, `as_str()` const methods
+    - Implements `Clone`, `Eq`, `Hash`, `Display`
+  - `ModuleError` enum - Module lifecycle errors (7 variants)
+    - `LoadFailed` - Failed to load shared object
+    - `NoEntryPoint` - Module missing entry function
+    - `InitFailed` - Initialization failed
+    - `IncompatibleVersion` - API version mismatch
+    - `InUse` - Module in use by another module
+    - `NotLoaded` - Module not currently loaded
+    - `NotFound` - Module file not found
+    - Implements `Display` and `std::error::Error`
+  - `SyntaxHighlight` trait - Mechanism for syntax highlight categories
+    - Kernel provides mechanism (trait), drivers provide policy (enum)
+    - Bounds: `Debug + Copy + Eq + Hash + Send + Sync + 'static`
+    - Single method: `fn category(&self) -> &'static str`
+  - 6 unit tests + 2 API integration tests
+
 - **Phase 2.7: Printk Module** (Issue #168) - Kernel printk/ logging subsystem
   - `Level` enum - Log severity levels (Error, Warn, Info, Debug, Trace)
     - Ordered by severity for filtering (Error < Warn < Info < Debug < Trace)

--- a/lib/kernel/src/api/mod.rs
+++ b/lib/kernel/src/api/mod.rs
@@ -30,6 +30,8 @@
 
 mod buffer_manager;
 mod context;
+mod module;
+mod syntax;
 mod version;
 
 // ============================================================================

--- a/lib/kernel/src/api/module.rs
+++ b/lib/kernel/src/api/module.rs
@@ -1,0 +1,124 @@
+//! Module identity and error types.
+//!
+//! Linux equivalent: `include/linux/module.h`
+
+use std::fmt;
+
+/// Unique identifier for a loadable module.
+///
+/// Convention: Use kebab-case names like "lang-rust", "feat-completion".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModuleId(pub &'static str);
+
+impl ModuleId {
+    /// Create a new module identifier.
+    #[must_use]
+    pub const fn new(id: &'static str) -> Self {
+        Self(id)
+    }
+
+    /// Get the identifier string.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Errors that can occur during module operations.
+#[derive(Debug)]
+pub enum ModuleError {
+    /// Failed to load the shared object file.
+    LoadFailed(String),
+
+    /// Module does not export the required entry point.
+    NoEntryPoint(String),
+
+    /// Module initialization failed.
+    InitFailed(String),
+
+    /// Module API version is incompatible with kernel.
+    IncompatibleVersion {
+        /// Version the module requires.
+        module: (u32, u32),
+        /// Version the kernel provides.
+        kernel: (u32, u32),
+    },
+
+    /// Module is in use by another module.
+    InUse {
+        /// The module that cannot be unloaded.
+        module: ModuleId,
+        /// The module that depends on it.
+        by: ModuleId,
+    },
+
+    /// Module is not currently loaded.
+    NotLoaded(ModuleId),
+
+    /// Module file was not found.
+    NotFound(String),
+}
+
+impl fmt::Display for ModuleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LoadFailed(msg) => write!(f, "failed to load module: {msg}"),
+            Self::NoEntryPoint(msg) => write!(f, "module missing entry point: {msg}"),
+            Self::InitFailed(msg) => write!(f, "module initialization failed: {msg}"),
+            Self::IncompatibleVersion { module, kernel } => {
+                write!(
+                    f,
+                    "module requires API {}.{}, kernel provides {}.{}",
+                    module.0, module.1, kernel.0, kernel.1
+                )
+            }
+            Self::InUse { module, by } => {
+                write!(f, "module '{module}' is in use by '{by}'")
+            }
+            Self::NotLoaded(id) => write!(f, "module '{id}' is not loaded"),
+            Self::NotFound(name) => write!(f, "module '{name}' not found"),
+        }
+    }
+}
+
+impl std::error::Error for ModuleError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_id() {
+        let id = ModuleId::new("lang-rust");
+        assert_eq!(id.as_str(), "lang-rust");
+        assert_eq!(format!("{id}"), "lang-rust");
+    }
+
+    #[test]
+    fn test_module_id_equality() {
+        let id1 = ModuleId::new("lang-rust");
+        let id2 = ModuleId::new("lang-rust");
+        let id3 = ModuleId::new("lang-python");
+        assert_eq!(id1, id2);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn test_module_error_display() {
+        let err = ModuleError::NotFound("test-module".into());
+        assert_eq!(format!("{err}"), "module 'test-module' not found");
+
+        let err = ModuleError::IncompatibleVersion {
+            module: (2, 0),
+            kernel: (1, 5),
+        };
+        assert!(format!("{err}").contains("2.0"));
+        assert!(format!("{err}").contains("1.5"));
+    }
+}

--- a/lib/kernel/src/api/syntax.rs
+++ b/lib/kernel/src/api/syntax.rs
@@ -1,0 +1,95 @@
+//! Syntax highlighting mechanism trait.
+//!
+//! Linux equivalent: Generic highlight categories (mechanism).
+//! The actual highlight groups (policy) are defined in `lib/drivers/syntax/`.
+//!
+//! # Design Principle
+//!
+//! The kernel provides the *mechanism* (how highlights are categorized),
+//! while drivers/modules provide the *policy* (what the categories are).
+
+use std::{fmt::Debug, hash::Hash};
+
+/// Trait for syntax highlight categories.
+///
+/// This is a mechanism trait that defines the interface for highlight types.
+/// Implementations (policies) are provided by the syntax driver layer.
+///
+/// # Example
+///
+/// ```ignore
+/// // In lib/drivers/syntax/
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// pub enum HighlightGroup {
+///     Keyword,
+///     Function,
+///     String,
+///     // ...
+/// }
+///
+/// impl SyntaxHighlight for HighlightGroup {
+///     fn category(&self) -> &'static str {
+///         match self {
+///             Self::Keyword => "keyword",
+///             Self::Function => "function",
+///             Self::String => "string",
+///         }
+///     }
+/// }
+/// ```
+pub trait SyntaxHighlight: Debug + Copy + Eq + Hash + Send + Sync + 'static {
+    /// Returns the category name for this highlight.
+    ///
+    /// Category names should be lowercase, hyphenated identifiers
+    /// (e.g., "keyword", "function-builtin", "string-escape").
+    fn category(&self) -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test implementation
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    enum TestHighlight {
+        Keyword,
+        Comment,
+    }
+
+    impl SyntaxHighlight for TestHighlight {
+        fn category(&self) -> &'static str {
+            match self {
+                Self::Keyword => "keyword",
+                Self::Comment => "comment",
+            }
+        }
+    }
+
+    #[test]
+    fn test_syntax_highlight_trait() {
+        let hl = TestHighlight::Keyword;
+        assert_eq!(hl.category(), "keyword");
+
+        let hl2 = TestHighlight::Comment;
+        assert_eq!(hl2.category(), "comment");
+    }
+
+    #[test]
+    fn test_syntax_highlight_equality() {
+        let hl1 = TestHighlight::Keyword;
+        let hl2 = TestHighlight::Keyword;
+        let hl3 = TestHighlight::Comment;
+
+        assert_eq!(hl1, hl2);
+        assert_ne!(hl1, hl3);
+    }
+
+    #[test]
+    fn test_syntax_highlight_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(TestHighlight::Keyword);
+        set.insert(TestHighlight::Comment);
+        assert_eq!(set.len(), 2);
+    }
+}

--- a/lib/kernel/src/api/v1.rs
+++ b/lib/kernel/src/api/v1.rs
@@ -133,6 +133,18 @@ pub use crate::printk::__log;
 pub use crate::{pr_debug, pr_err, pr_info, pr_trace, pr_warn};
 
 // ============================================================================
+// Module System (api/)
+// ============================================================================
+
+pub use super::module::{ModuleError, ModuleId};
+
+// ============================================================================
+// Syntax Mechanism (api/)
+// ============================================================================
+
+pub use super::syntax::SyntaxHighlight;
+
+// ============================================================================
 // Sync Primitives (from arch)
 // ============================================================================
 
@@ -180,5 +192,35 @@ mod tests {
         // Verify printk macros work via v1
         pr_info!("test message");
         pr_debug!("debug: {}", 42);
+    }
+
+    #[test]
+    fn test_module_types_accessible() {
+        // Verify ModuleId and ModuleError are accessible
+        let id = ModuleId::new("test-module");
+        assert_eq!(id.as_str(), "test-module");
+
+        let _err: ModuleError = ModuleError::NotFound("test".into());
+    }
+
+    #[test]
+    fn test_syntax_trait_accessible() {
+        // Verify SyntaxHighlight trait is accessible
+        fn _accepts_highlight<T: SyntaxHighlight>(_: T) {}
+
+        // The trait is available for implementation by drivers
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        enum TestHL {
+            Keyword,
+        }
+
+        impl SyntaxHighlight for TestHL {
+            fn category(&self) -> &'static str {
+                "keyword"
+            }
+        }
+
+        let hl = TestHL::Keyword;
+        assert_eq!(hl.category(), "keyword");
     }
 }


### PR DESCRIPTION
Add prerequisite types for Phase 3 (Driver Layer) implementation:

- ModuleId: Unique identifier for loadable modules
  - Kebab-case naming convention (e.g., "lang-rust")
  - Implements Clone, Eq, Hash, Display

- ModuleError: Module lifecycle errors (7 variants)
  - LoadFailed, NoEntryPoint, InitFailed
  - IncompatibleVersion, InUse, NotLoaded, NotFound

- SyntaxHighlight: Mechanism trait for highlight categories
  - Kernel provides mechanism, drivers provide policy
  - Bounds: Debug + Copy + Eq + Hash + Send + Sync + 'static

This unblocks Phase 3 driver implementations (#174-#180).

Closes: #173