### PR TITLE
feat(drivers): implement lsp/ LSP driver types (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.4: LSP Driver Types** (Issue #177) - Driver layer LSP client infrastructure
+  - `LspError` enum (9 variants) - Comprehensive LSP error handling
+    - `SpawnFailed` - Failed to spawn language server process
+    - `TransportError` - I/O error on server communication
+    - `ServerError` - Error response from language server
+    - `Timeout` - Request timed out
+    - `ChannelClosed` - Response channel closed unexpectedly
+    - `Serialization` - JSON serialization/deserialization error
+    - `NotInitialized` - Server not yet initialized
+    - `ServerNotRunning` - Server process not running
+    - `InvalidResponse` - Invalid response format from server
+  - `LspRequest` enum (7 core variants) - Request types with oneshot response channels
+    - Notifications: `DidOpen`, `DidChange`, `DidClose`, `Shutdown`
+    - Requests: `GotoDefinition`, `References`, `Hover`
+    - Uses kernel's `OneshotSender` for async responses
+    - Custom Debug impl hides response channels and large content
+  - `LspResponse` enum - Unified response type for generic handling
+    - Variants: `Definition`, `References`, `Hover`, `DocumentSymbol`, `Completion`, `SignatureHelp`, `CodeAction`, `Rename`, `WorkspaceSymbol`, `Formatting`, `Empty`
+    - `is_empty()` const method for response checking
+  - `DiagnosticCache` - Lock-free diagnostic storage using kernel's `ArcSwap`
+    - `BufferDiagnostics` struct with version tracking
+    - Methods: `store()`, `get()`, `get_all()`, `remove()`, `clear()`, `has()`, `len()`
+    - Follows mechanism/policy principle (kernel provides `ArcSwap`, driver implements cache policy)
+  - `LspServerConfig` - Server spawn configuration with factory methods
+    - Factories: `rust_analyzer()`, `clangd()`, `pylsp()`, `typescript()`, `custom()`
+    - Builder: `with_args()` for additional arguments
+    - `uri_from_path()` helper for URI conversion
+  - Re-exports essential `lsp-types` (v0.97): `Position`, `Range`, `Uri`, `Diagnostic`, `GotoDefinitionResponse`, `Hover`, `CompletionResponse`, `CodeActionResponse`, etc.
+  - **Types only** - Concrete `LspClient` implementation in Phase 4
+  - 33 unit tests
+
 - **Phase 3.3: Display Driver Traits** (Issue #176) - Driver layer display/rendering interfaces
   - `DisplayDriver` trait - Terminal lifecycle and rendering abstraction
     - `init()`, `shutdown()`, `is_initialized()` - Driver lifecycle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,10 @@ dependencies = [
 name = "reovim-driver-lsp"
 version = "0.9.0-dev"
 dependencies = [
+ "lsp-types",
  "reovim-kernel",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/lib/drivers/lsp/Cargo.toml
+++ b/lib/drivers/lsp/Cargo.toml
@@ -13,5 +13,12 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-# Only depends on kernel layer
+# Kernel layer (provides KernelContext, EventBus, ArcSwap, channels, etc.)
 reovim-kernel = { path = "../../kernel", version = "0.9.0-dev" }
+
+# LSP protocol types (matches lib/lsp version)
+lsp-types = "0.97"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/lib/drivers/lsp/src/cache.rs
+++ b/lib/drivers/lsp/src/cache.rs
@@ -1,0 +1,262 @@
+//! Lock-free diagnostic cache using `ArcSwap`.
+//!
+//! This cache follows the same pattern as reovim's treesitter saturator:
+//! - Saturator thread writes via atomic swap (~O(1))
+//! - Render thread reads via lock-free load (~6µs)
+//!
+//! This ensures the render thread never blocks on diagnostic updates.
+
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use {
+    lsp_types::{Diagnostic, Uri},
+    reovim_kernel::api::v1::ArcSwap,
+};
+
+/// Per-buffer diagnostic data.
+#[derive(Debug, Clone, Default)]
+pub struct BufferDiagnostics {
+    /// Document version when diagnostics were computed.
+    /// `None` if version was not provided by the server.
+    pub version: Option<i32>,
+    /// List of diagnostics for this buffer.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Internal cache storage.
+/// Uses String as key instead of Uri because Uri has interior mutability.
+#[derive(Debug, Default)]
+struct CacheData {
+    /// Map from document URI string to diagnostics.
+    entries: HashMap<String, BufferDiagnostics>,
+    /// When the cache was last updated.
+    last_updated: Option<Instant>,
+}
+
+/// Lock-free diagnostic cache.
+///
+/// Uses `ArcSwap` for atomic pointer swaps, enabling:
+/// - Lock-free reads from the render thread
+/// - Atomic updates from the saturator thread
+///
+/// # Thread Safety
+///
+/// This cache is designed for the following access pattern:
+/// - **Saturator thread**: Calls `store()` to update diagnostics
+/// - **Render thread**: Calls `get()` to read diagnostics
+///
+/// Both operations are lock-free and never block.
+#[derive(Debug)]
+pub struct DiagnosticCache {
+    /// Atomic pointer to current cache data.
+    current: ArcSwap<CacheData>,
+}
+
+impl DiagnosticCache {
+    /// Create a new empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            current: ArcSwap::from_pointee(CacheData::default()),
+        }
+    }
+
+    /// Store diagnostics for a document.
+    ///
+    /// This is an atomic operation that replaces all diagnostics for the given URI.
+    /// Called by the saturator thread when receiving `publishDiagnostics`.
+    pub fn store(&self, uri: &Uri, version: Option<i32>, diagnostics: Vec<Diagnostic>) {
+        // Load current data
+        let old = self.current.load();
+
+        // Create new data with updated entry
+        let mut new_entries = old.entries.clone();
+        new_entries.insert(
+            uri.as_str().to_string(),
+            BufferDiagnostics {
+                version,
+                diagnostics,
+            },
+        );
+
+        // Atomic swap
+        self.current.store(Arc::new(CacheData {
+            entries: new_entries,
+            last_updated: Some(Instant::now()),
+        }));
+    }
+
+    /// Get diagnostics for a document.
+    ///
+    /// This is a lock-free read (~6µs) that never blocks.
+    /// Called by the render thread when drawing diagnostic markers.
+    #[must_use]
+    pub fn get(&self, uri: &Uri) -> Option<BufferDiagnostics> {
+        let data = self.current.load();
+        data.entries.get(uri.as_str()).cloned()
+    }
+
+    /// Get all diagnostics.
+    ///
+    /// Returns a snapshot of all diagnostics in the cache.
+    #[must_use]
+    pub fn get_all(&self) -> HashMap<String, BufferDiagnostics> {
+        let data = self.current.load();
+        data.entries.clone()
+    }
+
+    /// Remove diagnostics for a document.
+    ///
+    /// Called when a buffer is closed.
+    pub fn remove(&self, uri: &Uri) {
+        let old = self.current.load();
+
+        let mut new_entries = old.entries.clone();
+        new_entries.remove(uri.as_str());
+
+        self.current.store(Arc::new(CacheData {
+            entries: new_entries,
+            last_updated: old.last_updated,
+        }));
+    }
+
+    /// Clear all diagnostics.
+    ///
+    /// Called when the language server shuts down or crashes.
+    pub fn clear(&self) {
+        self.current.store(Arc::new(CacheData::default()));
+    }
+
+    /// Check if there are any diagnostics for a document.
+    #[must_use]
+    pub fn has(&self, uri: &Uri) -> bool {
+        let data = self.current.load();
+        data.entries.contains_key(uri.as_str())
+    }
+
+    /// Get the count of documents with diagnostics.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let data = self.current.load();
+        data.entries.len()
+    }
+
+    /// Check if the cache is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get when the cache was last updated.
+    #[must_use]
+    pub fn last_updated(&self) -> Option<Instant> {
+        self.current.load().last_updated
+    }
+}
+
+impl Default for DiagnosticCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{DiagnosticSeverity, Position, Range};
+
+    use super::*;
+
+    fn make_uri(path: &str) -> Uri {
+        path.parse().expect("test URI should parse")
+    }
+
+    fn make_diagnostic(message: &str, severity: DiagnosticSeverity) -> Diagnostic {
+        Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 10)),
+            severity: Some(severity),
+            message: message.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_store_and_get() {
+        let cache = DiagnosticCache::new();
+        let uri = make_uri("file:///test.rs");
+        let diagnostics = vec![make_diagnostic("test error", DiagnosticSeverity::ERROR)];
+
+        cache.store(&uri, Some(1), diagnostics);
+
+        let result = cache.get(&uri).unwrap();
+        assert_eq!(result.version, Some(1));
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].message, "test error");
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let cache = DiagnosticCache::new();
+        let uri = make_uri("file:///nonexistent.rs");
+
+        assert!(cache.get(&uri).is_none());
+    }
+
+    #[test]
+    fn test_remove() {
+        let cache = DiagnosticCache::new();
+        let uri = make_uri("file:///test.rs");
+        let diagnostics = vec![make_diagnostic("error", DiagnosticSeverity::ERROR)];
+
+        cache.store(&uri, None, diagnostics);
+        assert!(cache.has(&uri));
+
+        cache.remove(&uri);
+        assert!(!cache.has(&uri));
+    }
+
+    #[test]
+    fn test_clear() {
+        let cache = DiagnosticCache::new();
+
+        for i in 0..5 {
+            let uri = make_uri(&format!("file:///test{i}.rs"));
+            cache.store(&uri, None, vec![]);
+        }
+
+        assert_eq!(cache.len(), 5);
+
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_update_replaces() {
+        let cache = DiagnosticCache::new();
+        let uri = make_uri("file:///test.rs");
+
+        cache.store(&uri, Some(1), vec![make_diagnostic("old", DiagnosticSeverity::ERROR)]);
+
+        cache.store(&uri, Some(2), vec![make_diagnostic("new", DiagnosticSeverity::WARNING)]);
+
+        let result = cache.get(&uri).unwrap();
+        assert_eq!(result.version, Some(2));
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].message, "new");
+    }
+
+    #[test]
+    fn test_get_all() {
+        let cache = DiagnosticCache::new();
+
+        let uri1 = make_uri("file:///a.rs");
+        let uri2 = make_uri("file:///b.rs");
+
+        cache.store(&uri1, None, vec![]);
+        cache.store(&uri2, None, vec![]);
+
+        let all = cache.get_all();
+        assert_eq!(all.len(), 2);
+        assert!(all.contains_key(uri1.as_str()));
+        assert!(all.contains_key(uri2.as_str()));
+    }
+}

--- a/lib/drivers/lsp/src/config.rs
+++ b/lib/drivers/lsp/src/config.rs
@@ -1,0 +1,221 @@
+//! LSP server configuration.
+
+use std::path::{Path, PathBuf};
+
+use lsp_types::{Uri, WorkspaceFolder};
+
+/// Configuration for an LSP server.
+#[derive(Debug, Clone)]
+pub struct LspServerConfig {
+    /// Command to spawn the language server.
+    pub command: String,
+    /// Arguments to pass to the server.
+    pub args: Vec<String>,
+    /// Working directory for the server.
+    pub root_path: PathBuf,
+    /// Workspace folders to register.
+    pub workspace_folders: Vec<WorkspaceFolder>,
+}
+
+impl LspServerConfig {
+    /// Create config for rust-analyzer.
+    #[must_use]
+    pub fn rust_analyzer(root_path: &Path) -> Self {
+        let root_uri = uri_from_path(root_path);
+        Self {
+            command: "rust-analyzer".to_string(),
+            args: vec![],
+            root_path: root_path.to_path_buf(),
+            workspace_folders: vec![WorkspaceFolder {
+                uri: root_uri,
+                name: root_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }],
+        }
+    }
+
+    /// Create config for clangd (C/C++).
+    #[must_use]
+    pub fn clangd(root_path: &Path) -> Self {
+        let root_uri = uri_from_path(root_path);
+        Self {
+            command: "clangd".to_string(),
+            args: vec![],
+            root_path: root_path.to_path_buf(),
+            workspace_folders: vec![WorkspaceFolder {
+                uri: root_uri,
+                name: root_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }],
+        }
+    }
+
+    /// Create config for pylsp (Python).
+    #[must_use]
+    pub fn pylsp(root_path: &Path) -> Self {
+        let root_uri = uri_from_path(root_path);
+        Self {
+            command: "pylsp".to_string(),
+            args: vec![],
+            root_path: root_path.to_path_buf(),
+            workspace_folders: vec![WorkspaceFolder {
+                uri: root_uri,
+                name: root_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }],
+        }
+    }
+
+    /// Create config for TypeScript language server.
+    #[must_use]
+    pub fn typescript(root_path: &Path) -> Self {
+        let root_uri = uri_from_path(root_path);
+        Self {
+            command: "typescript-language-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            root_path: root_path.to_path_buf(),
+            workspace_folders: vec![WorkspaceFolder {
+                uri: root_uri,
+                name: root_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }],
+        }
+    }
+
+    /// Create generic config for custom servers.
+    #[must_use]
+    pub fn custom(command: impl Into<String>, root_path: &Path) -> Self {
+        let root_uri = uri_from_path(root_path);
+        Self {
+            command: command.into(),
+            args: vec![],
+            root_path: root_path.to_path_buf(),
+            workspace_folders: vec![WorkspaceFolder {
+                uri: root_uri,
+                name: root_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+                    .to_string(),
+            }],
+        }
+    }
+
+    /// Add command-line arguments.
+    #[must_use]
+    pub fn with_args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+}
+
+/// Convert a file path to a `lsp_types::Uri`.
+///
+/// Uses proper file:// URI encoding.
+///
+/// # Panics
+///
+/// Panics if the fallback URI cannot be parsed (should never happen).
+#[must_use]
+pub fn uri_from_path(path: &Path) -> Uri {
+    // Canonicalize to absolute path if possible
+    let abs_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let path_str = abs_path.to_string_lossy();
+
+    // Handle Windows paths (convert backslashes, add leading slash)
+    #[cfg(windows)]
+    let uri_str = format!("file:///{}", path_str.replace('\\', "/"));
+
+    // Unix paths: file:///absolute/path (3 slashes)
+    #[cfg(not(windows))]
+    let uri_str = format!("file://{path_str}");
+
+    uri_str.parse().unwrap_or_else(|_| {
+        // Fallback to root
+        "file:///".parse().expect("fallback URI should parse")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rust_analyzer_config() {
+        let root = Path::new("/tmp/test-project");
+        let config = LspServerConfig::rust_analyzer(root);
+        assert_eq!(config.command, "rust-analyzer");
+        assert_eq!(config.root_path, root);
+        assert_eq!(config.workspace_folders.len(), 1);
+        assert!(config.args.is_empty());
+    }
+
+    #[test]
+    fn test_clangd_config() {
+        let root = Path::new("/tmp/cpp-project");
+        let config = LspServerConfig::clangd(root);
+        assert_eq!(config.command, "clangd");
+        assert_eq!(config.root_path, root);
+    }
+
+    #[test]
+    fn test_pylsp_config() {
+        let root = Path::new("/tmp/python-project");
+        let config = LspServerConfig::pylsp(root);
+        assert_eq!(config.command, "pylsp");
+        assert_eq!(config.root_path, root);
+    }
+
+    #[test]
+    fn test_typescript_config() {
+        let root = Path::new("/tmp/ts-project");
+        let config = LspServerConfig::typescript(root);
+        assert_eq!(config.command, "typescript-language-server");
+        assert_eq!(config.args, vec!["--stdio"]);
+    }
+
+    #[test]
+    fn test_custom_config() {
+        let root = Path::new("/tmp/custom-project");
+        let config = LspServerConfig::custom("my-lsp", root);
+        assert_eq!(config.command, "my-lsp");
+        assert_eq!(config.root_path, root);
+    }
+
+    #[test]
+    fn test_with_args() {
+        let root = Path::new("/tmp/test");
+        let config = LspServerConfig::rust_analyzer(root).with_args(["--log-file", "/tmp/ra.log"]);
+        assert_eq!(config.args, vec!["--log-file", "/tmp/ra.log"]);
+    }
+
+    #[test]
+    fn test_uri_from_path_unix() {
+        // Note: This test may behave differently on Windows
+        let path = Path::new("/tmp/test.rs");
+        let uri = uri_from_path(path);
+        let uri_str = uri.as_str();
+        assert!(uri_str.starts_with("file://"));
+        assert!(uri_str.contains("test.rs") || uri_str.contains("tmp"));
+    }
+
+    #[test]
+    fn test_workspace_folder_name() {
+        let root = Path::new("/home/user/my-project");
+        let config = LspServerConfig::rust_analyzer(root);
+        // Name should be extracted from path
+        assert!(!config.workspace_folders[0].name.is_empty());
+    }
+}

--- a/lib/drivers/lsp/src/error.rs
+++ b/lib/drivers/lsp/src/error.rs
@@ -1,0 +1,121 @@
+//! Error types for LSP operations.
+
+use std::fmt;
+
+/// Error type for LSP operations.
+#[derive(Debug)]
+pub enum LspError {
+    /// Failed to spawn the server process.
+    SpawnFailed(String),
+    /// Transport/communication error.
+    TransportError(String),
+    /// Server returned an error response.
+    ServerError {
+        /// LSP error code.
+        code: i32,
+        /// Error message from server.
+        message: String,
+    },
+    /// Request timed out.
+    Timeout,
+    /// Communication channel closed (server died).
+    ChannelClosed,
+    /// Serialization/deserialization error.
+    Serialization(String),
+    /// Server not initialized.
+    NotInitialized,
+    /// Server process not running.
+    ServerNotRunning,
+    /// Invalid or unexpected response.
+    InvalidResponse(String),
+}
+
+impl fmt::Display for LspError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SpawnFailed(e) => write!(f, "Failed to spawn LSP server: {e}"),
+            Self::TransportError(e) => write!(f, "LSP transport error: {e}"),
+            Self::ServerError { code, message } => {
+                write!(f, "LSP server error {code}: {message}")
+            }
+            Self::Timeout => write!(f, "LSP request timed out"),
+            Self::ChannelClosed => write!(f, "LSP channel closed"),
+            Self::Serialization(e) => write!(f, "LSP serialization error: {e}"),
+            Self::NotInitialized => write!(f, "LSP server not initialized"),
+            Self::ServerNotRunning => write!(f, "LSP server not running"),
+            Self::InvalidResponse(e) => write!(f, "Invalid LSP response: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LspError {}
+
+// Re-export ModuleError for consistency with other drivers
+pub use reovim_kernel::api::v1::ModuleError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = LspError::NotInitialized;
+        assert_eq!(format!("{err}"), "LSP server not initialized");
+
+        let err = LspError::ServerError {
+            code: -32600,
+            message: "Invalid request".to_string(),
+        };
+        let display = format!("{err}");
+        assert!(display.contains("-32600"));
+        assert!(display.contains("Invalid request"));
+    }
+
+    #[test]
+    fn test_spawn_failed_display() {
+        let err = LspError::SpawnFailed("command not found".to_string());
+        assert!(format!("{err}").contains("command not found"));
+    }
+
+    #[test]
+    fn test_transport_error_display() {
+        let err = LspError::TransportError("connection reset".to_string());
+        assert!(format!("{err}").contains("connection reset"));
+    }
+
+    #[test]
+    fn test_timeout_display() {
+        let err = LspError::Timeout;
+        assert_eq!(format!("{err}"), "LSP request timed out");
+    }
+
+    #[test]
+    fn test_channel_closed_display() {
+        let err = LspError::ChannelClosed;
+        assert_eq!(format!("{err}"), "LSP channel closed");
+    }
+
+    #[test]
+    fn test_serialization_display() {
+        let err = LspError::Serialization("invalid JSON".to_string());
+        assert!(format!("{err}").contains("invalid JSON"));
+    }
+
+    #[test]
+    fn test_server_not_running_display() {
+        let err = LspError::ServerNotRunning;
+        assert_eq!(format!("{err}"), "LSP server not running");
+    }
+
+    #[test]
+    fn test_invalid_response_display() {
+        let err = LspError::InvalidResponse("unexpected field".to_string());
+        assert!(format!("{err}").contains("unexpected field"));
+    }
+
+    #[test]
+    fn test_error_is_error_trait() {
+        fn assert_error<E: std::error::Error>() {}
+        assert_error::<LspError>();
+    }
+}

--- a/lib/drivers/lsp/src/lib.rs
+++ b/lib/drivers/lsp/src/lib.rs
@@ -1,12 +1,66 @@
 //! LSP driver for reovim.
 //!
-//! Provides Language Server Protocol client infrastructure.
+//! Provides Language Server Protocol client infrastructure following the
+//! kernel driver pattern. This module defines types for LSP communication;
+//! concrete implementations will be added in Phase 4.
+//!
+//! # Architecture
+//!
+//! Following Linux kernel principles of mechanism vs policy:
+//! - **Mechanism**: Request/response types, diagnostic caching, error handling
+//! - **Policy**: Concrete LSP client implementations (Phase 4)
 //!
 //! # Components
 //!
-//! - LSP client (server connection, message handling)
-//! - Protocol types (requests, responses, notifications)
-//! - Diagnostic cache (lock-free diagnostic storage)
+//! - [`LspRequest`] - LSP request variants with oneshot response channels
+//! - [`LspResponse`] - Unified response type for generic handling
+//! - [`DiagnosticCache`] - Lock-free diagnostic storage using `ArcSwap`
+//! - [`LspServerConfig`] - Server spawn configuration
+//! - [`LspError`] - Comprehensive error types
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_lsp::{LspServerConfig, LspRequest, DiagnosticCache};
+//! use std::path::Path;
+//!
+//! // Create server configuration
+//! let config = LspServerConfig::rust_analyzer(Path::new("/my/project"));
+//!
+//! // Diagnostic cache for lock-free reads
+//! let cache = DiagnosticCache::new();
+//! ```
+//!
+//! # Future Phases
+//!
+//! - **Phase 4**: `LspClient` struct with async methods
+//! - **Phase 5**: Additional request variants (completion, code actions)
+//! - **Phase 6**: Multi-server coordination
 
-// Placeholder - LspDriver trait will be added in Phase 3
-// Note: Will eventually absorb functionality from lib/lsp
+mod cache;
+mod config;
+mod error;
+mod request;
+mod response;
+mod types;
+
+// Error types
+pub use error::{LspError, ModuleError};
+
+// Configuration
+pub use config::{LspServerConfig, uri_from_path};
+
+// Request/Response types
+pub use {
+    request::{LspRequest, NavigationResult},
+    response::LspResponse,
+};
+
+// Diagnostic cache
+pub use cache::{BufferDiagnostics, DiagnosticCache};
+
+// Re-export essential LSP types
+pub mod lsp_types {
+    //! Re-exports from `lsp-types` crate.
+    pub use super::types::*;
+}

--- a/lib/drivers/lsp/src/request.rs
+++ b/lib/drivers/lsp/src/request.rs
@@ -1,0 +1,237 @@
+//! LSP request types.
+//!
+//! Defines the request variants for LSP operations. Currently implements
+//! 7 core variants; additional variants will be added in future phases.
+
+use std::fmt;
+
+use {
+    lsp_types::{GotoDefinitionResponse, Hover, Location, Position, Uri},
+    reovim_kernel::api::v1::OneshotSender,
+};
+
+use crate::error::LspError;
+
+/// Result type for navigation requests.
+pub type NavigationResult<T> = Result<T, LspError>;
+
+/// LSP request variants.
+///
+/// # Notification vs Request
+///
+/// - **Notifications** (`DidOpen`, `DidChange`, `DidClose`, `Shutdown`): Fire-and-forget,
+///   no response expected.
+/// - **Requests** (`GotoDefinition`, `References`, `Hover`): Include a `response_tx`
+///   oneshot channel for async response.
+///
+/// # Future Extensions
+///
+/// Additional variants will be added in Phase 5:
+/// - `Completion`
+/// - `SignatureHelp`
+/// - `CodeAction`
+/// - `Rename`
+/// - `DocumentSymbol`
+/// - `WorkspaceSymbol`
+/// - `Formatting`
+/// - `RangeFormatting`
+pub enum LspRequest {
+    /// Notify server that a document was opened.
+    DidOpen {
+        /// Document URI.
+        uri: Uri,
+        /// Language ID (e.g., "rust", "python").
+        language_id: String,
+        /// Document version.
+        version: i32,
+        /// Document content.
+        content: String,
+    },
+    /// Notify server that a document changed (full content sync).
+    DidChange {
+        /// Document URI.
+        uri: Uri,
+        /// Document version.
+        version: i32,
+        /// New content (FULL sync mode).
+        content: String,
+    },
+    /// Notify server that a document was closed.
+    DidClose {
+        /// Document URI.
+        uri: Uri,
+    },
+    /// Request go-to-definition.
+    GotoDefinition {
+        /// Document URI.
+        uri: Uri,
+        /// Cursor position.
+        position: Position,
+        /// Response channel.
+        response_tx: OneshotSender<NavigationResult<Option<GotoDefinitionResponse>>>,
+    },
+    /// Request find-references.
+    References {
+        /// Document URI.
+        uri: Uri,
+        /// Cursor position.
+        position: Position,
+        /// Include the declaration in results.
+        include_declaration: bool,
+        /// Response channel.
+        response_tx: OneshotSender<NavigationResult<Option<Vec<Location>>>>,
+    },
+    /// Request hover information.
+    Hover {
+        /// Document URI.
+        uri: Uri,
+        /// Cursor position.
+        position: Position,
+        /// Response channel.
+        response_tx: OneshotSender<NavigationResult<Option<Hover>>>,
+    },
+    /// Request server shutdown.
+    Shutdown,
+}
+
+// Custom Debug impl that hides response channels and large content
+impl fmt::Debug for LspRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DidOpen {
+                uri,
+                language_id,
+                version,
+                ..
+            } => f
+                .debug_struct("DidOpen")
+                .field("uri", uri)
+                .field("language_id", language_id)
+                .field("version", version)
+                .finish(),
+            Self::DidChange { uri, version, .. } => f
+                .debug_struct("DidChange")
+                .field("uri", uri)
+                .field("version", version)
+                .finish(),
+            Self::DidClose { uri } => f.debug_struct("DidClose").field("uri", uri).finish(),
+            Self::GotoDefinition { uri, position, .. } => f
+                .debug_struct("GotoDefinition")
+                .field("uri", uri)
+                .field("position", position)
+                .finish_non_exhaustive(),
+            Self::References {
+                uri,
+                position,
+                include_declaration,
+                ..
+            } => f
+                .debug_struct("References")
+                .field("uri", uri)
+                .field("position", position)
+                .field("include_declaration", include_declaration)
+                .finish_non_exhaustive(),
+            Self::Hover { uri, position, .. } => f
+                .debug_struct("Hover")
+                .field("uri", uri)
+                .field("position", position)
+                .finish_non_exhaustive(),
+            Self::Shutdown => write!(f, "Shutdown"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_uri(path: &str) -> Uri {
+        path.parse().expect("test URI should parse")
+    }
+
+    #[test]
+    fn test_did_open_debug() {
+        let req = LspRequest::DidOpen {
+            uri: make_uri("file:///test.rs"),
+            language_id: "rust".to_string(),
+            version: 1,
+            content: "fn main() {}".to_string(),
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("DidOpen"));
+        assert!(debug_str.contains("rust"));
+        assert!(debug_str.contains("version: 1"));
+        // Content should NOT be in debug output
+        assert!(!debug_str.contains("fn main"));
+    }
+
+    #[test]
+    fn test_did_change_debug() {
+        let req = LspRequest::DidChange {
+            uri: make_uri("file:///test.rs"),
+            version: 2,
+            content: "fn main() { println!(\"hello\"); }".to_string(),
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("DidChange"));
+        assert!(debug_str.contains("version: 2"));
+    }
+
+    #[test]
+    fn test_did_close_debug() {
+        let req = LspRequest::DidClose {
+            uri: make_uri("file:///test.rs"),
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("DidClose"));
+        assert!(debug_str.contains("test.rs"));
+    }
+
+    #[test]
+    fn test_shutdown_debug() {
+        let req = LspRequest::Shutdown;
+        assert_eq!(format!("{req:?}"), "Shutdown");
+    }
+
+    #[test]
+    fn test_goto_definition_debug() {
+        let (tx, _rx) = reovim_kernel::api::v1::oneshot();
+        let req = LspRequest::GotoDefinition {
+            uri: make_uri("file:///test.rs"),
+            position: Position::new(10, 5),
+            response_tx: tx,
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("GotoDefinition"));
+        assert!(debug_str.contains("position"));
+        // response_tx should NOT be in debug output
+        assert!(!debug_str.contains("response_tx"));
+    }
+
+    #[test]
+    fn test_references_debug() {
+        let (tx, _rx) = reovim_kernel::api::v1::oneshot();
+        let req = LspRequest::References {
+            uri: make_uri("file:///test.rs"),
+            position: Position::new(5, 10),
+            include_declaration: true,
+            response_tx: tx,
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("References"));
+        assert!(debug_str.contains("include_declaration: true"));
+    }
+
+    #[test]
+    fn test_hover_debug() {
+        let (tx, _rx) = reovim_kernel::api::v1::oneshot();
+        let req = LspRequest::Hover {
+            uri: make_uri("file:///test.rs"),
+            position: Position::new(1, 1),
+            response_tx: tx,
+        };
+        let debug_str = format!("{req:?}");
+        assert!(debug_str.contains("Hover"));
+        assert!(debug_str.contains("position"));
+    }
+}

--- a/lib/drivers/lsp/src/response.rs
+++ b/lib/drivers/lsp/src/response.rs
@@ -1,0 +1,91 @@
+//! LSP response types.
+//!
+//! Defines response variants for LSP operations. Most responses are
+//! handled via oneshot channels in [`LspRequest`], but this module
+//! provides unified types for response handling.
+
+use lsp_types::{
+    CodeActionResponse, CompletionResponse, DocumentSymbolResponse, GotoDefinitionResponse, Hover,
+    Location, SignatureHelp, SymbolInformation, TextEdit, WorkspaceEdit,
+};
+
+/// LSP response variants.
+///
+/// Corresponds to the request types in [`LspRequest`].
+///
+/// # Note
+///
+/// Most responses are sent via oneshot channels directly to the requester.
+/// This enum provides a unified type for cases where responses need to be
+/// stored or processed generically.
+#[derive(Debug)]
+pub enum LspResponse {
+    /// Response to `GotoDefinition` request.
+    Definition(Option<GotoDefinitionResponse>),
+    /// Response to `References` request.
+    References(Option<Vec<Location>>),
+    /// Response to `Hover` request.
+    Hover(Option<Hover>),
+    /// Response to `DocumentSymbol` request (future).
+    DocumentSymbol(Option<DocumentSymbolResponse>),
+    /// Response to `Completion` request (future).
+    Completion(Option<CompletionResponse>),
+    /// Response to `SignatureHelp` request (future).
+    SignatureHelp(Option<SignatureHelp>),
+    /// Response to `CodeAction` request (future).
+    CodeAction(Option<CodeActionResponse>),
+    /// Response to `Rename` request (future).
+    Rename(Option<WorkspaceEdit>),
+    /// Response to `WorkspaceSymbol` request (future).
+    WorkspaceSymbol(Option<Vec<SymbolInformation>>),
+    /// Response to `Formatting` request (future).
+    Formatting(Option<Vec<TextEdit>>),
+    /// Empty response (for notifications or void responses).
+    Empty,
+}
+
+impl LspResponse {
+    /// Check if the response is empty or None.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        matches!(
+            self,
+            Self::Empty
+                | Self::Definition(None)
+                | Self::References(None)
+                | Self::Hover(None)
+                | Self::DocumentSymbol(None)
+                | Self::Completion(None)
+                | Self::SignatureHelp(None)
+                | Self::CodeAction(None)
+                | Self::Rename(None)
+                | Self::WorkspaceSymbol(None)
+                | Self::Formatting(None)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_response_debug() {
+        let resp = LspResponse::Empty;
+        assert_eq!(format!("{resp:?}"), "Empty");
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(LspResponse::Empty.is_empty());
+        assert!(LspResponse::Definition(None).is_empty());
+        assert!(LspResponse::References(None).is_empty());
+        assert!(LspResponse::Hover(None).is_empty());
+    }
+
+    #[test]
+    fn test_is_not_empty() {
+        let locations = vec![];
+        assert!(!LspResponse::References(Some(locations)).is_empty());
+    }
+}

--- a/lib/drivers/lsp/src/types.rs
+++ b/lib/drivers/lsp/src/types.rs
@@ -1,0 +1,36 @@
+//! Re-exports from `lsp-types` crate.
+//!
+//! Provides convenient access to essential LSP protocol types.
+
+// Core types
+pub use lsp_types::{Diagnostic, DiagnosticSeverity, Location, Position, Range, Uri};
+
+// Document sync
+pub use lsp_types::TextDocumentContentChangeEvent;
+
+// Navigation
+pub use lsp_types::{GotoDefinitionResponse, Hover, HoverContents};
+
+// Completion (for future phases)
+pub use lsp_types::{CompletionResponse, CompletionTriggerKind};
+
+// Code action (for future phases)
+pub use lsp_types::CodeActionResponse;
+
+// Symbols
+pub use lsp_types::{DocumentSymbolResponse, SymbolInformation};
+
+// Formatting
+pub use lsp_types::{FormattingOptions, TextEdit};
+
+// Workspace
+pub use lsp_types::{WorkspaceEdit, WorkspaceFolder};
+
+// Progress
+pub use lsp_types::ProgressParams;
+
+// Messages
+pub use lsp_types::MessageType;
+
+// Signature
+pub use lsp_types::SignatureHelp;


### PR DESCRIPTION
Implements Phase 3.4 of the kernel architecture - LSP driver layer types following established patterns from syntax/ and input/ drivers.

Key components:
- LspError enum (9 variants) - Comprehensive error handling
- LspRequest enum (7 core variants) - DidOpen, DidChange, DidClose, GotoDefinition, References, Hover, Shutdown
- LspResponse enum - Unified response type for generic handling
- DiagnosticCache - Lock-free cache using kernel's ArcSwap mechanism
- LspServerConfig - Factory methods for common servers (rust-analyzer, clangd, pylsp, typescript)
- Re-exports essential lsp-types (Position, Range, Uri, Diagnostic, etc.)

Architecture notes:
- Uses kernel's ArcSwap (mechanism) for DiagnosticCache (policy)
- Uses kernel's OneshotSender for async response channels
- No async traits - concrete implementations in Phase 4
- 33 unit tests, zero clippy warnings

Closes: #177