### PR TITLE
feat(drivers): implement net/ RPC server infrastructure (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.5 + 4-6: Network Driver** (Issue #178) - Driver layer RPC server infrastructure
+  - `NetError` enum (12 variants) - Comprehensive network error handling
+    - `BindFailed`, `AcceptFailed` - Connection establishment errors
+    - `ConnectionClosed`, `NotInitialized`, `AlreadyListening` - State errors
+    - `Io`, `ReadFailed`, `WriteFailed` - I/O operation errors
+    - `PortExhausted`, `InvalidAddress` - Address/port errors
+    - `JsonError`, `InvalidMessage` - Serialization errors
+  - `NetDriver` trait - Network driver lifecycle management
+    - `init()`, `shutdown()`, `is_listening()` - Driver lifecycle
+    - `listen()` - Start listening on transport config
+    - `local_addr()` - Get bound TCP address
+    - `register_handler()` - Register RPC handlers
+  - `TransportListener` trait - Connection acceptance abstraction
+    - `bind()`, `accept()`, `local_addr()`
+  - `TransportConnection` trait - Read/write message abstraction
+    - `read_line()`, `write_line()`, `close()`
+  - `PortAllocator` trait - Multi-instance port allocation
+    - `default_port()` (12521), `port_range()`, `allocate()`, `is_port_available()`
+  - `TransportConfig` enum - Transport selection (Stdio, UnixSocket, TCP)
+    - Factory methods: `unix_socket()`, `tcp()`, `tcp_localhost()`
+    - Constants: `DEFAULT_PORT` (12521), `MAX_PORT` (12530)
+  - JSON-RPC 2.0 message types:
+    - `RpcRequest`, `RpcResponse`, `RpcNotification`, `RpcError`
+    - `RpcHandler` trait, `RpcResult` enum, `RpcHandlerContext`
+    - Error code constants: `PARSE_ERROR`, `INVALID_REQUEST`, `METHOD_NOT_FOUND`, etc.
+    - Method constants (`methods::INPUT_KEYS`, etc.) and notification constants
+  - Core migration: `lib/core` now imports types from driver (dependency inversion)
+  - 25 unit tests
+
 - **Phase 3.4: LSP Driver Types** (Issue #177) - Driver layer LSP client infrastructure
   - `LspError` enum (9 variants) - Comprehensive LSP error handling
     - `SpawnFailed` - Failed to spawn language server process

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,7 @@ dependencies = [
  "ignore",
  "nucleo",
  "regex",
+ "reovim-driver-net",
  "reovim-sys",
  "serde",
  "serde_json",
@@ -1659,6 +1660,8 @@ name = "reovim-driver-net"
 version = "0.9.0-dev"
 dependencies = [
  "reovim-kernel",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 reovim-sys.workspace = true
+reovim-driver-net = { path = "../drivers/net", version = "0.9.0-dev" }
 futures.workspace = true
 futures-timer.workspace = true
 tokio.workspace = true

--- a/lib/core/src/rpc/mod.rs
+++ b/lib/core/src/rpc/mod.rs
@@ -12,14 +12,21 @@ pub mod handler;
 pub mod server;
 pub mod state;
 pub mod transport;
-pub mod types;
+
+// Re-export types from driver (Phase 4-6 migration)
+pub use reovim_driver_net::{
+    BUFFER_NOT_FOUND, COMMAND_NOT_FOUND, INTERNAL_ERROR, INVALID_KEY_NOTATION, INVALID_PARAMS,
+    INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR, RpcError, RpcNotification, RpcRequest,
+    RpcResponse, TransportConfig, methods, notifications,
+};
+
+// Keep core-specific types (richer context for plugins)
+pub use handler::{RpcHandler, RpcHandlerContext, RpcHandlerRegistry, RpcResult};
 
 pub use {
-    handler::{RpcHandler, RpcHandlerContext, RpcHandlerRegistry, RpcResult},
     server::{RpcServer, ServerConfig},
     state::*,
-    transport::{TransportClient, TransportConfig, TransportConnection, TransportListener},
-    types::*,
+    transport::{TransportClient, TransportConnection, TransportListener},
 };
 
 // Re-export key notation parser from testing module

--- a/lib/core/src/rpc/transport.rs
+++ b/lib/core/src/rpc/transport.rs
@@ -12,39 +12,8 @@ use tokio::{
     net::{TcpListener, TcpStream, UnixListener, UnixStream},
 };
 
-/// Transport configuration
-#[derive(Debug, Clone)]
-pub enum TransportConfig {
-    /// Use stdin/stdout for communication
-    Stdio,
-    /// Listen on Unix socket at the given path
-    UnixSocket { path: PathBuf },
-    /// Listen on TCP at the given address
-    Tcp { host: String, port: u16 },
-}
-
-impl TransportConfig {
-    /// Create Unix socket config
-    #[must_use]
-    pub fn unix_socket(path: impl Into<PathBuf>) -> Self {
-        Self::UnixSocket { path: path.into() }
-    }
-
-    /// Create TCP config
-    #[must_use]
-    pub fn tcp(host: impl Into<String>, port: u16) -> Self {
-        Self::Tcp {
-            host: host.into(),
-            port,
-        }
-    }
-
-    /// Create TCP config with default host (localhost)
-    #[must_use]
-    pub fn tcp_localhost(port: u16) -> Self {
-        Self::tcp("127.0.0.1", port)
-    }
-}
+// Use TransportConfig from driver
+pub use reovim_driver_net::TransportConfig;
 
 /// Read half of a transport connection
 pub struct TransportReader {
@@ -327,6 +296,8 @@ impl TransportClient {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]

--- a/lib/drivers/net/Cargo.toml
+++ b/lib/drivers/net/Cargo.toml
@@ -15,3 +15,7 @@ workspace = true
 [dependencies]
 # Only depends on kernel layer
 reovim-kernel = { path = "../../kernel", version = "0.9.0-dev" }
+
+# Serialization for JSON-RPC types
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/lib/drivers/net/src/codes.rs
+++ b/lib/drivers/net/src/codes.rs
@@ -1,0 +1,49 @@
+//! Standard JSON-RPC 2.0 error codes.
+
+/// Parse error: Invalid JSON was received by the server.
+pub const PARSE_ERROR: i32 = -32700;
+
+/// Invalid Request: The JSON sent is not a valid Request object.
+pub const INVALID_REQUEST: i32 = -32600;
+
+/// Method not found: The method does not exist / is not available.
+pub const METHOD_NOT_FOUND: i32 = -32601;
+
+/// Invalid params: Invalid method parameter(s).
+pub const INVALID_PARAMS: i32 = -32602;
+
+/// Internal error: Internal JSON-RPC error.
+pub const INTERNAL_ERROR: i32 = -32603;
+
+// Application-specific error code range: -32000 to -32099
+
+/// Buffer not found (application-specific).
+pub const BUFFER_NOT_FOUND: i32 = -32001;
+
+/// Command not found (application-specific).
+pub const COMMAND_NOT_FOUND: i32 = -32002;
+
+/// Invalid key notation (application-specific).
+pub const INVALID_KEY_NOTATION: i32 = -32003;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_standard_error_codes() {
+        assert_eq!(PARSE_ERROR, -32700);
+        assert_eq!(INVALID_REQUEST, -32600);
+        assert_eq!(METHOD_NOT_FOUND, -32601);
+        assert_eq!(INVALID_PARAMS, -32602);
+        assert_eq!(INTERNAL_ERROR, -32603);
+    }
+
+    #[test]
+    fn test_application_error_codes_in_range() {
+        // Application-specific codes must be in -32000 to -32099
+        const { assert!(BUFFER_NOT_FOUND >= -32099 && BUFFER_NOT_FOUND <= -32000) };
+        const { assert!(COMMAND_NOT_FOUND >= -32099 && COMMAND_NOT_FOUND <= -32000) };
+        const { assert!(INVALID_KEY_NOTATION >= -32099 && INVALID_KEY_NOTATION <= -32000) };
+    }
+}

--- a/lib/drivers/net/src/error.rs
+++ b/lib/drivers/net/src/error.rs
@@ -1,0 +1,109 @@
+//! Network driver error types.
+
+use std::fmt;
+
+/// Errors that can occur during network operations.
+#[derive(Debug)]
+pub enum NetError {
+    /// Failed to bind to address.
+    BindFailed(String),
+
+    /// Failed to accept connection.
+    AcceptFailed(String),
+
+    /// Connection closed unexpectedly.
+    ConnectionClosed,
+
+    /// I/O error.
+    Io(String),
+
+    /// No more ports available in fallback range.
+    PortExhausted,
+
+    /// Invalid address format.
+    InvalidAddress(String),
+
+    /// Transport not initialized.
+    NotInitialized,
+
+    /// Transport already listening.
+    AlreadyListening,
+
+    /// Failed to read from transport.
+    ReadFailed(String),
+
+    /// Failed to write to transport.
+    WriteFailed(String),
+
+    /// JSON serialization/deserialization error.
+    JsonError(String),
+
+    /// Invalid RPC message format.
+    InvalidMessage(String),
+}
+
+impl fmt::Display for NetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BindFailed(msg) => write!(f, "failed to bind: {msg}"),
+            Self::AcceptFailed(msg) => write!(f, "failed to accept connection: {msg}"),
+            Self::ConnectionClosed => write!(f, "connection closed"),
+            Self::Io(msg) => write!(f, "I/O error: {msg}"),
+            Self::PortExhausted => write!(f, "no available ports in fallback range"),
+            Self::InvalidAddress(msg) => write!(f, "invalid address: {msg}"),
+            Self::NotInitialized => write!(f, "transport not initialized"),
+            Self::AlreadyListening => write!(f, "transport already listening"),
+            Self::ReadFailed(msg) => write!(f, "failed to read: {msg}"),
+            Self::WriteFailed(msg) => write!(f, "failed to write: {msg}"),
+            Self::JsonError(msg) => write!(f, "JSON error: {msg}"),
+            Self::InvalidMessage(msg) => write!(f, "invalid message: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for NetError {}
+
+impl From<std::io::Error> for NetError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for NetError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::JsonError(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        assert!(format!("{}", NetError::BindFailed("addr".into())).contains("addr"));
+        assert_eq!(format!("{}", NetError::ConnectionClosed), "connection closed");
+        assert_eq!(format!("{}", NetError::PortExhausted), "no available ports in fallback range");
+    }
+
+    #[test]
+    fn test_error_trait() {
+        fn assert_error<E: std::error::Error>() {}
+        assert_error::<NetError>();
+    }
+
+    #[test]
+    fn test_from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "test");
+        let net_err = NetError::from(io_err);
+        assert!(matches!(net_err, NetError::Io(_)));
+    }
+
+    #[test]
+    fn test_from_json_error() {
+        let json_str = "invalid json {";
+        let json_err: Result<serde_json::Value, _> = serde_json::from_str(json_str);
+        let net_err = NetError::from(json_err.unwrap_err());
+        assert!(matches!(net_err, NetError::JsonError(_)));
+    }
+}

--- a/lib/drivers/net/src/handler.rs
+++ b/lib/drivers/net/src/handler.rs
@@ -1,0 +1,207 @@
+//! RPC handler trait and types.
+//!
+//! This module provides the infrastructure for plugins to register
+//! custom RPC method handlers.
+
+use std::fmt::Debug;
+
+use serde_json::Value;
+
+/// Result of an RPC handler execution.
+#[derive(Debug)]
+pub enum RpcResult {
+    /// Successful response with a JSON value.
+    Success(Value),
+    /// Error response with code and message.
+    Error {
+        /// Error code.
+        code: i32,
+        /// Error message.
+        message: String,
+    },
+}
+
+impl RpcResult {
+    /// Create a successful result with a JSON value.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // Value is not const-constructible
+    pub fn success(value: Value) -> Self {
+        Self::Success(value)
+    }
+
+    /// Create an "ok" success result (empty success).
+    #[must_use]
+    pub fn ok() -> Self {
+        Self::Success(serde_json::json!({ "ok": true }))
+    }
+
+    /// Create an error result.
+    #[must_use]
+    pub fn error(code: i32, message: impl Into<String>) -> Self {
+        Self::Error {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Create an invalid params error.
+    #[must_use]
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::Error {
+            code: crate::INVALID_PARAMS,
+            message: message.into(),
+        }
+    }
+
+    /// Create an internal error.
+    #[must_use]
+    pub fn internal_error(message: impl Into<String>) -> Self {
+        Self::Error {
+            code: crate::INTERNAL_ERROR,
+            message: message.into(),
+        }
+    }
+}
+
+/// Context provided to RPC handlers for accessing runtime state.
+///
+/// This is a minimal context struct. Concrete implementations in
+/// `lib/core` provide richer context with access to plugin state,
+/// mode state, and buffer information.
+///
+/// Note: The actual context type used by handlers is defined in
+/// `lib/core/src/rpc/handler.rs` and includes references to
+/// `PluginStateRegistry`, `ModeState`, and `active_buffer_id`.
+pub struct RpcHandlerContext {
+    /// Active buffer ID.
+    pub active_buffer_id: usize,
+}
+
+impl RpcHandlerContext {
+    /// Create a new minimal context.
+    #[must_use]
+    pub const fn new(active_buffer_id: usize) -> Self {
+        Self { active_buffer_id }
+    }
+
+    /// Get the active buffer ID.
+    #[must_use]
+    pub const fn active_buffer_id(&self) -> usize {
+        self.active_buffer_id
+    }
+}
+
+/// Trait for RPC method handlers.
+///
+/// Plugins implement this trait to handle custom RPC methods.
+/// Handlers are registered with the runtime and invoked when
+/// matching RPC requests are received.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_driver_net::{RpcHandler, RpcHandlerContext, RpcResult};
+/// use serde_json::Value;
+///
+/// struct EchoHandler;
+///
+/// impl RpcHandler for EchoHandler {
+///     fn method(&self) -> &'static str {
+///         "echo"
+///     }
+///
+///     fn handle(&self, params: &Value, _ctx: &RpcHandlerContext) -> RpcResult {
+///         RpcResult::Success(params.clone())
+///     }
+/// }
+/// ```
+pub trait RpcHandler: Send + Sync {
+    /// The RPC method name this handler responds to.
+    ///
+    /// Convention: Use namespaced methods like `"plugin_name/method_name"`.
+    fn method(&self) -> &'static str;
+
+    /// Handle an RPC request.
+    ///
+    /// # Arguments
+    /// * `params` - The JSON parameters from the RPC request
+    /// * `ctx` - Context for accessing runtime state
+    ///
+    /// # Returns
+    /// The result of handling the request.
+    fn handle(&self, params: &Value, ctx: &RpcHandlerContext) -> RpcResult;
+
+    /// Human-readable description of this handler (for introspection).
+    fn description(&self) -> &'static str {
+        "No description available"
+    }
+}
+
+impl Debug for dyn RpcHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RpcHandler({})", self.method())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestHandler;
+
+    impl RpcHandler for TestHandler {
+        fn method(&self) -> &'static str {
+            "test/echo"
+        }
+
+        fn handle(&self, params: &Value, _ctx: &RpcHandlerContext) -> RpcResult {
+            RpcResult::Success(params.clone())
+        }
+
+        fn description(&self) -> &'static str {
+            "Echo back the params"
+        }
+    }
+
+    #[test]
+    fn test_rpc_result_variants() {
+        let success = RpcResult::success(serde_json::json!({ "value": 42 }));
+        assert!(matches!(success, RpcResult::Success(_)));
+
+        let ok = RpcResult::ok();
+        assert!(matches!(ok, RpcResult::Success(_)));
+
+        let error = RpcResult::error(-1, "test error");
+        assert!(matches!(error, RpcResult::Error { code: -1, .. }));
+
+        let invalid = RpcResult::invalid_params("missing field");
+        assert!(matches!(invalid, RpcResult::Error { code: -32602, .. }));
+
+        let internal = RpcResult::internal_error("something went wrong");
+        assert!(matches!(internal, RpcResult::Error { code: -32603, .. }));
+    }
+
+    #[test]
+    fn test_handler_trait() {
+        let handler = TestHandler;
+        assert_eq!(handler.method(), "test/echo");
+        assert_eq!(handler.description(), "Echo back the params");
+
+        let ctx = RpcHandlerContext::new(0);
+        let result = handler.handle(&serde_json::json!({"test": 1}), &ctx);
+        assert!(matches!(result, RpcResult::Success(_)));
+    }
+
+    #[test]
+    fn test_handler_debug() {
+        let handler: &dyn RpcHandler = &TestHandler;
+        let debug = format!("{handler:?}");
+        assert!(debug.contains("test/echo"));
+    }
+
+    #[test]
+    fn test_handler_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TestHandler>();
+    }
+}

--- a/lib/drivers/net/src/lib.rs
+++ b/lib/drivers/net/src/lib.rs
@@ -1,14 +1,104 @@
 //! Network driver for reovim.
 //!
-//! Linux equivalent: `drivers/net/`, `net/`
+//! Linux equivalent: `net/`, `include/linux/net.h`
 //!
-//! Provides RPC server infrastructure and transport abstractions.
+//! # Architecture
+//!
+//! This crate defines types and traits for RPC server infrastructure.
+//! Concrete implementations in `lib/core/src/rpc/` import from this driver.
+//!
+//! ```text
+//! lib/drivers/net/          <-- Types + Traits (this crate)
+//!        ^
+//!        |  imports from
+//!        |
+//! lib/core/src/rpc/         <-- Implementations
+//! ```
 //!
 //! # Components
 //!
-//! - RPC server (JSON-RPC 2.0)
-//! - Transport layer (TCP, Unix socket, stdio)
-//! - Request handlers
+//! ## Core Traits
+//!
+//! - [`NetDriver`] - Network driver lifecycle management
+//! - [`TransportListener`] - Bind and accept connections
+//! - [`TransportConnection`] - Read/write over a transport
+//! - [`PortAllocator`] - Port allocation for multi-instance support
+//!
+//! ## RPC Types
+//!
+//! - [`RpcRequest`], [`RpcResponse`], [`RpcNotification`] - JSON-RPC 2.0 messages
+//! - [`RpcError`] - Error responses with standard codes
+//! - [`RpcHandler`] - Plugin-based RPC method handlers
+//! - [`RpcResult`] - Handler return type
+//! - [`TransportConfig`] - Transport configuration enum
+//!
+//! ## Error Handling
+//!
+//! - [`NetError`] - Network operation errors
+//! - Error code constants: [`PARSE_ERROR`], [`INVALID_REQUEST`], etc.
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_driver_net::{
+//!     TransportConfig, RpcRequest, RpcResponse, RpcError,
+//!     NetError,
+//! };
+//!
+//! // Create transport config
+//! let config = TransportConfig::tcp_localhost(12521);
+//!
+//! // Create RPC request
+//! let request = RpcRequest::new(1, "state/cursor", serde_json::json!({}));
+//!
+//! // Create error response
+//! let error = RpcError::method_not_found("unknown");
+//! ```
 
-// Placeholder - NetDriver trait will be added in Phase 3
-// Note: Will eventually absorb functionality from lib/core/src/rpc/
+// ============================================================================
+// Modules
+// ============================================================================
+
+mod codes;
+mod error;
+mod handler;
+mod rpc;
+mod traits;
+pub mod transport;
+
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+// Error types
+pub use error::NetError;
+
+// JSON-RPC error codes
+pub use codes::{
+    BUFFER_NOT_FOUND, COMMAND_NOT_FOUND, INTERNAL_ERROR, INVALID_KEY_NOTATION, INVALID_PARAMS,
+    INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
+};
+
+// Transport configuration
+pub use transport::TransportConfig;
+
+// RPC message types
+pub use rpc::{RpcError, RpcNotification, RpcRequest, RpcResponse};
+
+// Handler types
+pub use handler::{RpcHandler, RpcHandlerContext, RpcResult};
+
+// Core traits
+pub use traits::{NetDriver, PortAllocator, TransportConnection, TransportListener};
+
+// Method name constants (for discoverability)
+pub mod methods {
+    //! Standard RPC method names.
+    pub use crate::rpc::methods::*;
+}
+
+// Notification name constants
+pub mod notifications {
+    //! Standard notification names.
+    pub use crate::rpc::notifications::*;
+}

--- a/lib/drivers/net/src/rpc.rs
+++ b/lib/drivers/net/src/rpc.rs
@@ -1,33 +1,38 @@
-//! JSON-RPC 2.0 message types for server mode
+//! JSON-RPC 2.0 message types.
 //!
 //! This module defines the core message types for the JSON-RPC protocol:
-//! - `RpcRequest`: Incoming requests from clients
-//! - `RpcResponse`: Responses to requests
-//! - `RpcNotification`: Server-to-client notifications
-//! - `RpcError`: Error information
+//! - [`RpcRequest`]: Incoming requests from clients
+//! - [`RpcResponse`]: Responses to requests
+//! - [`RpcNotification`]: Server-to-client notifications
+//! - [`RpcError`]: Error information
 
 use serde::{Deserialize, Serialize};
 
-/// JSON-RPC 2.0 request message
+use crate::codes::{
+    BUFFER_NOT_FOUND, COMMAND_NOT_FOUND, INTERNAL_ERROR, INVALID_KEY_NOTATION, INVALID_PARAMS,
+    INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
+};
+
+/// JSON-RPC 2.0 request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcRequest {
-    /// Protocol version (always "2.0")
+    /// Protocol version (always "2.0").
     pub jsonrpc: String,
 
-    /// Request ID (omitted for notifications)
+    /// Request ID (omitted for notifications).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<u64>,
 
-    /// Method name (e.g., "input/keys", "state/cursor")
+    /// Method name (e.g., "input/keys", "state/cursor").
     pub method: String,
 
-    /// Method parameters
+    /// Method parameters.
     #[serde(default)]
     pub params: serde_json::Value,
 }
 
 impl RpcRequest {
-    /// Create a new request with the given method and params
+    /// Create a new request with the given method and params.
     #[must_use]
     pub fn new(id: u64, method: impl Into<String>, params: serde_json::Value) -> Self {
         Self {
@@ -38,33 +43,44 @@ impl RpcRequest {
         }
     }
 
-    /// Check if this is a notification (no id)
+    /// Create a notification (request without ID).
+    #[must_use]
+    pub fn notification(method: impl Into<String>, params: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: method.into(),
+            params,
+        }
+    }
+
+    /// Check if this is a notification (no id).
     #[must_use]
     pub const fn is_notification(&self) -> bool {
         self.id.is_none()
     }
 }
 
-/// JSON-RPC 2.0 response message
+/// JSON-RPC 2.0 response message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcResponse {
-    /// Protocol version (always "2.0")
+    /// Protocol version (always "2.0").
     pub jsonrpc: String,
 
-    /// Request ID this response corresponds to
+    /// Request ID this response corresponds to.
     pub id: u64,
 
-    /// Result value (mutually exclusive with error)
+    /// Result value (mutually exclusive with error).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<serde_json::Value>,
 
-    /// Error information (mutually exclusive with result)
+    /// Error information (mutually exclusive with result).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<RpcError>,
 }
 
 impl RpcResponse {
-    /// Create a success response with the given result
+    /// Create a success response with the given result.
     #[must_use]
     pub fn success(id: u64, result: serde_json::Value) -> Self {
         Self {
@@ -75,7 +91,7 @@ impl RpcResponse {
         }
     }
 
-    /// Create an error response
+    /// Create an error response.
     #[must_use]
     pub fn error(id: u64, error: RpcError) -> Self {
         Self {
@@ -86,29 +102,29 @@ impl RpcResponse {
         }
     }
 
-    /// Create a success response with null result
+    /// Create a success response with null result.
     #[must_use]
     pub fn ok(id: u64) -> Self {
         Self::success(id, serde_json::Value::Null)
     }
 }
 
-/// JSON-RPC 2.0 error object
+/// JSON-RPC 2.0 error object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcError {
-    /// Error code
+    /// Error code.
     pub code: i32,
 
-    /// Human-readable error message
+    /// Human-readable error message.
     pub message: String,
 
-    /// Additional error data
+    /// Additional error data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
 }
 
 impl RpcError {
-    /// Create a new error
+    /// Create a new error.
     #[must_use]
     pub fn new(code: i32, message: impl Into<String>) -> Self {
         Self {
@@ -118,7 +134,7 @@ impl RpcError {
         }
     }
 
-    /// Create an error with additional data
+    /// Create an error with additional data.
     #[must_use]
     pub fn with_data(code: i32, message: impl Into<String>, data: serde_json::Value) -> Self {
         Self {
@@ -130,72 +146,72 @@ impl RpcError {
 
     // Standard JSON-RPC 2.0 error codes
 
-    /// Invalid JSON was received
+    /// Invalid JSON was received.
     #[must_use]
     pub fn parse_error() -> Self {
-        Self::new(-32700, "Parse error")
+        Self::new(PARSE_ERROR, "Parse error")
     }
 
-    /// The JSON sent is not a valid Request object
+    /// The JSON sent is not a valid Request object.
     #[must_use]
     pub fn invalid_request() -> Self {
-        Self::new(-32600, "Invalid Request")
+        Self::new(INVALID_REQUEST, "Invalid Request")
     }
 
-    /// The method does not exist / is not available
+    /// The method does not exist / is not available.
     #[must_use]
     pub fn method_not_found(method: &str) -> Self {
-        Self::new(-32601, format!("Method not found: {method}"))
+        Self::new(METHOD_NOT_FOUND, format!("Method not found: {method}"))
     }
 
-    /// Invalid method parameter(s)
+    /// Invalid method parameter(s).
     #[must_use]
     pub fn invalid_params(details: impl Into<String>) -> Self {
-        Self::new(-32602, format!("Invalid params: {}", details.into()))
+        Self::new(INVALID_PARAMS, format!("Invalid params: {}", details.into()))
     }
 
-    /// Internal JSON-RPC error
+    /// Internal JSON-RPC error.
     #[must_use]
     pub fn internal_error(details: impl Into<String>) -> Self {
-        Self::new(-32603, format!("Internal error: {}", details.into()))
+        Self::new(INTERNAL_ERROR, format!("Internal error: {}", details.into()))
     }
 
-    // Application-specific error codes (-32000 to -32099)
+    // Application-specific error codes
 
-    /// Buffer not found
+    /// Buffer not found.
     #[must_use]
     pub fn buffer_not_found(buffer_id: usize) -> Self {
-        Self::new(-32001, format!("Buffer not found: {buffer_id}"))
+        Self::new(BUFFER_NOT_FOUND, format!("Buffer not found: {buffer_id}"))
     }
 
-    /// Command not found
+    /// Command not found.
     #[must_use]
     pub fn command_not_found(command: &str) -> Self {
-        Self::new(-32002, format!("Command not found: {command}"))
+        Self::new(COMMAND_NOT_FOUND, format!("Command not found: {command}"))
     }
 
-    /// Invalid key notation
+    /// Invalid key notation.
     #[must_use]
     pub fn invalid_key_notation(details: impl Into<String>) -> Self {
-        Self::new(-32003, format!("Invalid key notation: {}", details.into()))
+        Self::new(INVALID_KEY_NOTATION, format!("Invalid key notation: {}", details.into()))
     }
 }
 
-/// JSON-RPC 2.0 notification message (server to client)
+/// JSON-RPC 2.0 notification message (server to client).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcNotification {
-    /// Protocol version (always "2.0")
+    /// Protocol version (always "2.0").
     pub jsonrpc: String,
 
-    /// Notification method name
+    /// Notification method name.
     pub method: String,
 
-    /// Notification parameters
+    /// Notification parameters.
     pub params: serde_json::Value,
 }
 
 impl RpcNotification {
-    /// Create a new notification
+    /// Create a new notification.
     #[must_use]
     pub fn new(method: impl Into<String>, params: serde_json::Value) -> Self {
         Self {
@@ -206,48 +222,72 @@ impl RpcNotification {
     }
 }
 
-/// Methods supported by the RPC server
+/// Standard RPC method names.
 pub mod methods {
     // Input methods
+    /// Inject key events.
     pub const INPUT_KEYS: &str = "input/keys";
 
     // Command methods
+    /// Execute an ex-command.
     pub const COMMAND_EXECUTE: &str = "command/execute";
 
     // Buffer methods
+    /// Get buffer content.
     pub const BUFFER_GET_CONTENT: &str = "buffer/get_content";
+    /// Set buffer content.
     pub const BUFFER_SET_CONTENT: &str = "buffer/set_content";
+    /// Open a file in a buffer.
     pub const BUFFER_OPEN_FILE: &str = "buffer/open_file";
+    /// List all buffers.
     pub const BUFFER_LIST: &str = "buffer/list";
 
     // State methods
+    /// Get current mode.
     pub const STATE_MODE: &str = "state/mode";
+    /// Get cursor position.
     pub const STATE_CURSOR: &str = "state/cursor";
+    /// Get selection.
     pub const STATE_SELECTION: &str = "state/selection";
+    /// Get screen state.
     pub const STATE_SCREEN: &str = "state/screen";
+    /// Get screen content.
     pub const STATE_SCREEN_CONTENT: &str = "state/screen_content";
+    /// Get telescope state.
     pub const STATE_TELESCOPE: &str = "state/telescope";
+    /// Get microscope state.
     pub const STATE_MICROSCOPE: &str = "state/microscope";
+    /// Get windows state.
     pub const STATE_WINDOWS: &str = "state/windows";
 
     // Visual methods (for debugging and AI understanding)
+    /// Get visual snapshot.
     pub const STATE_VISUAL_SNAPSHOT: &str = "state/visual_snapshot";
+    /// Get ASCII art representation.
     pub const STATE_ASCII_ART: &str = "state/ascii_art";
+    /// Get layer information.
     pub const STATE_LAYER_INFO: &str = "state/layer_info";
 
     // Editor methods
+    /// Resize the editor.
     pub const EDITOR_RESIZE: &str = "editor/resize";
+    /// Quit the editor.
     pub const EDITOR_QUIT: &str = "editor/quit";
 
     // Server methods
+    /// Kill the server.
     pub const SERVER_KILL: &str = "server/kill";
 }
 
-/// Notification types sent by the server
+/// Notification types sent by the server.
 pub mod notifications {
+    /// Mode changed notification.
     pub const MODE_CHANGED: &str = "notification/mode_changed";
+    /// Cursor moved notification.
     pub const CURSOR_MOVED: &str = "notification/cursor_moved";
+    /// Buffer modified notification.
     pub const BUFFER_MODIFIED: &str = "notification/buffer_modified";
+    /// Render complete notification.
     pub const RENDER_COMPLETE: &str = "notification/render_complete";
 }
 
@@ -262,6 +302,14 @@ mod tests {
         assert!(json.contains("\"jsonrpc\":\"2.0\""));
         assert!(json.contains("\"id\":1"));
         assert!(json.contains("\"method\":\"state/cursor\""));
+    }
+
+    #[test]
+    fn test_request_notification() {
+        let request = RpcRequest::notification("event/ping", serde_json::json!({}));
+        assert!(request.is_notification());
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(!json.contains("\"id\""));
     }
 
     #[test]
@@ -298,5 +346,21 @@ mod tests {
         let request: RpcRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.id, Some(42));
         assert_eq!(request.method, "input/keys");
+    }
+
+    #[test]
+    fn test_error_codes() {
+        assert_eq!(RpcError::parse_error().code, PARSE_ERROR);
+        assert_eq!(RpcError::invalid_request().code, INVALID_REQUEST);
+        assert_eq!(RpcError::method_not_found("test").code, METHOD_NOT_FOUND);
+        assert_eq!(RpcError::invalid_params("test").code, INVALID_PARAMS);
+        assert_eq!(RpcError::internal_error("test").code, INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_application_error_codes() {
+        assert_eq!(RpcError::buffer_not_found(0).code, BUFFER_NOT_FOUND);
+        assert_eq!(RpcError::command_not_found("test").code, COMMAND_NOT_FOUND);
+        assert_eq!(RpcError::invalid_key_notation("test").code, INVALID_KEY_NOTATION);
     }
 }

--- a/lib/drivers/net/src/traits.rs
+++ b/lib/drivers/net/src/traits.rs
@@ -1,0 +1,139 @@
+//! Network driver traits.
+
+use {
+    crate::{NetError, RpcHandler, TransportConfig},
+    std::net::SocketAddr,
+};
+
+/// Network driver for RPC server lifecycle management.
+///
+/// This trait manages the network subsystem lifecycle:
+/// initialization, listening for connections, and clean shutdown.
+pub trait NetDriver: Send + Sync {
+    /// Initialize the network driver.
+    ///
+    /// # Errors
+    /// Returns [`NetError::NotInitialized`] if initialization fails.
+    fn init(&mut self) -> Result<(), NetError>;
+
+    /// Start listening for connections on the specified transport.
+    ///
+    /// # Errors
+    /// Returns [`NetError::BindFailed`] if binding fails, or
+    /// [`NetError::AlreadyListening`] if already listening.
+    fn listen(&mut self, config: TransportConfig) -> Result<(), NetError>;
+
+    /// Shutdown the network driver.
+    ///
+    /// # Errors
+    /// Returns [`NetError::Io`] if shutdown fails.
+    fn shutdown(&mut self) -> Result<(), NetError>;
+
+    /// Check if the driver is currently listening.
+    fn is_listening(&self) -> bool;
+
+    /// Get the local address if listening on TCP.
+    fn local_addr(&self) -> Option<SocketAddr>;
+
+    /// Register an RPC handler for a custom method.
+    ///
+    /// # Errors
+    /// Returns [`NetError::NotInitialized`] if driver not initialized.
+    fn register_handler(&mut self, handler: Box<dyn RpcHandler>) -> Result<(), NetError>;
+}
+
+/// Transport listener for accepting connections.
+pub trait TransportListener: Send + Sync {
+    /// Bind to the configured address and start listening.
+    ///
+    /// # Errors
+    /// Returns [`NetError::BindFailed`] if binding fails.
+    fn bind(&mut self, config: TransportConfig) -> Result<(), NetError>;
+
+    /// Accept a new connection (blocking).
+    ///
+    /// # Errors
+    /// Returns [`NetError::AcceptFailed`] if accepting fails.
+    fn accept(&mut self) -> Result<Box<dyn TransportConnection>, NetError>;
+
+    /// Get the local address (TCP only).
+    fn local_addr(&self) -> Option<SocketAddr>;
+}
+
+/// Active transport connection for reading/writing messages.
+pub trait TransportConnection: Send + Sync {
+    /// Read a line from the connection.
+    /// Returns `Ok(None)` on EOF.
+    ///
+    /// # Errors
+    /// Returns [`NetError::ReadFailed`] if reading fails.
+    fn read_line(&mut self) -> Result<Option<String>, NetError>;
+
+    /// Write a line to the connection (appends newline, flushes).
+    ///
+    /// # Errors
+    /// Returns [`NetError::WriteFailed`] if writing fails.
+    fn write_line(&mut self, line: &str) -> Result<(), NetError>;
+
+    /// Close the connection gracefully.
+    ///
+    /// # Errors
+    /// Returns [`NetError::Io`] if closing fails.
+    fn close(&mut self) -> Result<(), NetError>;
+}
+
+/// Port allocator for multi-instance TCP server support.
+pub trait PortAllocator: Send + Sync {
+    /// Get the default port. Default: 12521 ('r'*100 + 'e'*10 + 'o')
+    fn default_port(&self) -> u16 {
+        crate::transport::TransportConfig::DEFAULT_PORT
+    }
+
+    /// Get the port fallback range. Default: (12521, 12530)
+    fn port_range(&self) -> (u16, u16) {
+        (
+            crate::transport::TransportConfig::DEFAULT_PORT,
+            crate::transport::TransportConfig::MAX_PORT,
+        )
+    }
+
+    /// Try to allocate a port, starting with default and falling back.
+    ///
+    /// # Errors
+    /// Returns [`NetError::PortExhausted`] if no ports are available.
+    fn allocate(&self) -> Result<u16, NetError>;
+
+    /// Check if a port is available.
+    fn is_port_available(&self, port: u16) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_port_allocator() {
+        struct DummyAllocator;
+        impl PortAllocator for DummyAllocator {
+            fn allocate(&self) -> Result<u16, NetError> {
+                Ok(12521)
+            }
+            fn is_port_available(&self, _port: u16) -> bool {
+                true
+            }
+        }
+
+        let allocator = DummyAllocator;
+        assert_eq!(allocator.default_port(), 12521);
+        assert_eq!(allocator.port_range(), (12521, 12530));
+    }
+
+    #[test]
+    fn test_trait_bounds() {
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+        assert_send_sync::<dyn NetDriver>();
+        assert_send_sync::<dyn TransportListener>();
+        assert_send_sync::<dyn TransportConnection>();
+        assert_send_sync::<dyn PortAllocator>();
+    }
+}

--- a/lib/drivers/net/src/transport.rs
+++ b/lib/drivers/net/src/transport.rs
@@ -1,0 +1,109 @@
+//! Transport layer configuration.
+//!
+//! Defines transport types for RPC communication:
+//! - Stdio: JSON-RPC over stdin/stdout (for process piping)
+//! - Unix socket: JSON-RPC over Unix domain socket
+//! - TCP: JSON-RPC over TCP connection
+
+use std::path::PathBuf;
+
+/// Transport configuration.
+#[derive(Debug, Clone)]
+pub enum TransportConfig {
+    /// Use stdin/stdout for communication.
+    Stdio,
+    /// Listen on Unix socket at the given path.
+    UnixSocket {
+        /// Path to the Unix socket.
+        path: PathBuf,
+    },
+    /// Listen on TCP at the given address.
+    Tcp {
+        /// Host address (e.g., "127.0.0.1").
+        host: String,
+        /// Port number.
+        port: u16,
+    },
+}
+
+impl TransportConfig {
+    /// Create Unix socket config.
+    #[must_use]
+    pub fn unix_socket(path: impl Into<PathBuf>) -> Self {
+        Self::UnixSocket { path: path.into() }
+    }
+
+    /// Create TCP config.
+    #[must_use]
+    pub fn tcp(host: impl Into<String>, port: u16) -> Self {
+        Self::Tcp {
+            host: host.into(),
+            port,
+        }
+    }
+
+    /// Create TCP config with default host (localhost).
+    #[must_use]
+    pub fn tcp_localhost(port: u16) -> Self {
+        Self::tcp("127.0.0.1", port)
+    }
+
+    /// Default port for reovim RPC server.
+    /// Calculated as: 'r' * 100 + 'e' * 10 + 'o' = 114*100 + 101*10 + 111 = 12521
+    pub const DEFAULT_PORT: u16 = 12521;
+
+    /// Maximum port in fallback range.
+    pub const MAX_PORT: u16 = 12530;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transport_config_stdio() {
+        let config = TransportConfig::Stdio;
+        assert!(matches!(config, TransportConfig::Stdio));
+    }
+
+    #[test]
+    fn test_transport_config_unix() {
+        let config = TransportConfig::unix_socket("/tmp/test.sock");
+        match config {
+            TransportConfig::UnixSocket { path } => {
+                assert_eq!(path, PathBuf::from("/tmp/test.sock"));
+            }
+            _ => panic!("Expected UnixSocket config"),
+        }
+    }
+
+    #[test]
+    fn test_transport_config_tcp() {
+        let config = TransportConfig::tcp("localhost", 9999);
+        match config {
+            TransportConfig::Tcp { host, port } => {
+                assert_eq!(host, "localhost");
+                assert_eq!(port, 9999);
+            }
+            _ => panic!("Expected Tcp config"),
+        }
+    }
+
+    #[test]
+    fn test_transport_config_tcp_localhost() {
+        let config = TransportConfig::tcp_localhost(8080);
+        match config {
+            TransportConfig::Tcp { host, port } => {
+                assert_eq!(host, "127.0.0.1");
+                assert_eq!(port, 8080);
+            }
+            _ => panic!("Expected Tcp config"),
+        }
+    }
+
+    #[test]
+    fn test_default_port() {
+        assert_eq!(TransportConfig::DEFAULT_PORT, 12521);
+        assert_eq!(TransportConfig::MAX_PORT, 12530);
+    }
+}


### PR DESCRIPTION
Phase 3.5 + 4-6 merged implementation for clean architecture. Types defined in driver, core imports from driver (dependency inversion).

Driver Layer (lib/drivers/net/):
- NetError enum (12 variants) for network operations
- NetDriver trait for RPC server lifecycle management
- TransportListener trait for connection acceptance
- TransportConnection trait for message I/O
- PortAllocator trait for multi-instance support
- TransportConfig enum (Stdio, UnixSocket, TCP)
- JSON-RPC 2.0 types: RpcRequest, RpcResponse, RpcNotification, RpcError
- RpcHandler trait for plugin-based method handlers
- Error code constants (PARSE_ERROR, INVALID_REQUEST, etc.)
- Method/notification name constants for discoverability

Core Migration (lib/core/src/rpc/):
- Re-export types from reovim-driver-net
- Remove local types.rs (now in driver)
- Keep richer RpcHandlerContext (plugin_state, mode_state)
- Keep RpcHandlerRegistry for plugin handler management

Testing:
- 25 unit tests in driver
- All workspace tests pass
- Zero clippy warnings

Closes: #178