### PR TITLE
feat(drivers): implement syntax/ SyntaxDriver traits (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.1: Syntax Driver Traits** (Issue #174) - Driver layer syntax highlighting interfaces
+  - `HighlightGroup` enum (31 variants) - Syntax category policy implementing kernel's `SyntaxHighlight`
+    - Keywords: `Keyword`, `KeywordControl`, `KeywordOperator`, `KeywordFunction`, `KeywordType`
+    - Types: `Type`, `TypeBuiltin`
+    - Functions: `Function`, `FunctionBuiltin`, `FunctionMacro`, `Method`
+    - Variables: `Variable`, `VariableBuiltin`, `Parameter`, `Field`, `Constant`
+    - Literals: `String`, `StringEscape`, `Character`, `Number`, `Boolean`
+    - Comments: `Comment`, `CommentDoc`
+    - Punctuation: `Punctuation`, `PunctuationBracket`, `PunctuationDelimiter`
+    - Operators: `Operator`
+    - Diagnostics: `Error`, `Warning`, `Info`, `Hint`
+    - Special: `Custom = 255`
+    - Classification methods: `is_keyword()`, `is_type()`, `is_function()`, etc.
+  - `HighlightSpan` struct - Byte-based highlight ranges with group
+  - `SyntaxEdit` struct - Incremental parsing edit info (mirrors tree-sitter's InputEdit)
+    - Constructors: `new()`, `insert()`, `delete()`
+    - Analysis: `affected_range()`, `byte_delta()`, `is_insert()`, `is_delete()`, `is_replace()`
+  - `FoldRange` + `FoldKind` - Code folding support
+    - `FoldKind`: Function, Class, Import, Comment, Block
+    - `FoldRange`: line-based ranges with preview text
+  - `Injection` struct - Embedded language regions for injections
+  - `LanguageInfo` + `CommentTokens` - Language metadata (extensions, MIME types, comment syntax)
+  - `SyntaxDriver` trait - Main parsing/highlighting interface (Send + Sync)
+    - `parse()`, `update()`, `highlights()`, `injections()`, `folds()`, `indent_for()`
+  - `SyntaxDriverFactory` trait - Creates drivers for languages
+  - `LanguageRegistry` trait - Language detection and metadata
+  - `SyntaxCache` trait - Highlight result caching
+  - Re-exports `ModuleError` from kernel for consistency
+  - **NO tree-sitter dependency** - Trait definitions only
+  - 60 unit tests + 8 doctests
+
 - **Phase 2.8: Module & Syntax API** (Issue #173) - Kernel API extensions for Phase 3
   - `ModuleId` struct - Unique identifier for loadable modules
     - Convention: kebab-case names (e.g., "lang-rust", "feat-completion")

--- a/lib/drivers/syntax/src/cache.rs
+++ b/lib/drivers/syntax/src/cache.rs
@@ -1,0 +1,183 @@
+//! Syntax cache trait.
+//!
+//! This module defines the [`SyntaxCache`] trait for caching highlight results.
+
+use std::ops::Range;
+
+use crate::highlight::HighlightSpan;
+
+/// Cache for highlight results.
+///
+/// Implementations can provide various caching strategies for
+/// highlight data to improve performance.
+///
+/// # Thread Safety
+///
+/// Implementations must be `Send + Sync` to allow use across threads.
+///
+/// # Example
+///
+/// ```ignore
+/// // Insert highlights for a range
+/// cache.insert(0..100, highlights);
+///
+/// // Later, retrieve cached highlights
+/// if let Some(cached) = cache.get(0..100) {
+///     // Use cached highlights
+/// }
+///
+/// // After an edit, invalidate affected ranges
+/// cache.invalidate_range(50..75);
+/// ```
+pub trait SyntaxCache: Send + Sync {
+    /// Get cached highlights for a byte range.
+    ///
+    /// Returns `None` if the range is not cached or cache is stale.
+    ///
+    /// # Arguments
+    ///
+    /// * `byte_range` - The byte range to look up
+    fn get(&self, byte_range: Range<usize>) -> Option<Vec<HighlightSpan>>;
+
+    /// Insert highlights into the cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `byte_range` - The byte range these highlights cover
+    /// * `highlights` - The highlights to cache
+    fn insert(&mut self, byte_range: Range<usize>, highlights: Vec<HighlightSpan>);
+
+    /// Invalidate cache entries that overlap with a range.
+    ///
+    /// Called after edits to mark affected regions as stale.
+    ///
+    /// # Arguments
+    ///
+    /// * `byte_range` - The byte range that was modified
+    fn invalidate_range(&mut self, byte_range: Range<usize>);
+
+    /// Clear all cached data.
+    fn clear(&mut self);
+
+    /// Check if the cache is empty.
+    fn is_empty(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::highlight::HighlightGroup, std::collections::HashMap};
+
+    /// Simple in-memory cache implementation for testing.
+    struct SimpleCache {
+        entries: HashMap<(usize, usize), Vec<HighlightSpan>>,
+    }
+
+    impl SimpleCache {
+        fn new() -> Self {
+            Self {
+                entries: HashMap::new(),
+            }
+        }
+    }
+
+    impl SyntaxCache for SimpleCache {
+        fn get(&self, byte_range: Range<usize>) -> Option<Vec<HighlightSpan>> {
+            self.entries
+                .get(&(byte_range.start, byte_range.end))
+                .cloned()
+        }
+
+        fn insert(&mut self, byte_range: Range<usize>, highlights: Vec<HighlightSpan>) {
+            self.entries
+                .insert((byte_range.start, byte_range.end), highlights);
+        }
+
+        fn invalidate_range(&mut self, byte_range: Range<usize>) {
+            self.entries.retain(|(start, end), _| {
+                // Keep entries that don't overlap with the invalidated range
+                *end <= byte_range.start || *start >= byte_range.end
+            });
+        }
+
+        fn clear(&mut self) {
+            self.entries.clear();
+        }
+
+        fn is_empty(&self) -> bool {
+            self.entries.is_empty()
+        }
+    }
+
+    #[test]
+    fn test_cache_insert_and_get() {
+        let mut cache = SimpleCache::new();
+
+        let highlights = vec![
+            HighlightSpan::new(0, 5, HighlightGroup::Keyword),
+            HighlightSpan::new(6, 10, HighlightGroup::Function),
+        ];
+
+        cache.insert(0..100, highlights.clone());
+
+        let cached = cache.get(0..100);
+        assert!(cached.is_some());
+        assert_eq!(cached.unwrap(), highlights);
+    }
+
+    #[test]
+    fn test_cache_get_missing() {
+        let cache = SimpleCache::new();
+
+        let cached = cache.get(0..100);
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_cache_invalidate_range() {
+        let mut cache = SimpleCache::new();
+
+        // Insert multiple entries
+        cache.insert(0..50, vec![HighlightSpan::new(0, 50, HighlightGroup::Keyword)]);
+        cache.insert(50..100, vec![HighlightSpan::new(50, 100, HighlightGroup::Function)]);
+        cache.insert(100..150, vec![HighlightSpan::new(100, 150, HighlightGroup::String)]);
+
+        // Invalidate middle range
+        cache.invalidate_range(40..60);
+
+        // First entry overlaps with invalidated range, should be removed
+        assert!(cache.get(0..50).is_none());
+        // Second entry overlaps with invalidated range, should be removed
+        assert!(cache.get(50..100).is_none());
+        // Third entry doesn't overlap, should remain
+        assert!(cache.get(100..150).is_some());
+    }
+
+    #[test]
+    fn test_cache_clear() {
+        let mut cache = SimpleCache::new();
+
+        cache.insert(0..50, vec![HighlightSpan::new(0, 50, HighlightGroup::Keyword)]);
+        cache.insert(50..100, vec![HighlightSpan::new(50, 100, HighlightGroup::Function)]);
+
+        assert!(!cache.is_empty());
+
+        cache.clear();
+
+        assert!(cache.is_empty());
+        assert!(cache.get(0..50).is_none());
+        assert!(cache.get(50..100).is_none());
+    }
+
+    #[test]
+    fn test_cache_is_empty() {
+        let mut cache = SimpleCache::new();
+
+        assert!(cache.is_empty());
+
+        cache.insert(0..50, vec![]);
+        assert!(!cache.is_empty());
+
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+}

--- a/lib/drivers/syntax/src/driver.rs
+++ b/lib/drivers/syntax/src/driver.rs
@@ -1,0 +1,205 @@
+//! Syntax driver trait definition.
+//!
+//! This module defines the [`SyntaxDriver`] trait, the main interface for
+//! syntax highlighting implementations. Implementations handle parsing and
+//! highlighting for specific languages.
+
+use std::ops::Range;
+
+use crate::{edit::SyntaxEdit, fold::FoldRange, highlight::HighlightSpan, injection::Injection};
+
+/// Main parsing interface for syntax highlighting.
+///
+/// Implementors provide language-specific parsing and highlighting.
+/// This trait is designed to be parser-agnostic - tree-sitter is just
+/// one possible implementation.
+///
+/// # Lifecycle
+///
+/// 1. Create driver via [`SyntaxDriverFactory`](crate::SyntaxDriverFactory)
+/// 2. Call [`parse()`](Self::parse) with initial content
+/// 3. Call [`update()`](Self::update) for incremental edits
+/// 4. Call [`highlights()`](Self::highlights) to get highlights for rendering
+///
+/// # Thread Safety
+///
+/// Implementations must be `Send + Sync` to allow use across threads.
+/// The driver may be shared between multiple views of the same buffer.
+///
+/// # Example
+///
+/// ```ignore
+/// // Get driver from factory
+/// let mut driver = factory.create("rust")?;
+///
+/// // Initial parse
+/// driver.parse("fn main() {}");
+/// assert!(driver.is_parsed());
+///
+/// // Get highlights for visible range
+/// let highlights = driver.highlights(0..100);
+///
+/// // After edit, update incrementally
+/// driver.update("fn main() { println!(); }", &edit);
+/// ```
+pub trait SyntaxDriver: Send + Sync {
+    /// Get the language identifier.
+    ///
+    /// Returns a unique identifier like "rust", "python", "javascript".
+    /// This should match the language ID used to create the driver.
+    fn language(&self) -> &str;
+
+    /// Perform a full parse of the content.
+    ///
+    /// Called on initial file open or when incremental update isn't possible.
+    /// After calling this, [`is_parsed()`](Self::is_parsed) should return true.
+    fn parse(&mut self, content: &str);
+
+    /// Apply an incremental edit.
+    ///
+    /// For efficient re-parsing after buffer modifications.
+    /// The edit describes what changed; the driver updates its internal state.
+    ///
+    /// # Arguments
+    ///
+    /// * `content` - The new full content after the edit
+    /// * `edit` - Description of what changed
+    fn update(&mut self, content: &str, edit: &SyntaxEdit);
+
+    /// Get highlights for a byte range.
+    ///
+    /// Returns all highlights that overlap with the given range.
+    /// Results should be sorted by start position.
+    ///
+    /// # Arguments
+    ///
+    /// * `byte_range` - The byte range to get highlights for
+    ///
+    /// # Returns
+    ///
+    /// A vector of highlights overlapping the requested range.
+    fn highlights(&self, byte_range: Range<usize>) -> Vec<HighlightSpan>;
+
+    /// Get language injection points.
+    ///
+    /// Returns regions where a different language should be highlighted.
+    /// Used for embedded languages (markdown code blocks, HTML scripts, etc.).
+    ///
+    /// # Default
+    ///
+    /// Returns an empty vector. Override for languages that support injections.
+    fn injections(&self) -> Vec<Injection> {
+        Vec::new()
+    }
+
+    /// Get foldable ranges.
+    ///
+    /// Returns all foldable regions in the document.
+    ///
+    /// # Default
+    ///
+    /// Returns an empty vector. Override to provide folding support.
+    fn folds(&self) -> Vec<FoldRange> {
+        Vec::new()
+    }
+
+    /// Get suggested indentation for a line.
+    ///
+    /// Returns the suggested indent level (in spaces) for a given line,
+    /// or None if indentation cannot be determined.
+    ///
+    /// # Arguments
+    ///
+    /// * `line` - The 0-indexed line number
+    ///
+    /// # Default
+    ///
+    /// Returns None. Override to provide indentation hints.
+    fn indent_for(&self, _line: usize) -> Option<usize> {
+        None
+    }
+
+    /// Check if the driver has valid parse state.
+    ///
+    /// Returns true if the driver has successfully parsed content.
+    /// This should return false before [`parse()`](Self::parse) is called,
+    /// and true after a successful parse.
+    fn is_parsed(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::highlight::HighlightGroup};
+
+    /// A minimal test implementation of SyntaxDriver.
+    struct TestDriver {
+        language: String,
+        parsed: bool,
+    }
+
+    impl TestDriver {
+        fn new(language: impl Into<String>) -> Self {
+            Self {
+                language: language.into(),
+                parsed: false,
+            }
+        }
+    }
+
+    impl SyntaxDriver for TestDriver {
+        fn language(&self) -> &str {
+            &self.language
+        }
+
+        fn parse(&mut self, _content: &str) {
+            self.parsed = true;
+        }
+
+        fn update(&mut self, _content: &str, _edit: &SyntaxEdit) {
+            // No-op for test
+        }
+
+        fn highlights(&self, byte_range: Range<usize>) -> Vec<HighlightSpan> {
+            if self.parsed {
+                // Return a single highlight spanning the range
+                vec![HighlightSpan::new(
+                    byte_range.start,
+                    byte_range.end,
+                    HighlightGroup::Comment,
+                )]
+            } else {
+                Vec::new()
+            }
+        }
+
+        fn is_parsed(&self) -> bool {
+            self.parsed
+        }
+    }
+
+    #[test]
+    fn test_syntax_driver_basic() {
+        let mut driver = TestDriver::new("test");
+
+        assert_eq!(driver.language(), "test");
+        assert!(!driver.is_parsed());
+
+        driver.parse("some content");
+        assert!(driver.is_parsed());
+
+        let highlights = driver.highlights(0..10);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].start_byte, 0);
+        assert_eq!(highlights[0].end_byte, 10);
+    }
+
+    #[test]
+    fn test_syntax_driver_defaults() {
+        let driver = TestDriver::new("test");
+
+        // Default implementations return empty/None
+        assert!(driver.injections().is_empty());
+        assert!(driver.folds().is_empty());
+        assert_eq!(driver.indent_for(0), None);
+    }
+}

--- a/lib/drivers/syntax/src/edit.rs
+++ b/lib/drivers/syntax/src/edit.rs
@@ -1,0 +1,309 @@
+//! Edit types for incremental parsing.
+//!
+//! This module defines the [`SyntaxEdit`] type used to describe text
+//! modifications for efficient incremental re-parsing.
+
+use std::ops::Range;
+
+/// Edit information for incremental parsing.
+///
+/// Describes a text modification in terms that parsers can use for
+/// efficient incremental re-parsing. Mirrors tree-sitter's `InputEdit`
+/// structure but without the tree-sitter dependency.
+///
+/// # Fields
+///
+/// The edit is described in terms of both byte offsets and row/column positions:
+/// - `start_*`: Where the edit begins
+/// - `old_end_*`: Where the old (replaced) content ended
+/// - `new_end_*`: Where the new (inserted) content ends
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::SyntaxEdit;
+///
+/// // Inserting "Hello" at position 0
+/// let edit = SyntaxEdit::insert(0, 0, 0, 5, 0, 5);
+/// assert_eq!(edit.new_end_byte, 5);
+/// assert_eq!(edit.old_end_byte, 0); // Nothing was replaced
+///
+/// // Deleting 10 bytes starting at position 5
+/// let edit = SyntaxEdit::delete(5, 0, 5, 15, 0, 15);
+/// assert_eq!(edit.start_byte, 5);
+/// assert_eq!(edit.old_end_byte, 15);
+/// assert_eq!(edit.new_end_byte, 5); // Nothing was inserted
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyntaxEdit {
+    /// Byte offset where the edit starts.
+    pub start_byte: usize,
+    /// Byte offset where the old content ended.
+    pub old_end_byte: usize,
+    /// Byte offset where the new content ends.
+    pub new_end_byte: usize,
+    /// Row (line) where the edit starts (0-indexed).
+    pub start_row: u32,
+    /// Column where the edit starts (0-indexed).
+    pub start_col: u32,
+    /// Row where old content ended.
+    pub old_end_row: u32,
+    /// Column where old content ended.
+    pub old_end_col: u32,
+    /// Row where new content ends.
+    pub new_end_row: u32,
+    /// Column where new content ends.
+    pub new_end_col: u32,
+}
+
+impl SyntaxEdit {
+    /// Create a new syntax edit with all fields specified.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        start_byte: usize,
+        old_end_byte: usize,
+        new_end_byte: usize,
+        start_row: u32,
+        start_col: u32,
+        old_end_row: u32,
+        old_end_col: u32,
+        new_end_row: u32,
+        new_end_col: u32,
+    ) -> Self {
+        Self {
+            start_byte,
+            old_end_byte,
+            new_end_byte,
+            start_row,
+            start_col,
+            old_end_row,
+            old_end_col,
+            new_end_row,
+            new_end_col,
+        }
+    }
+
+    /// Create an edit for an insertion (no content replaced).
+    ///
+    /// When inserting, `old_end` equals `start` since nothing was removed.
+    #[must_use]
+    pub const fn insert(
+        start_byte: usize,
+        start_row: u32,
+        start_col: u32,
+        new_end_byte: usize,
+        new_end_row: u32,
+        new_end_col: u32,
+    ) -> Self {
+        Self {
+            start_byte,
+            old_end_byte: start_byte,
+            new_end_byte,
+            start_row,
+            start_col,
+            old_end_row: start_row,
+            old_end_col: start_col,
+            new_end_row,
+            new_end_col,
+        }
+    }
+
+    /// Create an edit for a deletion (no content inserted).
+    ///
+    /// When deleting, `new_end` equals `start` since nothing was inserted.
+    #[must_use]
+    pub const fn delete(
+        start_byte: usize,
+        start_row: u32,
+        start_col: u32,
+        old_end_byte: usize,
+        old_end_row: u32,
+        old_end_col: u32,
+    ) -> Self {
+        Self {
+            start_byte,
+            old_end_byte,
+            new_end_byte: start_byte,
+            start_row,
+            start_col,
+            old_end_row,
+            old_end_col,
+            new_end_row: start_row,
+            new_end_col: start_col,
+        }
+    }
+
+    /// Get the byte range that was affected by this edit.
+    ///
+    /// Returns the range from start to the maximum of old and new end.
+    #[must_use]
+    pub const fn affected_range(&self) -> Range<usize> {
+        let end = if self.old_end_byte > self.new_end_byte {
+            self.old_end_byte
+        } else {
+            self.new_end_byte
+        };
+        self.start_byte..end
+    }
+
+    /// Get the number of bytes that were removed.
+    #[must_use]
+    pub const fn bytes_removed(&self) -> usize {
+        self.old_end_byte - self.start_byte
+    }
+
+    /// Get the number of bytes that were inserted.
+    #[must_use]
+    pub const fn bytes_inserted(&self) -> usize {
+        self.new_end_byte - self.start_byte
+    }
+
+    /// Get the net change in bytes (positive = growth, negative = shrink).
+    #[must_use]
+    #[allow(clippy::cast_possible_wrap)]
+    pub const fn byte_delta(&self) -> isize {
+        self.new_end_byte as isize - self.old_end_byte as isize
+    }
+
+    /// Check if this edit is an insertion (no removal).
+    #[must_use]
+    pub const fn is_insert(&self) -> bool {
+        self.old_end_byte == self.start_byte
+    }
+
+    /// Check if this edit is a deletion (no insertion).
+    #[must_use]
+    pub const fn is_delete(&self) -> bool {
+        self.new_end_byte == self.start_byte
+    }
+
+    /// Check if this edit is a replacement (both removal and insertion).
+    #[must_use]
+    pub const fn is_replace(&self) -> bool {
+        self.old_end_byte != self.start_byte && self.new_end_byte != self.start_byte
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_syntax_edit_new() {
+        let edit = SyntaxEdit::new(10, 20, 15, 2, 5, 3, 0, 2, 10);
+
+        assert_eq!(edit.start_byte, 10);
+        assert_eq!(edit.old_end_byte, 20);
+        assert_eq!(edit.new_end_byte, 15);
+        assert_eq!(edit.start_row, 2);
+        assert_eq!(edit.start_col, 5);
+        assert_eq!(edit.old_end_row, 3);
+        assert_eq!(edit.old_end_col, 0);
+        assert_eq!(edit.new_end_row, 2);
+        assert_eq!(edit.new_end_col, 10);
+    }
+
+    #[test]
+    fn test_syntax_edit_insert() {
+        let edit = SyntaxEdit::insert(10, 2, 5, 15, 2, 10);
+
+        assert_eq!(edit.start_byte, 10);
+        assert_eq!(edit.old_end_byte, 10); // No old content
+        assert_eq!(edit.new_end_byte, 15);
+        assert_eq!(edit.start_row, 2);
+        assert_eq!(edit.start_col, 5);
+        assert_eq!(edit.old_end_row, 2);
+        assert_eq!(edit.old_end_col, 5);
+        assert_eq!(edit.new_end_row, 2);
+        assert_eq!(edit.new_end_col, 10);
+
+        assert!(edit.is_insert());
+        assert!(!edit.is_delete());
+        assert!(!edit.is_replace());
+    }
+
+    #[test]
+    fn test_syntax_edit_delete() {
+        let edit = SyntaxEdit::delete(10, 2, 5, 20, 3, 0);
+
+        assert_eq!(edit.start_byte, 10);
+        assert_eq!(edit.old_end_byte, 20);
+        assert_eq!(edit.new_end_byte, 10); // No new content
+        assert_eq!(edit.start_row, 2);
+        assert_eq!(edit.start_col, 5);
+        assert_eq!(edit.old_end_row, 3);
+        assert_eq!(edit.old_end_col, 0);
+        assert_eq!(edit.new_end_row, 2);
+        assert_eq!(edit.new_end_col, 5);
+
+        assert!(edit.is_delete());
+        assert!(!edit.is_insert());
+        assert!(!edit.is_replace());
+    }
+
+    #[test]
+    fn test_syntax_edit_replace() {
+        let edit = SyntaxEdit::new(10, 20, 15, 2, 5, 3, 0, 2, 10);
+
+        assert!(edit.is_replace());
+        assert!(!edit.is_insert());
+        assert!(!edit.is_delete());
+    }
+
+    #[test]
+    fn test_syntax_edit_affected_range() {
+        // Insertion: range is start..new_end
+        let insert = SyntaxEdit::insert(10, 0, 0, 15, 0, 5);
+        assert_eq!(insert.affected_range(), 10..15);
+
+        // Deletion: range is start..old_end
+        let delete = SyntaxEdit::delete(10, 0, 0, 20, 1, 0);
+        assert_eq!(delete.affected_range(), 10..20);
+
+        // Replace with shrink: range is start..old_end
+        let shrink = SyntaxEdit::new(10, 30, 20, 0, 0, 0, 0, 0, 0);
+        assert_eq!(shrink.affected_range(), 10..30);
+
+        // Replace with growth: range is start..new_end
+        let grow = SyntaxEdit::new(10, 20, 30, 0, 0, 0, 0, 0, 0);
+        assert_eq!(grow.affected_range(), 10..30);
+    }
+
+    #[test]
+    fn test_syntax_edit_bytes_removed() {
+        let edit = SyntaxEdit::new(10, 25, 15, 0, 0, 0, 0, 0, 0);
+        assert_eq!(edit.bytes_removed(), 15); // 25 - 10
+
+        let insert = SyntaxEdit::insert(10, 0, 0, 20, 0, 0);
+        assert_eq!(insert.bytes_removed(), 0);
+    }
+
+    #[test]
+    fn test_syntax_edit_bytes_inserted() {
+        let edit = SyntaxEdit::new(10, 25, 18, 0, 0, 0, 0, 0, 0);
+        assert_eq!(edit.bytes_inserted(), 8); // 18 - 10
+
+        let delete = SyntaxEdit::delete(10, 0, 0, 20, 0, 0);
+        assert_eq!(delete.bytes_inserted(), 0);
+    }
+
+    #[test]
+    fn test_syntax_edit_byte_delta() {
+        // Shrink: 10 bytes removed, 5 inserted = -5 delta
+        let shrink = SyntaxEdit::new(10, 20, 15, 0, 0, 0, 0, 0, 0);
+        assert_eq!(shrink.byte_delta(), -5);
+
+        // Grow: 5 bytes removed, 10 inserted = +5 delta
+        let grow = SyntaxEdit::new(10, 15, 20, 0, 0, 0, 0, 0, 0);
+        assert_eq!(grow.byte_delta(), 5);
+
+        // Pure insert
+        let insert = SyntaxEdit::insert(10, 0, 0, 15, 0, 0);
+        assert_eq!(insert.byte_delta(), 5);
+
+        // Pure delete
+        let delete = SyntaxEdit::delete(10, 0, 0, 20, 0, 0);
+        assert_eq!(delete.byte_delta(), -10);
+    }
+}

--- a/lib/drivers/syntax/src/error.rs
+++ b/lib/drivers/syntax/src/error.rs
@@ -1,0 +1,6 @@
+//! Error types for syntax operations.
+//!
+//! Re-exports [`ModuleError`] from the kernel for consistency with the
+//! module system.
+
+pub use reovim_kernel::api::v1::ModuleError;

--- a/lib/drivers/syntax/src/factory.rs
+++ b/lib/drivers/syntax/src/factory.rs
@@ -1,0 +1,149 @@
+//! Syntax driver factory trait.
+//!
+//! This module defines the [`SyntaxDriverFactory`] trait for creating
+//! syntax drivers for specific languages.
+
+use crate::driver::SyntaxDriver;
+
+/// Factory for creating syntax drivers.
+///
+/// Implementations know how to create drivers for specific languages.
+/// The factory is registered with the runtime and called when files are opened.
+///
+/// # Thread Safety
+///
+/// Implementations must be `Send + Sync` to allow use across threads.
+///
+/// # Example
+///
+/// ```ignore
+/// // Factory creates drivers for supported languages
+/// let factory: Box<dyn SyntaxDriverFactory> = get_factory();
+///
+/// // Check if language is supported
+/// if factory.supports("rust") {
+///     // Create driver for Rust
+///     let driver = factory.create("rust").unwrap();
+///     assert_eq!(driver.language(), "rust");
+/// }
+///
+/// // List all supported languages
+/// for lang in factory.supported_languages() {
+///     println!("Supports: {}", lang);
+/// }
+/// ```
+pub trait SyntaxDriverFactory: Send + Sync {
+    /// Create a syntax driver for a language.
+    ///
+    /// # Arguments
+    ///
+    /// * `language_id` - The language identifier (e.g., "rust", "python")
+    ///
+    /// # Returns
+    ///
+    /// `Some(driver)` if the language is supported, `None` otherwise.
+    fn create(&self, language_id: &str) -> Option<Box<dyn SyntaxDriver>>;
+
+    /// List all supported language IDs.
+    ///
+    /// Returns a list of language identifiers that can be passed to
+    /// [`create()`](Self::create).
+    fn supported_languages(&self) -> Vec<&str>;
+
+    /// Check if a language is supported.
+    ///
+    /// # Default
+    ///
+    /// Checks if the language ID is in [`supported_languages()`](Self::supported_languages).
+    fn supports(&self, language_id: &str) -> bool {
+        self.supported_languages().contains(&language_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            edit::SyntaxEdit,
+            highlight::{HighlightGroup, HighlightSpan},
+        },
+        std::ops::Range,
+    };
+
+    /// Minimal driver for testing.
+    struct MinimalDriver {
+        language: &'static str,
+    }
+
+    impl SyntaxDriver for MinimalDriver {
+        fn language(&self) -> &str {
+            self.language
+        }
+
+        fn parse(&mut self, _content: &str) {}
+
+        fn update(&mut self, _content: &str, _edit: &SyntaxEdit) {}
+
+        fn highlights(&self, _byte_range: Range<usize>) -> Vec<HighlightSpan> {
+            vec![HighlightSpan::new(0, 1, HighlightGroup::Comment)]
+        }
+
+        fn is_parsed(&self) -> bool {
+            true
+        }
+    }
+
+    /// Test factory implementation.
+    struct TestFactory;
+
+    impl SyntaxDriverFactory for TestFactory {
+        fn create(&self, language_id: &str) -> Option<Box<dyn SyntaxDriver>> {
+            match language_id {
+                "rust" => Some(Box::new(MinimalDriver { language: "rust" })),
+                "python" => Some(Box::new(MinimalDriver { language: "python" })),
+                _ => None,
+            }
+        }
+
+        fn supported_languages(&self) -> Vec<&str> {
+            vec!["rust", "python"]
+        }
+    }
+
+    #[test]
+    fn test_factory_create() {
+        let factory = TestFactory;
+
+        let rust = factory.create("rust");
+        assert!(rust.is_some());
+        assert_eq!(rust.unwrap().language(), "rust");
+
+        let python = factory.create("python");
+        assert!(python.is_some());
+        assert_eq!(python.unwrap().language(), "python");
+
+        let unknown = factory.create("unknown");
+        assert!(unknown.is_none());
+    }
+
+    #[test]
+    fn test_factory_supported_languages() {
+        let factory = TestFactory;
+
+        let languages = factory.supported_languages();
+        assert_eq!(languages.len(), 2);
+        assert!(languages.contains(&"rust"));
+        assert!(languages.contains(&"python"));
+    }
+
+    #[test]
+    fn test_factory_supports() {
+        let factory = TestFactory;
+
+        assert!(factory.supports("rust"));
+        assert!(factory.supports("python"));
+        assert!(!factory.supports("unknown"));
+        assert!(!factory.supports("javascript"));
+    }
+}

--- a/lib/drivers/syntax/src/fold.rs
+++ b/lib/drivers/syntax/src/fold.rs
@@ -1,0 +1,221 @@
+//! Fold range types for code folding.
+//!
+//! This module defines types for representing foldable regions in source code,
+//! such as function bodies, class definitions, and import blocks.
+
+/// Kind of fold (what construct it represents).
+///
+/// Classifies foldable regions by the type of syntax construct they contain.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::FoldKind;
+///
+/// let kind = FoldKind::Function;
+/// assert_eq!(kind, FoldKind::Function);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FoldKind {
+    /// Function or method body.
+    Function,
+    /// Class, struct, or impl body.
+    Class,
+    /// Import/use group.
+    Import,
+    /// Comment block (multi-line comments or doc comments).
+    Comment,
+    /// Generic block (if, for, while, match arms, etc.).
+    Block,
+}
+
+impl FoldKind {
+    /// Check if this fold represents a definition (function or class).
+    #[must_use]
+    pub const fn is_definition(self) -> bool {
+        matches!(self, Self::Function | Self::Class)
+    }
+}
+
+/// A foldable range in the buffer.
+///
+/// Fold ranges are identified by the syntax driver and can be
+/// collapsed by the editor UI. Lines are 0-indexed.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::{FoldRange, FoldKind};
+///
+/// let fold = FoldRange::new(5, 10, FoldKind::Function, "fn foo() {");
+/// assert!(fold.is_foldable());
+/// assert_eq!(fold.line_count(), 6);
+/// ```
+#[derive(Debug, Clone)]
+pub struct FoldRange {
+    /// Starting line (0-indexed).
+    pub start_line: u32,
+    /// Ending line (0-indexed, inclusive).
+    pub end_line: u32,
+    /// Kind of fold.
+    pub kind: FoldKind,
+    /// Preview text (first line content, for display when folded).
+    pub preview: String,
+}
+
+impl FoldRange {
+    /// Create a new fold range.
+    #[must_use]
+    pub fn new(start_line: u32, end_line: u32, kind: FoldKind, preview: impl Into<String>) -> Self {
+        Self {
+            start_line,
+            end_line,
+            kind,
+            preview: preview.into(),
+        }
+    }
+
+    /// Create a fold range without a preview.
+    #[must_use]
+    pub const fn without_preview(start_line: u32, end_line: u32, kind: FoldKind) -> Self {
+        Self {
+            start_line,
+            end_line,
+            kind,
+            preview: String::new(),
+        }
+    }
+
+    /// Check if this range spans multiple lines (is foldable).
+    #[must_use]
+    pub const fn is_foldable(&self) -> bool {
+        self.end_line > self.start_line
+    }
+
+    /// Get the number of lines in this fold.
+    #[must_use]
+    pub const fn line_count(&self) -> u32 {
+        self.end_line - self.start_line + 1
+    }
+
+    /// Get the number of hidden lines when folded.
+    ///
+    /// This is `line_count() - 1` since the first line is shown.
+    #[must_use]
+    pub const fn hidden_lines(&self) -> u32 {
+        self.end_line.saturating_sub(self.start_line)
+    }
+
+    /// Check if this fold contains a line.
+    #[must_use]
+    pub const fn contains_line(&self, line: u32) -> bool {
+        line >= self.start_line && line <= self.end_line
+    }
+
+    /// Check if this fold overlaps with another.
+    #[must_use]
+    pub const fn overlaps(&self, other: &Self) -> bool {
+        self.start_line <= other.end_line && self.end_line >= other.start_line
+    }
+
+    /// Check if this fold contains another fold entirely.
+    #[must_use]
+    pub const fn contains(&self, other: &Self) -> bool {
+        self.start_line <= other.start_line && self.end_line >= other.end_line
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fold_kind_is_definition() {
+        assert!(FoldKind::Function.is_definition());
+        assert!(FoldKind::Class.is_definition());
+        assert!(!FoldKind::Import.is_definition());
+        assert!(!FoldKind::Comment.is_definition());
+        assert!(!FoldKind::Block.is_definition());
+    }
+
+    #[test]
+    fn test_fold_range_new() {
+        let fold = FoldRange::new(5, 10, FoldKind::Function, "fn foo() {");
+
+        assert_eq!(fold.start_line, 5);
+        assert_eq!(fold.end_line, 10);
+        assert_eq!(fold.kind, FoldKind::Function);
+        assert_eq!(fold.preview, "fn foo() {");
+    }
+
+    #[test]
+    fn test_fold_range_without_preview() {
+        let fold = FoldRange::without_preview(5, 10, FoldKind::Block);
+
+        assert_eq!(fold.start_line, 5);
+        assert_eq!(fold.end_line, 10);
+        assert_eq!(fold.kind, FoldKind::Block);
+        assert!(fold.preview.is_empty());
+    }
+
+    #[test]
+    fn test_fold_range_is_foldable() {
+        let foldable = FoldRange::new(5, 10, FoldKind::Function, "");
+        assert!(foldable.is_foldable());
+
+        let single = FoldRange::new(5, 5, FoldKind::Block, "");
+        assert!(!single.is_foldable());
+    }
+
+    #[test]
+    fn test_fold_range_line_count() {
+        let fold = FoldRange::new(5, 10, FoldKind::Function, "");
+        assert_eq!(fold.line_count(), 6); // 5, 6, 7, 8, 9, 10
+
+        let single = FoldRange::new(5, 5, FoldKind::Block, "");
+        assert_eq!(single.line_count(), 1);
+    }
+
+    #[test]
+    fn test_fold_range_hidden_lines() {
+        let fold = FoldRange::new(5, 10, FoldKind::Function, "");
+        assert_eq!(fold.hidden_lines(), 5); // Lines 6-10 are hidden
+
+        let single = FoldRange::new(5, 5, FoldKind::Block, "");
+        assert_eq!(single.hidden_lines(), 0);
+    }
+
+    #[test]
+    fn test_fold_range_contains_line() {
+        let fold = FoldRange::new(5, 10, FoldKind::Function, "");
+
+        assert!(fold.contains_line(5));
+        assert!(fold.contains_line(7));
+        assert!(fold.contains_line(10));
+        assert!(!fold.contains_line(4));
+        assert!(!fold.contains_line(11));
+    }
+
+    #[test]
+    fn test_fold_range_overlaps() {
+        let fold1 = FoldRange::new(5, 10, FoldKind::Function, "");
+        let fold2 = FoldRange::new(8, 15, FoldKind::Block, "");
+        let fold3 = FoldRange::new(11, 15, FoldKind::Block, "");
+
+        assert!(fold1.overlaps(&fold2)); // 8-10 overlap
+        assert!(fold2.overlaps(&fold1));
+        assert!(!fold1.overlaps(&fold3)); // No overlap
+        assert!(!fold3.overlaps(&fold1));
+    }
+
+    #[test]
+    fn test_fold_range_contains() {
+        let outer = FoldRange::new(5, 15, FoldKind::Class, "");
+        let inner = FoldRange::new(7, 12, FoldKind::Function, "");
+        let overlapping = FoldRange::new(10, 20, FoldKind::Block, "");
+
+        assert!(outer.contains(&inner));
+        assert!(!inner.contains(&outer));
+        assert!(!outer.contains(&overlapping));
+    }
+}

--- a/lib/drivers/syntax/src/highlight.rs
+++ b/lib/drivers/syntax/src/highlight.rs
@@ -1,0 +1,440 @@
+//! Syntax highlight categories and spans.
+//!
+//! This module defines the highlight types used by syntax drivers.
+//! The [`HighlightGroup`] enum implements the kernel's [`SyntaxHighlight`]
+//! trait to provide category names for theme mapping.
+
+use std::ops::Range;
+
+use reovim_kernel::api::v1::SyntaxHighlight;
+
+/// Syntax highlight categories.
+///
+/// This enum defines all supported highlight groups for syntax highlighting.
+/// It implements the kernel's [`SyntaxHighlight`] trait to provide
+/// category names that themes can use for color mapping.
+///
+/// # Design
+///
+/// This is POLICY (what categories exist) implementing kernel's MECHANISM
+/// (how highlights work). The driver decides which specific categories
+/// to support, while the kernel defines the abstract interface.
+///
+/// Uses `#[repr(u8)]` for compact storage.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::HighlightGroup;
+/// use reovim_kernel::api::v1::SyntaxHighlight;
+///
+/// let group = HighlightGroup::Keyword;
+/// assert_eq!(group.category(), "keyword");
+/// assert!(group.is_keyword());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum HighlightGroup {
+    // === Keywords (0-4) ===
+    /// Generic keyword (if, else, for, while, return, etc.)
+    Keyword = 0,
+    /// Control flow keywords (if, else, match, loop)
+    KeywordControl = 1,
+    /// Operator keywords (and, or, not, in)
+    KeywordOperator = 2,
+    /// Function-related keywords (fn, def, function)
+    KeywordFunction = 3,
+    /// Type-related keywords (struct, class, enum, type)
+    KeywordType = 4,
+
+    // === Types (5-6) ===
+    /// User-defined types
+    Type = 5,
+    /// Built-in types (int, str, bool)
+    TypeBuiltin = 6,
+
+    // === Functions (7-10) ===
+    /// Function names
+    Function = 7,
+    /// Built-in functions (print, len)
+    FunctionBuiltin = 8,
+    /// Macro invocations
+    FunctionMacro = 9,
+    /// Method calls
+    Method = 10,
+
+    // === Variables (11-15) ===
+    /// Generic variable
+    Variable = 11,
+    /// Built-in variables (self, super, this)
+    VariableBuiltin = 12,
+    /// Function parameters
+    Parameter = 13,
+    /// Struct/class fields
+    Field = 14,
+    /// Constants
+    Constant = 15,
+
+    // === Literals (16-20) ===
+    /// String literals
+    String = 16,
+    /// Escape sequences in strings
+    StringEscape = 17,
+    /// Character literals
+    Character = 18,
+    /// Numeric literals
+    Number = 19,
+    /// Boolean literals (true, false)
+    Boolean = 20,
+
+    // === Comments (21-22) ===
+    /// Regular comments
+    Comment = 21,
+    /// Documentation comments
+    CommentDoc = 22,
+
+    // === Punctuation (23-25) ===
+    /// Generic punctuation
+    Punctuation = 23,
+    /// Brackets, braces, parentheses
+    PunctuationBracket = 24,
+    /// Commas, semicolons, colons
+    PunctuationDelimiter = 25,
+
+    // === Operators (26) ===
+    /// Operators (+, -, *, /, =, etc.)
+    Operator = 26,
+
+    // === Diagnostics (27-30) ===
+    /// Error highlights
+    Error = 27,
+    /// Warning highlights
+    Warning = 28,
+    /// Info highlights
+    Info = 29,
+    /// Hint highlights
+    Hint = 30,
+
+    // === Special (255) ===
+    /// Custom highlight (for extensions)
+    Custom = 255,
+}
+
+impl SyntaxHighlight for HighlightGroup {
+    fn category(&self) -> &'static str {
+        match self {
+            Self::Keyword => "keyword",
+            Self::KeywordControl => "keyword.control",
+            Self::KeywordOperator => "keyword.operator",
+            Self::KeywordFunction => "keyword.function",
+            Self::KeywordType => "keyword.type",
+            Self::Type => "type",
+            Self::TypeBuiltin => "type.builtin",
+            Self::Function => "function",
+            Self::FunctionBuiltin => "function.builtin",
+            Self::FunctionMacro => "function.macro",
+            Self::Method => "function.method",
+            Self::Variable => "variable",
+            Self::VariableBuiltin => "variable.builtin",
+            Self::Parameter => "variable.parameter",
+            Self::Field => "variable.field",
+            Self::Constant => "constant",
+            Self::String => "string",
+            Self::StringEscape => "string.escape",
+            Self::Character => "character",
+            Self::Number => "number",
+            Self::Boolean => "boolean",
+            Self::Comment => "comment",
+            Self::CommentDoc => "comment.doc",
+            Self::Punctuation => "punctuation",
+            Self::PunctuationBracket => "punctuation.bracket",
+            Self::PunctuationDelimiter => "punctuation.delimiter",
+            Self::Operator => "operator",
+            Self::Error => "diagnostic.error",
+            Self::Warning => "diagnostic.warning",
+            Self::Info => "diagnostic.info",
+            Self::Hint => "diagnostic.hint",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+impl HighlightGroup {
+    /// Check if this is a keyword category.
+    #[must_use]
+    pub const fn is_keyword(self) -> bool {
+        matches!(
+            self,
+            Self::Keyword
+                | Self::KeywordControl
+                | Self::KeywordOperator
+                | Self::KeywordFunction
+                | Self::KeywordType
+        )
+    }
+
+    /// Check if this is a type category.
+    #[must_use]
+    pub const fn is_type(self) -> bool {
+        matches!(self, Self::Type | Self::TypeBuiltin)
+    }
+
+    /// Check if this is a function category.
+    #[must_use]
+    pub const fn is_function(self) -> bool {
+        matches!(
+            self,
+            Self::Function | Self::FunctionBuiltin | Self::FunctionMacro | Self::Method
+        )
+    }
+
+    /// Check if this is a variable category.
+    #[must_use]
+    pub const fn is_variable(self) -> bool {
+        matches!(
+            self,
+            Self::Variable | Self::VariableBuiltin | Self::Parameter | Self::Field | Self::Constant
+        )
+    }
+
+    /// Check if this is a literal category.
+    #[must_use]
+    pub const fn is_literal(self) -> bool {
+        matches!(
+            self,
+            Self::String | Self::StringEscape | Self::Character | Self::Number | Self::Boolean
+        )
+    }
+
+    /// Check if this is a comment category.
+    #[must_use]
+    pub const fn is_comment(self) -> bool {
+        matches!(self, Self::Comment | Self::CommentDoc)
+    }
+
+    /// Check if this is a punctuation category.
+    #[must_use]
+    pub const fn is_punctuation(self) -> bool {
+        matches!(self, Self::Punctuation | Self::PunctuationBracket | Self::PunctuationDelimiter)
+    }
+
+    /// Check if this is a diagnostic category.
+    #[must_use]
+    pub const fn is_diagnostic(self) -> bool {
+        matches!(self, Self::Error | Self::Warning | Self::Info | Self::Hint)
+    }
+}
+
+/// A highlighted byte range in source code.
+///
+/// Uses byte offsets for efficient incremental updates.
+/// Byte offsets align with tree-sitter's native representation.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::{HighlightSpan, HighlightGroup};
+///
+/// let span = HighlightSpan::new(0, 5, HighlightGroup::Keyword);
+/// assert_eq!(span.len(), 5);
+/// assert!(!span.is_empty());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightSpan {
+    /// Start byte offset (inclusive).
+    pub start_byte: usize,
+    /// End byte offset (exclusive).
+    pub end_byte: usize,
+    /// Highlight category.
+    pub group: HighlightGroup,
+}
+
+impl HighlightSpan {
+    /// Create a new highlight span.
+    #[must_use]
+    pub const fn new(start_byte: usize, end_byte: usize, group: HighlightGroup) -> Self {
+        Self {
+            start_byte,
+            end_byte,
+            group,
+        }
+    }
+
+    /// Get the length in bytes.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.end_byte - self.start_byte
+    }
+
+    /// Check if the span is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.start_byte == self.end_byte
+    }
+
+    /// Check if this span overlaps with a byte range.
+    #[must_use]
+    pub const fn overlaps(&self, range: &Range<usize>) -> bool {
+        self.start_byte < range.end && self.end_byte > range.start
+    }
+
+    /// Check if this span contains a byte offset.
+    #[must_use]
+    pub const fn contains(&self, byte: usize) -> bool {
+        self.start_byte <= byte && byte < self.end_byte
+    }
+
+    /// Get this span as a byte range.
+    #[must_use]
+    pub const fn byte_range(&self) -> Range<usize> {
+        self.start_byte..self.end_byte
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_highlight_group_implements_syntax_highlight() {
+        assert_eq!(HighlightGroup::Keyword.category(), "keyword");
+        assert_eq!(HighlightGroup::KeywordControl.category(), "keyword.control");
+        assert_eq!(HighlightGroup::Function.category(), "function");
+        assert_eq!(HighlightGroup::String.category(), "string");
+        assert_eq!(HighlightGroup::Comment.category(), "comment");
+        assert_eq!(HighlightGroup::Error.category(), "diagnostic.error");
+        assert_eq!(HighlightGroup::Custom.category(), "custom");
+    }
+
+    #[test]
+    fn test_highlight_group_is_keyword() {
+        assert!(HighlightGroup::Keyword.is_keyword());
+        assert!(HighlightGroup::KeywordControl.is_keyword());
+        assert!(HighlightGroup::KeywordOperator.is_keyword());
+        assert!(HighlightGroup::KeywordFunction.is_keyword());
+        assert!(HighlightGroup::KeywordType.is_keyword());
+        assert!(!HighlightGroup::Function.is_keyword());
+        assert!(!HighlightGroup::String.is_keyword());
+    }
+
+    #[test]
+    fn test_highlight_group_is_type() {
+        assert!(HighlightGroup::Type.is_type());
+        assert!(HighlightGroup::TypeBuiltin.is_type());
+        assert!(!HighlightGroup::Keyword.is_type());
+    }
+
+    #[test]
+    fn test_highlight_group_is_function() {
+        assert!(HighlightGroup::Function.is_function());
+        assert!(HighlightGroup::FunctionBuiltin.is_function());
+        assert!(HighlightGroup::FunctionMacro.is_function());
+        assert!(HighlightGroup::Method.is_function());
+        assert!(!HighlightGroup::Variable.is_function());
+    }
+
+    #[test]
+    fn test_highlight_group_is_variable() {
+        assert!(HighlightGroup::Variable.is_variable());
+        assert!(HighlightGroup::VariableBuiltin.is_variable());
+        assert!(HighlightGroup::Parameter.is_variable());
+        assert!(HighlightGroup::Field.is_variable());
+        assert!(HighlightGroup::Constant.is_variable());
+        assert!(!HighlightGroup::Function.is_variable());
+    }
+
+    #[test]
+    fn test_highlight_group_is_literal() {
+        assert!(HighlightGroup::String.is_literal());
+        assert!(HighlightGroup::StringEscape.is_literal());
+        assert!(HighlightGroup::Character.is_literal());
+        assert!(HighlightGroup::Number.is_literal());
+        assert!(HighlightGroup::Boolean.is_literal());
+        assert!(!HighlightGroup::Comment.is_literal());
+    }
+
+    #[test]
+    fn test_highlight_group_is_comment() {
+        assert!(HighlightGroup::Comment.is_comment());
+        assert!(HighlightGroup::CommentDoc.is_comment());
+        assert!(!HighlightGroup::String.is_comment());
+    }
+
+    #[test]
+    fn test_highlight_group_is_punctuation() {
+        assert!(HighlightGroup::Punctuation.is_punctuation());
+        assert!(HighlightGroup::PunctuationBracket.is_punctuation());
+        assert!(HighlightGroup::PunctuationDelimiter.is_punctuation());
+        assert!(!HighlightGroup::Operator.is_punctuation());
+    }
+
+    #[test]
+    fn test_highlight_group_is_diagnostic() {
+        assert!(HighlightGroup::Error.is_diagnostic());
+        assert!(HighlightGroup::Warning.is_diagnostic());
+        assert!(HighlightGroup::Info.is_diagnostic());
+        assert!(HighlightGroup::Hint.is_diagnostic());
+        assert!(!HighlightGroup::Keyword.is_diagnostic());
+    }
+
+    #[test]
+    fn test_highlight_span_new() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+        assert_eq!(span.start_byte, 10);
+        assert_eq!(span.end_byte, 20);
+        assert_eq!(span.group, HighlightGroup::Keyword);
+    }
+
+    #[test]
+    fn test_highlight_span_len() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+        assert_eq!(span.len(), 10);
+
+        let empty = HighlightSpan::new(5, 5, HighlightGroup::Comment);
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn test_highlight_span_is_empty() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+        assert!(!span.is_empty());
+
+        let empty = HighlightSpan::new(5, 5, HighlightGroup::Comment);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_highlight_span_overlaps() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+
+        // Overlapping ranges
+        assert!(span.overlaps(&(5..15)));
+        assert!(span.overlaps(&(15..25)));
+        assert!(span.overlaps(&(12..18)));
+        assert!(span.overlaps(&(5..25)));
+        assert!(span.overlaps(&(10..20)));
+
+        // Non-overlapping ranges
+        assert!(!span.overlaps(&(0..10)));
+        assert!(!span.overlaps(&(20..30)));
+        assert!(!span.overlaps(&(0..5)));
+    }
+
+    #[test]
+    fn test_highlight_span_contains() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+
+        assert!(span.contains(10));
+        assert!(span.contains(15));
+        assert!(span.contains(19));
+        assert!(!span.contains(9));
+        assert!(!span.contains(20));
+        assert!(!span.contains(25));
+    }
+
+    #[test]
+    fn test_highlight_span_byte_range() {
+        let span = HighlightSpan::new(10, 20, HighlightGroup::Keyword);
+        assert_eq!(span.byte_range(), 10..20);
+    }
+}

--- a/lib/drivers/syntax/src/injection.rs
+++ b/lib/drivers/syntax/src/injection.rs
@@ -1,0 +1,208 @@
+//! Language injection types.
+//!
+//! This module defines types for representing embedded language regions
+//! within a source file, such as code blocks in markdown or script tags in HTML.
+
+use std::ops::Range;
+
+/// An injection point for embedded languages.
+///
+/// Injections allow one language to be embedded within another,
+/// such as code blocks in markdown or script tags in HTML.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::Injection;
+///
+/// // A Rust code block in a markdown file
+/// let inj = Injection::new("rust", 100..200, 5, 3, 10, 3);
+/// assert_eq!(inj.language_id, "rust");
+/// assert!(inj.overlaps_lines(6, 8));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Injection {
+    /// The language ID to use for the injected region.
+    pub language_id: String,
+    /// Byte range in the parent document (start..end, exclusive).
+    pub byte_range: Range<usize>,
+    /// Start row (0-indexed).
+    pub start_row: u32,
+    /// Start column (0-indexed).
+    pub start_col: u32,
+    /// End row (0-indexed).
+    pub end_row: u32,
+    /// End column (0-indexed).
+    pub end_col: u32,
+}
+
+impl Injection {
+    /// Create a new injection.
+    #[must_use]
+    pub fn new(
+        language_id: impl Into<String>,
+        byte_range: Range<usize>,
+        start_row: u32,
+        start_col: u32,
+        end_row: u32,
+        end_col: u32,
+    ) -> Self {
+        Self {
+            language_id: language_id.into(),
+            byte_range,
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        }
+    }
+
+    /// Create an injection from byte range only (row/col set to 0).
+    ///
+    /// Useful when only byte positions are known.
+    #[must_use]
+    pub fn from_bytes(language_id: impl Into<String>, byte_range: Range<usize>) -> Self {
+        Self {
+            language_id: language_id.into(),
+            byte_range,
+            start_row: 0,
+            start_col: 0,
+            end_row: 0,
+            end_col: 0,
+        }
+    }
+
+    /// Check if this injection overlaps with a line range.
+    ///
+    /// Both `start_line` and `end_line` are inclusive.
+    #[must_use]
+    pub const fn overlaps_lines(&self, start_line: u32, end_line: u32) -> bool {
+        self.start_row <= end_line && self.end_row >= start_line
+    }
+
+    /// Check if this injection contains a specific line.
+    #[must_use]
+    pub const fn contains_line(&self, line: u32) -> bool {
+        line >= self.start_row && line <= self.end_row
+    }
+
+    /// Check if this injection overlaps with a byte range.
+    #[must_use]
+    pub const fn overlaps_bytes(&self, range: &Range<usize>) -> bool {
+        self.byte_range.start < range.end && self.byte_range.end > range.start
+    }
+
+    /// Get the number of bytes in this injection.
+    #[must_use]
+    pub const fn byte_len(&self) -> usize {
+        self.byte_range.end - self.byte_range.start
+    }
+
+    /// Check if this injection spans multiple lines.
+    #[must_use]
+    pub const fn is_multiline(&self) -> bool {
+        self.end_row > self.start_row
+    }
+
+    /// Get the number of lines spanned by this injection.
+    #[must_use]
+    pub const fn line_count(&self) -> u32 {
+        self.end_row - self.start_row + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_injection_new() {
+        let inj = Injection::new("rust", 100..200, 5, 3, 10, 3);
+
+        assert_eq!(inj.language_id, "rust");
+        assert_eq!(inj.byte_range, 100..200);
+        assert_eq!(inj.start_row, 5);
+        assert_eq!(inj.start_col, 3);
+        assert_eq!(inj.end_row, 10);
+        assert_eq!(inj.end_col, 3);
+    }
+
+    #[test]
+    fn test_injection_from_bytes() {
+        let inj = Injection::from_bytes("python", 50..150);
+
+        assert_eq!(inj.language_id, "python");
+        assert_eq!(inj.byte_range, 50..150);
+        assert_eq!(inj.start_row, 0);
+        assert_eq!(inj.start_col, 0);
+        assert_eq!(inj.end_row, 0);
+        assert_eq!(inj.end_col, 0);
+    }
+
+    #[test]
+    fn test_injection_overlaps_lines() {
+        let inj = Injection::new("rust", 100..200, 5, 0, 10, 0);
+
+        // Overlapping line ranges
+        assert!(inj.overlaps_lines(5, 10)); // Exact match
+        assert!(inj.overlaps_lines(0, 7)); // Overlaps start
+        assert!(inj.overlaps_lines(8, 15)); // Overlaps end
+        assert!(inj.overlaps_lines(6, 8)); // Fully inside
+        assert!(inj.overlaps_lines(0, 20)); // Fully contains
+
+        // Non-overlapping line ranges
+        assert!(!inj.overlaps_lines(0, 4));
+        assert!(!inj.overlaps_lines(11, 20));
+    }
+
+    #[test]
+    fn test_injection_contains_line() {
+        let inj = Injection::new("rust", 100..200, 5, 0, 10, 0);
+
+        assert!(inj.contains_line(5));
+        assert!(inj.contains_line(7));
+        assert!(inj.contains_line(10));
+        assert!(!inj.contains_line(4));
+        assert!(!inj.contains_line(11));
+    }
+
+    #[test]
+    fn test_injection_overlaps_bytes() {
+        let inj = Injection::new("rust", 100..200, 0, 0, 0, 0);
+
+        assert!(inj.overlaps_bytes(&(50..150)));
+        assert!(inj.overlaps_bytes(&(150..250)));
+        assert!(inj.overlaps_bytes(&(120..180)));
+        assert!(inj.overlaps_bytes(&(50..250)));
+
+        assert!(!inj.overlaps_bytes(&(0..100)));
+        assert!(!inj.overlaps_bytes(&(200..300)));
+    }
+
+    #[test]
+    fn test_injection_byte_len() {
+        let inj = Injection::new("rust", 100..200, 0, 0, 0, 0);
+        assert_eq!(inj.byte_len(), 100);
+
+        let empty = Injection::new("rust", 100..100, 0, 0, 0, 0);
+        assert_eq!(empty.byte_len(), 0);
+    }
+
+    #[test]
+    fn test_injection_is_multiline() {
+        let multiline = Injection::new("rust", 100..200, 5, 0, 10, 0);
+        assert!(multiline.is_multiline());
+
+        let single = Injection::new("rust", 100..200, 5, 0, 5, 10);
+        assert!(!single.is_multiline());
+    }
+
+    #[test]
+    fn test_injection_line_count() {
+        let inj = Injection::new("rust", 100..200, 5, 0, 10, 0);
+        assert_eq!(inj.line_count(), 6); // Lines 5, 6, 7, 8, 9, 10
+
+        let single = Injection::new("rust", 100..200, 5, 0, 5, 10);
+        assert_eq!(single.line_count(), 1);
+    }
+}

--- a/lib/drivers/syntax/src/lib.rs
+++ b/lib/drivers/syntax/src/lib.rs
@@ -2,22 +2,105 @@
 //!
 //! **IMPORTANT:** This crate defines ONLY the trait interface for syntax
 //! highlighting. It does NOT depend on tree-sitter or any parsing library.
-//! Those are implementation details of language modules (plugins/languages/*).
+//! Those are implementation details of language modules (`plugins/languages/*`).
+//!
+//! # Design Philosophy
+//!
+//! This crate follows the Linux kernel "mechanism vs policy" principle:
+//!
+//! - **Kernel provides MECHANISM**: The [`SyntaxHighlight`] trait in `reovim-kernel`
+//!   defines HOW highlights are categorized (abstract interface).
+//! - **Driver provides POLICY**: The [`HighlightGroup`] enum here defines WHAT
+//!   categories exist (specific implementation).
 //!
 //! # Architecture
 //!
 //! ```text
-//! lib/drivers/syntax/     <-- Trait definitions (this crate)
+//! lib/kernel/api/syntax.rs  <-- SyntaxHighlight trait (mechanism)
 //!        ^
+//!        |  implements
 //!        |
-//! plugins/languages/*     <-- Implementations (tree-sitter, etc.)
+//! lib/drivers/syntax/       <-- HighlightGroup, SyntaxDriver (policy)
+//!        ^
+//!        |  implements
+//!        |
+//! plugins/features/treesitter/  <-- Tree-sitter based implementations
 //! ```
 //!
 //! # Components
 //!
-//! - `SyntaxDriver` trait (parsing, highlighting)
-//! - `LanguageRegistry` (language discovery)
-//! - Highlight cache infrastructure
+//! - [`SyntaxDriver`] - Main parsing and highlighting interface
+//! - [`SyntaxDriverFactory`] - Creates drivers for languages
+//! - [`LanguageRegistry`] - Language detection and metadata
+//! - [`SyntaxCache`] - Highlight result caching
+//! - [`HighlightGroup`] - Highlight categories (implements kernel's `SyntaxHighlight`)
+//! - [`HighlightSpan`] - A highlighted byte range
+//! - [`SyntaxEdit`] - Edit description for incremental parsing
+//! - [`FoldRange`], [`FoldKind`] - Foldable code regions
+//! - [`Injection`] - Embedded language regions
+//! - [`LanguageInfo`], [`CommentTokens`] - Language metadata
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_syntax::*;
+//!
+//! // Factory creates drivers for supported languages
+//! let factory: Box<dyn SyntaxDriverFactory> = get_factory();
+//!
+//! // Create driver for Rust
+//! let mut driver = factory.create("rust").unwrap();
+//!
+//! // Parse content
+//! driver.parse("fn main() { println!(\"Hello\"); }");
+//!
+//! // Get highlights for rendering
+//! let highlights = driver.highlights(0..100);
+//! for span in highlights {
+//!     println!("{:?}: {}", span.byte_range(), span.group.category());
+//! }
+//! ```
+//!
+//! # NO tree-sitter dependency!
+//!
+//! This crate must NOT depend on tree-sitter or any parsing library.
+//! Tree-sitter is an implementation detail of language modules.
 
-// Placeholder - SyntaxDriver trait will be added in Phase 3
-// NO tree-sitter imports allowed here!
+// ============================================================================
+// Modules
+// ============================================================================
+
+mod cache;
+mod driver;
+mod edit;
+mod error;
+mod factory;
+mod fold;
+mod highlight;
+mod injection;
+mod registry;
+
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+// Core traits
+pub use {
+    cache::SyntaxCache, driver::SyntaxDriver, factory::SyntaxDriverFactory,
+    registry::LanguageRegistry,
+};
+
+// Types
+pub use {
+    edit::SyntaxEdit,
+    fold::{FoldKind, FoldRange},
+    highlight::{HighlightGroup, HighlightSpan},
+    injection::Injection,
+    registry::{CommentTokens, LanguageInfo},
+};
+
+// Error types
+pub use error::ModuleError;
+
+// Re-export kernel trait for convenience
+pub use reovim_kernel::api::v1::SyntaxHighlight;

--- a/lib/drivers/syntax/src/registry.rs
+++ b/lib/drivers/syntax/src/registry.rs
@@ -1,0 +1,341 @@
+//! Language metadata and registry types.
+//!
+//! This module defines types for language metadata (file extensions, MIME types,
+//! comment syntax) and the [`LanguageRegistry`] trait for language detection.
+
+/// Information about a supported language.
+///
+/// Contains metadata-only information about a language, not parsing capabilities.
+/// Used for language detection and editor configuration.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::{LanguageInfo, CommentTokens};
+///
+/// let rust = LanguageInfo::new("rust", "Rust")
+///     .with_extensions(["rs"])
+///     .with_mime_types(["text/x-rust"])
+///     .with_comments(CommentTokens::with_block("//", "/*", "*/"));
+///
+/// assert!(rust.matches_extension("rs"));
+/// assert!(rust.matches_extension("RS")); // Case insensitive
+/// ```
+#[derive(Debug, Clone)]
+pub struct LanguageInfo {
+    /// Language identifier (e.g., "rust", "python").
+    pub id: String,
+    /// Human-readable name (e.g., "Rust", "Python").
+    pub name: String,
+    /// File extensions (without dot, e.g., `["rs"]`, `["py", "pyw"]`).
+    pub extensions: Vec<String>,
+    /// MIME types (e.g., `["text/x-rust"]`).
+    pub mime_types: Vec<String>,
+    /// Comment tokens for this language.
+    pub comment_tokens: CommentTokens,
+}
+
+impl LanguageInfo {
+    /// Create new language info with minimal fields.
+    #[must_use]
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            extensions: Vec::new(),
+            mime_types: Vec::new(),
+            comment_tokens: CommentTokens::default(),
+        }
+    }
+
+    /// Add file extensions.
+    #[must_use]
+    pub fn with_extensions<I, S>(mut self, extensions: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extensions = extensions.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add MIME types.
+    #[must_use]
+    pub fn with_mime_types<I, S>(mut self, mime_types: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.mime_types = mime_types.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set comment tokens.
+    #[must_use]
+    pub fn with_comments(mut self, tokens: CommentTokens) -> Self {
+        self.comment_tokens = tokens;
+        self
+    }
+
+    /// Check if this language matches a file extension.
+    ///
+    /// Comparison is case-insensitive.
+    #[must_use]
+    pub fn matches_extension(&self, ext: &str) -> bool {
+        self.extensions.iter().any(|e| e.eq_ignore_ascii_case(ext))
+    }
+
+    /// Check if this language matches a MIME type.
+    ///
+    /// Comparison is case-insensitive.
+    #[must_use]
+    pub fn matches_mime(&self, mime: &str) -> bool {
+        self.mime_types.iter().any(|m| m.eq_ignore_ascii_case(mime))
+    }
+
+    /// Check if this language has any registered extensions.
+    #[must_use]
+    pub const fn has_extensions(&self) -> bool {
+        !self.extensions.is_empty()
+    }
+
+    /// Check if this language has comment syntax defined.
+    #[must_use]
+    pub const fn has_comments(&self) -> bool {
+        self.comment_tokens.has_any()
+    }
+}
+
+/// Comment syntax for a language.
+///
+/// Describes how to create line and block comments.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_syntax::CommentTokens;
+///
+/// // C-style comments
+/// let c_style = CommentTokens::with_block("//", "/*", "*/");
+/// assert!(c_style.has_line_comment());
+/// assert!(c_style.has_block_comment());
+///
+/// // Python-style (line only)
+/// let python = CommentTokens::line_only("#");
+/// assert!(python.has_line_comment());
+/// assert!(!python.has_block_comment());
+///
+/// // HTML-style (block only)
+/// let html = CommentTokens::block_only("<!--", "-->");
+/// assert!(!html.has_line_comment());
+/// assert!(html.has_block_comment());
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CommentTokens {
+    /// Line comment prefix (e.g., "//", "#", "--").
+    pub line: Option<String>,
+    /// Block comment start (e.g., "/*", "<!--").
+    pub block_start: Option<String>,
+    /// Block comment end (e.g., "*/", "-->").
+    pub block_end: Option<String>,
+}
+
+impl CommentTokens {
+    /// Create comment tokens with only a line comment.
+    #[must_use]
+    pub fn line_only(prefix: impl Into<String>) -> Self {
+        Self {
+            line: Some(prefix.into()),
+            block_start: None,
+            block_end: None,
+        }
+    }
+
+    /// Create comment tokens with both line and block comments.
+    #[must_use]
+    pub fn with_block(
+        line: impl Into<String>,
+        block_start: impl Into<String>,
+        block_end: impl Into<String>,
+    ) -> Self {
+        Self {
+            line: Some(line.into()),
+            block_start: Some(block_start.into()),
+            block_end: Some(block_end.into()),
+        }
+    }
+
+    /// Create comment tokens with only block comments (no line comments).
+    #[must_use]
+    pub fn block_only(start: impl Into<String>, end: impl Into<String>) -> Self {
+        Self {
+            line: None,
+            block_start: Some(start.into()),
+            block_end: Some(end.into()),
+        }
+    }
+
+    /// Check if line comments are supported.
+    #[must_use]
+    pub const fn has_line_comment(&self) -> bool {
+        self.line.is_some()
+    }
+
+    /// Check if block comments are supported.
+    #[must_use]
+    pub const fn has_block_comment(&self) -> bool {
+        self.block_start.is_some() && self.block_end.is_some()
+    }
+
+    /// Check if any comment syntax is defined.
+    #[must_use]
+    pub const fn has_any(&self) -> bool {
+        self.line.is_some() || (self.block_start.is_some() && self.block_end.is_some())
+    }
+}
+
+/// Registry for language metadata and detection.
+///
+/// Manages the mapping between file extensions, MIME types, and language IDs.
+/// Does not create syntax drivers - that's the factory's job.
+///
+/// Implementations must be thread-safe (`Send + Sync`).
+pub trait LanguageRegistry: Send + Sync {
+    /// Detect language from a file path.
+    ///
+    /// Uses file extension to determine the language.
+    /// Returns the language ID if detected.
+    fn detect_from_path(&self, path: &str) -> Option<String>;
+
+    /// Detect language from MIME type.
+    ///
+    /// Returns the language ID if a matching language is found.
+    fn detect_from_mime(&self, mime: &str) -> Option<String>;
+
+    /// Get language info by ID.
+    fn get_info(&self, language_id: &str) -> Option<&LanguageInfo>;
+
+    /// Check if a language is registered.
+    fn is_registered(&self, language_id: &str) -> bool;
+
+    /// List all registered language IDs.
+    fn language_ids(&self) -> Vec<String>;
+
+    /// Get the total number of registered languages.
+    fn len(&self) -> usize {
+        self.language_ids().len()
+    }
+
+    /// Check if the registry is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_language_info_new() {
+        let info = LanguageInfo::new("rust", "Rust");
+
+        assert_eq!(info.id, "rust");
+        assert_eq!(info.name, "Rust");
+        assert!(info.extensions.is_empty());
+        assert!(info.mime_types.is_empty());
+        assert!(!info.has_comments());
+    }
+
+    #[test]
+    fn test_language_info_with_extensions() {
+        let info = LanguageInfo::new("rust", "Rust").with_extensions(["rs"]);
+
+        assert_eq!(info.extensions, vec!["rs"]);
+        assert!(info.has_extensions());
+    }
+
+    #[test]
+    fn test_language_info_with_mime_types() {
+        let info = LanguageInfo::new("rust", "Rust").with_mime_types(["text/x-rust"]);
+
+        assert_eq!(info.mime_types, vec!["text/x-rust"]);
+    }
+
+    #[test]
+    fn test_language_info_with_comments() {
+        let info = LanguageInfo::new("rust", "Rust")
+            .with_comments(CommentTokens::with_block("//", "/*", "*/"));
+
+        assert!(info.has_comments());
+        assert!(info.comment_tokens.has_line_comment());
+        assert!(info.comment_tokens.has_block_comment());
+    }
+
+    #[test]
+    fn test_language_info_matches_extension() {
+        let info = LanguageInfo::new("rust", "Rust").with_extensions(["rs"]);
+
+        assert!(info.matches_extension("rs"));
+        assert!(info.matches_extension("RS")); // Case insensitive
+        assert!(info.matches_extension("Rs"));
+        assert!(!info.matches_extension("py"));
+    }
+
+    #[test]
+    fn test_language_info_matches_mime() {
+        let info = LanguageInfo::new("rust", "Rust").with_mime_types(["text/x-rust"]);
+
+        assert!(info.matches_mime("text/x-rust"));
+        assert!(info.matches_mime("TEXT/X-RUST")); // Case insensitive
+        assert!(!info.matches_mime("text/plain"));
+    }
+
+    #[test]
+    fn test_comment_tokens_line_only() {
+        let tokens = CommentTokens::line_only("#");
+
+        assert_eq!(tokens.line, Some("#".to_string()));
+        assert_eq!(tokens.block_start, None);
+        assert_eq!(tokens.block_end, None);
+        assert!(tokens.has_line_comment());
+        assert!(!tokens.has_block_comment());
+        assert!(tokens.has_any());
+    }
+
+    #[test]
+    fn test_comment_tokens_with_block() {
+        let tokens = CommentTokens::with_block("//", "/*", "*/");
+
+        assert_eq!(tokens.line, Some("//".to_string()));
+        assert_eq!(tokens.block_start, Some("/*".to_string()));
+        assert_eq!(tokens.block_end, Some("*/".to_string()));
+        assert!(tokens.has_line_comment());
+        assert!(tokens.has_block_comment());
+        assert!(tokens.has_any());
+    }
+
+    #[test]
+    fn test_comment_tokens_block_only() {
+        let tokens = CommentTokens::block_only("<!--", "-->");
+
+        assert_eq!(tokens.line, None);
+        assert_eq!(tokens.block_start, Some("<!--".to_string()));
+        assert_eq!(tokens.block_end, Some("-->".to_string()));
+        assert!(!tokens.has_line_comment());
+        assert!(tokens.has_block_comment());
+        assert!(tokens.has_any());
+    }
+
+    #[test]
+    fn test_comment_tokens_default() {
+        let tokens = CommentTokens::default();
+
+        assert_eq!(tokens.line, None);
+        assert_eq!(tokens.block_start, None);
+        assert_eq!(tokens.block_end, None);
+        assert!(!tokens.has_line_comment());
+        assert!(!tokens.has_block_comment());
+        assert!(!tokens.has_any());
+    }
+}


### PR DESCRIPTION
Implement the syntax driver layer which provides abstract interfaces for syntax highlighting. This crate defines only traits and types - NO tree-sitter dependency.

Key additions:
- HighlightGroup enum (31 variants) implementing kernel's SyntaxHighlight
- HighlightSpan struct for byte-based highlight ranges
- SyntaxEdit struct for incremental parsing (mirrors tree-sitter InputEdit)
- FoldRange + FoldKind for code folding support
- Injection struct for embedded language regions
- LanguageInfo + CommentTokens for language metadata
- SyntaxDriver trait - main parsing/highlighting interface
- SyntaxDriverFactory trait - driver creation
- LanguageRegistry trait - language detection
- SyntaxCache trait - highlight caching

Design follows kernel's "mechanism vs policy" principle:
- Kernel provides MECHANISM (SyntaxHighlight trait)
- Driver provides POLICY (HighlightGroup enum with specific categories)

Files: 10 new files in lib/drivers/syntax/src/
Tests: 60 unit tests + 8 doctests

Part of Epic #150 (Project Kernel) - Phase 3.1 (Driver Layer)

Closes: #174