### PR TITLE
feat(drivers): implement log/ Logger driver using tracing (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Phase 3.7: Log Driver** (Issue #180) - Driver layer Logger implementation
+  - `TracingLogger` struct - Implements kernel `Logger` trait
+    - Zero-sized type (ZST) - all state in global tracing subscriber
+    - Maps kernel `Record` to tracing events with metadata (module_path, file, line)
+    - Efficient `enabled()` check before message formatting
+    - Send + Sync for thread-safe logging
+  - `LogConfig` struct - Logging configuration with defaults
+    - `level` - Minimum log level (default: Info)
+    - `output` - Where logs go (Stderr, Stdout, File)
+    - `format` - Message format (Plain, Json, Pretty)
+    - `file_path` - File path for File output
+    - `rotation` - File rotation policy (Never, Daily, Hourly)
+  - `LogOutput` enum - Output destination selection
+    - `Stderr` (default), `Stdout`, `File`
+  - `LogFormat` enum - Message formatting options
+    - `Plain` - Standard `[LEVEL] file:line message` format
+    - `Json` - Structured JSON output for log aggregation
+    - `Pretty` - Colorized terminal output for development
+  - `RotationPolicy` enum - Log file rotation
+    - `Never`, `Daily`, `Hourly`
+  - `init_logging()` function - Tracing subscriber setup
+    - REOVIM_LOG environment variable support (takes precedence)
+    - Non-blocking file writes via `tracing-appender`
+    - ANSI color control for terminal vs file output
+  - `LogError` enum - Initialization error handling
+    - `MissingFilePath`, `InvalidFilter`, `SetGlobalDefault`, `Io`
+  - Level mapping utilities: `to_tracing_level()`, `from_tracing_level()`
+  - Re-exports kernel types: `Level`, `Logger`, `set_logger`
+  - 19 unit tests
+
 - **Phase 3.6: VFS Driver** (Issue #179) - Driver layer Virtual Filesystem traits
   - `VfsError` enum (12 variants) - Comprehensive filesystem error handling
     - `NotFound`, `PermissionDenied`, `AlreadyExists` - Common filesystem errors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "reovim-driver-log"
+version = "0.9.0-dev"
+dependencies = [
+ "reovim-kernel",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "reovim-driver-lsp"
 version = "0.9.0-dev"
 dependencies = [
@@ -2509,6 +2519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2538,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -2525,6 +2547,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "lib/drivers/lsp",
     "lib/drivers/net",
     "lib/drivers/vfs",
+    "lib/drivers/log",
 
     # Runner and tools
     "runner/",
@@ -87,6 +88,7 @@ reovim-driver-syntax = { path = "./lib/drivers/syntax", version = "0.9.0-dev" }
 reovim-driver-lsp = { path = "./lib/drivers/lsp", version = "0.9.0-dev" }
 reovim-driver-net = { path = "./lib/drivers/net", version = "0.9.0-dev" }
 reovim-driver-vfs = { path = "./lib/drivers/vfs", version = "0.9.0-dev" }
+reovim-driver-log = { path = "./lib/drivers/log", version = "0.9.0-dev" }
 
 # plugins
 reovim-plugin-range-finder = { path = "./plugins/features/range-finder", version = "0.8.1" }

--- a/lib/drivers/log/Cargo.toml
+++ b/lib/drivers/log/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "reovim-driver-log"
+version = "0.9.0-dev"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Logging driver for reovim (bridges kernel printk to tracing)"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Kernel layer (Logger trait)
+reovim-kernel = { path = "../../kernel", version = "0.9.0-dev" }
+
+# Tracing ecosystem
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json", "time"] }
+tracing-appender = "0.2"

--- a/lib/drivers/log/src/config.rs
+++ b/lib/drivers/log/src/config.rs
@@ -1,0 +1,202 @@
+//! Logging configuration types.
+//!
+//! These types define the **policy** for logging: where logs go,
+//! how they're formatted, and when files rotate.
+//!
+//! Following Linux kernel "mechanism vs policy":
+//! - Kernel provides mechanism (`Logger` trait)
+//! - This driver provides policy (output, format, rotation)
+
+use std::path::PathBuf;
+
+use reovim_kernel::api::v1::Level;
+
+/// Configuration for the logging driver.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_log::{LogConfig, LogOutput, LogFormat};
+///
+/// let config = LogConfig {
+///     level: reovim_driver_log::Level::Debug,
+///     output: LogOutput::Stderr,
+///     format: LogFormat::Pretty,
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct LogConfig {
+    /// Minimum log level to emit.
+    ///
+    /// Messages below this level will be filtered out.
+    /// Can be overridden by `REOVIM_LOG` environment variable.
+    pub level: Level,
+
+    /// Where to send log output.
+    pub output: LogOutput,
+
+    /// Log message format.
+    pub format: LogFormat,
+
+    /// File path (required when output is `File`).
+    pub file_path: Option<PathBuf>,
+
+    /// Log file rotation policy (only used when output is `File`).
+    pub rotation: RotationPolicy,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            level: Level::Info,
+            output: LogOutput::Stderr,
+            format: LogFormat::Plain,
+            file_path: None,
+            rotation: RotationPolicy::Never,
+        }
+    }
+}
+
+/// Log output destination.
+///
+/// Determines where log messages are written.
+#[derive(Debug, Clone, Default)]
+pub enum LogOutput {
+    /// Write to stderr (default).
+    ///
+    /// This is the standard destination for log output,
+    /// keeping stdout free for program output.
+    #[default]
+    Stderr,
+
+    /// Write to stdout.
+    ///
+    /// Use when logs should go to standard output
+    /// (e.g., for piping to other programs).
+    Stdout,
+
+    /// Write to file.
+    ///
+    /// Requires `file_path` to be set in `LogConfig`.
+    /// Supports rotation via `RotationPolicy`.
+    File,
+}
+
+/// Log message format.
+///
+/// Controls how log messages are formatted in output.
+#[derive(Debug, Clone, Default)]
+pub enum LogFormat {
+    /// Plain text format.
+    ///
+    /// Output: `2024-01-15T10:30:00Z INFO file.rs:42 message`
+    #[default]
+    Plain,
+
+    /// JSON structured format.
+    ///
+    /// Each log entry is a JSON object with fields:
+    /// `timestamp`, `level`, `target`, `file`, `line`, `message`
+    ///
+    /// Useful for log aggregation systems.
+    Json,
+
+    /// Pretty formatted with colors (for terminal).
+    ///
+    /// Human-readable format with ANSI colors for levels.
+    /// Best for development and debugging.
+    Pretty,
+}
+
+/// Log file rotation policy.
+///
+/// Controls when log files are rotated (new file created).
+/// Only applicable when `LogOutput::File` is used.
+#[derive(Debug, Clone, Default)]
+pub enum RotationPolicy {
+    /// Never rotate - single log file.
+    #[default]
+    Never,
+
+    /// Rotate daily at midnight (UTC).
+    ///
+    /// Creates files like: `reovim.2024-01-15.log`
+    Daily,
+
+    /// Rotate hourly.
+    ///
+    /// Creates files like: `reovim.2024-01-15-10.log`
+    Hourly,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_config_default() {
+        let config = LogConfig::default();
+        assert_eq!(config.level, Level::Info);
+        assert!(matches!(config.output, LogOutput::Stderr));
+        assert!(matches!(config.format, LogFormat::Plain));
+        assert!(config.file_path.is_none());
+        assert!(matches!(config.rotation, RotationPolicy::Never));
+    }
+
+    #[test]
+    fn test_log_config_custom() {
+        let config = LogConfig {
+            level: Level::Debug,
+            output: LogOutput::File,
+            format: LogFormat::Json,
+            file_path: Some(PathBuf::from("/tmp/reovim.log")),
+            rotation: RotationPolicy::Daily,
+        };
+
+        assert_eq!(config.level, Level::Debug);
+        assert!(matches!(config.output, LogOutput::File));
+        assert!(matches!(config.format, LogFormat::Json));
+        assert_eq!(config.file_path, Some(PathBuf::from("/tmp/reovim.log")));
+        assert!(matches!(config.rotation, RotationPolicy::Daily));
+    }
+
+    #[test]
+    fn test_log_output_default() {
+        let output = LogOutput::default();
+        assert!(matches!(output, LogOutput::Stderr));
+    }
+
+    #[test]
+    fn test_log_format_default() {
+        let format = LogFormat::default();
+        assert!(matches!(format, LogFormat::Plain));
+    }
+
+    #[test]
+    fn test_rotation_policy_default() {
+        let rotation = RotationPolicy::default();
+        assert!(matches!(rotation, RotationPolicy::Never));
+    }
+
+    #[test]
+    fn test_log_config_clone() {
+        let config = LogConfig {
+            level: Level::Warn,
+            output: LogOutput::Stdout,
+            format: LogFormat::Pretty,
+            file_path: None,
+            rotation: RotationPolicy::Hourly,
+        };
+
+        // Clone and consume original to verify Clone actually works
+        let cloned = config.clone();
+        drop(config);
+
+        // Verify cloned values
+        assert_eq!(cloned.level, Level::Warn);
+        assert!(matches!(cloned.output, LogOutput::Stdout));
+        assert!(matches!(cloned.format, LogFormat::Pretty));
+        assert!(matches!(cloned.rotation, RotationPolicy::Hourly));
+    }
+}

--- a/lib/drivers/log/src/lib.rs
+++ b/lib/drivers/log/src/lib.rs
@@ -1,0 +1,93 @@
+//! Logging driver for reovim.
+//!
+//! This driver implements the kernel's `Logger` trait using the tracing ecosystem.
+//! It bridges kernel `pr_*!` macros to tracing subscribers.
+//!
+//! # Architecture
+//!
+//! Following Linux kernel design (mechanism vs policy):
+//! - **Kernel provides mechanism**: `Logger` trait, `Level`, `Record`, `pr_*!` macros
+//! - **This driver provides policy**: Where logs go, formatting, filtering
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                         User Code                                │
+//! │   pr_info!("buffer {} opened", id);                              │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!                               ▼
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                     Kernel (printk/)                             │
+//! │   Level │ Record │ Logger trait │ Global OnceLock                │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!                               ▼
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                 Driver (drivers/log/)                            │
+//! │   TracingLogger │ LogConfig │ init_logging()                     │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!                               ▼
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                     tracing ecosystem                            │
+//! │   tracing │ tracing-subscriber │ tracing-appender                │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use reovim_driver_log::{TracingLogger, init_logging, LogConfig};
+//! use reovim_kernel::api::v1::set_logger;
+//!
+//! // Step 1: Initialize tracing subscriber
+//! let config = LogConfig::default();
+//! init_logging(&config)?;
+//!
+//! // Step 2: Set TracingLogger as global kernel logger
+//! static LOGGER: TracingLogger = TracingLogger;
+//! set_logger(&LOGGER)?;
+//!
+//! // Step 3: Now pr_*! macros route to tracing
+//! pr_info!("editor started");
+//! pr_debug!("buffer count: {}", 5);
+//! ```
+//!
+//! # Environment Variable
+//!
+//! Set `REOVIM_LOG` to control log level (overrides `LogConfig.level`):
+//!
+//! ```bash
+//! REOVIM_LOG=debug reovim myfile.txt
+//! REOVIM_LOG=trace reovim --log=- myfile.txt
+//! REOVIM_LOG=reovim_kernel=trace,warn reovim myfile.txt  # Fine-grained control
+//! ```
+//!
+//! # Output Formats
+//!
+//! - **Plain**: `2024-01-15T10:30:00Z INFO file.rs:42 message`
+//! - **JSON**: `{"timestamp":"...","level":"INFO","target":"...","message":"..."}`
+//! - **Pretty**: Colorized output for terminal (development)
+//!
+//! # File Rotation
+//!
+//! When using `LogOutput::File`, log files can be rotated:
+//! - `RotationPolicy::Never` - Single file
+//! - `RotationPolicy::Daily` - Rotate at midnight UTC
+//! - `RotationPolicy::Hourly` - Rotate every hour
+
+mod config;
+mod logger;
+mod subscriber;
+
+// Configuration types
+pub use config::{LogConfig, LogFormat, LogOutput, RotationPolicy};
+
+// Logger implementation
+pub use logger::{TracingLogger, from_tracing_level, to_tracing_level};
+
+// Subscriber setup
+pub use subscriber::{LogError, init_logging};
+
+// Re-export kernel types for convenience
+pub use reovim_kernel::api::v1::{Level, Logger, set_logger};

--- a/lib/drivers/log/src/logger.rs
+++ b/lib/drivers/log/src/logger.rs
@@ -1,0 +1,210 @@
+//! `TracingLogger` - bridges kernel `Logger` trait to tracing.
+//!
+//! This is the core of the driver: it receives `Record` from kernel
+//! and emits tracing events to whatever subscriber is configured.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Kernel                           Driver
+//! ┌─────────────┐                  ┌─────────────────┐
+//! │ pr_info!()  │ ──Record──────▶ │ TracingLogger   │
+//! │             │                  │   .log()        │
+//! └─────────────┘                  └────────┬────────┘
+//!                                           │
+//!                                           ▼
+//!                                  ┌─────────────────┐
+//!                                  │ tracing::info!  │
+//!                                  │ (subscriber)    │
+//!                                  └─────────────────┘
+//! ```
+
+use reovim_kernel::api::v1::{Level, Logger, Record};
+
+/// Logger implementation that forwards to tracing.
+///
+/// This is a zero-sized type (ZST) - all state lives in the global
+/// tracing subscriber. This allows `TracingLogger` to be a static.
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_log::TracingLogger;
+/// use reovim_kernel::api::v1::set_logger;
+///
+/// static LOGGER: TracingLogger = TracingLogger;
+///
+/// // In main(), after init_logging():
+/// // set_logger(&LOGGER).expect("logger already set");
+/// ```
+///
+/// # Thread Safety
+///
+/// `TracingLogger` is `Send + Sync` as required by the `Logger` trait.
+/// Since it's a ZST with no state, it's inherently thread-safe.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TracingLogger;
+
+impl Logger for TracingLogger {
+    fn log(&self, record: &Record) {
+        // Emit tracing event with all metadata from kernel Record.
+        // Note: `target:` in tracing macros must be a compile-time constant,
+        // so we include module_path as a regular field instead.
+        match record.level() {
+            Level::Error => tracing::error!(
+                module_path = record.module_path(),
+                file = record.file(),
+                line = record.line(),
+                "{}",
+                record.message()
+            ),
+            Level::Warn => tracing::warn!(
+                module_path = record.module_path(),
+                file = record.file(),
+                line = record.line(),
+                "{}",
+                record.message()
+            ),
+            Level::Info => tracing::info!(
+                module_path = record.module_path(),
+                file = record.file(),
+                line = record.line(),
+                "{}",
+                record.message()
+            ),
+            Level::Debug => tracing::debug!(
+                module_path = record.module_path(),
+                file = record.file(),
+                line = record.line(),
+                "{}",
+                record.message()
+            ),
+            Level::Trace => tracing::trace!(
+                module_path = record.module_path(),
+                file = record.file(),
+                line = record.line(),
+                "{}",
+                record.message()
+            ),
+        }
+    }
+
+    fn flush(&self) {
+        // tracing-subscriber handles flushing automatically.
+        // For file output, tracing-appender flushes on drop.
+        // This is a no-op for TracingLogger.
+    }
+
+    fn enabled(&self, level: Level) -> bool {
+        // This is called BEFORE message formatting - must be fast.
+        // We check if the tracing subscriber would accept this level.
+        match level {
+            Level::Error => tracing::enabled!(tracing::Level::ERROR),
+            Level::Warn => tracing::enabled!(tracing::Level::WARN),
+            Level::Info => tracing::enabled!(tracing::Level::INFO),
+            Level::Debug => tracing::enabled!(tracing::Level::DEBUG),
+            Level::Trace => tracing::enabled!(tracing::Level::TRACE),
+        }
+    }
+}
+
+/// Convert kernel `Level` to tracing `Level`.
+///
+/// The mapping is 1:1 - kernel levels were designed to match tracing levels.
+///
+/// | Kernel | tracing |
+/// |--------|---------|
+/// | Error  | ERROR   |
+/// | Warn   | WARN    |
+/// | Info   | INFO    |
+/// | Debug  | DEBUG   |
+/// | Trace  | TRACE   |
+#[must_use]
+pub const fn to_tracing_level(level: Level) -> tracing::Level {
+    match level {
+        Level::Error => tracing::Level::ERROR,
+        Level::Warn => tracing::Level::WARN,
+        Level::Info => tracing::Level::INFO,
+        Level::Debug => tracing::Level::DEBUG,
+        Level::Trace => tracing::Level::TRACE,
+    }
+}
+
+/// Convert tracing `Level` to kernel `Level`.
+///
+/// Inverse of [`to_tracing_level`].
+#[must_use]
+pub const fn from_tracing_level(level: tracing::Level) -> Level {
+    match level {
+        tracing::Level::ERROR => Level::Error,
+        tracing::Level::WARN => Level::Warn,
+        tracing::Level::INFO => Level::Info,
+        tracing::Level::DEBUG => Level::Debug,
+        tracing::Level::TRACE => Level::Trace,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_level_mapping_to_tracing() {
+        assert_eq!(to_tracing_level(Level::Error), tracing::Level::ERROR);
+        assert_eq!(to_tracing_level(Level::Warn), tracing::Level::WARN);
+        assert_eq!(to_tracing_level(Level::Info), tracing::Level::INFO);
+        assert_eq!(to_tracing_level(Level::Debug), tracing::Level::DEBUG);
+        assert_eq!(to_tracing_level(Level::Trace), tracing::Level::TRACE);
+    }
+
+    #[test]
+    fn test_level_mapping_from_tracing() {
+        assert_eq!(from_tracing_level(tracing::Level::ERROR), Level::Error);
+        assert_eq!(from_tracing_level(tracing::Level::WARN), Level::Warn);
+        assert_eq!(from_tracing_level(tracing::Level::INFO), Level::Info);
+        assert_eq!(from_tracing_level(tracing::Level::DEBUG), Level::Debug);
+        assert_eq!(from_tracing_level(tracing::Level::TRACE), Level::Trace);
+    }
+
+    #[test]
+    fn test_level_roundtrip() {
+        for level in Level::ALL {
+            let tracing_level = to_tracing_level(level);
+            let back = from_tracing_level(tracing_level);
+            assert_eq!(level, back);
+        }
+    }
+
+    #[test]
+    fn test_tracing_logger_is_zst() {
+        assert_eq!(std::mem::size_of::<TracingLogger>(), 0);
+    }
+
+    #[test]
+    fn test_tracing_logger_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TracingLogger>();
+    }
+
+    #[test]
+    fn test_tracing_logger_default() {
+        let logger = TracingLogger;
+        // Should compile and not panic
+        logger.flush();
+    }
+
+    #[test]
+    fn test_tracing_logger_copy() {
+        let logger = TracingLogger;
+        let copied = logger;
+        // ZST is Copy, so both are valid
+        copied.flush();
+    }
+
+    #[test]
+    fn test_tracing_logger_debug() {
+        let logger = TracingLogger;
+        let debug_str = format!("{logger:?}");
+        assert_eq!(debug_str, "TracingLogger");
+    }
+}

--- a/lib/drivers/log/src/subscriber.rs
+++ b/lib/drivers/log/src/subscriber.rs
@@ -1,0 +1,320 @@
+//! Subscriber setup utilities.
+//!
+//! This module handles the tracing subscriber configuration based on `LogConfig`.
+//! It provides `init_logging()` to set up the tracing subscriber before
+//! setting the kernel logger.
+//!
+//! # Usage Order
+//!
+//! 1. Call `init_logging(&config)` to set up tracing subscriber
+//! 2. Call `set_logger(&LOGGER)` to route kernel `pr_*!` macros to tracing
+//!
+//! ```rust,ignore
+//! use reovim_driver_log::{init_logging, LogConfig, TracingLogger};
+//! use reovim_kernel::api::v1::set_logger;
+//!
+//! // Step 1: Set up tracing subscriber
+//! init_logging(&LogConfig::default())?;
+//!
+//! // Step 2: Set kernel logger
+//! static LOGGER: TracingLogger = TracingLogger;
+//! set_logger(&LOGGER)?;
+//! ```
+
+use std::{io, path::Path};
+
+use {
+    tracing_appender::rolling,
+    tracing_subscriber::{EnvFilter, fmt},
+};
+
+use {
+    crate::config::{LogConfig, LogFormat, LogOutput, RotationPolicy},
+    reovim_kernel::api::v1::Level,
+};
+
+/// Error type for logging initialization.
+#[derive(Debug)]
+pub enum LogError {
+    /// File path required for `File` output but not provided.
+    MissingFilePath,
+
+    /// Invalid filter string.
+    InvalidFilter(String),
+
+    /// Failed to set global subscriber.
+    SetGlobalDefault(String),
+
+    /// I/O error during setup.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for LogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingFilePath => write!(f, "file_path required for File output"),
+            Self::InvalidFilter(s) => write!(f, "invalid filter: {s}"),
+            Self::SetGlobalDefault(s) => write!(f, "failed to set global subscriber: {s}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LogError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for LogError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+/// Initialize logging with the given configuration.
+///
+/// This sets up the tracing subscriber. Call this **before** `set_logger()`.
+///
+/// # Environment Variable
+///
+/// The `REOVIM_LOG` environment variable takes precedence over `config.level`.
+/// Examples:
+/// - `REOVIM_LOG=debug` - enable debug and above
+/// - `REOVIM_LOG=warn` - enable warn and error only
+/// - `REOVIM_LOG=reovim_kernel=trace` - trace for kernel crate only
+///
+/// # Errors
+///
+/// Returns error if:
+/// - `LogOutput::File` is used but `file_path` is `None`
+/// - Invalid filter string
+/// - Subscriber setup fails
+///
+/// # Example
+///
+/// ```
+/// use reovim_driver_log::{init_logging, LogConfig, LogFormat};
+///
+/// let config = LogConfig {
+///     format: LogFormat::Pretty,
+///     ..Default::default()
+/// };
+///
+/// // In a real application (can only be called once):
+/// // init_logging(&config).expect("failed to initialize logging");
+/// ```
+pub fn init_logging(config: &LogConfig) -> Result<(), LogError> {
+    let filter = build_filter(config)?;
+
+    match (&config.output, &config.format) {
+        (LogOutput::Stderr, LogFormat::Plain) => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stderr)
+                .with_file(true)
+                .with_line_number(true)
+                .with_target(true)
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))?;
+        }
+        (LogOutput::Stderr, LogFormat::Json) => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stderr)
+                .json()
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))?;
+        }
+        (LogOutput::Stderr, LogFormat::Pretty) => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stderr)
+                .pretty()
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))?;
+        }
+        (LogOutput::Stdout, format) => {
+            init_stdout(filter, format)?;
+        }
+        (LogOutput::File, format) => {
+            let path = config.file_path.as_ref().ok_or(LogError::MissingFilePath)?;
+            init_file(filter, path, &config.rotation, format)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Build the `EnvFilter` from config, respecting `REOVIM_LOG` env var.
+fn build_filter(config: &LogConfig) -> Result<EnvFilter, LogError> {
+    // REOVIM_LOG env var takes precedence
+    if let Ok(filter) = EnvFilter::try_from_env("REOVIM_LOG") {
+        return Ok(filter);
+    }
+
+    // Fall back to config level
+    let level_str = level_to_filter_str(config.level);
+
+    EnvFilter::try_new(level_str).map_err(|e| LogError::InvalidFilter(e.to_string()))
+}
+
+/// Convert kernel `Level` to filter string.
+const fn level_to_filter_str(level: Level) -> &'static str {
+    match level {
+        Level::Error => "error",
+        Level::Warn => "warn",
+        Level::Info => "info",
+        Level::Debug => "debug",
+        Level::Trace => "trace",
+    }
+}
+
+/// Initialize stdout subscriber.
+fn init_stdout(filter: EnvFilter, format: &LogFormat) -> Result<(), LogError> {
+    match format {
+        LogFormat::Plain => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stdout)
+                .with_file(true)
+                .with_line_number(true)
+                .with_target(true)
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))
+        }
+        LogFormat::Json => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stdout)
+                .json()
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))
+        }
+        LogFormat::Pretty => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(io::stdout)
+                .pretty()
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))
+        }
+    }
+}
+
+/// Initialize file subscriber with rotation.
+fn init_file(
+    filter: EnvFilter,
+    path: &Path,
+    rotation: &RotationPolicy,
+    format: &LogFormat,
+) -> Result<(), LogError> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let prefix = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("reovim");
+
+    let appender = match rotation {
+        RotationPolicy::Never => rolling::never(dir, prefix),
+        RotationPolicy::Daily => rolling::daily(dir, prefix),
+        RotationPolicy::Hourly => rolling::hourly(dir, prefix),
+    };
+
+    // Non-blocking writer to avoid blocking the main thread on I/O.
+    // The guard is leaked to keep the writer alive for the program lifetime.
+    // This is intentional - logging should work until program exit.
+    let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+    std::mem::forget(guard);
+
+    match format {
+        LogFormat::Json => {
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .json()
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))
+        }
+        LogFormat::Plain | LogFormat::Pretty => {
+            // Pretty doesn't make sense for files (no colors), use plain
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .with_file(true)
+                .with_line_number(true)
+                .with_target(true)
+                .with_ansi(false) // No ANSI colors in file output
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| LogError::SetGlobalDefault(e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn test_log_error_display() {
+        assert_eq!(LogError::MissingFilePath.to_string(), "file_path required for File output");
+
+        assert_eq!(LogError::InvalidFilter("bad".into()).to_string(), "invalid filter: bad");
+
+        assert_eq!(
+            LogError::SetGlobalDefault("already set".into()).to_string(),
+            "failed to set global subscriber: already set"
+        );
+    }
+
+    #[test]
+    fn test_level_to_filter_str() {
+        assert_eq!(level_to_filter_str(Level::Error), "error");
+        assert_eq!(level_to_filter_str(Level::Warn), "warn");
+        assert_eq!(level_to_filter_str(Level::Info), "info");
+        assert_eq!(level_to_filter_str(Level::Debug), "debug");
+        assert_eq!(level_to_filter_str(Level::Trace), "trace");
+    }
+
+    #[test]
+    fn test_log_error_debug() {
+        let err = LogError::MissingFilePath;
+        let debug_str = format!("{err:?}");
+        assert!(debug_str.contains("MissingFilePath"));
+    }
+
+    #[test]
+    fn test_log_error_from_io() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
+        let log_err = LogError::from(io_err);
+        assert!(matches!(log_err, LogError::Io(_)));
+    }
+
+    #[test]
+    fn test_log_error_source() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
+        let log_err = LogError::Io(io_err);
+        assert!(log_err.source().is_some());
+
+        let missing_err = LogError::MissingFilePath;
+        assert!(missing_err.source().is_none());
+    }
+
+    // Note: We can't test init_logging() easily because:
+    // 1. Global subscriber can only be set once
+    // 2. Tests run in parallel
+    // Integration tests should cover actual initialization.
+}

--- a/lib/drivers/log/tests/integration.rs
+++ b/lib/drivers/log/tests/integration.rs
@@ -1,0 +1,68 @@
+//! Integration test: verify `TracingLogger` works with kernel `Logger` trait.
+//!
+//! This test demonstrates the full kernel -> driver integration.
+
+use {
+    reovim_driver_log::{LogConfig, LogFormat, LogOutput, Logger, TracingLogger},
+    reovim_kernel::api::v1::Level,
+};
+
+const fn assert_send_sync<T: Send + Sync>() {}
+const fn assert_logger<T: Logger>(_: &T) {}
+
+#[test]
+fn test_tracing_logger_implements_logger_trait() {
+    // This test verifies that TracingLogger correctly implements the Logger trait
+    // from the kernel. We can't actually call set_logger() here because:
+    // 1. Global logger can only be set once per process
+    // 2. Tests run in parallel
+    //
+    // Instead, we verify:
+    // 1. TracingLogger implements Logger (compile-time check)
+    // 2. TracingLogger has correct trait bounds (Send + Sync)
+    // 3. Methods are callable
+
+    let logger = TracingLogger;
+
+    // Verify trait bounds
+    assert_send_sync::<TracingLogger>();
+
+    // Verify Logger trait is implemented (compile-time check)
+    assert_logger(&logger);
+
+    // Verify enabled() is callable
+    let _ = logger.enabled(Level::Info);
+
+    // Verify flush() is callable
+    logger.flush();
+}
+
+#[test]
+fn test_log_config_defaults() {
+    // Verify LogConfig has sensible defaults
+    let config = LogConfig::default();
+
+    assert_eq!(config.level, Level::Info);
+    assert!(matches!(config.output, LogOutput::Stderr));
+    assert!(matches!(config.format, LogFormat::Plain));
+    assert!(config.file_path.is_none());
+}
+
+#[test]
+fn test_level_filtering() {
+    // Verify TracingLogger respects level filtering
+    let logger = TracingLogger;
+
+    // All levels should be callable
+    for level in Level::ALL {
+        let _ = logger.enabled(level);
+    }
+}
+
+// Note: We cannot test actual logging output easily because:
+// 1. set_logger() can only be called once globally
+// 2. Tests run in parallel
+// 3. Global tracing subscriber can only be set once
+//
+// These would be better tested in a dedicated integration test binary
+// or end-to-end tests that run serially.


### PR DESCRIPTION
Implements the drivers/log/ crate that bridges kernel's printk/ Logger trait to the tracing ecosystem. Following Linux kernel design pattern (mechanism vs policy), the kernel provides the Logger trait while this driver provides the policy (output destination, formatting, filtering).

Key features:
- TracingLogger: Zero-sized type implementing kernel Logger trait
- LogConfig: Configuration for output, format, level, rotation
- REOVIM_LOG env var: Runtime log level control (overrides config)
- Output targets: Stderr, Stdout, File (with rotation)
- Formats: Plain, JSON, Pretty (colored for terminal)
- Rotation policies: Never, Daily, Hourly

Phase 3.7 of Project Kernel (Epic #150).

Closes: #180