### PR TITLE
feat(drivers): implement display/ DisplayDriver traits (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.3: Display Driver Traits** (Issue #176) - Driver layer display/rendering interfaces
+  - `DisplayDriver` trait - Terminal lifecycle and rendering abstraction
+    - `init()`, `shutdown()`, `is_initialized()` - Driver lifecycle
+    - `frame_buffer()`, `frame_buffer_mut()` - Frame buffer access
+    - `render()`, `invalidate()` - Diff-based rendering
+    - `resize()`, `size()` - Terminal size management
+    - `cursor_position()`, `set_cursor_position()`, `hide_cursor()`, `show_cursor()`
+    - `color_mode()`, `set_color_mode()` - Runtime color mode switching
+    - `capabilities()` - Terminal feature detection
+    - `execute_commands()` - Direct render command execution
+  - `WindowManager` trait - Window splits, tabs, and layout management
+    - `active_window()`, `set_active_window()` - Focus management
+    - `create_window()`, `close_window()`, `split()` - Window lifecycle
+    - `bounds()`, `navigate()`, `swap()` - Layout operations
+    - `window_ids()`, `window_count()`, `equalize()`, `resize_window()`
+  - `Compositor` trait - Z-ordered element rendering
+    - `register()`, `unregister()`, `get()`, `get_mut()` - Element management
+    - `set_z_order()`, `bring_to_front()`, `send_to_back()` - Z-order control
+    - `render_order()`, `render()` - Rendering pipeline
+    - `hit_test()`, `keyboard_target()` - Input routing
+  - `DisplayCapabilities` struct - Terminal feature detection
+    - `color_mode` - Detected color rendering mode
+    - `supports_underline_color`, `supports_extended_underlines` - ANSI 58 / Kitty extensions
+    - `supports_mouse`, `supports_kitty_graphics`, `supports_sixel` - Input/graphics support
+    - `detect()` - Auto-detection from environment
+  - `RenderCommand` enum - Terminal render operations
+    - `MoveTo`, `Print`, `SetStyle`, `ResetStyle`
+    - `ClearToEndOfLine`, `ClearLine`, `ClearRect`
+    - `ShowCursor`, `HideCursor`
+  - `DisplayError` enum - Display operation errors
+    - `NotInitialized`, `InvalidSize`, `RenderFailed`, `WindowNotFound`
+    - `Io`, `CompositorError`, `CursorOutOfBounds`
+  - Window management types:
+    - `WindowId` - Unique window identifier
+    - `SplitDirection` (Horizontal, Vertical) - Split layout direction
+    - `NavigateDirection` (Left, Down, Up, Right) - Window navigation
+    - `TerminalSize` - Width/height with validity check
+    - `Rect` - Window bounds with containment check
+  - **Staged migration architecture**: Re-exports from `reovim-core` (Cell, FrameBuffer, Style, Attributes, Color, ColorMode, ZGroup, ZOrder, Composable, ComposableId) with TODO markers for Phase 5-6 type migration
+  - `ZGroup` values verified: Base=0, Sidebar=100, Editor=200, Floating=300, Overlay=400, Popup=500, Panel=600, Modal=700, Alert=800
+  - 4 unit tests (ZGroup values, WindowId, TerminalSize, Rect)
+
 - **Phase 3.2: Input Driver Traits** (Issue #175) - Driver layer input handling interfaces
   - `KeyCode` enum (56 variants) - Platform-agnostic key codes
     - Printable: `Char(char)` for all Unicode characters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,8 @@ dependencies = [
 name = "reovim-driver-display"
 version = "0.9.0-dev"
 dependencies = [
+ "reovim-core",
+ "reovim-driver-syntax",
  "reovim-kernel",
 ]
 

--- a/lib/drivers/display/Cargo.toml
+++ b/lib/drivers/display/Cargo.toml
@@ -13,5 +13,13 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-# Only depends on kernel layer
+# Kernel layer
 reovim-kernel = { path = "../../kernel", version = "0.9.0-dev" }
+
+# Syntax driver (for HighlightGroup if needed)
+reovim-driver-syntax = { path = "../syntax", version = "0.9.0-dev" }
+
+# TODO(Phase 5-6): Remove this dependency after migrating types to this crate.
+# Currently re-exporting Cell, Style, Color, FrameBuffer, ZGroup, ZOrder from core.
+# After migration, core will depend on this driver instead.
+reovim-core = { path = "../../core" }

--- a/lib/drivers/display/src/capabilities.rs
+++ b/lib/drivers/display/src/capabilities.rs
@@ -1,0 +1,64 @@
+//! Terminal capability detection.
+
+// TODO(Phase 5-6): Move ColorMode from lib/core/src/highlight/color.rs to lib/drivers/display/src/color.rs
+// After move, import from local module instead of reovim_core
+use reovim_core::highlight::ColorMode;
+
+/// Terminal display capabilities.
+///
+/// Contains detected terminal features for adaptive rendering.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct DisplayCapabilities {
+    /// Color rendering mode (`Ansi16`, `Color256`, `TrueColor`).
+    pub color_mode: ColorMode,
+    /// Supports ANSI code 58 (underline color).
+    pub supports_underline_color: bool,
+    /// Supports Kitty/VTE extended underlines (curly, dotted, dashed).
+    pub supports_extended_underlines: bool,
+    /// Supports mouse input.
+    pub supports_mouse: bool,
+    /// Supports Kitty graphics protocol.
+    pub supports_kitty_graphics: bool,
+    /// Supports Sixel graphics.
+    pub supports_sixel: bool,
+}
+
+impl DisplayCapabilities {
+    /// Detect terminal capabilities from environment.
+    #[must_use]
+    pub fn detect() -> Self {
+        Self {
+            color_mode: ColorMode::detect(),
+            supports_underline_color: Self::detect_underline_color(),
+            supports_extended_underlines: Self::detect_extended_underlines(),
+            supports_mouse: true, // Most terminals support this
+            supports_kitty_graphics: Self::detect_kitty(),
+            supports_sixel: false, // Requires terminal query
+        }
+    }
+
+    fn detect_underline_color() -> bool {
+        // Check for modern terminals (Kitty, iTerm2, VTE, Windows Terminal)
+        std::env::var("TERM").is_ok_and(|t| {
+            t.contains("kitty") || t.contains("xterm-256color") || t.contains("alacritty")
+        }) || std::env::var("TERM_PROGRAM").is_ok_and(|p| p == "iTerm.app")
+            || std::env::var("WT_SESSION").is_ok()
+    }
+
+    fn detect_extended_underlines() -> bool {
+        // Kitty and VTE-based terminals
+        std::env::var("TERM").is_ok_and(|t| t.contains("kitty"))
+            || std::env::var("VTE_VERSION").is_ok()
+    }
+
+    fn detect_kitty() -> bool {
+        std::env::var("TERM").is_ok_and(|t| t.contains("kitty"))
+    }
+}
+
+impl Default for DisplayCapabilities {
+    fn default() -> Self {
+        Self::detect()
+    }
+}

--- a/lib/drivers/display/src/command.rs
+++ b/lib/drivers/display/src/command.rs
@@ -1,0 +1,29 @@
+//! Render commands for terminal output.
+
+/// Commands emitted during rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenderCommand {
+    /// Move cursor to position.
+    MoveTo { x: u16, y: u16 },
+    /// Print a string at current position.
+    Print(String),
+    /// Set style (ANSI escape sequence).
+    SetStyle(String),
+    /// Reset style to default.
+    ResetStyle,
+    /// Clear to end of line.
+    ClearToEndOfLine,
+    /// Clear entire line.
+    ClearLine,
+    /// Clear rectangular region.
+    ClearRect {
+        x: u16,
+        y: u16,
+        width: u16,
+        height: u16,
+    },
+    /// Show cursor.
+    ShowCursor,
+    /// Hide cursor.
+    HideCursor,
+}

--- a/lib/drivers/display/src/compositor.rs
+++ b/lib/drivers/display/src/compositor.rs
@@ -1,0 +1,74 @@
+//! Compositor types and trait for z-ordered rendering.
+
+// TODO(Phase 5-6): Move ZGroup, ZOrder, Composable, ComposableId from lib/core/src/compositor/
+// to this file. After move, remove these re-exports and define types locally.
+// CRITICAL: ZGroup values MUST remain: Base=0, Sidebar=100, Editor=200, Floating=300,
+//           Overlay=400, Popup=500, Panel=600, Modal=700, Alert=800
+pub use reovim_core::compositor::{Composable, ComposableId, ZGroup, ZOrder};
+
+// TODO(Phase 5-6): These will be imported from local modules after type migration
+pub use reovim_core::{frame::FrameBuffer, highlight::Style};
+
+/// Compositor trait for managing z-ordered elements.
+///
+/// Handles registration, ordering, and rendering of composable elements.
+pub trait Compositor: Send + Sync {
+    /// Register a composable element.
+    fn register(&mut self, composable: Box<dyn Composable>);
+
+    /// Unregister by ID.
+    fn unregister(&mut self, id: ComposableId);
+
+    /// Get composable by ID.
+    fn get(&self, id: ComposableId) -> Option<&dyn Composable>;
+
+    /// Get mutable composable by ID.
+    fn get_mut(&mut self, id: ComposableId) -> Option<&mut dyn Composable>;
+
+    /// Set z-order for a composable.
+    fn set_z_order(&mut self, id: ComposableId, z: ZOrder);
+
+    /// Bring composable to front within its z-group.
+    fn bring_to_front(&mut self, id: ComposableId);
+
+    /// Send composable to back within its z-group.
+    fn send_to_back(&mut self, id: ComposableId);
+
+    /// Get render order (sorted by z-order).
+    fn render_order(&self) -> Vec<ComposableId>;
+
+    /// Render all visible composables, returns cursor position if any.
+    fn render(&mut self, buffer: &mut FrameBuffer, default_style: &Style) -> Option<(u16, u16)>;
+
+    /// Hit test for mouse clicks (returns topmost at position).
+    fn hit_test(
+        &self,
+        x: u16,
+        y: u16,
+        screen_width: u16,
+        screen_height: u16,
+    ) -> Option<ComposableId>;
+
+    /// Find keyboard target (topmost that captures keyboard).
+    fn keyboard_target(&self) -> Option<ComposableId>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify `ZGroup` values match the issue #176 specification.
+    /// These values are critical for correct z-order rendering.
+    #[test]
+    fn test_zgroup_values_match_spec() {
+        assert_eq!(ZGroup::Base as u16, 0);
+        assert_eq!(ZGroup::Sidebar as u16, 100);
+        assert_eq!(ZGroup::Editor as u16, 200);
+        assert_eq!(ZGroup::Floating as u16, 300);
+        assert_eq!(ZGroup::Overlay as u16, 400);
+        assert_eq!(ZGroup::Popup as u16, 500);
+        assert_eq!(ZGroup::Panel as u16, 600);
+        assert_eq!(ZGroup::Modal as u16, 700);
+        assert_eq!(ZGroup::Alert as u16, 800);
+    }
+}

--- a/lib/drivers/display/src/error.rs
+++ b/lib/drivers/display/src/error.rs
@@ -1,0 +1,55 @@
+//! Display driver error types.
+
+use std::fmt;
+
+/// Errors that can occur during display operations.
+#[derive(Debug)]
+pub enum DisplayError {
+    /// Driver not initialized.
+    NotInitialized,
+    /// Invalid terminal size.
+    InvalidSize { width: u16, height: u16 },
+    /// Render operation failed.
+    RenderFailed(String),
+    /// Window not found.
+    WindowNotFound(usize),
+    /// I/O error.
+    Io(std::io::Error),
+    /// Compositor error.
+    CompositorError(String),
+    /// Cursor position out of bounds.
+    CursorOutOfBounds { x: u16, y: u16 },
+}
+
+impl fmt::Display for DisplayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInitialized => write!(f, "display driver not initialized"),
+            Self::InvalidSize { width, height } => {
+                write!(f, "invalid terminal size: {width}x{height}")
+            }
+            Self::RenderFailed(msg) => write!(f, "render failed: {msg}"),
+            Self::WindowNotFound(id) => write!(f, "window not found: {id}"),
+            Self::Io(err) => write!(f, "I/O error: {err}"),
+            Self::CompositorError(msg) => write!(f, "compositor error: {msg}"),
+            Self::CursorOutOfBounds { x, y } => {
+                write!(f, "cursor position out of bounds: ({x}, {y})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DisplayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for DisplayError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}

--- a/lib/drivers/display/src/lib.rs
+++ b/lib/drivers/display/src/lib.rs
@@ -2,13 +2,82 @@
 //!
 //! Linux equivalent: `drivers/video/`, `drivers/gpu/`
 //!
-//! Provides frame buffer management, layer compositing, and window management.
+//! # Architecture
+//!
+//! This crate defines trait interfaces for display operations.
+//! Types are re-exported from `reovim-core` during the staged migration.
+//!
+//! ```text
+//! lib/drivers/display/      <-- Traits (this crate)
+//!        ^
+//!        |  re-exports types from (Phase 3.3)
+//!        |
+//! lib/core/                 <-- Cell, Style, FrameBuffer, ZGroup, ZOrder
+//! ```
+//!
+//! # Migration Path
+//!
+//! - **Phase 3.3 (current)**: Re-export types from `reovim-core`
+//! - **Phase 5-6 (future)**: Types move to this crate, `lib/core` imports from here
 //!
 //! # Components
 //!
-//! - Frame buffer (2D cell grid)
-//! - Compositor (layer blending, z-order)
-//! - Window manager (splits, tabs, layout)
-//! - Terminal renderer (ANSI output)
+//! - [`DisplayDriver`] - Terminal lifecycle and rendering
+//! - [`WindowManager`] - Window splits, tabs, layout
+//! - [`Compositor`] - Z-order layer management
+//! - [`DisplayCapabilities`] - Terminal feature detection
+//! - [`RenderCommand`] - Render operation commands
 
-// Placeholder - DisplayDriver trait and implementations will be added in Phase 3
+// ============================================================================
+// Modules
+// ============================================================================
+
+mod capabilities;
+mod command;
+mod compositor;
+mod error;
+mod traits;
+mod window;
+
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+// Error types
+pub use error::DisplayError;
+
+// Capability detection
+pub use capabilities::DisplayCapabilities;
+
+// Render commands
+pub use command::RenderCommand;
+
+// Window types
+pub use window::{NavigateDirection, Rect, SplitDirection, TerminalSize, WindowId};
+
+// Traits
+pub use traits::{DisplayDriver, WindowManager};
+
+// Compositor (trait + re-exports from core)
+pub use compositor::{Composable, ComposableId, Compositor, ZGroup, ZOrder};
+
+// ============================================================================
+// TODO(Phase 5-6): Type Migration
+// ============================================================================
+//
+// After type migration, these will be local definitions:
+//   - Cell, FrameBuffer → from crate::cell, crate::buffer
+//   - Style, Attributes, Color, ColorMode → from crate::style, crate::color
+//   - ZGroup, ZOrder, Composable, ComposableId → from crate::compositor (already exported above)
+//
+// For now, re-export from lib/core to maintain type compatibility.
+// When migration happens:
+//   1. Move type definitions from lib/core to this crate
+//   2. Update lib/core to import FROM this driver
+//   3. Remove reovim-core dependency from this crate's Cargo.toml
+// ============================================================================
+
+pub use reovim_core::{
+    frame::{Cell, FrameBuffer},
+    highlight::{Attributes, Color, ColorMode, Style},
+};

--- a/lib/drivers/display/src/traits.rs
+++ b/lib/drivers/display/src/traits.rs
@@ -1,0 +1,159 @@
+//! Display driver traits.
+
+use crate::{
+    DisplayCapabilities, DisplayError, NavigateDirection, Rect, RenderCommand, SplitDirection,
+    TerminalSize, WindowId,
+};
+
+// TODO(Phase 5-6): Move FrameBuffer from lib/core/src/frame/ to lib/drivers/display/src/buffer.rs
+// After move, use local definition instead
+use reovim_core::frame::FrameBuffer;
+
+// TODO(Phase 5-6): Move ColorMode from lib/core/src/highlight/ to lib/drivers/display/src/color.rs
+// After move, use local definition instead
+use reovim_core::highlight::ColorMode;
+
+/// Display driver for terminal operations.
+///
+/// Manages the terminal lifecycle, frame buffer, and rendering.
+pub trait DisplayDriver: Send + Sync {
+    /// Initialize the display driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError` if initialization fails.
+    fn init(&mut self) -> Result<(), DisplayError>;
+
+    /// Shutdown the display driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError` if shutdown fails.
+    fn shutdown(&mut self) -> Result<(), DisplayError>;
+
+    /// Check if initialized.
+    fn is_initialized(&self) -> bool;
+
+    /// Get mutable access to the frame buffer.
+    fn frame_buffer_mut(&mut self) -> &mut FrameBuffer;
+
+    /// Get read-only access to the frame buffer.
+    fn frame_buffer(&self) -> &FrameBuffer;
+
+    /// Render the frame buffer to terminal (diff-based).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::RenderFailed` if rendering fails.
+    fn render(&mut self) -> Result<(), DisplayError>;
+
+    /// Force full redraw (invalidate diff cache).
+    fn invalidate(&mut self);
+
+    /// Resize the display.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::InvalidSize` if the size is invalid.
+    fn resize(&mut self, size: TerminalSize) -> Result<(), DisplayError>;
+
+    /// Get current terminal size.
+    fn size(&self) -> TerminalSize;
+
+    /// Get terminal capabilities.
+    fn capabilities(&self) -> &DisplayCapabilities;
+
+    /// Get cursor position.
+    fn cursor_position(&self) -> (u16, u16);
+
+    /// Set cursor position.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::CursorOutOfBounds` if position is out of bounds.
+    fn set_cursor_position(&mut self, x: u16, y: u16) -> Result<(), DisplayError>;
+
+    /// Hide the cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::Io` if the terminal operation fails.
+    fn hide_cursor(&mut self) -> Result<(), DisplayError>;
+
+    /// Show the cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::Io` if the terminal operation fails.
+    fn show_cursor(&mut self) -> Result<(), DisplayError>;
+
+    /// Get current color mode.
+    fn color_mode(&self) -> ColorMode;
+
+    /// Set color mode (runtime switching).
+    fn set_color_mode(&mut self, mode: ColorMode);
+
+    /// Execute render commands directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::RenderFailed` if command execution fails.
+    fn execute_commands(&mut self, commands: &[RenderCommand]) -> Result<(), DisplayError>;
+}
+
+/// Window manager for layout management.
+///
+/// Manages window splits, navigation, and layout operations.
+pub trait WindowManager: Send + Sync {
+    /// Get the active window ID.
+    fn active_window(&self) -> Option<WindowId>;
+
+    /// Set the active window.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::WindowNotFound` if the window doesn't exist.
+    fn set_active_window(&mut self, id: WindowId) -> Result<(), DisplayError>;
+
+    /// Create a new window.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError` if window creation fails.
+    fn create_window(&mut self) -> Result<WindowId, DisplayError>;
+
+    /// Close a window.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError::WindowNotFound` if the window doesn't exist.
+    fn close_window(&mut self, id: WindowId) -> Result<(), DisplayError>;
+
+    /// Split the active window.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DisplayError` if split fails (e.g., no active window).
+    fn split(&mut self, direction: SplitDirection) -> Result<WindowId, DisplayError>;
+
+    /// Get window bounds.
+    fn bounds(&self, id: WindowId) -> Option<Rect>;
+
+    /// Navigate to adjacent window.
+    fn navigate(&mut self, direction: NavigateDirection) -> Option<WindowId>;
+
+    /// Get all window IDs.
+    fn window_ids(&self) -> Vec<WindowId>;
+
+    /// Get window count.
+    fn window_count(&self) -> usize;
+
+    /// Equalize window sizes.
+    fn equalize(&mut self);
+
+    /// Resize active window.
+    fn resize_window(&mut self, direction: SplitDirection, delta: f32);
+
+    /// Swap active window with neighbor.
+    fn swap(&mut self, direction: NavigateDirection) -> bool;
+}

--- a/lib/drivers/display/src/window.rs
+++ b/lib/drivers/display/src/window.rs
@@ -1,0 +1,136 @@
+//! Window management types.
+
+/// Unique window identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct WindowId(pub usize);
+
+impl WindowId {
+    /// Create a new window ID.
+    #[must_use]
+    pub const fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Get the raw ID value.
+    #[must_use]
+    pub const fn raw(&self) -> usize {
+        self.0
+    }
+}
+
+/// Split direction for window layouts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitDirection {
+    /// Top/bottom split.
+    Horizontal,
+    /// Left/right split.
+    Vertical,
+}
+
+/// Navigation direction between windows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavigateDirection {
+    /// Navigate left.
+    Left,
+    /// Navigate down.
+    Down,
+    /// Navigate up.
+    Up,
+    /// Navigate right.
+    Right,
+}
+
+/// Terminal size in columns and rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TerminalSize {
+    /// Width in columns.
+    pub width: u16,
+    /// Height in rows.
+    pub height: u16,
+}
+
+impl TerminalSize {
+    /// Create a new terminal size.
+    #[must_use]
+    pub const fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+
+    /// Check if the size is valid (non-zero dimensions).
+    #[must_use]
+    pub const fn is_valid(&self) -> bool {
+        self.width > 0 && self.height > 0
+    }
+}
+
+/// Rectangle for window bounds.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Rect {
+    /// X coordinate (column).
+    pub x: u16,
+    /// Y coordinate (row).
+    pub y: u16,
+    /// Width in columns.
+    pub width: u16,
+    /// Height in rows.
+    pub height: u16,
+}
+
+impl Rect {
+    /// Create a new rectangle.
+    #[must_use]
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Check if a point is within this rectangle.
+    #[must_use]
+    pub const fn contains(&self, px: u16, py: u16) -> bool {
+        px >= self.x && px < self.x + self.width && py >= self.y && py < self.y + self.height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_window_id() {
+        let id = WindowId::new(42);
+        assert_eq!(id.raw(), 42);
+
+        let default_id = WindowId::default();
+        assert_eq!(default_id.raw(), 0);
+    }
+
+    #[test]
+    fn test_terminal_size_is_valid() {
+        assert!(TerminalSize::new(80, 24).is_valid());
+        assert!(TerminalSize::new(1, 1).is_valid());
+
+        assert!(!TerminalSize::new(0, 24).is_valid());
+        assert!(!TerminalSize::new(80, 0).is_valid());
+        assert!(!TerminalSize::new(0, 0).is_valid());
+    }
+
+    #[test]
+    fn test_rect_contains() {
+        let rect = Rect::new(10, 20, 30, 40);
+
+        // Inside
+        assert!(rect.contains(10, 20)); // Top-left corner
+        assert!(rect.contains(25, 40)); // Middle
+        assert!(rect.contains(39, 59)); // Bottom-right corner (exclusive bounds)
+
+        // Outside
+        assert!(!rect.contains(9, 20)); // Left of rect
+        assert!(!rect.contains(10, 19)); // Above rect
+        assert!(!rect.contains(40, 20)); // Right of rect (at boundary)
+        assert!(!rect.contains(10, 60)); // Below rect (at boundary)
+    }
+}


### PR DESCRIPTION
Phase 3.3 of Linux-inspired clean architecture refactoring.

Adds trait interfaces for display operations following the staged migration architecture - traits defined in driver layer, types temporarily re-exported from reovim-core with TODO markers for Phase 5-6 migration.

Components:
- DisplayDriver trait: terminal lifecycle, frame buffer, rendering
- WindowManager trait: window splits, navigation, layout
- Compositor trait: z-order management, hit testing
- DisplayCapabilities: terminal feature detection
- RenderCommand enum: render operation commands
- DisplayError enum: comprehensive error types
- Window types: WindowId, Rect, TerminalSize, SplitDirection

Re-exports from reovim-core (will move in Phase 5-6):
- Cell, FrameBuffer, Style, Attributes, Color, ColorMode
- ZGroup, ZOrder, Composable, ComposableId

ZGroup values verified via test: Base=0, Sidebar=100, Editor=200, Floating=300, Overlay=400, Popup=500, Panel=600, Modal=700, Alert=800

Closes: #176