### PR TITLE
feat(drivers): implement vfs/ VFS driver traits (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.6: VFS Driver** (Issue #179) - Driver layer Virtual Filesystem traits
+  - `VfsError` enum (12 variants) - Comprehensive filesystem error handling
+    - `NotFound`, `PermissionDenied`, `AlreadyExists` - Common filesystem errors
+    - `NotADirectory`, `NotAFile`, `IsADirectory` - Type mismatch errors
+    - `DirectoryNotEmpty`, `InvalidPath`, `PathTooLong` - Path errors
+    - `ReadOnlyFilesystem`, `NotSupported`, `Io` - System errors
+  - `VfsDriver` trait - Core filesystem operations (Send + Sync)
+    - `read()`, `write()`, `delete()`, `rename()`, `copy()` - File operations
+    - `list_dir()`, `create_dir()`, `create_dir_all()` - Directory operations
+    - `exists()`, `is_file()`, `is_dir()`, `metadata()` - Queries
+    - `canonicalize()`, `read_to_string()`, `write_str()` - Utilities
+    - Complete `std::fs` replacement mapping documented in trait docs
+  - `FileHandle` trait - Streaming file I/O with seek support
+    - `read()`, `write()`, `seek()`, `flush()` - Core operations
+    - `read_exact()`, `read_to_end()`, `write_all()` - Convenience methods
+    - `sync_all()`, `metadata()`, `position()`, `size()` - Extended API
+  - `FileWatcher` trait - File change monitoring (inotify equivalent)
+    - `watch()`, `unwatch()`, `poll_events()`, `has_events()`
+  - `PathNormalizer` trait - Cross-platform path manipulation
+    - `normalize()`, `canonicalize()`, `is_absolute()`, `join()`
+    - `file_name()`, `extension()`, `stem()`, `parent()`
+    - `strip_prefix()`, `relative_to()`, `starts_with()`, `ends_with()`
+    - `StandardPathNormalizer` implementation
+  - `FileMetadata` struct - File information with builder pattern
+    - `file()`, `directory()`, `symlink()` constructors
+    - `with_modified()`, `with_permissions()`, `with_readonly()` builders
+  - `FilePermissions` struct - Unix-style mode bits (0o755, 0o644)
+    - Permission bit constants: `OWNER_READ`, `GROUP_WRITE`, etc.
+    - `is_readable()`, `is_writable()`, `is_executable()` checks
+  - `WatchEvent` enum - File change events
+    - `Created`, `Modified`, `Deleted`, `Renamed`, `MetadataChanged`, `Error`
+  - `OpenOptions` struct - File opening configuration with builders
+  - `SeekFrom` enum - Seek position with `std::io::SeekFrom` conversions
+  - `DirEntry` struct - Directory entry with convenience constructors
+  - 52 unit tests
+
 - **Phase 3.5 + 4-6: Network Driver** (Issue #178) - Driver layer RPC server infrastructure
   - `NetError` enum (12 variants) - Comprehensive network error handling
     - `BindFailed`, `AcceptFailed` - Connection establishment errors

--- a/lib/drivers/vfs/src/error.rs
+++ b/lib/drivers/vfs/src/error.rs
@@ -1,0 +1,148 @@
+//! VFS driver error types.
+//!
+//! Linux equivalent: `include/linux/errno.h` (filesystem errors)
+
+use std::{fmt, path::PathBuf};
+
+/// Errors that can occur during VFS operations.
+#[derive(Debug)]
+pub enum VfsError {
+    /// File or directory not found.
+    NotFound(PathBuf),
+    /// Permission denied.
+    PermissionDenied(PathBuf),
+    /// File or directory already exists.
+    AlreadyExists(PathBuf),
+    /// Expected a directory but found a file.
+    NotADirectory(PathBuf),
+    /// Expected a file but found a directory.
+    NotAFile(PathBuf),
+    /// Cannot perform operation on a directory.
+    IsADirectory(PathBuf),
+    /// Directory is not empty.
+    DirectoryNotEmpty(PathBuf),
+    /// Invalid path format.
+    InvalidPath(String),
+    /// Underlying I/O error.
+    Io(std::io::Error),
+    /// Path is too long.
+    PathTooLong(PathBuf),
+    /// Read-only filesystem.
+    ReadOnlyFilesystem,
+    /// Operation not supported.
+    NotSupported(String),
+}
+
+impl fmt::Display for VfsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(path) => write!(f, "not found: {}", path.display()),
+            Self::PermissionDenied(path) => write!(f, "permission denied: {}", path.display()),
+            Self::AlreadyExists(path) => write!(f, "already exists: {}", path.display()),
+            Self::NotADirectory(path) => write!(f, "not a directory: {}", path.display()),
+            Self::NotAFile(path) => write!(f, "not a file: {}", path.display()),
+            Self::IsADirectory(path) => write!(f, "is a directory: {}", path.display()),
+            Self::DirectoryNotEmpty(path) => write!(f, "directory not empty: {}", path.display()),
+            Self::InvalidPath(msg) => write!(f, "invalid path: {msg}"),
+            Self::Io(err) => write!(f, "I/O error: {err}"),
+            Self::PathTooLong(path) => write!(f, "path too long: {}", path.display()),
+            Self::ReadOnlyFilesystem => write!(f, "read-only filesystem"),
+            Self::NotSupported(msg) => write!(f, "not supported: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for VfsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for VfsError {
+    fn from(err: std::io::Error) -> Self {
+        use std::io::ErrorKind;
+        match err.kind() {
+            ErrorKind::NotFound => Self::NotFound(PathBuf::new()),
+            ErrorKind::PermissionDenied => Self::PermissionDenied(PathBuf::new()),
+            ErrorKind::AlreadyExists => Self::AlreadyExists(PathBuf::new()),
+            _ => Self::Io(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::error::Error};
+
+    #[test]
+    fn test_vfs_error_display() {
+        let path = PathBuf::from("/test/path");
+        assert_eq!(format!("{}", VfsError::NotFound(path.clone())), "not found: /test/path");
+        assert_eq!(
+            format!("{}", VfsError::PermissionDenied(path.clone())),
+            "permission denied: /test/path"
+        );
+        assert_eq!(
+            format!("{}", VfsError::AlreadyExists(path.clone())),
+            "already exists: /test/path"
+        );
+        assert_eq!(
+            format!("{}", VfsError::NotADirectory(path.clone())),
+            "not a directory: /test/path"
+        );
+        assert_eq!(format!("{}", VfsError::NotAFile(path.clone())), "not a file: /test/path");
+        assert_eq!(
+            format!("{}", VfsError::IsADirectory(path.clone())),
+            "is a directory: /test/path"
+        );
+        assert_eq!(
+            format!("{}", VfsError::DirectoryNotEmpty(path.clone())),
+            "directory not empty: /test/path"
+        );
+        assert_eq!(format!("{}", VfsError::InvalidPath("bad".into())), "invalid path: bad");
+        assert_eq!(format!("{}", VfsError::PathTooLong(path)), "path too long: /test/path");
+        assert_eq!(format!("{}", VfsError::ReadOnlyFilesystem), "read-only filesystem");
+        assert_eq!(format!("{}", VfsError::NotSupported("op".into())), "not supported: op");
+    }
+
+    #[test]
+    fn test_from_io_error_not_found() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "test");
+        let vfs_err: VfsError = io_err.into();
+        assert!(matches!(vfs_err, VfsError::NotFound(_)));
+    }
+
+    #[test]
+    fn test_from_io_error_permission_denied() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test");
+        let vfs_err: VfsError = io_err.into();
+        assert!(matches!(vfs_err, VfsError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn test_from_io_error_already_exists() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::AlreadyExists, "test");
+        let vfs_err: VfsError = io_err.into();
+        assert!(matches!(vfs_err, VfsError::AlreadyExists(_)));
+    }
+
+    #[test]
+    fn test_from_io_error_other() {
+        let io_err = std::io::Error::other("test");
+        let vfs_err: VfsError = io_err.into();
+        assert!(matches!(vfs_err, VfsError::Io(_)));
+    }
+
+    #[test]
+    fn test_error_source() {
+        let io_err = std::io::Error::other("test");
+        let vfs_err = VfsError::Io(io_err);
+        assert!(vfs_err.source().is_some());
+
+        let vfs_err = VfsError::NotFound(PathBuf::new());
+        assert!(vfs_err.source().is_none());
+    }
+}

--- a/lib/drivers/vfs/src/lib.rs
+++ b/lib/drivers/vfs/src/lib.rs
@@ -2,12 +2,87 @@
 //!
 //! Linux equivalent: `fs/`
 //!
-//! Provides filesystem abstraction for file operations and watching.
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                         VFS Layer                           │
+//! │                                                             │
+//! │  ┌─────────────────┐  ┌─────────────────┐                   │
+//! │  │   VfsDriver     │  │  PathNormalizer │                   │
+//! │  │ (filesystem     │  │ (path utilities)│                   │
+//! │  │  operations)    │  │                 │                   │
+//! │  └────────┬────────┘  └─────────────────┘                   │
+//! │           │                                                 │
+//! │           ├──────────────────┐                              │
+//! │           │                  │                              │
+//! │           ▼                  ▼                              │
+//! │  ┌─────────────────┐  ┌─────────────────┐                   │
+//! │  │   FileHandle    │  │   FileWatcher   │                   │
+//! │  │ (streaming I/O) │  │ (change events) │                   │
+//! │  └─────────────────┘  └─────────────────┘                   │
+//! │                                                             │
+//! └─────────────────────────────────────────────────────────────┘
+//!                              │
+//!                              │ (implementations in runner/ or plugins/)
+//!                              ▼
+//!              ┌───────────────────────────────┐
+//!              │      Concrete VFS Impls       │
+//!              │  - StandardVfs (std::fs)      │
+//!              │  - RemoteVfs (future)         │
+//!              │  - MemoryVfs (testing)        │
+//!              └───────────────────────────────┘
+//! ```
 //!
 //! # Components
 //!
-//! - Local filesystem operations
-//! - File watcher integration
-//! - Path normalization
+//! - [`VfsDriver`] - Main filesystem operations trait
+//! - [`FileHandle`] - Open file streaming operations
+//! - [`FileWatcher`] - File change monitoring
+//! - [`PathNormalizer`] - Cross-platform path handling
+//! - [`FileMetadata`] - File information
+//! - [`FilePermissions`] - Unix-style permissions
+//! - [`VfsError`] - Error types
+//!
+//! # Migration Note
+//!
+//! This driver is designed to replace ALL `std::fs` usage in the codebase.
+//! When `lib/core` is removed, all filesystem access will go through VFS.
+//!
+//! See the `VfsDriver` trait documentation for the complete replacement mapping.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_vfs::{VfsDriver, OpenOptions, VfsError};
+//! use std::path::Path;
+//!
+//! fn read_file(vfs: &dyn VfsDriver, path: &Path) -> Result<String, VfsError> {
+//!     vfs.read_to_string(path)
+//! }
+//!
+//! fn write_file(vfs: &dyn VfsDriver, path: &Path, content: &str) -> Result<(), VfsError> {
+//!     vfs.write_str(path, content)
+//! }
+//! ```
 
-// Placeholder - VfsDriver trait will be added in Phase 3
+mod error;
+mod metadata;
+mod path;
+mod traits;
+mod watch;
+
+// Re-export error types
+pub use error::VfsError;
+
+// Re-export metadata types
+pub use metadata::{FileMetadata, FilePermissions};
+
+// Re-export path types
+pub use path::{PathNormalizer, StandardPathNormalizer};
+
+// Re-export watch types
+pub use watch::{WatchEvent, WatchHandle, WatchId};
+
+// Re-export traits and related types
+pub use traits::{DirEntry, FileHandle, FileWatcher, OpenOptions, SeekFrom, VfsDriver};

--- a/lib/drivers/vfs/src/metadata.rs
+++ b/lib/drivers/vfs/src/metadata.rs
@@ -1,0 +1,352 @@
+//! File metadata types.
+//!
+//! Linux equivalent: `struct stat`, `struct inode`
+
+use std::time::SystemTime;
+
+/// File metadata information.
+///
+/// Mirrors `std::fs::Metadata` but is VFS-agnostic.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct FileMetadata {
+    /// File size in bytes.
+    pub size: u64,
+    /// Last modification time.
+    pub modified: Option<SystemTime>,
+    /// Creation time (platform-dependent).
+    pub created: Option<SystemTime>,
+    /// Last access time.
+    pub accessed: Option<SystemTime>,
+    /// Whether this is a directory.
+    pub is_dir: bool,
+    /// Whether this is a regular file.
+    pub is_file: bool,
+    /// Whether this is a symbolic link.
+    pub is_symlink: bool,
+    /// Whether the file is read-only.
+    pub is_readonly: bool,
+    /// File permissions.
+    pub permissions: FilePermissions,
+}
+
+impl FileMetadata {
+    /// Create metadata for a regular file.
+    #[must_use]
+    pub const fn file(size: u64) -> Self {
+        Self {
+            size,
+            modified: None,
+            created: None,
+            accessed: None,
+            is_dir: false,
+            is_file: true,
+            is_symlink: false,
+            is_readonly: false,
+            permissions: FilePermissions::default_file(),
+        }
+    }
+
+    /// Create metadata for a directory.
+    #[must_use]
+    pub const fn directory() -> Self {
+        Self {
+            size: 0,
+            modified: None,
+            created: None,
+            accessed: None,
+            is_dir: true,
+            is_file: false,
+            is_symlink: false,
+            is_readonly: false,
+            permissions: FilePermissions::default_dir(),
+        }
+    }
+
+    /// Create metadata for a symbolic link.
+    #[must_use]
+    pub const fn symlink() -> Self {
+        Self {
+            size: 0,
+            modified: None,
+            created: None,
+            accessed: None,
+            is_dir: false,
+            is_file: false,
+            is_symlink: true,
+            is_readonly: false,
+            permissions: FilePermissions::default_file(),
+        }
+    }
+
+    /// Set the modification time.
+    #[must_use]
+    pub const fn with_modified(mut self, time: SystemTime) -> Self {
+        self.modified = Some(time);
+        self
+    }
+
+    /// Set the creation time.
+    #[must_use]
+    pub const fn with_created(mut self, time: SystemTime) -> Self {
+        self.created = Some(time);
+        self
+    }
+
+    /// Set the access time.
+    #[must_use]
+    pub const fn with_accessed(mut self, time: SystemTime) -> Self {
+        self.accessed = Some(time);
+        self
+    }
+
+    /// Set the permissions.
+    #[must_use]
+    pub const fn with_permissions(mut self, permissions: FilePermissions) -> Self {
+        self.permissions = permissions;
+        self
+    }
+
+    /// Set the read-only flag.
+    #[must_use]
+    pub const fn with_readonly(mut self, readonly: bool) -> Self {
+        self.is_readonly = readonly;
+        self
+    }
+}
+
+impl Default for FileMetadata {
+    fn default() -> Self {
+        Self::file(0)
+    }
+}
+
+/// Unix-style file permissions.
+///
+/// Uses standard Unix mode bits (e.g., 0o755, 0o644).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FilePermissions {
+    /// Unix mode bits (e.g., 0o755).
+    mode: u32,
+}
+
+impl FilePermissions {
+    /// Permission bits for owner read.
+    pub const OWNER_READ: u32 = 0o400;
+    /// Permission bits for owner write.
+    pub const OWNER_WRITE: u32 = 0o200;
+    /// Permission bits for owner execute.
+    pub const OWNER_EXEC: u32 = 0o100;
+    /// Permission bits for group read.
+    pub const GROUP_READ: u32 = 0o040;
+    /// Permission bits for group write.
+    pub const GROUP_WRITE: u32 = 0o020;
+    /// Permission bits for group execute.
+    pub const GROUP_EXEC: u32 = 0o010;
+    /// Permission bits for other read.
+    pub const OTHER_READ: u32 = 0o004;
+    /// Permission bits for other write.
+    pub const OTHER_WRITE: u32 = 0o002;
+    /// Permission bits for other execute.
+    pub const OTHER_EXEC: u32 = 0o001;
+
+    /// Create permissions from raw mode bits.
+    #[must_use]
+    pub const fn from_mode(mode: u32) -> Self {
+        Self { mode: mode & 0o777 }
+    }
+
+    /// Get the raw mode bits.
+    #[must_use]
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+
+    /// Default permissions for a new file (0o644).
+    #[must_use]
+    pub const fn default_file() -> Self {
+        Self::from_mode(0o644)
+    }
+
+    /// Default permissions for a new directory (0o755).
+    #[must_use]
+    pub const fn default_dir() -> Self {
+        Self::from_mode(0o755)
+    }
+
+    /// Check if owner can read.
+    #[must_use]
+    pub const fn owner_read(&self) -> bool {
+        self.mode & Self::OWNER_READ != 0
+    }
+
+    /// Check if owner can write.
+    #[must_use]
+    pub const fn owner_write(&self) -> bool {
+        self.mode & Self::OWNER_WRITE != 0
+    }
+
+    /// Check if owner can execute.
+    #[must_use]
+    pub const fn owner_exec(&self) -> bool {
+        self.mode & Self::OWNER_EXEC != 0
+    }
+
+    /// Check if group can read.
+    #[must_use]
+    pub const fn group_read(&self) -> bool {
+        self.mode & Self::GROUP_READ != 0
+    }
+
+    /// Check if group can write.
+    #[must_use]
+    pub const fn group_write(&self) -> bool {
+        self.mode & Self::GROUP_WRITE != 0
+    }
+
+    /// Check if group can execute.
+    #[must_use]
+    pub const fn group_exec(&self) -> bool {
+        self.mode & Self::GROUP_EXEC != 0
+    }
+
+    /// Check if others can read.
+    #[must_use]
+    pub const fn other_read(&self) -> bool {
+        self.mode & Self::OTHER_READ != 0
+    }
+
+    /// Check if others can write.
+    #[must_use]
+    pub const fn other_write(&self) -> bool {
+        self.mode & Self::OTHER_WRITE != 0
+    }
+
+    /// Check if others can execute.
+    #[must_use]
+    pub const fn other_exec(&self) -> bool {
+        self.mode & Self::OTHER_EXEC != 0
+    }
+
+    /// Check if file is readable (owner).
+    #[must_use]
+    pub const fn is_readable(&self) -> bool {
+        self.owner_read()
+    }
+
+    /// Check if file is writable (owner).
+    #[must_use]
+    pub const fn is_writable(&self) -> bool {
+        self.owner_write()
+    }
+
+    /// Check if file is executable (owner).
+    #[must_use]
+    pub const fn is_executable(&self) -> bool {
+        self.owner_exec()
+    }
+}
+
+impl Default for FilePermissions {
+    fn default() -> Self {
+        Self::default_file()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_permissions_mode() {
+        let perms = FilePermissions::from_mode(0o755);
+        assert_eq!(perms.mode(), 0o755);
+        assert!(perms.owner_read());
+        assert!(perms.owner_write());
+        assert!(perms.owner_exec());
+        assert!(perms.group_read());
+        assert!(!perms.group_write());
+        assert!(perms.group_exec());
+        assert!(perms.other_read());
+        assert!(!perms.other_write());
+        assert!(perms.other_exec());
+    }
+
+    #[test]
+    fn test_file_permissions_defaults() {
+        let file_perms = FilePermissions::default_file();
+        assert_eq!(file_perms.mode(), 0o644);
+        assert!(file_perms.is_readable());
+        assert!(file_perms.is_writable());
+        assert!(!file_perms.is_executable());
+
+        let dir_perms = FilePermissions::default_dir();
+        assert_eq!(dir_perms.mode(), 0o755);
+        assert!(dir_perms.is_executable());
+    }
+
+    #[test]
+    fn test_file_permissions_mode_mask() {
+        // Mode should be masked to lower 9 bits
+        let perms = FilePermissions::from_mode(0o7755);
+        assert_eq!(perms.mode(), 0o755);
+    }
+
+    #[test]
+    fn test_file_metadata_file() {
+        let meta = FileMetadata::file(1024);
+        assert!(meta.is_file);
+        assert!(!meta.is_dir);
+        assert!(!meta.is_symlink);
+        assert_eq!(meta.size, 1024);
+        assert!(!meta.is_readonly);
+    }
+
+    #[test]
+    fn test_file_metadata_directory() {
+        let meta = FileMetadata::directory();
+        assert!(meta.is_dir);
+        assert!(!meta.is_file);
+        assert!(!meta.is_symlink);
+        assert_eq!(meta.size, 0);
+    }
+
+    #[test]
+    fn test_file_metadata_symlink() {
+        let meta = FileMetadata::symlink();
+        assert!(meta.is_symlink);
+        assert!(!meta.is_file);
+        assert!(!meta.is_dir);
+    }
+
+    #[test]
+    fn test_file_metadata_builders() {
+        let now = SystemTime::now();
+        let meta = FileMetadata::file(100)
+            .with_modified(now)
+            .with_created(now)
+            .with_accessed(now)
+            .with_permissions(FilePermissions::from_mode(0o755))
+            .with_readonly(true);
+
+        assert_eq!(meta.size, 100);
+        assert_eq!(meta.modified, Some(now));
+        assert_eq!(meta.created, Some(now));
+        assert_eq!(meta.accessed, Some(now));
+        assert_eq!(meta.permissions.mode(), 0o755);
+        assert!(meta.is_readonly);
+    }
+
+    #[test]
+    fn test_file_metadata_default() {
+        let meta = FileMetadata::default();
+        assert!(meta.is_file);
+        assert_eq!(meta.size, 0);
+    }
+
+    #[test]
+    fn test_file_permissions_default() {
+        let perms = FilePermissions::default();
+        assert_eq!(perms.mode(), 0o644);
+    }
+}

--- a/lib/drivers/vfs/src/path.rs
+++ b/lib/drivers/vfs/src/path.rs
@@ -1,0 +1,297 @@
+//! Path utilities and normalization.
+//!
+//! Linux equivalent: `fs/namei.c` (path resolution)
+
+#![allow(clippy::missing_errors_doc)]
+
+use {
+    crate::VfsError,
+    std::{
+        ffi::OsStr,
+        path::{Path, PathBuf},
+    },
+};
+
+/// Path normalization and manipulation.
+///
+/// Handles cross-platform path differences and provides utilities
+/// for working with filesystem paths.
+pub trait PathNormalizer: Send + Sync {
+    /// Normalize a path (resolve `.`, `..`, but not symlinks).
+    ///
+    /// Unlike `canonicalize`, this does not access the filesystem
+    /// and works on paths that may not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let normalizer = StandardPathNormalizer;
+    /// assert_eq!(
+    ///     normalizer.normalize(Path::new("./foo/../bar")),
+    ///     PathBuf::from("bar")
+    /// );
+    /// ```
+    fn normalize(&self, path: &Path) -> PathBuf;
+
+    /// Canonicalize a path (resolve symlinks, make absolute).
+    ///
+    /// This accesses the filesystem and may fail if the path doesn't exist.
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, VfsError>;
+
+    /// Check if a path is absolute.
+    fn is_absolute(&self, path: &Path) -> bool;
+
+    /// Join two paths.
+    ///
+    /// If `relative` is absolute, it replaces `base`.
+    fn join(&self, base: &Path, relative: &Path) -> PathBuf;
+
+    /// Get the parent directory.
+    ///
+    /// Returns `None` for root paths or paths without a parent.
+    fn parent(&self, path: &Path) -> Option<PathBuf>;
+
+    /// Get the file name component.
+    ///
+    /// Returns `None` if the path ends in `..` or is empty.
+    fn file_name<'a>(&self, path: &'a Path) -> Option<&'a OsStr>;
+
+    /// Get the file extension.
+    ///
+    /// Returns `None` if there is no extension.
+    fn extension<'a>(&self, path: &'a Path) -> Option<&'a OsStr>;
+
+    /// Get the file stem (name without extension).
+    ///
+    /// Returns `None` if there is no file name.
+    fn stem<'a>(&self, path: &'a Path) -> Option<&'a OsStr>;
+
+    /// Convert to string (lossy).
+    ///
+    /// Non-UTF-8 sequences are replaced with the replacement character.
+    fn to_string_lossy(&self, path: &Path) -> String {
+        path.to_string_lossy().into_owned()
+    }
+
+    /// Check if a path starts with another path.
+    fn starts_with(&self, path: &Path, prefix: &Path) -> bool {
+        path.starts_with(prefix)
+    }
+
+    /// Check if a path ends with another path.
+    fn ends_with(&self, path: &Path, suffix: &Path) -> bool {
+        path.ends_with(suffix)
+    }
+
+    /// Get the components iterator for a path.
+    fn components<'a>(&self, path: &'a Path) -> std::path::Components<'a> {
+        path.components()
+    }
+
+    /// Strip a prefix from a path.
+    fn strip_prefix(&self, path: &Path, prefix: &Path) -> Option<PathBuf> {
+        path.strip_prefix(prefix).ok().map(Path::to_path_buf)
+    }
+
+    /// Make a path relative to a base.
+    ///
+    /// Returns `None` if `path` is not under `base`.
+    fn relative_to(&self, path: &Path, base: &Path) -> Option<PathBuf> {
+        self.strip_prefix(path, base)
+    }
+}
+
+/// Standard path normalizer using `std::path`.
+///
+/// This is the default implementation that works with local filesystem paths.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StandardPathNormalizer;
+
+impl PathNormalizer for StandardPathNormalizer {
+    fn normalize(&self, path: &Path) -> PathBuf {
+        let mut result = PathBuf::new();
+        for component in path.components() {
+            use std::path::Component;
+            match component {
+                Component::CurDir => {} // Skip `.`
+                Component::ParentDir => {
+                    // Check if last component is a regular path segment (not "..")
+                    let can_pop = result.file_name().is_some_and(|name| name != "..");
+                    if can_pop {
+                        result.pop();
+                    } else {
+                        // Either empty, root, or last component is ".."
+                        // Preserve the ".." for relative paths
+                        result.push(component);
+                    }
+                }
+                c => result.push(c),
+            }
+        }
+        if result.as_os_str().is_empty() {
+            result.push(".");
+        }
+        result
+    }
+
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, VfsError> {
+        std::fs::canonicalize(path).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => VfsError::NotFound(path.to_path_buf()),
+            _ => VfsError::Io(e),
+        })
+    }
+
+    fn is_absolute(&self, path: &Path) -> bool {
+        path.is_absolute()
+    }
+
+    fn join(&self, base: &Path, relative: &Path) -> PathBuf {
+        base.join(relative)
+    }
+
+    fn parent(&self, path: &Path) -> Option<PathBuf> {
+        path.parent().map(Path::to_path_buf)
+    }
+
+    fn file_name<'a>(&self, path: &'a Path) -> Option<&'a OsStr> {
+        path.file_name()
+    }
+
+    fn extension<'a>(&self, path: &'a Path) -> Option<&'a OsStr> {
+        path.extension()
+    }
+
+    fn stem<'a>(&self, path: &'a Path) -> Option<&'a OsStr> {
+        path.file_stem()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_current_dir() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.normalize(Path::new("./foo/bar")), PathBuf::from("foo/bar"));
+        assert_eq!(normalizer.normalize(Path::new("./foo/./bar")), PathBuf::from("foo/bar"));
+    }
+
+    #[test]
+    fn test_normalize_parent_dir() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.normalize(Path::new("foo/../bar")), PathBuf::from("bar"));
+        assert_eq!(normalizer.normalize(Path::new("foo/baz/../bar")), PathBuf::from("foo/bar"));
+    }
+
+    #[test]
+    fn test_normalize_absolute() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.normalize(Path::new("/a/b/../c/./d")), PathBuf::from("/a/c/d"));
+    }
+
+    #[test]
+    fn test_normalize_empty() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.normalize(Path::new("")), PathBuf::from("."));
+        assert_eq!(normalizer.normalize(Path::new(".")), PathBuf::from("."));
+    }
+
+    #[test]
+    fn test_normalize_relative_parent() {
+        let normalizer = StandardPathNormalizer;
+        // Going up from empty should preserve ..
+        assert_eq!(normalizer.normalize(Path::new("../foo")), PathBuf::from("../foo"));
+        assert_eq!(normalizer.normalize(Path::new("../../foo")), PathBuf::from("../../foo"));
+    }
+
+    #[test]
+    fn test_is_absolute() {
+        let normalizer = StandardPathNormalizer;
+        assert!(normalizer.is_absolute(Path::new("/absolute/path")));
+        assert!(!normalizer.is_absolute(Path::new("relative/path")));
+        assert!(!normalizer.is_absolute(Path::new("./relative")));
+    }
+
+    #[test]
+    fn test_join() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(
+            normalizer.join(Path::new("/base"), Path::new("rel")),
+            PathBuf::from("/base/rel")
+        );
+        // Absolute relative replaces base
+        assert_eq!(normalizer.join(Path::new("/base"), Path::new("/abs")), PathBuf::from("/abs"));
+    }
+
+    #[test]
+    fn test_parent() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.parent(Path::new("/foo/bar")), Some(PathBuf::from("/foo")));
+        assert_eq!(normalizer.parent(Path::new("/foo")), Some(PathBuf::from("/")));
+        // Root path has no parent (terminates in root)
+        assert_eq!(normalizer.parent(Path::new("/")), None);
+    }
+
+    #[test]
+    fn test_file_name() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.file_name(Path::new("/foo/bar.txt")), Some(OsStr::new("bar.txt")));
+        assert_eq!(normalizer.file_name(Path::new("/foo/")), Some(OsStr::new("foo")));
+    }
+
+    #[test]
+    fn test_extension() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.extension(Path::new("/foo/bar.txt")), Some(OsStr::new("txt")));
+        assert_eq!(normalizer.extension(Path::new("/foo/bar.tar.gz")), Some(OsStr::new("gz")));
+        assert_eq!(normalizer.extension(Path::new("/foo/bar")), None);
+    }
+
+    #[test]
+    fn test_stem() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.stem(Path::new("/foo/bar.txt")), Some(OsStr::new("bar")));
+        assert_eq!(normalizer.stem(Path::new("/foo/bar.tar.gz")), Some(OsStr::new("bar.tar")));
+    }
+
+    #[test]
+    fn test_to_string_lossy() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(normalizer.to_string_lossy(Path::new("/foo/bar")), "/foo/bar");
+    }
+
+    #[test]
+    fn test_starts_with() {
+        let normalizer = StandardPathNormalizer;
+        assert!(normalizer.starts_with(Path::new("/foo/bar"), Path::new("/foo")));
+        assert!(!normalizer.starts_with(Path::new("/foo/bar"), Path::new("/bar")));
+    }
+
+    #[test]
+    fn test_ends_with() {
+        let normalizer = StandardPathNormalizer;
+        assert!(normalizer.ends_with(Path::new("/foo/bar"), Path::new("bar")));
+        assert!(!normalizer.ends_with(Path::new("/foo/bar"), Path::new("foo")));
+    }
+
+    #[test]
+    fn test_strip_prefix() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(
+            normalizer.strip_prefix(Path::new("/foo/bar/baz"), Path::new("/foo")),
+            Some(PathBuf::from("bar/baz"))
+        );
+        assert_eq!(normalizer.strip_prefix(Path::new("/foo/bar"), Path::new("/other")), None);
+    }
+
+    #[test]
+    fn test_relative_to() {
+        let normalizer = StandardPathNormalizer;
+        assert_eq!(
+            normalizer.relative_to(Path::new("/foo/bar/baz"), Path::new("/foo")),
+            Some(PathBuf::from("bar/baz"))
+        );
+        assert_eq!(normalizer.relative_to(Path::new("/foo/bar"), Path::new("/other")), None);
+    }
+}

--- a/lib/drivers/vfs/src/traits.rs
+++ b/lib/drivers/vfs/src/traits.rs
@@ -1,0 +1,616 @@
+//! VFS driver traits.
+//!
+//! Linux equivalent: `struct file_operations`, `struct inode_operations`
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────┐
+//! │   VfsDriver     │  <-- Main filesystem interface
+//! │ (init, read,    │
+//! │  write, delete) │
+//! └────────┬────────┘
+//!          │
+//!          ├──────────────────┐
+//!          │                  │
+//!          ▼                  ▼
+//! ┌─────────────────┐  ┌─────────────────┐
+//! │   FileHandle    │  │   FileWatcher   │
+//! │ (open file ops) │  │ (change events) │
+//! └─────────────────┘  └─────────────────┘
+//! ```
+//!
+//! # Migration Note
+//!
+//! These traits are designed to replace ALL `std::fs` usage in the codebase.
+//! When `lib/core` is removed, all filesystem access will go through VFS.
+
+#![allow(clippy::missing_errors_doc)]
+
+use {
+    crate::{FileMetadata, VfsError, WatchEvent, WatchHandle},
+    std::path::{Path, PathBuf},
+};
+
+/// Options for opening a file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct OpenOptions {
+    /// Open for reading.
+    pub read: bool,
+    /// Open for writing.
+    pub write: bool,
+    /// Create file if it doesn't exist.
+    pub create: bool,
+    /// Truncate file to zero length.
+    pub truncate: bool,
+    /// Append to file instead of overwriting.
+    pub append: bool,
+}
+
+impl OpenOptions {
+    /// Create a new `OpenOptions` with all flags set to false.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            read: false,
+            write: false,
+            create: false,
+            truncate: false,
+            append: false,
+        }
+    }
+
+    /// Create options for reading only.
+    #[must_use]
+    pub const fn read() -> Self {
+        Self {
+            read: true,
+            write: false,
+            create: false,
+            truncate: false,
+            append: false,
+        }
+    }
+
+    /// Create options for writing (create + truncate).
+    #[must_use]
+    pub const fn write() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: true,
+            truncate: true,
+            append: false,
+        }
+    }
+
+    /// Create options for appending.
+    #[must_use]
+    pub const fn append() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: true,
+            truncate: false,
+            append: true,
+        }
+    }
+
+    /// Create options for read+write.
+    #[must_use]
+    pub const fn read_write() -> Self {
+        Self {
+            read: true,
+            write: true,
+            create: false,
+            truncate: false,
+            append: false,
+        }
+    }
+
+    /// Create options for creating a new file (fails if exists).
+    #[must_use]
+    pub const fn create_new() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: true,
+            truncate: false,
+            append: false,
+        }
+    }
+
+    /// Set the read flag.
+    #[must_use]
+    pub const fn with_read(mut self, read: bool) -> Self {
+        self.read = read;
+        self
+    }
+
+    /// Set the write flag.
+    #[must_use]
+    pub const fn with_write(mut self, write: bool) -> Self {
+        self.write = write;
+        self
+    }
+
+    /// Set the create flag.
+    #[must_use]
+    pub const fn with_create(mut self, create: bool) -> Self {
+        self.create = create;
+        self
+    }
+
+    /// Set the truncate flag.
+    #[must_use]
+    pub const fn with_truncate(mut self, truncate: bool) -> Self {
+        self.truncate = truncate;
+        self
+    }
+
+    /// Set the append flag.
+    #[must_use]
+    pub const fn with_append(mut self, append: bool) -> Self {
+        self.append = append;
+        self
+    }
+}
+
+/// Seek position for file operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekFrom {
+    /// Seek from the start of the file.
+    Start(u64),
+    /// Seek from the end of the file.
+    End(i64),
+    /// Seek from the current position.
+    Current(i64),
+}
+
+impl From<std::io::SeekFrom> for SeekFrom {
+    fn from(seek: std::io::SeekFrom) -> Self {
+        match seek {
+            std::io::SeekFrom::Start(n) => Self::Start(n),
+            std::io::SeekFrom::End(n) => Self::End(n),
+            std::io::SeekFrom::Current(n) => Self::Current(n),
+        }
+    }
+}
+
+impl From<SeekFrom> for std::io::SeekFrom {
+    fn from(seek: SeekFrom) -> Self {
+        match seek {
+            SeekFrom::Start(n) => Self::Start(n),
+            SeekFrom::End(n) => Self::End(n),
+            SeekFrom::Current(n) => Self::Current(n),
+        }
+    }
+}
+
+/// Virtual filesystem driver.
+///
+/// Provides an abstraction over filesystem operations.
+/// Implementations can wrap local fs, remote fs, or virtual fs.
+///
+/// # Replacement Mapping
+///
+/// This trait replaces the following `std::fs` functions:
+///
+/// | std::fs | VfsDriver |
+/// |---------|-----------|
+/// | `read()` | `read()` |
+/// | `read_to_string()` | `read_to_string()` |
+/// | `write()` | `write()`, `write_str()` |
+/// | `remove_file()` | `delete()` |
+/// | `rename()` | `rename()` |
+/// | `copy()` | `copy()` |
+/// | `metadata()` | `metadata()` |
+/// | `symlink_metadata()` | `symlink_metadata()` |
+/// | `canonicalize()` | `canonicalize()` |
+/// | `read_link()` | `read_link()` |
+/// | `read_dir()` | `list_dir()` |
+/// | `create_dir()` | `create_dir()` |
+/// | `create_dir_all()` | `create_dir_all()` |
+/// | `remove_dir()` | `remove_dir()` |
+/// | `remove_dir_all()` | `remove_dir_all()` |
+/// | `File::open()` | `open()` |
+/// | `File::create()` | `open(path, OpenOptions::write())` |
+pub trait VfsDriver: Send + Sync {
+    /// Initialize the VFS driver.
+    fn init(&mut self) -> Result<(), VfsError>;
+
+    /// Shutdown the VFS driver.
+    fn shutdown(&mut self) -> Result<(), VfsError>;
+
+    // ========================================================================
+    // File I/O (replaces std::fs file operations)
+    // ========================================================================
+
+    /// Read entire file contents as bytes.
+    ///
+    /// Replaces: `std::fs::read()`
+    fn read(&self, path: &Path) -> Result<Vec<u8>, VfsError>;
+
+    /// Read entire file contents as string (UTF-8).
+    ///
+    /// Replaces: `std::fs::read_to_string()`
+    fn read_to_string(&self, path: &Path) -> Result<String, VfsError> {
+        let bytes = self.read(path)?;
+        String::from_utf8(bytes).map_err(|e| VfsError::InvalidPath(e.to_string()))
+    }
+
+    /// Write bytes to a file (creates or overwrites).
+    ///
+    /// Replaces: `std::fs::write()`
+    fn write(&self, path: &Path, content: &[u8]) -> Result<(), VfsError>;
+
+    /// Write string to a file (creates or overwrites).
+    ///
+    /// Convenience wrapper for `write()`.
+    fn write_str(&self, path: &Path, content: &str) -> Result<(), VfsError> {
+        self.write(path, content.as_bytes())
+    }
+
+    /// Delete a file.
+    ///
+    /// Replaces: `std::fs::remove_file()`
+    fn delete(&self, path: &Path) -> Result<(), VfsError>;
+
+    /// Rename/move a file or directory.
+    ///
+    /// Replaces: `std::fs::rename()`
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), VfsError>;
+
+    /// Copy a file.
+    ///
+    /// Returns the number of bytes copied.
+    ///
+    /// Replaces: `std::fs::copy()`
+    fn copy(&self, from: &Path, to: &Path) -> Result<u64, VfsError>;
+
+    // ========================================================================
+    // Query Operations
+    // ========================================================================
+
+    /// Check if a path exists.
+    ///
+    /// Replaces: `Path::exists()`
+    fn exists(&self, path: &Path) -> bool;
+
+    /// Get file/directory metadata.
+    ///
+    /// Follows symlinks.
+    ///
+    /// Replaces: `std::fs::metadata()`
+    fn metadata(&self, path: &Path) -> Result<FileMetadata, VfsError>;
+
+    /// Get metadata without following symlinks.
+    ///
+    /// Replaces: `std::fs::symlink_metadata()`
+    fn symlink_metadata(&self, path: &Path) -> Result<FileMetadata, VfsError>;
+
+    /// Canonicalize a path (resolve symlinks, make absolute).
+    ///
+    /// Replaces: `std::fs::canonicalize()`
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, VfsError>;
+
+    /// Read symlink target.
+    ///
+    /// Replaces: `std::fs::read_link()`
+    fn read_link(&self, path: &Path) -> Result<PathBuf, VfsError>;
+
+    // ========================================================================
+    // Directory Operations
+    // ========================================================================
+
+    /// List directory contents.
+    ///
+    /// Replaces: `std::fs::read_dir()`
+    fn list_dir(&self, path: &Path) -> Result<Vec<DirEntry>, VfsError>;
+
+    /// Create a directory.
+    ///
+    /// Replaces: `std::fs::create_dir()`
+    fn create_dir(&self, path: &Path) -> Result<(), VfsError>;
+
+    /// Create a directory and all parent directories.
+    ///
+    /// Replaces: `std::fs::create_dir_all()`
+    fn create_dir_all(&self, path: &Path) -> Result<(), VfsError>;
+
+    /// Remove an empty directory.
+    ///
+    /// Replaces: `std::fs::remove_dir()`
+    fn remove_dir(&self, path: &Path) -> Result<(), VfsError>;
+
+    /// Remove a directory and all its contents.
+    ///
+    /// Replaces: `std::fs::remove_dir_all()`
+    fn remove_dir_all(&self, path: &Path) -> Result<(), VfsError>;
+
+    // ========================================================================
+    // File Handle Operations
+    // ========================================================================
+
+    /// Open a file with specified options.
+    ///
+    /// Replaces: `std::fs::File::open()`, `std::fs::File::create()`
+    fn open(&self, path: &Path, options: OpenOptions) -> Result<Box<dyn FileHandle>, VfsError>;
+}
+
+/// Directory entry from `list_dir`.
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    /// Entry path (full path).
+    pub path: PathBuf,
+    /// Entry name (file name only).
+    pub name: String,
+    /// Whether this is a directory.
+    pub is_dir: bool,
+    /// Whether this is a file.
+    pub is_file: bool,
+    /// Whether this is a symlink.
+    pub is_symlink: bool,
+}
+
+impl DirEntry {
+    /// Create a new directory entry.
+    #[must_use]
+    pub fn new(path: PathBuf, is_dir: bool, is_file: bool, is_symlink: bool) -> Self {
+        let name = path
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        Self {
+            path,
+            name,
+            is_dir,
+            is_file,
+            is_symlink,
+        }
+    }
+
+    /// Create a directory entry for a file.
+    #[must_use]
+    pub fn file(path: PathBuf) -> Self {
+        Self::new(path, false, true, false)
+    }
+
+    /// Create a directory entry for a directory.
+    #[must_use]
+    pub fn directory(path: PathBuf) -> Self {
+        Self::new(path, true, false, false)
+    }
+
+    /// Create a directory entry for a symlink.
+    #[must_use]
+    pub fn symlink(path: PathBuf) -> Self {
+        Self::new(path, false, false, true)
+    }
+}
+
+/// Handle to an open file.
+///
+/// Provides streaming read/write operations for efficient I/O
+/// on large files.
+///
+/// Replaces: `std::fs::File`
+pub trait FileHandle: Send + Sync {
+    /// Read bytes into buffer, returns number of bytes read.
+    ///
+    /// Returns 0 when EOF is reached.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, VfsError>;
+
+    /// Read exact number of bytes.
+    ///
+    /// Returns error if not enough bytes available.
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), VfsError> {
+        let mut total = 0;
+        while total < buf.len() {
+            match self.read(&mut buf[total..])? {
+                0 => {
+                    return Err(VfsError::Io(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "unexpected end of file",
+                    )));
+                }
+                n => total += n,
+            }
+        }
+        Ok(())
+    }
+
+    /// Read all remaining bytes into a vector.
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize, VfsError> {
+        let mut total = 0;
+        let mut chunk = [0u8; 8192];
+        loop {
+            match self.read(&mut chunk)? {
+                0 => break,
+                n => {
+                    buf.extend_from_slice(&chunk[..n]);
+                    total += n;
+                }
+            }
+        }
+        Ok(total)
+    }
+
+    /// Write bytes from buffer, returns number of bytes written.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, VfsError>;
+
+    /// Write all bytes from buffer.
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), VfsError> {
+        let mut total = 0;
+        while total < buf.len() {
+            total += self.write(&buf[total..])?;
+        }
+        Ok(())
+    }
+
+    /// Seek to a position in the file.
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, VfsError>;
+
+    /// Flush pending writes to storage.
+    fn flush(&mut self) -> Result<(), VfsError>;
+
+    /// Sync all data and metadata to storage.
+    fn sync_all(&mut self) -> Result<(), VfsError> {
+        self.flush()
+    }
+
+    /// Get file metadata.
+    fn metadata(&self) -> Result<FileMetadata, VfsError>;
+
+    /// Get the file path.
+    fn path(&self) -> &Path;
+
+    /// Get current position in file.
+    fn position(&self) -> u64;
+
+    /// Get the file size.
+    fn size(&self) -> Result<u64, VfsError> {
+        self.metadata().map(|m| m.size)
+    }
+}
+
+/// File watcher for monitoring filesystem changes.
+///
+/// Provides a platform-independent interface for watching
+/// files and directories for changes.
+pub trait FileWatcher: Send + Sync {
+    /// Watch a path for changes.
+    ///
+    /// If `recursive` is true and path is a directory,
+    /// watch all subdirectories as well.
+    fn watch(&mut self, path: &Path, recursive: bool) -> Result<WatchHandle, VfsError>;
+
+    /// Stop watching a path.
+    fn unwatch(&mut self, handle: WatchHandle) -> Result<(), VfsError>;
+
+    /// Poll for pending events (non-blocking).
+    ///
+    /// Returns all events that have occurred since the last poll.
+    fn poll_events(&mut self) -> Vec<WatchEvent>;
+
+    /// Check if there are pending events.
+    fn has_events(&self) -> bool;
+
+    /// Get the number of active watches.
+    fn watch_count(&self) -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_open_options_new() {
+        let opts = OpenOptions::new();
+        assert!(!opts.read);
+        assert!(!opts.write);
+        assert!(!opts.create);
+        assert!(!opts.truncate);
+        assert!(!opts.append);
+    }
+
+    #[test]
+    fn test_open_options_read() {
+        let opts = OpenOptions::read();
+        assert!(opts.read);
+        assert!(!opts.write);
+        assert!(!opts.create);
+    }
+
+    #[test]
+    fn test_open_options_write() {
+        let opts = OpenOptions::write();
+        assert!(!opts.read);
+        assert!(opts.write);
+        assert!(opts.create);
+        assert!(opts.truncate);
+        assert!(!opts.append);
+    }
+
+    #[test]
+    fn test_open_options_append() {
+        let opts = OpenOptions::append();
+        assert!(!opts.read);
+        assert!(opts.write);
+        assert!(opts.create);
+        assert!(!opts.truncate);
+        assert!(opts.append);
+    }
+
+    #[test]
+    fn test_open_options_read_write() {
+        let opts = OpenOptions::read_write();
+        assert!(opts.read);
+        assert!(opts.write);
+        assert!(!opts.create);
+        assert!(!opts.truncate);
+    }
+
+    #[test]
+    fn test_open_options_builders() {
+        let opts = OpenOptions::new()
+            .with_read(true)
+            .with_write(true)
+            .with_create(true);
+        assert!(opts.read);
+        assert!(opts.write);
+        assert!(opts.create);
+    }
+
+    #[test]
+    fn test_seek_from_conversion() {
+        let start = SeekFrom::Start(100);
+        let std_start: std::io::SeekFrom = start.into();
+        assert!(matches!(std_start, std::io::SeekFrom::Start(100)));
+
+        let end = SeekFrom::End(-50);
+        let std_end: std::io::SeekFrom = end.into();
+        assert!(matches!(std_end, std::io::SeekFrom::End(-50)));
+
+        let current = SeekFrom::Current(25);
+        let std_current: std::io::SeekFrom = current.into();
+        assert!(matches!(std_current, std::io::SeekFrom::Current(25)));
+
+        // Reverse conversion
+        let back: SeekFrom = std::io::SeekFrom::Start(200).into();
+        assert!(matches!(back, SeekFrom::Start(200)));
+    }
+
+    #[test]
+    fn test_dir_entry_new() {
+        let entry = DirEntry::new(PathBuf::from("/test/file.txt"), false, true, false);
+        assert_eq!(entry.name, "file.txt");
+        assert_eq!(entry.path, PathBuf::from("/test/file.txt"));
+        assert!(entry.is_file);
+        assert!(!entry.is_dir);
+        assert!(!entry.is_symlink);
+    }
+
+    #[test]
+    fn test_dir_entry_file() {
+        let entry = DirEntry::file(PathBuf::from("/test/doc.txt"));
+        assert!(entry.is_file);
+        assert!(!entry.is_dir);
+    }
+
+    #[test]
+    fn test_dir_entry_directory() {
+        let entry = DirEntry::directory(PathBuf::from("/test/subdir"));
+        assert!(entry.is_dir);
+        assert!(!entry.is_file);
+    }
+
+    #[test]
+    fn test_dir_entry_symlink() {
+        let entry = DirEntry::symlink(PathBuf::from("/test/link"));
+        assert!(entry.is_symlink);
+        assert!(!entry.is_file);
+        assert!(!entry.is_dir);
+    }
+}

--- a/lib/drivers/vfs/src/watch.rs
+++ b/lib/drivers/vfs/src/watch.rs
@@ -1,0 +1,251 @@
+//! File watching types.
+//!
+//! Linux equivalent: `inotify`, `fsnotify`
+
+use std::path::PathBuf;
+
+/// Unique identifier for a watch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WatchId(u64);
+
+impl WatchId {
+    /// Create a new watch ID.
+    #[must_use]
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Get the raw ID value.
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for WatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WatchId({})", self.0)
+    }
+}
+
+/// Handle to a registered file watch.
+///
+/// Represents an active watch on a path. The watch remains active
+/// until explicitly unwatched via `FileWatcher::unwatch()`.
+#[derive(Debug)]
+pub struct WatchHandle {
+    id: WatchId,
+    path: PathBuf,
+}
+
+impl WatchHandle {
+    /// Create a new watch handle.
+    #[must_use]
+    pub const fn new(id: WatchId, path: PathBuf) -> Self {
+        Self { id, path }
+    }
+
+    /// Get the watch ID.
+    #[must_use]
+    pub const fn id(&self) -> WatchId {
+        self.id
+    }
+
+    /// Get the watched path.
+    #[must_use]
+    pub const fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+/// File system event.
+///
+/// Emitted when watched files or directories change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchEvent {
+    /// A new file or directory was created.
+    Created(PathBuf),
+    /// An existing file was modified.
+    Modified(PathBuf),
+    /// A file or directory was deleted.
+    Deleted(PathBuf),
+    /// A file or directory was renamed.
+    Renamed {
+        /// Original path.
+        from: PathBuf,
+        /// New path.
+        to: PathBuf,
+    },
+    /// File metadata changed (permissions, timestamps).
+    MetadataChanged(PathBuf),
+    /// Watch error occurred.
+    Error {
+        /// Path that caused the error (if known).
+        path: Option<PathBuf>,
+        /// Error description.
+        message: String,
+    },
+}
+
+impl WatchEvent {
+    /// Get the primary path affected by this event.
+    #[must_use]
+    pub const fn path(&self) -> Option<&PathBuf> {
+        match self {
+            Self::Created(p) | Self::Modified(p) | Self::Deleted(p) | Self::MetadataChanged(p) => {
+                Some(p)
+            }
+            Self::Renamed { to, .. } => Some(to),
+            Self::Error { path, .. } => path.as_ref(),
+        }
+    }
+
+    /// Check if this is an error event.
+    #[must_use]
+    pub const fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+
+    /// Check if this event indicates a file/directory was created.
+    #[must_use]
+    pub const fn is_created(&self) -> bool {
+        matches!(self, Self::Created(_))
+    }
+
+    /// Check if this event indicates a file was modified.
+    #[must_use]
+    pub const fn is_modified(&self) -> bool {
+        matches!(self, Self::Modified(_))
+    }
+
+    /// Check if this event indicates a file/directory was deleted.
+    #[must_use]
+    pub const fn is_deleted(&self) -> bool {
+        matches!(self, Self::Deleted(_))
+    }
+
+    /// Check if this event indicates a rename.
+    #[must_use]
+    pub const fn is_renamed(&self) -> bool {
+        matches!(self, Self::Renamed { .. })
+    }
+
+    /// Check if this event indicates metadata changed.
+    #[must_use]
+    pub const fn is_metadata_changed(&self) -> bool {
+        matches!(self, Self::MetadataChanged(_))
+    }
+}
+
+impl std::fmt::Display for WatchEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Created(p) => write!(f, "created: {}", p.display()),
+            Self::Modified(p) => write!(f, "modified: {}", p.display()),
+            Self::Deleted(p) => write!(f, "deleted: {}", p.display()),
+            Self::Renamed { from, to } => {
+                write!(f, "renamed: {} -> {}", from.display(), to.display())
+            }
+            Self::MetadataChanged(p) => write!(f, "metadata changed: {}", p.display()),
+            Self::Error { path, message } => {
+                if let Some(p) = path {
+                    write!(f, "error at {}: {message}", p.display())
+                } else {
+                    write!(f, "error: {message}")
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_watch_id() {
+        let id = WatchId::new(42);
+        assert_eq!(id.as_u64(), 42);
+        assert_eq!(format!("{id}"), "WatchId(42)");
+    }
+
+    #[test]
+    fn test_watch_id_equality() {
+        let id1 = WatchId::new(1);
+        let id2 = WatchId::new(1);
+        let id3 = WatchId::new(2);
+        assert_eq!(id1, id2);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn test_watch_handle() {
+        let handle = WatchHandle::new(WatchId::new(1), PathBuf::from("/test"));
+        assert_eq!(handle.id().as_u64(), 1);
+        assert_eq!(handle.path(), &PathBuf::from("/test"));
+    }
+
+    #[test]
+    fn test_watch_event_created() {
+        let event = WatchEvent::Created(PathBuf::from("/new"));
+        assert_eq!(event.path(), Some(&PathBuf::from("/new")));
+        assert!(event.is_created());
+        assert!(!event.is_modified());
+        assert!(!event.is_error());
+        assert_eq!(format!("{event}"), "created: /new");
+    }
+
+    #[test]
+    fn test_watch_event_modified() {
+        let event = WatchEvent::Modified(PathBuf::from("/file"));
+        assert!(event.is_modified());
+        assert_eq!(format!("{event}"), "modified: /file");
+    }
+
+    #[test]
+    fn test_watch_event_deleted() {
+        let event = WatchEvent::Deleted(PathBuf::from("/old"));
+        assert!(event.is_deleted());
+        assert_eq!(format!("{event}"), "deleted: /old");
+    }
+
+    #[test]
+    fn test_watch_event_renamed() {
+        let event = WatchEvent::Renamed {
+            from: PathBuf::from("/old"),
+            to: PathBuf::from("/new"),
+        };
+        assert_eq!(event.path(), Some(&PathBuf::from("/new")));
+        assert!(event.is_renamed());
+        assert_eq!(format!("{event}"), "renamed: /old -> /new");
+    }
+
+    #[test]
+    fn test_watch_event_metadata_changed() {
+        let event = WatchEvent::MetadataChanged(PathBuf::from("/file"));
+        assert!(event.is_metadata_changed());
+        assert_eq!(format!("{event}"), "metadata changed: /file");
+    }
+
+    #[test]
+    fn test_watch_event_error_with_path() {
+        let event = WatchEvent::Error {
+            path: Some(PathBuf::from("/bad")),
+            message: "failed".to_string(),
+        };
+        assert!(event.is_error());
+        assert_eq!(event.path(), Some(&PathBuf::from("/bad")));
+        assert_eq!(format!("{event}"), "error at /bad: failed");
+    }
+
+    #[test]
+    fn test_watch_event_error_without_path() {
+        let event = WatchEvent::Error {
+            path: None,
+            message: "unknown error".to_string(),
+        };
+        assert!(event.is_error());
+        assert_eq!(event.path(), None);
+        assert_eq!(format!("{event}"), "error: unknown error");
+    }
+}


### PR DESCRIPTION
Implement complete VFS (Virtual Filesystem) driver traits for the clean architecture migration. This provides the abstraction layer to replace ALL std::fs usage when lib/core is removed.

Components:
- VfsDriver trait: Core filesystem operations (read, write, delete, rename, copy, list_dir, create_dir, metadata, canonicalize)
- FileHandle trait: Streaming file I/O with seek support
- FileWatcher trait: File change monitoring (inotify equivalent)
- PathNormalizer trait: Cross-platform path manipulation
- FileMetadata: File information (size, timestamps, permissions)
- FilePermissions: Unix-style mode bits (0o755, 0o644)
- VfsError: Comprehensive error types (12 variants)
- WatchEvent: File change events (Created, Modified, Deleted, etc.)

Key design decisions:
- All traits are Send + Sync for thread-safe implementations
- Explicit lifetime parameters on path methods for zero-copy ops
- Smart path normalization handles consecutive .. correctly
- Complete std::fs -> VfsDriver replacement mapping in docs

Test coverage: 52 unit tests covering all major functionality.

Linux equivalents documented:
- VFS layer -> fs/
- VfsDriver -> struct file_operations, struct inode_operations
- FileMetadata -> struct stat, struct inode
- FileWatcher -> inotify, fsnotify
- PathNormalizer -> fs/namei.c
- VfsError -> include/linux/errno.h

Closes: #179