### PR TITLE
feat(drivers): implement input/ InputDriver traits (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.2: Input Driver Traits** (Issue #175) - Driver layer input handling interfaces
+  - `KeyCode` enum (56 variants) - Platform-agnostic key codes
+    - Printable: `Char(char)` for all Unicode characters
+    - Function keys: `F(u8)` for F1-F24
+    - Navigation: `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`
+    - Editing: `Backspace`, `Delete`, `Insert`, `Tab`, `BackTab`, `Enter`, `Escape`
+    - Special: `Null`, `CapsLock`, `ScrollLock`, `NumLock`, `PrintScreen`, `Pause`, `Menu`, `KeypadBegin`
+    - Media: `MediaPlay`, `MediaPause`, `MediaPlayPause`, `MediaStop`, `MediaNext`, `MediaPrevious`, etc.
+    - Modifiers: `Left/RightShift`, `Left/RightCtrl`, `Left/RightAlt`, `Left/RightSuper`, `Left/RightHyper`, `Left/RightMeta`
+    - ISO: `IsoLevel3Shift` (`AltGr`), `IsoLevel5Shift`
+  - `Modifiers` bitflags - Combinable key modifiers (SHIFT, CTRL, ALT, SUPER, HYPER, META)
+  - `KeyEventKind` enum (Press, Repeat, Release) - Key event lifecycle
+  - `KeyEvent` struct - Complete key event with code, modifiers, and kind
+    - Constructors: `new()`, `with_modifiers()`, `full()`
+    - Checkers: `is_press()`, `is_release()`, `is_repeat()`
+  - `KeymapResult<T>` enum - Multi-key sequence lookup result (Match, Prefix, None)
+    - Methods: `is_match()`, `is_prefix()`, `is_none()`, `into_option()`, `map()`, `unwrap()`
+  - `MouseButton` enum (Left, Right, Middle)
+  - `MouseEventKind` enum (Down, Up, Drag, Moved, ScrollUp/Down/Left/Right)
+  - `MouseEvent` struct - Mouse event with position and modifiers
+    - Checkers: `is_down()`, `is_up()`, `is_scroll()`, `is_drag()`, `is_moved()`
+  - `InputDriver` trait - Input subsystem lifecycle (init, start, stop, inject_key, inject_mouse)
+  - `KeyHandler` trait - Key event handler with priority ordering
+  - `KeyHandlerResult` enum (Consumed, Pending, Ignored)
+  - `HandlerPriority` type with constants: INTERCEPT (1000), MODAL (500), NORMAL (0), FALLBACK (-500)
+  - `KeymapRegistry<A>` trait - Generic keymap binding/lookup (bind, unbind, lookup, is_prefix, scopes)
+  - `ClipboardProvider` trait - System clipboard abstraction (read, write, is_available)
+  - `InputError` and `ClipboardError` - Comprehensive error types
+  - Bidirectional `From` conversions between `reovim_arch` and driver types
+  - 31 unit tests + 4 doctests
+
 - **Phase 3.1: Syntax Driver Traits** (Issue #174) - Driver layer syntax highlighting interfaces
   - `HighlightGroup` enum (31 variants) - Syntax category policy implementing kernel's `SyntaxHighlight`
     - Keywords: `Keyword`, `KeywordControl`, `KeywordOperator`, `KeywordFunction`, `KeywordType`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,8 @@ dependencies = [
 name = "reovim-driver-input"
 version = "0.9.0-dev"
 dependencies = [
+ "bitflags 2.10.0",
+ "reovim-arch",
  "reovim-kernel",
 ]
 

--- a/lib/drivers/input/Cargo.toml
+++ b/lib/drivers/input/Cargo.toml
@@ -13,5 +13,6 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-# Only depends on kernel layer
 reovim-kernel = { path = "../../kernel", version = "0.9.0-dev" }
+reovim-arch = { path = "../../arch", version = "0.9.0-dev" }
+bitflags = "2.4"

--- a/lib/drivers/input/src/convert.rs
+++ b/lib/drivers/input/src/convert.rs
@@ -1,0 +1,431 @@
+//! Conversions between arch types and canonical driver types.
+//!
+//! This module bridges the existing arch layer types with the new
+//! canonical driver types. Platform code can use either, but the
+//! driver types are the source of truth.
+
+use crate::{
+    key::{KeyCode, KeyEvent, KeyEventKind, Modifiers},
+    mouse::{MouseButton, MouseEvent, MouseEventKind},
+};
+
+// =============================================================================
+// Modifiers conversion
+// =============================================================================
+
+impl From<reovim_arch::Modifiers> for Modifiers {
+    fn from(m: reovim_arch::Modifiers) -> Self {
+        let mut result = Self::empty();
+        if m.contains(reovim_arch::Modifiers::SHIFT) {
+            result |= Self::SHIFT;
+        }
+        if m.contains(reovim_arch::Modifiers::CTRL) {
+            result |= Self::CTRL;
+        }
+        if m.contains(reovim_arch::Modifiers::ALT) {
+            result |= Self::ALT;
+        }
+        if m.contains(reovim_arch::Modifiers::SUPER) {
+            result |= Self::SUPER;
+        }
+        if m.contains(reovim_arch::Modifiers::HYPER) {
+            result |= Self::HYPER;
+        }
+        if m.contains(reovim_arch::Modifiers::META) {
+            result |= Self::META;
+        }
+        result
+    }
+}
+
+impl From<Modifiers> for reovim_arch::Modifiers {
+    fn from(m: Modifiers) -> Self {
+        let mut result = Self::NONE;
+        if m.contains(Modifiers::SHIFT) {
+            result = result.union(Self::SHIFT);
+        }
+        if m.contains(Modifiers::CTRL) {
+            result = result.union(Self::CTRL);
+        }
+        if m.contains(Modifiers::ALT) {
+            result = result.union(Self::ALT);
+        }
+        if m.contains(Modifiers::SUPER) {
+            result = result.union(Self::SUPER);
+        }
+        if m.contains(Modifiers::HYPER) {
+            result = result.union(Self::HYPER);
+        }
+        if m.contains(Modifiers::META) {
+            result = result.union(Self::META);
+        }
+        result
+    }
+}
+
+// =============================================================================
+// KeyCode conversion
+// =============================================================================
+
+impl From<reovim_arch::KeyCode> for KeyCode {
+    fn from(k: reovim_arch::KeyCode) -> Self {
+        use reovim_arch::KeyCode as AK;
+        match k {
+            AK::Char(c) => Self::Char(c),
+            AK::F(n) => Self::F(n),
+            AK::Backspace => Self::Backspace,
+            AK::Enter => Self::Enter,
+            AK::Tab => Self::Tab,
+            AK::BackTab => Self::BackTab,
+            AK::Escape => Self::Escape,
+            AK::Up => Self::Up,
+            AK::Down => Self::Down,
+            AK::Left => Self::Left,
+            AK::Right => Self::Right,
+            AK::Home => Self::Home,
+            AK::End => Self::End,
+            AK::PageUp => Self::PageUp,
+            AK::PageDown => Self::PageDown,
+            AK::Insert => Self::Insert,
+            AK::Delete => Self::Delete,
+            AK::Null => Self::Null,
+            AK::CapsLock => Self::CapsLock,
+            AK::ScrollLock => Self::ScrollLock,
+            AK::NumLock => Self::NumLock,
+            AK::PrintScreen => Self::PrintScreen,
+            AK::Pause => Self::Pause,
+            AK::Menu => Self::Menu,
+            AK::KeypadBegin => Self::KeypadBegin,
+            AK::MediaPlay => Self::MediaPlay,
+            AK::MediaPause => Self::MediaPause,
+            AK::MediaPlayPause => Self::MediaPlayPause,
+            AK::MediaStop => Self::MediaStop,
+            AK::MediaReverse => Self::MediaReverse,
+            AK::MediaFastForward => Self::MediaFastForward,
+            AK::MediaRewind => Self::MediaRewind,
+            AK::MediaNext => Self::MediaNext,
+            AK::MediaPrevious => Self::MediaPrevious,
+            AK::MediaRecord => Self::MediaRecord,
+            AK::MediaLowerVolume => Self::MediaLowerVolume,
+            AK::MediaRaiseVolume => Self::MediaRaiseVolume,
+            AK::MediaMuteVolume => Self::MediaMuteVolume,
+            AK::LeftShift => Self::LeftShift,
+            AK::RightShift => Self::RightShift,
+            AK::LeftCtrl => Self::LeftCtrl,
+            AK::RightCtrl => Self::RightCtrl,
+            AK::LeftAlt => Self::LeftAlt,
+            AK::RightAlt => Self::RightAlt,
+            AK::LeftSuper => Self::LeftSuper,
+            AK::RightSuper => Self::RightSuper,
+            AK::LeftHyper => Self::LeftHyper,
+            AK::RightHyper => Self::RightHyper,
+            AK::LeftMeta => Self::LeftMeta,
+            AK::RightMeta => Self::RightMeta,
+            AK::IsoLevel3Shift => Self::IsoLevel3Shift,
+            AK::IsoLevel5Shift => Self::IsoLevel5Shift,
+        }
+    }
+}
+
+impl From<KeyCode> for reovim_arch::KeyCode {
+    fn from(k: KeyCode) -> Self {
+        match k {
+            KeyCode::Char(c) => Self::Char(c),
+            KeyCode::F(n) => Self::F(n),
+            KeyCode::Backspace => Self::Backspace,
+            KeyCode::Enter => Self::Enter,
+            KeyCode::Tab => Self::Tab,
+            KeyCode::BackTab => Self::BackTab,
+            KeyCode::Escape => Self::Escape,
+            KeyCode::Up => Self::Up,
+            KeyCode::Down => Self::Down,
+            KeyCode::Left => Self::Left,
+            KeyCode::Right => Self::Right,
+            KeyCode::Home => Self::Home,
+            KeyCode::End => Self::End,
+            KeyCode::PageUp => Self::PageUp,
+            KeyCode::PageDown => Self::PageDown,
+            KeyCode::Insert => Self::Insert,
+            KeyCode::Delete => Self::Delete,
+            KeyCode::Null => Self::Null,
+            KeyCode::CapsLock => Self::CapsLock,
+            KeyCode::ScrollLock => Self::ScrollLock,
+            KeyCode::NumLock => Self::NumLock,
+            KeyCode::PrintScreen => Self::PrintScreen,
+            KeyCode::Pause => Self::Pause,
+            KeyCode::Menu => Self::Menu,
+            KeyCode::KeypadBegin => Self::KeypadBegin,
+            KeyCode::MediaPlay => Self::MediaPlay,
+            KeyCode::MediaPause => Self::MediaPause,
+            KeyCode::MediaPlayPause => Self::MediaPlayPause,
+            KeyCode::MediaStop => Self::MediaStop,
+            KeyCode::MediaReverse => Self::MediaReverse,
+            KeyCode::MediaFastForward => Self::MediaFastForward,
+            KeyCode::MediaRewind => Self::MediaRewind,
+            KeyCode::MediaNext => Self::MediaNext,
+            KeyCode::MediaPrevious => Self::MediaPrevious,
+            KeyCode::MediaRecord => Self::MediaRecord,
+            KeyCode::MediaLowerVolume => Self::MediaLowerVolume,
+            KeyCode::MediaRaiseVolume => Self::MediaRaiseVolume,
+            KeyCode::MediaMuteVolume => Self::MediaMuteVolume,
+            KeyCode::LeftShift => Self::LeftShift,
+            KeyCode::RightShift => Self::RightShift,
+            KeyCode::LeftCtrl => Self::LeftCtrl,
+            KeyCode::RightCtrl => Self::RightCtrl,
+            KeyCode::LeftAlt => Self::LeftAlt,
+            KeyCode::RightAlt => Self::RightAlt,
+            KeyCode::LeftSuper => Self::LeftSuper,
+            KeyCode::RightSuper => Self::RightSuper,
+            KeyCode::LeftHyper => Self::LeftHyper,
+            KeyCode::RightHyper => Self::RightHyper,
+            KeyCode::LeftMeta => Self::LeftMeta,
+            KeyCode::RightMeta => Self::RightMeta,
+            KeyCode::IsoLevel3Shift => Self::IsoLevel3Shift,
+            KeyCode::IsoLevel5Shift => Self::IsoLevel5Shift,
+        }
+    }
+}
+
+// =============================================================================
+// KeyEventKind conversion
+// =============================================================================
+
+impl From<reovim_arch::KeyEventKind> for KeyEventKind {
+    fn from(k: reovim_arch::KeyEventKind) -> Self {
+        match k {
+            reovim_arch::KeyEventKind::Press => Self::Press,
+            reovim_arch::KeyEventKind::Repeat => Self::Repeat,
+            reovim_arch::KeyEventKind::Release => Self::Release,
+        }
+    }
+}
+
+impl From<KeyEventKind> for reovim_arch::KeyEventKind {
+    fn from(k: KeyEventKind) -> Self {
+        match k {
+            KeyEventKind::Press => Self::Press,
+            KeyEventKind::Repeat => Self::Repeat,
+            KeyEventKind::Release => Self::Release,
+        }
+    }
+}
+
+// =============================================================================
+// KeyEvent conversion
+// =============================================================================
+
+impl From<reovim_arch::KeyEvent> for KeyEvent {
+    fn from(e: reovim_arch::KeyEvent) -> Self {
+        Self {
+            code: e.code.into(),
+            modifiers: e.modifiers.into(),
+            kind: e.kind.into(),
+        }
+    }
+}
+
+impl From<KeyEvent> for reovim_arch::KeyEvent {
+    fn from(e: KeyEvent) -> Self {
+        Self {
+            code: e.code.into(),
+            modifiers: e.modifiers.into(),
+            kind: e.kind.into(),
+            state: reovim_arch::KeyEventState::NONE,
+        }
+    }
+}
+
+// =============================================================================
+// MouseButton conversion
+// =============================================================================
+
+impl From<reovim_arch::MouseButton> for MouseButton {
+    fn from(b: reovim_arch::MouseButton) -> Self {
+        match b {
+            reovim_arch::MouseButton::Left => Self::Left,
+            reovim_arch::MouseButton::Right => Self::Right,
+            reovim_arch::MouseButton::Middle => Self::Middle,
+        }
+    }
+}
+
+impl From<MouseButton> for reovim_arch::MouseButton {
+    fn from(b: MouseButton) -> Self {
+        match b {
+            MouseButton::Left => Self::Left,
+            MouseButton::Right => Self::Right,
+            MouseButton::Middle => Self::Middle,
+        }
+    }
+}
+
+// =============================================================================
+// MouseEventKind conversion
+// =============================================================================
+
+impl From<reovim_arch::MouseEventKind> for MouseEventKind {
+    fn from(k: reovim_arch::MouseEventKind) -> Self {
+        use reovim_arch::MouseEventKind as AMK;
+        match k {
+            AMK::Down(b) => Self::Down(b.into()),
+            AMK::Up(b) => Self::Up(b.into()),
+            AMK::Drag(b) => Self::Drag(b.into()),
+            AMK::Moved => Self::Moved,
+            AMK::ScrollUp => Self::ScrollUp,
+            AMK::ScrollDown => Self::ScrollDown,
+            AMK::ScrollLeft => Self::ScrollLeft,
+            AMK::ScrollRight => Self::ScrollRight,
+        }
+    }
+}
+
+impl From<MouseEventKind> for reovim_arch::MouseEventKind {
+    fn from(k: MouseEventKind) -> Self {
+        match k {
+            MouseEventKind::Down(b) => Self::Down(b.into()),
+            MouseEventKind::Up(b) => Self::Up(b.into()),
+            MouseEventKind::Drag(b) => Self::Drag(b.into()),
+            MouseEventKind::Moved => Self::Moved,
+            MouseEventKind::ScrollUp => Self::ScrollUp,
+            MouseEventKind::ScrollDown => Self::ScrollDown,
+            MouseEventKind::ScrollLeft => Self::ScrollLeft,
+            MouseEventKind::ScrollRight => Self::ScrollRight,
+        }
+    }
+}
+
+// =============================================================================
+// MouseEvent conversion
+// =============================================================================
+
+impl From<reovim_arch::MouseEvent> for MouseEvent {
+    fn from(e: reovim_arch::MouseEvent) -> Self {
+        Self {
+            kind: e.kind.into(),
+            column: e.column,
+            row: e.row,
+            modifiers: e.modifiers.into(),
+        }
+    }
+}
+
+impl From<MouseEvent> for reovim_arch::MouseEvent {
+    fn from(e: MouseEvent) -> Self {
+        Self {
+            kind: e.kind.into(),
+            column: e.column,
+            row: e.row,
+            modifiers: e.modifiers.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_modifiers_roundtrip() {
+        let driver_mods = Modifiers::CTRL | Modifiers::SHIFT;
+        let arch_mods: reovim_arch::Modifiers = driver_mods.into();
+        let back: Modifiers = arch_mods.into();
+        assert_eq!(driver_mods, back);
+    }
+
+    #[test]
+    fn test_modifiers_all_flags_roundtrip() {
+        let driver_mods = Modifiers::SHIFT
+            | Modifiers::CTRL
+            | Modifiers::ALT
+            | Modifiers::SUPER
+            | Modifiers::HYPER
+            | Modifiers::META;
+        let arch_mods: reovim_arch::Modifiers = driver_mods.into();
+        let back: Modifiers = arch_mods.into();
+        assert_eq!(driver_mods, back);
+    }
+
+    #[test]
+    fn test_key_code_roundtrip() {
+        let codes = [
+            KeyCode::Char('a'),
+            KeyCode::F(12),
+            KeyCode::Enter,
+            KeyCode::Escape,
+            KeyCode::Up,
+            KeyCode::Home,
+            KeyCode::MediaPlay,
+            KeyCode::LeftCtrl,
+        ];
+
+        for code in codes {
+            let arch_code: reovim_arch::KeyCode = code.into();
+            let back: KeyCode = arch_code.into();
+            assert_eq!(code, back);
+        }
+    }
+
+    #[test]
+    fn test_key_event_roundtrip() {
+        let driver_event = KeyEvent::with_modifiers(KeyCode::Char('a'), Modifiers::CTRL);
+        let arch_event: reovim_arch::KeyEvent = driver_event.into();
+        let back: KeyEvent = arch_event.into();
+        assert_eq!(driver_event.code, back.code);
+        assert_eq!(driver_event.modifiers, back.modifiers);
+        assert_eq!(driver_event.kind, back.kind);
+    }
+
+    #[test]
+    fn test_key_event_kind_roundtrip() {
+        let kinds = [
+            KeyEventKind::Press,
+            KeyEventKind::Repeat,
+            KeyEventKind::Release,
+        ];
+
+        for kind in kinds {
+            let arch_kind: reovim_arch::KeyEventKind = kind.into();
+            let back: KeyEventKind = arch_kind.into();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn test_mouse_button_roundtrip() {
+        let buttons = [MouseButton::Left, MouseButton::Right, MouseButton::Middle];
+
+        for button in buttons {
+            let arch_button: reovim_arch::MouseButton = button.into();
+            let back: MouseButton = arch_button.into();
+            assert_eq!(button, back);
+        }
+    }
+
+    #[test]
+    fn test_mouse_event_roundtrip() {
+        let driver_event = MouseEvent::new(MouseEventKind::Down(MouseButton::Left), 10, 20);
+        let arch_event: reovim_arch::MouseEvent = driver_event.into();
+        let back: MouseEvent = arch_event.into();
+        assert_eq!(driver_event, back);
+    }
+
+    #[test]
+    fn test_mouse_event_kind_roundtrip() {
+        let kinds = [
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Right),
+            MouseEventKind::Drag(MouseButton::Middle),
+            MouseEventKind::Moved,
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+            MouseEventKind::ScrollLeft,
+            MouseEventKind::ScrollRight,
+        ];
+
+        for kind in kinds {
+            let arch_kind: reovim_arch::MouseEventKind = kind.into();
+            let back: MouseEventKind = arch_kind.into();
+            assert_eq!(kind, back);
+        }
+    }
+}

--- a/lib/drivers/input/src/error.rs
+++ b/lib/drivers/input/src/error.rs
@@ -1,0 +1,106 @@
+//! Input driver error types.
+//!
+//! Linux equivalent: `include/linux/errno.h` (input-specific errors)
+
+use std::fmt;
+
+/// Errors that can occur during input operations.
+#[derive(Debug)]
+pub enum InputError {
+    /// Input driver is not initialized.
+    NotInitialized,
+    /// Input driver is already running.
+    AlreadyRunning,
+    /// Input driver is not running.
+    NotRunning,
+    /// Input driver failed to start.
+    StartFailed(String),
+    /// Input driver failed to stop.
+    StopFailed(String),
+    /// Key injection failed.
+    InjectionFailed(String),
+    /// Invalid key sequence.
+    InvalidKeySequence(String),
+    /// Keymap operation failed.
+    KeymapError(String),
+    /// Handler registration failed.
+    HandlerRegistrationFailed(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInitialized => write!(f, "input driver not initialized"),
+            Self::AlreadyRunning => write!(f, "input driver already running"),
+            Self::NotRunning => write!(f, "input driver not running"),
+            Self::StartFailed(msg) => write!(f, "failed to start input driver: {msg}"),
+            Self::StopFailed(msg) => write!(f, "failed to stop input driver: {msg}"),
+            Self::InjectionFailed(msg) => write!(f, "key injection failed: {msg}"),
+            Self::InvalidKeySequence(msg) => write!(f, "invalid key sequence: {msg}"),
+            Self::KeymapError(msg) => write!(f, "keymap error: {msg}"),
+            Self::HandlerRegistrationFailed(msg) => {
+                write!(f, "handler registration failed: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InputError {}
+
+/// Errors that can occur during clipboard operations.
+#[derive(Debug)]
+pub enum ClipboardError {
+    /// Clipboard is not available on this platform.
+    NotAvailable,
+    /// Failed to read from clipboard.
+    ReadFailed(String),
+    /// Failed to write to clipboard.
+    WriteFailed(String),
+    /// Clipboard content is not text.
+    NotText,
+    /// Clipboard provider not configured.
+    NoProvider,
+}
+
+impl fmt::Display for ClipboardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAvailable => write!(f, "clipboard not available"),
+            Self::ReadFailed(msg) => write!(f, "failed to read clipboard: {msg}"),
+            Self::WriteFailed(msg) => write!(f, "failed to write clipboard: {msg}"),
+            Self::NotText => write!(f, "clipboard content is not text"),
+            Self::NoProvider => write!(f, "no clipboard provider configured"),
+        }
+    }
+}
+
+impl std::error::Error for ClipboardError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_error_display() {
+        assert_eq!(format!("{}", InputError::NotInitialized), "input driver not initialized");
+        assert_eq!(format!("{}", InputError::AlreadyRunning), "input driver already running");
+        assert_eq!(format!("{}", InputError::NotRunning), "input driver not running");
+        assert!(format!("{}", InputError::StartFailed("test".into())).contains("test"));
+        assert!(format!("{}", InputError::StopFailed("test".into())).contains("test"));
+        assert!(format!("{}", InputError::InjectionFailed("test".into())).contains("test"));
+        assert!(format!("{}", InputError::InvalidKeySequence("test".into())).contains("test"));
+        assert!(format!("{}", InputError::KeymapError("test".into())).contains("test"));
+        assert!(
+            format!("{}", InputError::HandlerRegistrationFailed("test".into())).contains("test")
+        );
+    }
+
+    #[test]
+    fn test_clipboard_error_display() {
+        assert_eq!(format!("{}", ClipboardError::NotAvailable), "clipboard not available");
+        assert_eq!(format!("{}", ClipboardError::NotText), "clipboard content is not text");
+        assert_eq!(format!("{}", ClipboardError::NoProvider), "no clipboard provider configured");
+        assert!(format!("{}", ClipboardError::ReadFailed("test".into())).contains("test"));
+        assert!(format!("{}", ClipboardError::WriteFailed("test".into())).contains("test"));
+    }
+}

--- a/lib/drivers/input/src/key.rs
+++ b/lib/drivers/input/src/key.rs
@@ -1,0 +1,455 @@
+//! Canonical keyboard input types.
+//!
+//! These types are the source of truth for keyboard input across all platforms.
+//! Platform-specific code (arch/unix, arch/wasm, etc.) converts native events
+//! to these canonical types.
+//!
+//! Linux equivalent: `include/uapi/linux/input-event-codes.h`
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Key modifiers (platform-agnostic).
+    ///
+    /// Supports combinations via bitwise operations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_driver_input::Modifiers;
+    ///
+    /// let ctrl_shift = Modifiers::CTRL | Modifiers::SHIFT;
+    /// assert!(ctrl_shift.contains(Modifiers::CTRL));
+    /// assert!(ctrl_shift.contains(Modifiers::SHIFT));
+    /// assert!(!ctrl_shift.contains(Modifiers::ALT));
+    /// ```
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct Modifiers: u8 {
+        /// No modifiers.
+        const NONE  = 0;
+        /// Shift key.
+        const SHIFT = 1 << 0;
+        /// Control key.
+        const CTRL  = 1 << 1;
+        /// Alt/Option key.
+        const ALT   = 1 << 2;
+        /// Super/Meta/Command key.
+        const SUPER = 1 << 3;
+        /// Hyper key (rare).
+        const HYPER = 1 << 4;
+        /// Meta key (distinct from Super on some systems).
+        const META  = 1 << 5;
+    }
+}
+
+/// Platform-agnostic key codes.
+///
+/// Covers all printable ASCII, function keys F1-F24, navigation keys,
+/// editing keys, and special keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyCode {
+    // =========================================================================
+    // Printable characters
+    // =========================================================================
+    /// A character key (covers all printable ASCII and Unicode).
+    Char(char),
+
+    // =========================================================================
+    // Function keys (F1-F24)
+    // =========================================================================
+    /// Function key (F1-F24, stored as 1-24).
+    F(u8),
+
+    // =========================================================================
+    // Navigation keys
+    // =========================================================================
+    /// Up arrow.
+    Up,
+    /// Down arrow.
+    Down,
+    /// Left arrow.
+    Left,
+    /// Right arrow.
+    Right,
+    /// Home key.
+    Home,
+    /// End key.
+    End,
+    /// Page up.
+    PageUp,
+    /// Page down.
+    PageDown,
+
+    // =========================================================================
+    // Editing keys
+    // =========================================================================
+    /// Backspace key.
+    Backspace,
+    /// Delete key.
+    Delete,
+    /// Insert key.
+    Insert,
+    /// Tab key.
+    Tab,
+    /// Shift+Tab (backtab).
+    BackTab,
+    /// Enter/Return key.
+    Enter,
+    /// Escape key.
+    Escape,
+
+    // =========================================================================
+    // Special keys
+    // =========================================================================
+    /// Null character (Ctrl+@).
+    Null,
+    /// Caps lock (if reported).
+    CapsLock,
+    /// Scroll lock (if reported).
+    ScrollLock,
+    /// Num lock (if reported).
+    NumLock,
+    /// Print screen (if reported).
+    PrintScreen,
+    /// Pause key (if reported).
+    Pause,
+    /// Menu/Application key (if reported).
+    Menu,
+    /// Keypad begin (center key on keypad).
+    KeypadBegin,
+
+    // =========================================================================
+    // Media keys (for future platforms)
+    // =========================================================================
+    /// Media play.
+    MediaPlay,
+    /// Media pause.
+    MediaPause,
+    /// Media play/pause toggle.
+    MediaPlayPause,
+    /// Media stop.
+    MediaStop,
+    /// Media reverse.
+    MediaReverse,
+    /// Media fast forward.
+    MediaFastForward,
+    /// Media rewind.
+    MediaRewind,
+    /// Media next track.
+    MediaNext,
+    /// Media previous track.
+    MediaPrevious,
+    /// Media record.
+    MediaRecord,
+    /// Media lower volume.
+    MediaLowerVolume,
+    /// Media raise volume.
+    MediaRaiseVolume,
+    /// Media mute volume.
+    MediaMuteVolume,
+
+    // =========================================================================
+    // Modifier keys (when reported as separate events)
+    // =========================================================================
+    /// Left shift key.
+    LeftShift,
+    /// Right shift key.
+    RightShift,
+    /// Left control key.
+    LeftCtrl,
+    /// Right control key.
+    RightCtrl,
+    /// Left alt key.
+    LeftAlt,
+    /// Right alt key.
+    RightAlt,
+    /// Left super/meta key.
+    LeftSuper,
+    /// Right super/meta key.
+    RightSuper,
+    /// Left hyper key.
+    LeftHyper,
+    /// Right hyper key.
+    RightHyper,
+    /// Left meta key.
+    LeftMeta,
+    /// Right meta key.
+    RightMeta,
+    /// ISO Level 3 Shift (`AltGr` on some keyboards).
+    IsoLevel3Shift,
+    /// ISO Level 5 Shift.
+    IsoLevel5Shift,
+}
+
+/// Key event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum KeyEventKind {
+    /// Key was pressed.
+    #[default]
+    Press,
+    /// Key is being held (repeat).
+    Repeat,
+    /// Key was released.
+    Release,
+}
+
+/// Complete key event.
+///
+/// Represents a keyboard event with key code, modifiers, and event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyEvent {
+    /// The key code.
+    pub code: KeyCode,
+    /// Active modifiers.
+    pub modifiers: Modifiers,
+    /// Event kind (press, repeat, release).
+    pub kind: KeyEventKind,
+}
+
+impl KeyEvent {
+    /// Create a new key event with just a key code (press, no modifiers).
+    #[must_use]
+    pub const fn new(code: KeyCode) -> Self {
+        Self {
+            code,
+            modifiers: Modifiers::NONE,
+            kind: KeyEventKind::Press,
+        }
+    }
+
+    /// Create a key event with modifiers (press).
+    #[must_use]
+    pub const fn with_modifiers(code: KeyCode, modifiers: Modifiers) -> Self {
+        Self {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+        }
+    }
+
+    /// Create a key event with full specification.
+    #[must_use]
+    pub const fn full(code: KeyCode, modifiers: Modifiers, kind: KeyEventKind) -> Self {
+        Self {
+            code,
+            modifiers,
+            kind,
+        }
+    }
+
+    /// Check if this is a press event.
+    #[must_use]
+    pub const fn is_press(&self) -> bool {
+        matches!(self.kind, KeyEventKind::Press)
+    }
+
+    /// Check if this is a release event.
+    #[must_use]
+    pub const fn is_release(&self) -> bool {
+        matches!(self.kind, KeyEventKind::Release)
+    }
+
+    /// Check if this is a repeat event.
+    #[must_use]
+    pub const fn is_repeat(&self) -> bool {
+        matches!(self.kind, KeyEventKind::Repeat)
+    }
+}
+
+/// Result of keymap lookup.
+///
+/// Supports multi-key sequences like `gg`, `<C-w>h`.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_input::KeymapResult;
+///
+/// let result: KeymapResult<&str> = KeymapResult::Match("delete_line");
+/// assert!(result.is_match());
+///
+/// let prefix: KeymapResult<&str> = KeymapResult::Prefix;
+/// assert!(prefix.is_prefix());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeymapResult<T> {
+    /// Full match: the key sequence maps to an action.
+    Match(T),
+    /// Partial match: the key sequence is a prefix of one or more bindings.
+    Prefix,
+    /// No match: the key sequence does not match any binding.
+    None,
+}
+
+impl<T> KeymapResult<T> {
+    /// Returns `true` if this is a full match.
+    #[must_use]
+    pub const fn is_match(&self) -> bool {
+        matches!(self, Self::Match(_))
+    }
+
+    /// Returns `true` if this is a prefix.
+    #[must_use]
+    pub const fn is_prefix(&self) -> bool {
+        matches!(self, Self::Prefix)
+    }
+
+    /// Returns `true` if there is no match.
+    #[must_use]
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    /// Convert to Option, returning Some only for Match.
+    #[must_use]
+    pub fn into_option(self) -> Option<T> {
+        match self {
+            Self::Match(action) => Some(action),
+            Self::Prefix | Self::None => None,
+        }
+    }
+
+    /// Map the action type.
+    #[must_use]
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> KeymapResult<U> {
+        match self {
+            Self::Match(action) => KeymapResult::Match(f(action)),
+            Self::Prefix => KeymapResult::Prefix,
+            Self::None => KeymapResult::None,
+        }
+    }
+
+    /// Returns the contained Match value, consuming self.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not Match.
+    #[must_use]
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Match(action) => action,
+            Self::Prefix => panic!("called `KeymapResult::unwrap()` on a `Prefix` value"),
+            Self::None => panic!("called `KeymapResult::unwrap()` on a `None` value"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_modifiers_bitflags() {
+        let ctrl_shift = Modifiers::CTRL | Modifiers::SHIFT;
+        assert!(ctrl_shift.contains(Modifiers::CTRL));
+        assert!(ctrl_shift.contains(Modifiers::SHIFT));
+        assert!(!ctrl_shift.contains(Modifiers::ALT));
+        assert!(!ctrl_shift.is_empty());
+        assert!(Modifiers::NONE.is_empty());
+    }
+
+    #[test]
+    fn test_modifiers_all_variants() {
+        // Test all modifier flags can be combined
+        let all = Modifiers::SHIFT
+            | Modifiers::CTRL
+            | Modifiers::ALT
+            | Modifiers::SUPER
+            | Modifiers::HYPER
+            | Modifiers::META;
+        assert!(all.contains(Modifiers::SHIFT));
+        assert!(all.contains(Modifiers::CTRL));
+        assert!(all.contains(Modifiers::ALT));
+        assert!(all.contains(Modifiers::SUPER));
+        assert!(all.contains(Modifiers::HYPER));
+        assert!(all.contains(Modifiers::META));
+    }
+
+    #[test]
+    fn test_key_event_creation() {
+        let key = KeyEvent::new(KeyCode::Char('a'));
+        assert_eq!(key.code, KeyCode::Char('a'));
+        assert_eq!(key.modifiers, Modifiers::NONE);
+        assert!(key.is_press());
+        assert!(!key.is_release());
+        assert!(!key.is_repeat());
+
+        let ctrl_a = KeyEvent::with_modifiers(KeyCode::Char('a'), Modifiers::CTRL);
+        assert!(ctrl_a.modifiers.contains(Modifiers::CTRL));
+        assert!(ctrl_a.is_press());
+
+        let release = KeyEvent::full(KeyCode::Escape, Modifiers::NONE, KeyEventKind::Release);
+        assert!(release.is_release());
+    }
+
+    #[test]
+    fn test_keymap_result_is_match() {
+        let match_result: KeymapResult<i32> = KeymapResult::Match(42);
+        assert!(match_result.is_match());
+        assert!(!match_result.is_prefix());
+        assert!(!match_result.is_none());
+    }
+
+    #[test]
+    fn test_keymap_result_is_prefix() {
+        let prefix: KeymapResult<i32> = KeymapResult::Prefix;
+        assert!(!prefix.is_match());
+        assert!(prefix.is_prefix());
+        assert!(!prefix.is_none());
+    }
+
+    #[test]
+    fn test_keymap_result_is_none() {
+        let none: KeymapResult<i32> = KeymapResult::None;
+        assert!(!none.is_match());
+        assert!(!none.is_prefix());
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn test_keymap_result_into_option() {
+        let match_result: KeymapResult<i32> = KeymapResult::Match(42);
+        assert_eq!(match_result.into_option(), Some(42));
+
+        let prefix: KeymapResult<i32> = KeymapResult::Prefix;
+        assert_eq!(prefix.into_option(), None);
+
+        let none: KeymapResult<i32> = KeymapResult::None;
+        assert_eq!(none.into_option(), None);
+    }
+
+    #[test]
+    fn test_keymap_result_map() {
+        let result: KeymapResult<i32> = KeymapResult::Match(21);
+        let mapped = result.map(|x| x * 2);
+        assert_eq!(mapped, KeymapResult::Match(42));
+
+        let prefix: KeymapResult<i32> = KeymapResult::Prefix;
+        let mapped_prefix: KeymapResult<String> = prefix.map(|x| x.to_string());
+        assert!(mapped_prefix.is_prefix());
+
+        let none: KeymapResult<i32> = KeymapResult::None;
+        let mapped_none: KeymapResult<String> = none.map(|x| x.to_string());
+        assert!(mapped_none.is_none());
+    }
+
+    #[test]
+    fn test_keymap_result_unwrap() {
+        let result: KeymapResult<i32> = KeymapResult::Match(42);
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "Prefix")]
+    fn test_keymap_result_unwrap_prefix_panics() {
+        let prefix: KeymapResult<i32> = KeymapResult::Prefix;
+        let _ = prefix.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "None")]
+    fn test_keymap_result_unwrap_none_panics() {
+        let none: KeymapResult<i32> = KeymapResult::None;
+        let _ = none.unwrap();
+    }
+}

--- a/lib/drivers/input/src/lib.rs
+++ b/lib/drivers/input/src/lib.rs
@@ -1,13 +1,69 @@
-//! Input driver for reovim.
+//! Input driver for reovim - canonical input types and traits.
 //!
-//! Linux equivalent: `drivers/input/`
+//! Linux equivalent: `drivers/input/` + `include/linux/input.h`
 //!
-//! Provides keyboard event handling, mouse support, and clipboard operations.
+//! # Architecture
+//!
+//! This crate defines the **canonical input vocabulary** for all platforms.
+//! Platform-specific code converts native events to these types.
+//!
+//! ```text
+//! lib/drivers/input/        <-- Canonical types (this crate)
+//!        ^
+//!        |  (platform code converts to canonical types)
+//!        |
+//! lib/arch/unix/            <-- crossterm → canonical
+//! lib/arch/wasm/            <-- JS events → canonical [future]
+//! lib/arch/android/         <-- Android events → canonical [future]
+//! ```
 //!
 //! # Components
 //!
-//! - Keyboard broker (key event dispatch)
-//! - Mouse broker (click, scroll, drag)
-//! - Clipboard backend (system clipboard integration)
+//! - **Types**: [`KeyCode`], [`KeyEvent`], [`Modifiers`], [`MouseEvent`]
+//! - **Traits**: [`InputDriver`], [`KeyHandler`], [`KeymapRegistry`], [`ClipboardProvider`]
+//! - **Conversions**: `From` impls between arch types and driver types
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_driver_input::{KeyCode, KeyEvent, Modifiers, KeymapResult};
+//!
+//! // Create a simple key event
+//! let key = KeyEvent::new(KeyCode::Char('j'));
+//! assert!(key.is_press());
+//!
+//! // Create a key event with modifiers
+//! let ctrl_s = KeyEvent::with_modifiers(KeyCode::Char('s'), Modifiers::CTRL);
+//! assert!(ctrl_s.modifiers.contains(Modifiers::CTRL));
+//! ```
+//!
+//! # Converting from arch types
+//!
+//! ```
+//! use reovim_driver_input::KeyEvent;
+//!
+//! // Convert from arch KeyEvent to driver KeyEvent
+//! let arch_event = reovim_arch::KeyEvent::new(reovim_arch::KeyCode::Char('x'));
+//! let driver_event: KeyEvent = arch_event.into();
+//! ```
 
-// Placeholder - InputDriver trait and implementations will be added in Phase 3
+mod convert;
+mod error;
+mod key;
+mod mouse;
+mod traits;
+
+// Re-export error types
+pub use error::{ClipboardError, InputError};
+
+// Re-export key types
+pub use key::{KeyCode, KeyEvent, KeyEventKind, KeymapResult, Modifiers};
+
+// Re-export mouse types
+pub use mouse::{MouseButton, MouseEvent, MouseEventKind};
+
+// Re-export traits
+pub use traits::{
+    ClipboardProvider, HandlerPriority, InputDriver, KeyHandler, KeyHandlerResult, KeymapRegistry,
+    priority,
+};

--- a/lib/drivers/input/src/mouse.rs
+++ b/lib/drivers/input/src/mouse.rs
@@ -1,0 +1,195 @@
+//! Canonical mouse input types.
+//!
+//! These types are the source of truth for mouse input across all platforms.
+//! Platform-specific code converts native events to these canonical types.
+
+use crate::key::Modifiers;
+
+/// Mouse button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// Left mouse button.
+    Left,
+    /// Right mouse button.
+    Right,
+    /// Middle mouse button (wheel click).
+    Middle,
+}
+
+/// Mouse event kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseEventKind {
+    /// Button pressed down.
+    Down(MouseButton),
+    /// Button released.
+    Up(MouseButton),
+    /// Mouse dragged with button held.
+    Drag(MouseButton),
+    /// Mouse moved (without button).
+    Moved,
+    /// Scroll up.
+    ScrollUp,
+    /// Scroll down.
+    ScrollDown,
+    /// Scroll left (horizontal).
+    ScrollLeft,
+    /// Scroll right (horizontal).
+    ScrollRight,
+}
+
+/// Mouse event with position and modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouseEvent {
+    /// The event kind.
+    pub kind: MouseEventKind,
+    /// Column (0-based).
+    pub column: u16,
+    /// Row (0-based).
+    pub row: u16,
+    /// Active modifiers.
+    pub modifiers: Modifiers,
+}
+
+impl MouseEvent {
+    /// Create a new mouse event.
+    #[must_use]
+    pub const fn new(kind: MouseEventKind, column: u16, row: u16) -> Self {
+        Self {
+            kind,
+            column,
+            row,
+            modifiers: Modifiers::NONE,
+        }
+    }
+
+    /// Create a mouse event with modifiers.
+    #[must_use]
+    pub const fn with_modifiers(
+        kind: MouseEventKind,
+        column: u16,
+        row: u16,
+        modifiers: Modifiers,
+    ) -> Self {
+        Self {
+            kind,
+            column,
+            row,
+            modifiers,
+        }
+    }
+
+    /// Check if this is a click event (down).
+    #[must_use]
+    pub const fn is_down(&self) -> bool {
+        matches!(self.kind, MouseEventKind::Down(_))
+    }
+
+    /// Check if this is a release event (up).
+    #[must_use]
+    pub const fn is_up(&self) -> bool {
+        matches!(self.kind, MouseEventKind::Up(_))
+    }
+
+    /// Check if this is a scroll event.
+    #[must_use]
+    pub const fn is_scroll(&self) -> bool {
+        matches!(
+            self.kind,
+            MouseEventKind::ScrollUp
+                | MouseEventKind::ScrollDown
+                | MouseEventKind::ScrollLeft
+                | MouseEventKind::ScrollRight
+        )
+    }
+
+    /// Check if this is a drag event.
+    #[must_use]
+    pub const fn is_drag(&self) -> bool {
+        matches!(self.kind, MouseEventKind::Drag(_))
+    }
+
+    /// Check if this is a move event.
+    #[must_use]
+    pub const fn is_moved(&self) -> bool {
+        matches!(self.kind, MouseEventKind::Moved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mouse_event_creation() {
+        let event = MouseEvent::new(MouseEventKind::Down(MouseButton::Left), 10, 20);
+        assert_eq!(event.column, 10);
+        assert_eq!(event.row, 20);
+        assert!(event.is_down());
+        assert!(!event.is_up());
+        assert!(!event.is_scroll());
+        assert!(!event.is_drag());
+        assert!(!event.is_moved());
+    }
+
+    #[test]
+    fn test_mouse_event_with_modifiers() {
+        let event = MouseEvent::with_modifiers(
+            MouseEventKind::Down(MouseButton::Left),
+            5,
+            10,
+            Modifiers::CTRL | Modifiers::SHIFT,
+        );
+        assert!(event.modifiers.contains(Modifiers::CTRL));
+        assert!(event.modifiers.contains(Modifiers::SHIFT));
+    }
+
+    #[test]
+    fn test_mouse_scroll() {
+        let scroll_up = MouseEvent::new(MouseEventKind::ScrollUp, 0, 0);
+        assert!(scroll_up.is_scroll());
+        assert!(!scroll_up.is_down());
+
+        let scroll_down = MouseEvent::new(MouseEventKind::ScrollDown, 0, 0);
+        assert!(scroll_down.is_scroll());
+
+        let scroll_left = MouseEvent::new(MouseEventKind::ScrollLeft, 0, 0);
+        assert!(scroll_left.is_scroll());
+
+        let scroll_right = MouseEvent::new(MouseEventKind::ScrollRight, 0, 0);
+        assert!(scroll_right.is_scroll());
+    }
+
+    #[test]
+    fn test_mouse_up() {
+        let event = MouseEvent::new(MouseEventKind::Up(MouseButton::Right), 0, 0);
+        assert!(event.is_up());
+        assert!(!event.is_down());
+    }
+
+    #[test]
+    fn test_mouse_drag() {
+        let event = MouseEvent::new(MouseEventKind::Drag(MouseButton::Left), 15, 25);
+        assert!(event.is_drag());
+        assert!(!event.is_down());
+        assert!(!event.is_up());
+    }
+
+    #[test]
+    fn test_mouse_moved() {
+        let event = MouseEvent::new(MouseEventKind::Moved, 30, 40);
+        assert!(event.is_moved());
+        assert!(!event.is_down());
+        assert!(!event.is_drag());
+    }
+
+    #[test]
+    fn test_mouse_button_variants() {
+        let left = MouseEvent::new(MouseEventKind::Down(MouseButton::Left), 0, 0);
+        let right = MouseEvent::new(MouseEventKind::Down(MouseButton::Right), 0, 0);
+        let middle = MouseEvent::new(MouseEventKind::Down(MouseButton::Middle), 0, 0);
+
+        assert!(left.is_down());
+        assert!(right.is_down());
+        assert!(middle.is_down());
+    }
+}

--- a/lib/drivers/input/src/traits.rs
+++ b/lib/drivers/input/src/traits.rs
@@ -1,0 +1,215 @@
+//! Input driver traits.
+//!
+//! Linux equivalent: `include/linux/input.h` (input subsystem)
+//!
+//! # Architecture
+//!
+//! ```text
+//! +-----------------+
+//! | InputDriver     |  <-- Lifecycle: init, start, stop
+//! +-----------------+
+//!         |
+//!         v
+//! +-----------------+
+//! | KeyHandler      |  <-- Receives and processes key events
+//! +-----------------+
+//!         |
+//!         v
+//! +-----------------+
+//! | KeymapRegistry  |  <-- Maps key sequences to actions
+//! +-----------------+
+//!
+//! +-----------------+
+//! | ClipboardProvider |  <-- System clipboard access
+//! +-----------------+
+//! ```
+
+#![allow(clippy::missing_errors_doc)]
+
+use crate::{
+    error::{ClipboardError, InputError},
+    key::{KeyEvent, KeymapResult},
+    mouse::MouseEvent,
+};
+
+/// Input driver lifecycle management.
+///
+/// This trait manages the input driver lifecycle and provides
+/// key/mouse injection for testing and RPC.
+pub trait InputDriver: Send + Sync {
+    /// Initialize the input driver.
+    ///
+    /// Called once before `start()`. Setup resources here.
+    fn init(&mut self) -> Result<(), InputError>;
+
+    /// Start the input driver.
+    ///
+    /// Begin reading input events and dispatching to handlers.
+    fn start(&mut self) -> Result<(), InputError>;
+
+    /// Stop the input driver.
+    ///
+    /// Stop reading events. Resources may be kept for restart.
+    fn stop(&mut self) -> Result<(), InputError>;
+
+    /// Check if the driver is currently running.
+    fn is_running(&self) -> bool;
+
+    /// Inject a key event (for testing/RPC).
+    ///
+    /// The event is processed as if it came from the terminal.
+    fn inject_key(&mut self, event: KeyEvent) -> Result<(), InputError>;
+
+    /// Inject a mouse event (for testing/RPC).
+    ///
+    /// The event is processed as if it came from the terminal.
+    fn inject_mouse(&mut self, event: MouseEvent) -> Result<(), InputError>;
+
+    /// Register a key handler.
+    ///
+    /// Handlers are called in priority order (higher priority first).
+    fn register_handler(&mut self, handler: Box<dyn KeyHandler>) -> Result<(), InputError>;
+
+    /// Unregister a key handler by ID.
+    fn unregister_handler(&mut self, handler_id: &str) -> Result<(), InputError>;
+}
+
+/// Handler priority type.
+///
+/// Higher values are processed first.
+pub type HandlerPriority = i32;
+
+/// Priority levels for common handler types.
+pub mod priority {
+    use super::HandlerPriority;
+
+    /// Highest priority - intercepts all keys (e.g., escape sequences).
+    pub const INTERCEPT: HandlerPriority = 1000;
+
+    /// High priority - modal handlers (e.g., command mode).
+    pub const MODAL: HandlerPriority = 500;
+
+    /// Normal priority - standard key bindings.
+    pub const NORMAL: HandlerPriority = 0;
+
+    /// Low priority - fallback handlers.
+    pub const FALLBACK: HandlerPriority = -500;
+}
+
+/// Key event handler.
+///
+/// Handlers receive key events in priority order. If a handler
+/// consumes an event, lower-priority handlers are not called.
+pub trait KeyHandler: Send {
+    /// Unique identifier for this handler.
+    fn id(&self) -> &str;
+
+    /// Priority for event dispatch (higher = earlier).
+    fn priority(&self) -> HandlerPriority;
+
+    /// Handle a key event.
+    ///
+    /// Returns how the event was processed.
+    fn handle(&mut self, event: &KeyEvent) -> KeyHandlerResult;
+
+    /// Check if this handler is currently active.
+    ///
+    /// Inactive handlers are skipped during dispatch.
+    fn is_active(&self) -> bool {
+        true
+    }
+}
+
+/// Result of handling a key event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyHandlerResult {
+    /// Event was consumed - do not dispatch to lower-priority handlers.
+    Consumed,
+
+    /// Event is part of a multi-key sequence - wait for more keys.
+    Pending,
+
+    /// Event was not handled - dispatch to next handler.
+    Ignored,
+}
+
+/// Keymap registry for binding key sequences to actions.
+///
+/// This trait provides the interface for managing keymaps.
+/// Implementations handle the trie/lookup structure.
+///
+/// The generic type `A` represents the action type (command ID, callback, etc.).
+pub trait KeymapRegistry<A>: Send + Sync {
+    /// Bind a key sequence to an action in a scope.
+    ///
+    /// # Arguments
+    ///
+    /// * `scope` - The keymap scope (e.g., "normal", "insert", "command")
+    /// * `keys` - The key sequence to bind
+    /// * `action` - The action to execute when keys are pressed
+    fn bind(&mut self, scope: &str, keys: &[KeyEvent], action: A) -> Result<(), InputError>;
+
+    /// Unbind a key sequence from a scope.
+    fn unbind(&mut self, scope: &str, keys: &[KeyEvent]) -> Result<(), InputError>;
+
+    /// Look up a key sequence in a scope.
+    fn lookup(&self, scope: &str, keys: &[KeyEvent]) -> KeymapResult<&A>;
+
+    /// Check if a key sequence is a valid prefix in a scope.
+    fn is_prefix(&self, scope: &str, keys: &[KeyEvent]) -> bool;
+
+    /// List all scopes.
+    fn scopes(&self) -> Vec<&str>;
+
+    /// Clear all bindings in a scope.
+    fn clear_scope(&mut self, scope: &str);
+}
+
+/// System clipboard provider.
+///
+/// Provides read/write access to the system clipboard.
+/// Implementations handle platform-specific clipboard APIs.
+pub trait ClipboardProvider: Send + Sync {
+    /// Read text from the system clipboard.
+    fn read(&self) -> Result<String, ClipboardError>;
+
+    /// Write text to the system clipboard.
+    fn write(&mut self, text: &str) -> Result<(), ClipboardError>;
+
+    /// Check if clipboard is available.
+    fn is_available(&self) -> bool;
+
+    /// Get the name of this provider (for debugging).
+    fn name(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_handler_result_variants() {
+        assert_eq!(KeyHandlerResult::Consumed, KeyHandlerResult::Consumed);
+        assert_eq!(KeyHandlerResult::Pending, KeyHandlerResult::Pending);
+        assert_eq!(KeyHandlerResult::Ignored, KeyHandlerResult::Ignored);
+        assert_ne!(KeyHandlerResult::Consumed, KeyHandlerResult::Ignored);
+        assert_ne!(KeyHandlerResult::Consumed, KeyHandlerResult::Pending);
+        assert_ne!(KeyHandlerResult::Pending, KeyHandlerResult::Ignored);
+    }
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn test_priority_ordering() {
+        assert!(priority::INTERCEPT > priority::MODAL);
+        assert!(priority::MODAL > priority::NORMAL);
+        assert!(priority::NORMAL > priority::FALLBACK);
+    }
+
+    #[test]
+    fn test_priority_values() {
+        assert_eq!(priority::INTERCEPT, 1000);
+        assert_eq!(priority::MODAL, 500);
+        assert_eq!(priority::NORMAL, 0);
+        assert_eq!(priority::FALLBACK, -500);
+    }
+}

--- a/lib/drivers/syntax/src/driver.rs
+++ b/lib/drivers/syntax/src/driver.rs
@@ -131,7 +131,7 @@ pub trait SyntaxDriver: Send + Sync {
 mod tests {
     use {super::*, crate::highlight::HighlightGroup};
 
-    /// A minimal test implementation of SyntaxDriver.
+    /// A minimal test implementation of `SyntaxDriver`.
     struct TestDriver {
         language: String,
         parsed: bool,


### PR DESCRIPTION
Add canonical input types and traits for keyboard, mouse, and clipboard handling. These types are the source of truth for all platforms - platform code (arch layer) converts native events to these canonical types.

Types:
- KeyCode enum (56 variants): Char, F-keys, navigation, editing, media, modifiers
- Modifiers bitflags: SHIFT, CTRL, ALT, SUPER, HYPER, META
- KeyEvent struct with code, modifiers, and kind (Press/Repeat/Release)
- KeymapResult<T> for multi-key sequence lookup (Match/Prefix/None)
- MouseButton, MouseEventKind, MouseEvent for mouse handling
- InputError, ClipboardError for comprehensive error handling

Traits:
- InputDriver: lifecycle management (init, start, stop, inject_key/mouse)
- KeyHandler: priority-based key event handling
- KeymapRegistry<A>: generic keymap binding/lookup
- ClipboardProvider: system clipboard abstraction

Also includes:
- Bidirectional From conversions between reovim_arch and driver types
- 31 unit tests + 4 doctests
- Zero clippy warnings (pedantic + nursery)

Part of epic #150 (Linux-Inspired Architecture Overhaul)

Closes: #175