### PR TITLE
feat(editor): add Visual Mode with selection commands and operators (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,32 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Visual Mode** (Issue #242)
+  - **Three selection types** in `EditorMode` enum:
+    - Character-wise selection (`v`) - standard visual mode
+    - Line-wise selection (`V`) - selects entire lines
+    - Block selection (`Ctrl-V`) - rectangular selection
+  - **Selection Commands** (`modules/editor/src/visual.rs`):
+    - Entry: `EnterVisualMode`, `EnterVisualLineMode`, `EnterVisualBlockMode`
+    - Exit: `ExitVisualMode` - clears selection and returns to normal
+    - Toggle: `ToggleVisualChar`, `ToggleVisualLine`, `ToggleVisualBlock`
+    - Manipulation: `SwapAnchor` (o) - swap cursor and anchor positions
+    - Restore: `ReselectLast` (gv) - restore previous selection
+  - **Visual Operators**:
+    - `DeleteSelection` (d) - delete selected text
+    - `YankSelection` (y) - copy selected text to register
+    - `ChangeSelection` (c) - delete and enter insert mode
+    - `IndentSelection` (>) - add 4 spaces to selected lines
+    - `DedentSelection` (<) - remove 4 spaces from selected lines
+  - **LastVisualSelection Tracking** (`runner/src/server/app.rs`):
+    - Persists buffer_id, anchor, cursor, mode for gv restoration
+    - Saved before exit-visual commands via `save_visual_selection_if_active()`
+  - **Mode Transitions** (`runner/src/server/event_loop.rs`):
+    - `mode_for_command()` maps visual commands to mode changes
+    - Event loop handles visual → normal transitions for operators
+  - 51 unit tests covering all commands and operators
+  - Deferred: Block mode I/A insert (requires multi-cursor support)
+
 - **Phase 7-E: Text Objects** (Issue #241)
   - **New `textobjects` module** (`modules/textobjects/`):
     - Word objects: `iw` (inner word), `aw` (a word), `iW` (inner WORD), `aW` (a WORD)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "reovim-driver-input",
  "reovim-driver-vfs",
  "reovim-kernel",
+ "reovim-module-operators",
 ]
 
 [[package]]

--- a/modules/editor/Cargo.toml
+++ b/modules/editor/Cargo.toml
@@ -15,6 +15,7 @@ reovim-driver-command = { path = "../../lib/drivers/command" }
 reovim-driver-display = { path = "../../lib/drivers/display" }
 reovim-driver-input = { path = "../../lib/drivers/input" }
 reovim-driver-vfs = { path = "../../lib/drivers/vfs" }
+reovim-module-operators = { path = "../operators" }
 
 [lints]
 workspace = true

--- a/modules/editor/src/lib.rs
+++ b/modules/editor/src/lib.rs
@@ -34,6 +34,7 @@ pub mod command;
 pub mod display_lines;
 mod fallback;
 mod mode;
+pub mod visual;
 
 pub use {
     fallback::EditorFallbackHandler,

--- a/modules/editor/src/mode.rs
+++ b/modules/editor/src/mode.rs
@@ -1,8 +1,11 @@
-//! Editor modes - Normal and Insert.
+//! Editor modes - Normal, Insert, and Visual.
 //!
-//! These are the two fundamental modes for basic text editing:
+//! These are the fundamental modes for vim-style text editing:
 //! - **Normal**: Navigation mode with cursor movement commands
 //! - **Insert**: Text input mode where characters are inserted
+//! - **Visual**: Selection mode for character-wise selection
+//! - **`VisualLine`**: Selection mode for line-wise selection
+//! - **`VisualBlock`**: Selection mode for block (rectangular) selection
 
 use {
     reovim_driver_display::{CursorStyle, ModeDisplay},
@@ -18,6 +21,9 @@ pub const EDITOR_MODULE: ModuleId = ModuleId::new("editor");
 /// These implement the core vim-style modes:
 /// - `Normal`: Block cursor, movement commands, doesn't accept direct char input
 /// - `Insert`: Bar cursor, accepts character input directly
+/// - `Visual`: Block cursor, character-wise selection
+/// - `VisualLine`: Block cursor, line-wise selection
+/// - `VisualBlock`: Block cursor, block (rectangular) selection
 ///
 /// # Trait Implementations
 ///
@@ -32,6 +38,12 @@ pub enum EditorMode {
     Normal,
     /// Insert mode - text input.
     Insert,
+    /// Visual mode - character-wise selection.
+    Visual,
+    /// Visual line mode - line-wise selection.
+    VisualLine,
+    /// Visual block mode - block (rectangular) selection.
+    VisualBlock,
 }
 
 impl EditorMode {
@@ -41,12 +53,24 @@ impl EditorMode {
     /// Mode ID for Insert mode.
     pub const INSERT_ID: ModeId = ModeId::new(EDITOR_MODULE, "insert");
 
+    /// Mode ID for Visual mode (character-wise).
+    pub const VISUAL_ID: ModeId = ModeId::new(EDITOR_MODULE, "visual");
+
+    /// Mode ID for Visual Line mode.
+    pub const VISUAL_LINE_ID: ModeId = ModeId::new(EDITOR_MODULE, "visual-line");
+
+    /// Mode ID for Visual Block mode.
+    pub const VISUAL_BLOCK_ID: ModeId = ModeId::new(EDITOR_MODULE, "visual-block");
+
     /// Get the mode ID for this mode.
     #[must_use]
     pub const fn mode_id(&self) -> ModeId {
         match self {
             Self::Normal => Self::NORMAL_ID,
             Self::Insert => Self::INSERT_ID,
+            Self::Visual => Self::VISUAL_ID,
+            Self::VisualLine => Self::VISUAL_LINE_ID,
+            Self::VisualBlock => Self::VISUAL_BLOCK_ID,
         }
     }
 
@@ -60,6 +84,30 @@ impl EditorMode {
     #[must_use]
     pub const fn is_insert(&self) -> bool {
         matches!(self, Self::Insert)
+    }
+
+    /// Check if this is Visual mode (character-wise).
+    #[must_use]
+    pub const fn is_visual(&self) -> bool {
+        matches!(self, Self::Visual)
+    }
+
+    /// Check if this is Visual Line mode.
+    #[must_use]
+    pub const fn is_visual_line(&self) -> bool {
+        matches!(self, Self::VisualLine)
+    }
+
+    /// Check if this is Visual Block mode.
+    #[must_use]
+    pub const fn is_visual_block(&self) -> bool {
+        matches!(self, Self::VisualBlock)
+    }
+
+    /// Check if this is any visual mode (Visual, `VisualLine`, or `VisualBlock`).
+    #[must_use]
+    pub const fn is_any_visual(&self) -> bool {
+        matches!(self, Self::Visual | Self::VisualLine | Self::VisualBlock)
     }
 }
 
@@ -76,7 +124,9 @@ impl Mode for EditorMode {
 impl ModeDisplay for EditorMode {
     fn cursor_style(&self) -> CursorStyle {
         match self {
-            Self::Normal => CursorStyle::Block,
+            Self::Normal | Self::Visual | Self::VisualLine | Self::VisualBlock => {
+                CursorStyle::Block
+            }
             Self::Insert => CursorStyle::Bar,
         }
     }
@@ -85,6 +135,9 @@ impl ModeDisplay for EditorMode {
         match self {
             Self::Normal => "NORMAL",
             Self::Insert => "INSERT",
+            Self::Visual => "VISUAL",
+            Self::VisualLine => "V-LINE",
+            Self::VisualBlock => "V-BLOCK",
         }
     }
 }
@@ -103,36 +156,54 @@ mod tests {
     fn test_editor_mode_ids() {
         assert_eq!(EditorMode::Normal.id(), EditorMode::NORMAL_ID);
         assert_eq!(EditorMode::Insert.id(), EditorMode::INSERT_ID);
+        assert_eq!(EditorMode::Visual.id(), EditorMode::VISUAL_ID);
+        assert_eq!(EditorMode::VisualLine.id(), EditorMode::VISUAL_LINE_ID);
+        assert_eq!(EditorMode::VisualBlock.id(), EditorMode::VISUAL_BLOCK_ID);
     }
 
     #[test]
     fn test_editor_mode_id_module() {
         assert_eq!(EditorMode::NORMAL_ID.module(), &EDITOR_MODULE);
         assert_eq!(EditorMode::INSERT_ID.module(), &EDITOR_MODULE);
+        assert_eq!(EditorMode::VISUAL_ID.module(), &EDITOR_MODULE);
+        assert_eq!(EditorMode::VISUAL_LINE_ID.module(), &EDITOR_MODULE);
+        assert_eq!(EditorMode::VISUAL_BLOCK_ID.module(), &EDITOR_MODULE);
     }
 
     #[test]
     fn test_editor_mode_id_names() {
         assert_eq!(EditorMode::NORMAL_ID.name(), "normal");
         assert_eq!(EditorMode::INSERT_ID.name(), "insert");
+        assert_eq!(EditorMode::VISUAL_ID.name(), "visual");
+        assert_eq!(EditorMode::VISUAL_LINE_ID.name(), "visual-line");
+        assert_eq!(EditorMode::VISUAL_BLOCK_ID.name(), "visual-block");
     }
 
     #[test]
     fn test_editor_mode_cursor_style() {
         assert_eq!(EditorMode::Normal.cursor_style(), CursorStyle::Block);
         assert_eq!(EditorMode::Insert.cursor_style(), CursorStyle::Bar);
+        assert_eq!(EditorMode::Visual.cursor_style(), CursorStyle::Block);
+        assert_eq!(EditorMode::VisualLine.cursor_style(), CursorStyle::Block);
+        assert_eq!(EditorMode::VisualBlock.cursor_style(), CursorStyle::Block);
     }
 
     #[test]
     fn test_editor_mode_status_text() {
         assert_eq!(EditorMode::Normal.status_text(), "NORMAL");
         assert_eq!(EditorMode::Insert.status_text(), "INSERT");
+        assert_eq!(EditorMode::Visual.status_text(), "VISUAL");
+        assert_eq!(EditorMode::VisualLine.status_text(), "V-LINE");
+        assert_eq!(EditorMode::VisualBlock.status_text(), "V-BLOCK");
     }
 
     #[test]
     fn test_editor_mode_accepts_char_input() {
         assert!(!EditorMode::Normal.accepts_char_input());
         assert!(EditorMode::Insert.accepts_char_input());
+        assert!(!EditorMode::Visual.accepts_char_input());
+        assert!(!EditorMode::VisualLine.accepts_char_input());
+        assert!(!EditorMode::VisualBlock.accepts_char_input());
     }
 
     #[test]
@@ -141,6 +212,30 @@ mod tests {
         assert!(!EditorMode::Normal.is_insert());
         assert!(!EditorMode::Insert.is_normal());
         assert!(EditorMode::Insert.is_insert());
+    }
+
+    #[test]
+    fn test_visual_mode_is_methods() {
+        assert!(EditorMode::Visual.is_visual());
+        assert!(!EditorMode::Visual.is_visual_line());
+        assert!(!EditorMode::Visual.is_visual_block());
+
+        assert!(!EditorMode::VisualLine.is_visual());
+        assert!(EditorMode::VisualLine.is_visual_line());
+        assert!(!EditorMode::VisualLine.is_visual_block());
+
+        assert!(!EditorMode::VisualBlock.is_visual());
+        assert!(!EditorMode::VisualBlock.is_visual_line());
+        assert!(EditorMode::VisualBlock.is_visual_block());
+    }
+
+    #[test]
+    fn test_is_any_visual() {
+        assert!(!EditorMode::Normal.is_any_visual());
+        assert!(!EditorMode::Insert.is_any_visual());
+        assert!(EditorMode::Visual.is_any_visual());
+        assert!(EditorMode::VisualLine.is_any_visual());
+        assert!(EditorMode::VisualBlock.is_any_visual());
     }
 
     #[test]

--- a/modules/editor/src/visual.rs
+++ b/modules/editor/src/visual.rs
@@ -1,0 +1,1552 @@
+//! Visual mode commands - entry, exit, selection manipulation, and operators.
+//!
+//! This module provides commands for visual mode operation:
+//! - Mode entry: enter visual, visual-line, visual-block
+//! - Mode exit: exit visual mode
+//! - Selection manipulation: swap anchor/cursor, mode switching
+//! - Selection operators: delete, yank, change, indent, dedent
+//!
+//! # Visual Mode Philosophy
+//!
+//! Visual mode commands follow Vim semantics:
+//! - `v` enters character-wise selection from cursor position
+//! - `V` enters line-wise selection
+//! - `Ctrl-V` enters block (rectangular) selection
+//! - `Esc` exits visual mode, clearing selection
+//! - `o` swaps cursor and anchor positions
+//! - `d` deletes selection
+//! - `y` yanks selection
+//! - `c` changes selection (delete + insert mode)
+
+use {
+    reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
+    reovim_kernel::api::v1::{
+        CommandId, KernelContext, Position, SelectionMode, events::ModeChanged,
+    },
+    reovim_module_operators::{DeleteOperator, Operator, OperatorContext, Range, YankOperator},
+};
+
+use super::mode::EDITOR_MODULE;
+
+// =============================================================================
+// Visual Mode Entry Commands
+// =============================================================================
+
+/// Enter visual mode (character-wise selection).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterVisualMode;
+
+impl Command for EnterVisualMode {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-visual")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter visual mode (character-wise)"
+    }
+}
+
+impl CommandHandler for EnterVisualMode {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        // Start character-wise selection at current cursor position
+        {
+            let mut buffer = buffer_arc.write();
+            let pos = buffer.position();
+            buffer.selection_mut().start(pos, SelectionMode::Character);
+        }
+
+        // Emit mode change event
+        ctx.event_bus.emit(ModeChanged {
+            from: "normal".to_string(),
+            to: "visual".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Enter visual line mode (line-wise selection).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterVisualLineMode;
+
+impl Command for EnterVisualLineMode {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-visual-line")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter visual line mode"
+    }
+}
+
+impl CommandHandler for EnterVisualLineMode {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        // Start line-wise selection at current cursor position
+        {
+            let mut buffer = buffer_arc.write();
+            let pos = buffer.position();
+            buffer.selection_mut().start(pos, SelectionMode::Line);
+        }
+
+        // Emit mode change event
+        ctx.event_bus.emit(ModeChanged {
+            from: "normal".to_string(),
+            to: "visual-line".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Enter visual block mode (rectangular selection).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterVisualBlockMode;
+
+impl Command for EnterVisualBlockMode {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-visual-block")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter visual block mode"
+    }
+}
+
+impl CommandHandler for EnterVisualBlockMode {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        // Start block selection at current cursor position
+        {
+            let mut buffer = buffer_arc.write();
+            let pos = buffer.position();
+            buffer.selection_mut().start(pos, SelectionMode::Block);
+        }
+
+        // Emit mode change event
+        ctx.event_bus.emit(ModeChanged {
+            from: "normal".to_string(),
+            to: "visual-block".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Visual Mode Exit Commands
+// =============================================================================
+
+/// Exit visual mode and return to normal mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExitVisualMode;
+
+impl Command for ExitVisualMode {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "exit-visual")
+    }
+
+    fn description(&self) -> &'static str {
+        "Exit visual mode and return to normal mode"
+    }
+}
+
+impl CommandHandler for ExitVisualMode {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        // Clear selection if we have a buffer
+        if let Some(buffer_id) = args.buffer_id()
+            && let Some(buffer_arc) = ctx.buffers.get(buffer_id)
+        {
+            let mut buffer = buffer_arc.write();
+            buffer.selection_mut().clear();
+        }
+
+        // Emit mode change event
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "normal".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Selection Manipulation Commands
+// =============================================================================
+
+/// Swap cursor and anchor positions (o in visual mode).
+///
+/// In Vim, pressing 'o' in visual mode swaps the cursor position with the
+/// anchor position, allowing you to adjust the other end of the selection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SwapAnchor;
+
+impl Command for SwapAnchor {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "visual-swap-anchor")
+    }
+
+    fn description(&self) -> &'static str {
+        "Swap cursor and anchor in visual mode"
+    }
+}
+
+impl CommandHandler for SwapAnchor {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+
+        // Only operate if selection is active
+        if !buffer.selection().is_active() {
+            return CommandResult::Success;
+        }
+
+        // Swap anchor and cursor
+        let old_anchor = buffer.selection().anchor;
+        let cursor = buffer.position();
+
+        buffer.selection_mut().anchor = cursor;
+        buffer.set_position(old_anchor);
+
+        CommandResult::Success
+    }
+}
+
+/// Toggle to character-wise visual mode (v in visual mode).
+///
+/// If already in character-wise mode, exit to normal mode.
+/// Otherwise, switch to character-wise selection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToggleVisualChar;
+
+impl Command for ToggleVisualChar {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "toggle-visual-char")
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggle to character-wise visual mode"
+    }
+}
+
+impl CommandHandler for ToggleVisualChar {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+        let (from_mode, to_mode) =
+            if buffer.selection().is_active() && buffer.selection().mode().is_character() {
+                // Already in character mode - exit to normal
+                buffer.selection_mut().clear();
+                ("visual", "normal")
+            } else {
+                // Switch to character mode
+                buffer.selection_mut().set_mode(SelectionMode::Character);
+                ("visual-line", "visual")
+            };
+        drop(buffer);
+
+        ctx.event_bus.emit(ModeChanged {
+            from: from_mode.to_string(),
+            to: to_mode.to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Toggle to line-wise visual mode (V in visual mode).
+///
+/// If already in line-wise mode, exit to normal mode.
+/// Otherwise, switch to line-wise selection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToggleVisualLine;
+
+impl Command for ToggleVisualLine {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "toggle-visual-line")
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggle to line-wise visual mode"
+    }
+}
+
+impl CommandHandler for ToggleVisualLine {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+        let (from_mode, to_mode) =
+            if buffer.selection().is_active() && buffer.selection().mode().is_line() {
+                // Already in line mode - exit to normal
+                buffer.selection_mut().clear();
+                ("visual-line", "normal")
+            } else {
+                // Switch to line mode
+                buffer.selection_mut().set_mode(SelectionMode::Line);
+                ("visual", "visual-line")
+            };
+        drop(buffer);
+
+        ctx.event_bus.emit(ModeChanged {
+            from: from_mode.to_string(),
+            to: to_mode.to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Toggle to block-wise visual mode (Ctrl-V in visual mode).
+///
+/// If already in block mode, exit to normal mode.
+/// Otherwise, switch to block selection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToggleVisualBlock;
+
+impl Command for ToggleVisualBlock {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "toggle-visual-block")
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggle to block-wise visual mode"
+    }
+}
+
+impl CommandHandler for ToggleVisualBlock {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+        let (from_mode, to_mode) =
+            if buffer.selection().is_active() && buffer.selection().mode().is_block() {
+                // Already in block mode - exit to normal
+                buffer.selection_mut().clear();
+                ("visual-block", "normal")
+            } else {
+                // Switch to block mode
+                buffer.selection_mut().set_mode(SelectionMode::Block);
+                ("visual", "visual-block")
+            };
+        drop(buffer);
+
+        ctx.event_bus.emit(ModeChanged {
+            from: from_mode.to_string(),
+            to: to_mode.to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Reselect the last visual selection (gv in normal mode).
+///
+/// Restores the previous visual selection bounds and enters the appropriate
+/// visual mode. If no previous selection exists, this is a no-op.
+///
+/// Note: The actual restoration logic is handled by the event loop since it
+/// requires access to `AppState.last_visual_selection`. This command just signals
+/// the intent to reselect.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReselectLast;
+
+impl Command for ReselectLast {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "reselect-last")
+    }
+
+    fn description(&self) -> &'static str {
+        "Reselect the last visual selection (gv)"
+    }
+}
+
+impl CommandHandler for ReselectLast {
+    fn execute(&self, _ctx: &mut KernelContext, _args: &CommandContext) -> CommandResult {
+        // The actual reselection is handled by the event loop since it requires
+        // AppState.last_visual_selection. This command just signals the intent.
+        // If there's no last selection, the event loop handles it as a no-op.
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Visual Operators
+// =============================================================================
+
+/// Helper function to get selection range from buffer.
+///
+/// Returns (range, `cursor_position`) if selection is active, None otherwise.
+fn get_selection_range(
+    ctx: &KernelContext,
+    buffer_id: reovim_kernel::api::v1::BufferId,
+) -> Option<(Range, Position)> {
+    let buffer_arc = ctx.buffers.get(buffer_id)?;
+    let buffer = buffer_arc.read();
+
+    let selection = buffer.selection();
+    if !selection.is_active() {
+        return None;
+    }
+
+    let cursor = buffer.position();
+    let anchor = selection.anchor;
+    let mode = selection.mode();
+
+    // Normalize: start should be before end
+    let (start, end) = if anchor < cursor {
+        (anchor, cursor)
+    } else {
+        (cursor, anchor)
+    };
+
+    // Get line info for Line mode (must be done before dropping buffer)
+    let end_line_len = buffer.line_len(end.line).unwrap_or(0);
+    let total_lines = buffer.line_count();
+    drop(buffer);
+
+    // Create range based on selection mode
+    let range = match mode {
+        SelectionMode::Character => {
+            // Include the character at end position
+            Range::new(start, Position::new(end.line, end.column + 1))
+        }
+        SelectionMode::Line => {
+            // Expand to full lines, including the trailing newline
+            let start = Position::new(start.line, 0);
+            // For non-last lines, extend to start of next line (includes newline)
+            // For last line, end at line length
+            let end = if end.line + 1 < total_lines {
+                Position::new(end.line + 1, 0)
+            } else {
+                Position::new(end.line, end_line_len)
+            };
+            Range::linewise(start, end)
+        }
+        SelectionMode::Block => {
+            // Block mode: for now, treat as character range
+            // Full block support is deferred
+            Range::new(start, Position::new(end.line, end.column + 1))
+        }
+    };
+
+    Some((range, start))
+}
+
+/// Delete selection (d in visual mode).
+///
+/// Deletes the selected text and stores it in the register.
+/// Returns to Normal mode after execution.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DeleteSelection;
+
+impl Command for DeleteSelection {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "delete-selection")
+    }
+
+    fn description(&self) -> &'static str {
+        "Delete visual selection"
+    }
+}
+
+impl CommandHandler for DeleteSelection {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some((range, cursor_pos)) = get_selection_range(ctx, buffer_id) else {
+            return CommandResult::Success; // No selection - no-op
+        };
+
+        // Execute delete operator
+        let delete_op = DeleteOperator;
+        let mut op_ctx = OperatorContext {
+            kernel: ctx,
+            buffer_id,
+            register: args.register(),
+            count: 1,
+        };
+
+        if let Err(e) = delete_op.execute(&mut op_ctx, range) {
+            return CommandResult::error(format!("Delete failed: {e}"));
+        }
+
+        // Clear selection and set cursor
+        if let Some(buffer_arc) = ctx.buffers.get(buffer_id) {
+            let mut buffer = buffer_arc.write();
+            buffer.selection_mut().clear();
+            buffer.set_position(cursor_pos);
+        }
+
+        // Mode transition to Normal is handled by event loop
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "normal".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Yank selection (y in visual mode).
+///
+/// Copies the selected text to the register without deleting it.
+/// Returns to Normal mode after execution.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct YankSelection;
+
+impl Command for YankSelection {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "yank-selection")
+    }
+
+    fn description(&self) -> &'static str {
+        "Yank visual selection"
+    }
+}
+
+impl CommandHandler for YankSelection {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some((range, _cursor_pos)) = get_selection_range(ctx, buffer_id) else {
+            return CommandResult::Success; // No selection - no-op
+        };
+
+        // Execute yank operator
+        let yank_op = YankOperator;
+        let mut op_ctx = OperatorContext {
+            kernel: ctx,
+            buffer_id,
+            register: args.register(),
+            count: 1,
+        };
+
+        if let Err(e) = yank_op.execute(&mut op_ctx, range) {
+            return CommandResult::error(format!("Yank failed: {e}"));
+        }
+
+        // Clear selection (yank doesn't move cursor in Vim, but returns to normal)
+        if let Some(buffer_arc) = ctx.buffers.get(buffer_id) {
+            let mut buffer = buffer_arc.write();
+            buffer.selection_mut().clear();
+        }
+
+        // Mode transition to Normal is handled by event loop
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "normal".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Change selection (c in visual mode).
+///
+/// Deletes the selected text and enters Insert mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChangeSelection;
+
+impl Command for ChangeSelection {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "change-selection")
+    }
+
+    fn description(&self) -> &'static str {
+        "Change visual selection (delete and enter insert mode)"
+    }
+}
+
+impl CommandHandler for ChangeSelection {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some((range, cursor_pos)) = get_selection_range(ctx, buffer_id) else {
+            return CommandResult::Success; // No selection - no-op
+        };
+
+        // Execute delete operator (change = delete + insert mode)
+        let delete_op = DeleteOperator;
+        let mut op_ctx = OperatorContext {
+            kernel: ctx,
+            buffer_id,
+            register: args.register(),
+            count: 1,
+        };
+
+        if let Err(e) = delete_op.execute(&mut op_ctx, range) {
+            return CommandResult::error(format!("Change failed: {e}"));
+        }
+
+        // Clear selection and set cursor
+        if let Some(buffer_arc) = ctx.buffers.get(buffer_id) {
+            let mut buffer = buffer_arc.write();
+            buffer.selection_mut().clear();
+            buffer.set_position(cursor_pos);
+        }
+
+        // Mode transition to Insert is handled by event loop
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "insert".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Indent selection (> in visual mode).
+///
+/// Increases indentation of selected lines.
+/// Returns to Normal mode after execution.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IndentSelection;
+
+impl Command for IndentSelection {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "indent-selection")
+    }
+
+    fn description(&self) -> &'static str {
+        "Indent visual selection"
+    }
+}
+
+impl CommandHandler for IndentSelection {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+        let selection = buffer.selection();
+
+        if !selection.is_active() {
+            return CommandResult::Success; // No selection - no-op
+        }
+
+        let cursor = buffer.position();
+        let anchor = selection.anchor;
+
+        // Get line range
+        let start_line = anchor.line.min(cursor.line);
+        let end_line = anchor.line.max(cursor.line);
+
+        // Indent each line (add tab/spaces at start)
+        // Using 4 spaces as default indent
+        let indent = "    ";
+        for line_idx in start_line..=end_line {
+            buffer.insert_at(Position::new(line_idx, 0), indent);
+        }
+
+        // Clear selection
+        buffer.selection_mut().clear();
+
+        // Mode transition to Normal is handled by event loop
+        drop(buffer);
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "normal".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+/// Dedent selection (< in visual mode).
+///
+/// Decreases indentation of selected lines.
+/// Returns to Normal mode after execution.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DedentSelection;
+
+impl Command for DedentSelection {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "dedent-selection")
+    }
+
+    fn description(&self) -> &'static str {
+        "Dedent visual selection"
+    }
+}
+
+impl CommandHandler for DedentSelection {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let mut buffer = buffer_arc.write();
+        let selection = buffer.selection();
+
+        if !selection.is_active() {
+            return CommandResult::Success; // No selection - no-op
+        }
+
+        let cursor = buffer.position();
+        let anchor = selection.anchor;
+
+        // Get line range
+        let start_line = anchor.line.min(cursor.line);
+        let end_line = anchor.line.max(cursor.line);
+
+        // Dedent each line (remove leading whitespace, up to 4 chars or one tab)
+        for line_idx in start_line..=end_line {
+            if let Some(line) = buffer.lines().get(line_idx) {
+                let mut chars_to_remove = 0;
+                for (i, c) in line.chars().enumerate() {
+                    if c == '\t' {
+                        chars_to_remove = i + 1;
+                        break;
+                    } else if c == ' ' && i < 4 {
+                        chars_to_remove = i + 1;
+                    } else {
+                        break;
+                    }
+                }
+                if chars_to_remove > 0 {
+                    buffer.delete_at(Position::new(line_idx, 0), chars_to_remove);
+                }
+            }
+        }
+
+        // Clear selection
+        buffer.selection_mut().clear();
+
+        // Mode transition to Normal is handled by event loop
+        drop(buffer);
+        ctx.event_bus.emit(ModeChanged {
+            from: "visual".to_string(),
+            to: "normal".to_string(),
+        });
+
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Get all visual mode selection commands.
+#[must_use]
+pub fn visual_selection_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![
+        Box::new(SwapAnchor),
+        Box::new(ToggleVisualChar),
+        Box::new(ToggleVisualLine),
+        Box::new(ToggleVisualBlock),
+        Box::new(ReselectLast),
+    ]
+}
+
+/// Get all visual mode entry commands.
+#[must_use]
+pub fn visual_entry_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![
+        Box::new(EnterVisualMode),
+        Box::new(EnterVisualLineMode),
+        Box::new(EnterVisualBlockMode),
+    ]
+}
+
+/// Get all visual mode exit commands.
+#[must_use]
+pub fn visual_exit_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![Box::new(ExitVisualMode)]
+}
+
+/// Get all visual operator commands.
+#[must_use]
+pub fn visual_operator_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![
+        Box::new(DeleteSelection),
+        Box::new(YankSelection),
+        Box::new(ChangeSelection),
+        Box::new(IndentSelection),
+        Box::new(DedentSelection),
+    ]
+}
+
+/// Get all visual mode commands (entry + exit + selection + operators).
+#[must_use]
+pub fn visual_commands() -> Vec<Box<dyn CommandHandler>> {
+    let mut cmds = visual_entry_commands();
+    cmds.extend(visual_exit_commands());
+    cmds.extend(visual_selection_commands());
+    cmds.extend(visual_operator_commands());
+    cmds
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+#[allow(clippy::significant_drop_tightening)]
+mod tests {
+    use {
+        super::*,
+        reovim_kernel::api::v1::{
+            Buffer, BufferError, BufferId, BufferManager, EventBus, MarkBank, MotionEngine,
+            OptionRegistry, Position, RegisterBank, RwLock, TextObjectEngine,
+        },
+        std::{collections::HashMap, sync::Arc},
+    };
+
+    use super::super::mode::EDITOR_MODULE;
+
+    /// Test buffer manager that actually stores buffers.
+    struct TestBufferManager {
+        buffers: RwLock<HashMap<BufferId, Arc<RwLock<Buffer>>>>,
+    }
+
+    impl TestBufferManager {
+        fn new() -> Self {
+            Self {
+                buffers: RwLock::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl BufferManager for TestBufferManager {
+        fn get(&self, id: BufferId) -> Option<Arc<RwLock<Buffer>>> {
+            self.buffers.read().get(&id).cloned()
+        }
+
+        fn create(&self) -> BufferId {
+            let id = BufferId::new();
+            let buffer = Arc::new(RwLock::new(Buffer::new()));
+            self.buffers.write().insert(id, buffer);
+            id
+        }
+
+        fn register(&self, buffer: Buffer) -> BufferId {
+            let id = BufferId::new();
+            let buffer = Arc::new(RwLock::new(buffer));
+            self.buffers.write().insert(id, buffer);
+            id
+        }
+
+        fn unregister(&self, id: BufferId) -> Result<Buffer, BufferError> {
+            self.buffers
+                .write()
+                .remove(&id)
+                .map_or(Err(BufferError::NotFound(id)), |arc_buffer| {
+                    Arc::try_unwrap(arc_buffer)
+                        .map_or_else(|arc| Ok(arc.read().clone()), |rwlock| Ok(rwlock.into_inner()))
+                })
+        }
+
+        fn list(&self) -> Vec<BufferId> {
+            self.buffers.read().keys().copied().collect()
+        }
+
+        fn count(&self) -> usize {
+            self.buffers.read().len()
+        }
+    }
+
+    /// Create a `KernelContext` with a real buffer manager for testing.
+    fn create_test_context() -> KernelContext {
+        KernelContext::new(
+            Arc::new(EventBus::new()),
+            Arc::new(TestBufferManager::new()),
+            Arc::new(MotionEngine),
+            Arc::new(TextObjectEngine),
+            Arc::new(RwLock::new(RegisterBank::new())),
+            Arc::new(RwLock::new(MarkBank::new())),
+            Arc::new(OptionRegistry::default()),
+        )
+    }
+
+    // =========================================================================
+    // Command ID Tests
+    // =========================================================================
+
+    #[test]
+    fn test_enter_visual_command_id() {
+        let cmd = EnterVisualMode;
+        assert_eq!(cmd.id().name(), "enter-visual");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_enter_visual_line_command_id() {
+        let cmd = EnterVisualLineMode;
+        assert_eq!(cmd.id().name(), "enter-visual-line");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_enter_visual_block_command_id() {
+        let cmd = EnterVisualBlockMode;
+        assert_eq!(cmd.id().name(), "enter-visual-block");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_exit_visual_command_id() {
+        let cmd = ExitVisualMode;
+        assert_eq!(cmd.id().name(), "exit-visual");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    // =========================================================================
+    // Entry Command Execution Tests
+    // =========================================================================
+
+    #[test]
+    fn test_enter_visual_activates_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = EnterVisualMode.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Verify selection is active
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.selection().is_active());
+        assert!(buffer.selection().mode().is_character());
+    }
+
+    #[test]
+    fn test_enter_visual_line_activates_line_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("line 1\nline 2");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = EnterVisualLineMode.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Verify selection is active and in line mode
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.selection().is_active());
+        assert!(buffer.selection().mode().is_line());
+    }
+
+    #[test]
+    fn test_enter_visual_block_activates_block_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello\nworld");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = EnterVisualBlockMode.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Verify selection is active and in block mode
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.selection().is_active());
+        assert!(buffer.selection().mode().is_block());
+    }
+
+    #[test]
+    fn test_enter_visual_no_buffer_returns_error() {
+        let mut ctx = create_test_context();
+        let args = CommandContext::new();
+
+        let result = EnterVisualMode.execute(&mut ctx, &args);
+        assert!(matches!(result, CommandResult::Error(_)));
+    }
+
+    // =========================================================================
+    // Exit Command Execution Tests
+    // =========================================================================
+
+    #[test]
+    fn test_exit_visual_clears_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // First enter visual mode
+        let _ = EnterVisualMode.execute(&mut ctx, &args);
+
+        // Verify selection is active
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let buffer = buffer_arc.read();
+            assert!(buffer.selection().is_active());
+        }
+
+        // Exit visual mode
+        let result = ExitVisualMode.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Verify selection is cleared
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_exit_visual_without_buffer_succeeds() {
+        let mut ctx = create_test_context();
+        let args = CommandContext::new();
+
+        // Should still succeed (just emits event)
+        let result = ExitVisualMode.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    // =========================================================================
+    // Selection Manipulation Tests
+    // =========================================================================
+
+    #[test]
+    fn test_swap_anchor_command_id() {
+        let cmd = SwapAnchor;
+        assert_eq!(cmd.id().name(), "visual-swap-anchor");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_swap_anchor_swaps_positions() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Enter visual mode and move cursor
+        let _ = EnterVisualMode.execute(&mut ctx, &args);
+
+        // Move cursor to position 5
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer.set_position(Position::new(0, 5));
+        }
+
+        // Verify initial state: anchor at 0, cursor at 5
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let buffer = buffer_arc.read();
+            assert_eq!(buffer.selection().anchor, Position::new(0, 0));
+            assert_eq!(buffer.position(), Position::new(0, 5));
+        }
+
+        // Execute swap anchor
+        let result = SwapAnchor.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Verify swapped: anchor at 5, cursor at 0
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.selection().anchor, Position::new(0, 5));
+        assert_eq!(buffer.position(), Position::new(0, 0));
+    }
+
+    #[test]
+    fn test_swap_anchor_noop_without_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Don't enter visual mode - just execute swap
+        let result = SwapAnchor.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    #[test]
+    fn test_toggle_visual_char_exits_if_already_char() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Enter visual mode (character)
+        let _ = EnterVisualMode.execute(&mut ctx, &args);
+
+        // Toggle should exit
+        let result = ToggleVisualChar.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Selection should be cleared
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_toggle_visual_char_switches_from_line() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Enter visual line mode
+        let _ = EnterVisualLineMode.execute(&mut ctx, &args);
+
+        // Toggle to char mode
+        let result = ToggleVisualChar.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Should be in character mode
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.selection().is_active());
+        assert!(buffer.selection().mode().is_character());
+    }
+
+    #[test]
+    fn test_toggle_visual_line_exits_if_already_line() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Enter visual line mode
+        let _ = EnterVisualLineMode.execute(&mut ctx, &args);
+
+        // Toggle should exit
+        let result = ToggleVisualLine.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Selection should be cleared
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_toggle_visual_block_switches_mode() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Enter visual mode (character)
+        let _ = EnterVisualMode.execute(&mut ctx, &args);
+
+        // Toggle to block mode
+        let result = ToggleVisualBlock.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Should be in block mode
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.selection().is_active());
+        assert!(buffer.selection().mode().is_block());
+    }
+
+    // =========================================================================
+    // Helper Function Tests
+    // =========================================================================
+
+    #[test]
+    fn test_visual_selection_commands_count() {
+        let cmds = visual_selection_commands();
+        assert_eq!(cmds.len(), 5); // SwapAnchor, Toggle x3, ReselectLast
+    }
+
+    #[test]
+    fn test_visual_entry_commands_count() {
+        let cmds = visual_entry_commands();
+        assert_eq!(cmds.len(), 3);
+    }
+
+    #[test]
+    fn test_visual_exit_commands_count() {
+        let cmds = visual_exit_commands();
+        assert_eq!(cmds.len(), 1);
+    }
+
+    #[test]
+    fn test_visual_commands_count() {
+        let cmds = visual_commands();
+        assert_eq!(cmds.len(), 14); // 3 entry + 1 exit + 5 selection + 5 operators
+    }
+
+    #[test]
+    fn test_visual_operator_commands_count() {
+        let cmds = visual_operator_commands();
+        assert_eq!(cmds.len(), 5); // delete, yank, change, indent, dedent
+    }
+
+    // =========================================================================
+    // Reselect Last Tests
+    // =========================================================================
+
+    #[test]
+    fn test_reselect_last_command_id() {
+        let cmd = ReselectLast;
+        assert_eq!(cmd.id().name(), "reselect-last");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_reselect_last_returns_success() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // ReselectLast always returns Success (actual logic is in event loop)
+        let result = ReselectLast.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    // =========================================================================
+    // Visual Operator Tests
+    // =========================================================================
+
+    #[test]
+    fn test_delete_selection_command_id() {
+        let cmd = DeleteSelection;
+        assert_eq!(cmd.id().name(), "delete-selection");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_yank_selection_command_id() {
+        let cmd = YankSelection;
+        assert_eq!(cmd.id().name(), "yank-selection");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_change_selection_command_id() {
+        let cmd = ChangeSelection;
+        assert_eq!(cmd.id().name(), "change-selection");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_indent_selection_command_id() {
+        let cmd = IndentSelection;
+        assert_eq!(cmd.id().name(), "indent-selection");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_dedent_selection_command_id() {
+        let cmd = DedentSelection;
+        assert_eq!(cmd.id().name(), "dedent-selection");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_delete_selection_noop_without_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Without an active selection, should be a no-op
+        let result = DeleteSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Buffer should be unchanged
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.lines()[0], "hello world");
+    }
+
+    #[test]
+    fn test_yank_selection_noop_without_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Without an active selection, should be a no-op
+        let result = YankSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    #[test]
+    fn test_change_selection_noop_without_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        // Without an active selection, should be a no-op
+        let result = ChangeSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    #[test]
+    fn test_delete_selection_deletes_text() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate selection from position 0 to 5 (selecting "hello")
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+            buffer.set_position(Position::new(0, 4)); // Selecting "hello"
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = DeleteSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Buffer should have "hello" deleted
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.lines()[0], " world");
+    }
+
+    #[test]
+    fn test_indent_selection_adds_indentation() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("line1\nline2\nline3");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate line selection for lines 0-1
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Line);
+            buffer.set_position(Position::new(1, 0));
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = IndentSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Lines 0-1 should be indented
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(buffer.lines()[0].starts_with("    ")); // 4 spaces
+        assert!(buffer.lines()[1].starts_with("    "));
+        assert!(!buffer.lines()[2].starts_with("    ")); // Line 3 not selected
+    }
+
+    #[test]
+    fn test_dedent_selection_removes_indentation() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("    line1\n    line2\nline3");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate line selection for lines 0-1
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Line);
+            buffer.set_position(Position::new(1, 0));
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = DedentSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Lines 0-1 should be dedented
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.lines()[0], "line1");
+        assert_eq!(buffer.lines()[1], "line2");
+        assert_eq!(buffer.lines()[2], "line3"); // Line 3 unchanged
+    }
+
+    // ========================================================================
+    // P0 Missing Tests - Operator Behavior Validation
+    // ========================================================================
+
+    #[test]
+    fn test_yank_selection_yanks_text() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate character-wise selection for "hello"
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+            buffer.set_position(Position::new(0, 4)); // Selecting "hello"
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = YankSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Buffer content should remain unchanged (yank doesn't delete)
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.lines()[0], "hello world");
+
+        // Selection should be cleared after yank
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_change_selection_changes_text() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate character-wise selection for "hello"
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+            buffer.set_position(Position::new(0, 4)); // Selecting "hello"
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = ChangeSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Buffer should have "hello" deleted (like delete, but followed by insert mode)
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.lines()[0], " world");
+
+        // Selection should be cleared after change
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_delete_selection_line_mode_deletes_entire_lines() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("line one\nline two\nline three");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate line-wise selection for lines 0-1
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 3), SelectionMode::Line);
+            buffer.set_position(Position::new(1, 2)); // Selection spans lines 0 and 1
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = DeleteSelection.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Lines 0-1 should be completely deleted, leaving only "line three"
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.line_count(), 1);
+        assert_eq!(buffer.lines()[0], "line three");
+    }
+}

--- a/runner/src/server/app.rs
+++ b/runner/src/server/app.rs
@@ -10,6 +10,7 @@ use {
     reovim_driver_input::{FallbackContext, KeySequence},
     reovim_kernel::api::v1::{
         Buffer, BufferId, Direction, Edit, KernelContext, ModeId, ModeStack, Motion, Position,
+        SelectionMode,
     },
     std::sync::Arc,
 };
@@ -497,6 +498,44 @@ impl RepeatState {
     }
 }
 
+// ============================================================================
+// Visual Mode Selection Infrastructure
+// ============================================================================
+
+/// Record of the last visual selection for `gv` (reselect) command.
+///
+/// When visual mode is exited, the selection boundaries are stored here
+/// so that `gv` can restore the exact same selection.
+#[derive(Debug, Clone, Copy)]
+pub struct LastVisualSelection {
+    /// The buffer where the selection was made.
+    pub buffer_id: BufferId,
+    /// The anchor position (where visual mode was entered).
+    pub anchor: Position,
+    /// The cursor position (where visual mode was exited).
+    pub cursor: Position,
+    /// The selection mode (Character, Line, or Block).
+    pub mode: SelectionMode,
+}
+
+impl LastVisualSelection {
+    /// Create a new last visual selection record.
+    #[must_use]
+    pub const fn new(
+        buffer_id: BufferId,
+        anchor: Position,
+        cursor: Position,
+        mode: SelectionMode,
+    ) -> Self {
+        Self {
+            buffer_id,
+            anchor,
+            cursor,
+            mode,
+        }
+    }
+}
+
 /// Application state combining kernel context with runtime state.
 ///
 /// # Design Philosophy
@@ -610,6 +649,12 @@ pub struct AppState {
     /// - Any command execution (Backspace, arrow keys, etc.)
     /// - Buffer change (editing different buffer)
     pending_edits: PendingEditBatch,
+
+    /// Last visual selection for the `gv` (reselect) command.
+    ///
+    /// When visual mode is exited, the selection is saved here so that
+    /// `gv` can restore it. This allows re-selecting the last visual area.
+    pub last_visual_selection: Option<LastVisualSelection>,
 }
 
 impl AppState {
@@ -636,6 +681,7 @@ impl AppState {
             search: SearchState::new(),
             repeat_state: RepeatState::new(),
             pending_edits: PendingEditBatch::new(),
+            last_visual_selection: None,
         }
     }
 
@@ -835,6 +881,34 @@ impl AppState {
     #[must_use]
     pub const fn pending_edit_count(&self) -> usize {
         self.pending_edits.len()
+    }
+
+    // ========================================================================
+    // Visual Selection Methods
+    // ========================================================================
+
+    /// Save the current visual selection for later reselection with `gv`.
+    ///
+    /// Called when exiting visual mode to remember the selection boundaries.
+    pub const fn save_visual_selection(&mut self, selection: LastVisualSelection) {
+        self.last_visual_selection = Some(selection);
+    }
+
+    /// Get the last visual selection, if any.
+    #[must_use]
+    pub const fn last_visual_selection(&self) -> Option<&LastVisualSelection> {
+        self.last_visual_selection.as_ref()
+    }
+
+    /// Check if there is a saved visual selection.
+    #[must_use]
+    pub const fn has_last_visual_selection(&self) -> bool {
+        self.last_visual_selection.is_some()
+    }
+
+    /// Clear the last visual selection.
+    pub const fn clear_last_visual_selection(&mut self) {
+        self.last_visual_selection = None;
     }
 }
 
@@ -1538,5 +1612,127 @@ mod tests {
         app.flush_pending_edits();
 
         assert!(!app.has_pending_edits());
+    }
+
+    // ========================================================================
+    // LastVisualSelection Tests
+    // ========================================================================
+
+    #[test]
+    fn test_last_visual_selection_new() {
+        let buffer_id = BufferId::from_raw(1);
+        let anchor = Position::new(0, 5);
+        let cursor = Position::new(2, 10);
+        let mode = SelectionMode::Character;
+
+        let selection = LastVisualSelection::new(buffer_id, anchor, cursor, mode);
+
+        assert_eq!(selection.buffer_id, buffer_id);
+        assert_eq!(selection.anchor, anchor);
+        assert_eq!(selection.cursor, cursor);
+        assert_eq!(selection.mode, mode);
+    }
+
+    #[test]
+    fn test_last_visual_selection_line_mode() {
+        let buffer_id = BufferId::from_raw(2);
+        let selection = LastVisualSelection::new(
+            buffer_id,
+            Position::new(1, 0),
+            Position::new(3, 0),
+            SelectionMode::Line,
+        );
+
+        assert_eq!(selection.mode, SelectionMode::Line);
+    }
+
+    #[test]
+    fn test_last_visual_selection_block_mode() {
+        let buffer_id = BufferId::from_raw(3);
+        let selection = LastVisualSelection::new(
+            buffer_id,
+            Position::new(0, 0),
+            Position::new(5, 10),
+            SelectionMode::Block,
+        );
+
+        assert_eq!(selection.mode, SelectionMode::Block);
+    }
+
+    #[test]
+    fn test_app_state_last_visual_selection_initially_none() {
+        let kernel = KernelContext::default();
+        let app = AppState::new(kernel, test_mode_id());
+
+        assert!(!app.has_last_visual_selection());
+        assert!(app.last_visual_selection().is_none());
+    }
+
+    #[test]
+    fn test_app_state_save_visual_selection() {
+        let kernel = KernelContext::default();
+        let mut app = AppState::new(kernel, test_mode_id());
+
+        let selection = LastVisualSelection::new(
+            BufferId::from_raw(1),
+            Position::new(0, 0),
+            Position::new(1, 5),
+            SelectionMode::Character,
+        );
+
+        app.save_visual_selection(selection);
+
+        assert!(app.has_last_visual_selection());
+        let saved = app.last_visual_selection().unwrap();
+        assert_eq!(saved.anchor, Position::new(0, 0));
+        assert_eq!(saved.cursor, Position::new(1, 5));
+    }
+
+    #[test]
+    fn test_app_state_clear_last_visual_selection() {
+        let kernel = KernelContext::default();
+        let mut app = AppState::new(kernel, test_mode_id());
+
+        let selection = LastVisualSelection::new(
+            BufferId::from_raw(1),
+            Position::new(0, 0),
+            Position::new(1, 5),
+            SelectionMode::Character,
+        );
+
+        app.save_visual_selection(selection);
+        assert!(app.has_last_visual_selection());
+
+        app.clear_last_visual_selection();
+        assert!(!app.has_last_visual_selection());
+    }
+
+    #[test]
+    fn test_app_state_save_visual_selection_overwrites() {
+        let kernel = KernelContext::default();
+        let mut app = AppState::new(kernel, test_mode_id());
+
+        let selection1 = LastVisualSelection::new(
+            BufferId::from_raw(1),
+            Position::new(0, 0),
+            Position::new(1, 5),
+            SelectionMode::Character,
+        );
+        app.save_visual_selection(selection1);
+
+        let selection2 = LastVisualSelection::new(
+            BufferId::from_raw(2),
+            Position::new(5, 0),
+            Position::new(10, 20),
+            SelectionMode::Line,
+        );
+        app.save_visual_selection(selection2);
+
+        // Should have the second selection
+        let saved = app.last_visual_selection().unwrap();
+        assert_eq!(saved.buffer_id, BufferId::from_raw(2));
+        assert_eq!(saved.anchor, Position::new(5, 0));
+        assert_eq!(saved.cursor, Position::new(10, 20));
+        assert_eq!(saved.mode, SelectionMode::Line);
     }
 }

--- a/runner/src/server/event_loop.rs
+++ b/runner/src/server/event_loop.rs
@@ -16,13 +16,77 @@ use {
     reovim_driver_command::{CommandContext, CommandResult, UndoAction},
     reovim_driver_input::{FallbackResult, InputFallbackHandler, KeyCode, KeyEvent},
     reovim_kernel::{
-        api::v1::{Edit, Motion, MotionEngine, Position, UndoResult},
+        api::v1::{
+            CommandId, Edit, ModeId, ModuleId, Motion, MotionEngine, Position, SelectionMode,
+            UndoResult,
+        },
         profile_scope,
     },
 };
 
+// =============================================================================
+// Mode Transition Mapping
+// =============================================================================
+
+/// Determine the target mode for a command, if any.
+///
+/// This function maps command IDs to the mode they should transition to.
+/// Commands that don't change mode return `None`.
+///
+/// # Philosophy
+///
+/// This is MECHANISM, not policy - the mapping is defined here but the
+/// actual mode definitions come from the editor module.
+///
+/// # Note
+///
+/// Toggle commands (toggle-visual-char, etc.) are handled specially:
+/// they can either exit to normal or switch modes depending on current state.
+/// For simplicity, we don't track current mode here - the toggle commands
+/// already update the selection mode in the buffer. The `mode_stack` update
+/// happens based on `ModeChanged` events emitted by the commands.
+#[must_use]
+fn mode_for_command(cmd_id: &CommandId) -> Option<ModeId> {
+    let editor = ModuleId::new("editor");
+
+    // Visual mode entry commands
+    if cmd_id.module() == &editor {
+        let mode_name = match cmd_id.name() {
+            // Visual mode entry
+            "enter-visual" => Some("visual"),
+            "enter-visual-line" => Some("visual-line"),
+            "enter-visual-block" => Some("visual-block"),
+
+            // Visual/Insert mode exit to normal
+            "exit-visual" | "exit-insert" | "delete-selection" | "yank-selection"
+            | "indent-selection" | "dedent-selection" => Some("normal"),
+
+            // Insert mode entry
+            "enter-insert"
+            | "enter-insert-after"
+            | "enter-insert-first-non-blank"
+            | "enter-insert-end-of-line"
+            | "open-line-below"
+            | "open-line-above"
+            | "change-line"
+            | "change-to-end-of-line"
+            | "change-selection" => Some("insert"),
+
+            // Note: toggle-visual-* commands are NOT handled here because
+            // they can either exit or switch modes. They emit ModeChanged
+            // events which should be processed separately. For now, they
+            // don't trigger automatic mode stack changes.
+            _ => None,
+        };
+        mode_name.map(|name| ModeId::new(editor, name))
+    } else {
+        None
+    }
+}
+
 use super::{
     AppState,
+    app::LastVisualSelection,
     registry::{CommandRegistry, KeyLookupResult, KeymapRegistry, ModeRegistry},
 };
 
@@ -217,11 +281,33 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                 self.app.flush_pending_edits();
 
                 // Build command context (TODO: parse count/register from pending keys)
-                let ctx = CommandContext::new();
+                let mut ctx = CommandContext::new();
+
+                // Set buffer_id in context if we have an active buffer
+                if let Some(buffer_id) = self.app.active_buffer {
+                    ctx.set_buffer_id(buffer_id);
+                }
+
+                // BEFORE exit-visual: save the selection for gv
+                let is_visual_exit = Self::is_visual_exit_command(&cmd_id);
+                if is_visual_exit {
+                    self.save_visual_selection_if_active();
+                }
 
                 // Execute command
                 if let Some(result) = self.command_registry.execute(&cmd_id, &mut self.app, &ctx) {
                     self.handle_command_result(result);
+
+                    // Handle mode transition based on command
+                    // This updates mode_stack for commands like enter-visual, exit-insert, etc.
+                    if let Some(new_mode) = mode_for_command(&cmd_id) {
+                        self.app.mode_stack.set(new_mode);
+                    }
+
+                    // AFTER reselect-last: restore the saved selection
+                    if cmd_id.name() == "reselect-last" {
+                        self.handle_reselect_last();
+                    }
                 } else {
                     // Command not found in registry
                     self.set_error(format!("Unknown command: {cmd_id}"));
@@ -810,6 +896,109 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
     pub fn keymap_registry_mut(&mut self) -> &mut KeymapRegistry {
         &mut self.keymap_registry
     }
+
+    // ========================================================================
+    // Visual Mode Selection Helpers
+    // ========================================================================
+
+    /// Check if a command is a visual mode exit command.
+    ///
+    /// This includes explicit exit, toggle, and operator commands that exit visual mode.
+    fn is_visual_exit_command(cmd_id: &CommandId) -> bool {
+        let editor = ModuleId::new("editor");
+        if cmd_id.module() != &editor {
+            return false;
+        }
+
+        // Commands that potentially exit visual mode
+        matches!(
+            cmd_id.name(),
+            "exit-visual"
+                | "toggle-visual-char"
+                | "toggle-visual-line"
+                | "toggle-visual-block"
+                | "delete-selection"
+                | "yank-selection"
+                | "change-selection"
+                | "indent-selection"
+                | "dedent-selection"
+        )
+    }
+
+    /// Save the current visual selection if one is active.
+    ///
+    /// Called before exit-visual commands to preserve the selection for `gv`.
+    fn save_visual_selection_if_active(&mut self) {
+        let Some(buffer_id) = self.app.active_buffer else {
+            return;
+        };
+
+        let Some(buffer_arc) = self.app.kernel.buffers.get(buffer_id) else {
+            return;
+        };
+
+        let buffer = buffer_arc.read();
+        let selection = buffer.selection();
+
+        // Only save if selection is active
+        if !selection.is_active() {
+            return;
+        }
+
+        let last_selection = LastVisualSelection::new(
+            buffer_id,
+            selection.anchor,
+            buffer.position(),
+            selection.mode(),
+        );
+        drop(buffer);
+
+        self.app.save_visual_selection(last_selection);
+    }
+
+    /// Handle the reselect-last (gv) command.
+    ///
+    /// Restores the saved visual selection and enters the appropriate visual mode.
+    fn handle_reselect_last(&mut self) {
+        let Some(last_selection) = self.app.last_visual_selection() else {
+            // No saved selection - nothing to do
+            return;
+        };
+
+        // Copy values to avoid borrow issues
+        let buffer_id = last_selection.buffer_id;
+        let anchor = last_selection.anchor;
+        let cursor = last_selection.cursor;
+        let mode = last_selection.mode;
+
+        // Verify the buffer still exists and is the active buffer
+        // (In Vim, gv only works if you're in the same buffer)
+        if self.app.active_buffer != Some(buffer_id) {
+            // Different buffer - switch to it first (or ignore)
+            // For now, we'll only restore in the same buffer
+            return;
+        }
+
+        let Some(buffer_arc) = self.app.kernel.buffers.get(buffer_id) else {
+            return;
+        };
+
+        // Restore the selection
+        {
+            let mut buffer = buffer_arc.write();
+            buffer.selection_mut().start(anchor, mode);
+            buffer.set_position(cursor);
+        }
+
+        // Transition to the appropriate visual mode
+        let editor = ModuleId::new("editor");
+        let new_mode = match mode {
+            SelectionMode::Character => ModeId::new(editor, "visual"),
+            SelectionMode::Line => ModeId::new(editor, "visual-line"),
+            SelectionMode::Block => ModeId::new(editor, "visual-block"),
+        };
+        self.app.mode_stack.set(new_mode);
+    }
 }
 
 impl<F: InputFallbackHandler<AppState>> std::fmt::Debug for EventLoop<F> {
@@ -1064,5 +1253,90 @@ mod tests {
         let _ = event_loop.command_registry_mut();
         let _ = event_loop.keymap_registry();
         let _ = event_loop.keymap_registry_mut();
+    }
+
+    // =========================================================================
+    // Mode Transition Tests
+    // =========================================================================
+
+    fn editor_command_id(name: &'static str) -> CommandId {
+        CommandId::new(ModuleId::new("editor"), name)
+    }
+
+    fn editor_mode_id(name: &'static str) -> ModeId {
+        ModeId::new(ModuleId::new("editor"), name)
+    }
+
+    #[test]
+    fn test_mode_for_command_visual_entry() {
+        assert_eq!(
+            mode_for_command(&editor_command_id("enter-visual")),
+            Some(editor_mode_id("visual"))
+        );
+        assert_eq!(
+            mode_for_command(&editor_command_id("enter-visual-line")),
+            Some(editor_mode_id("visual-line"))
+        );
+        assert_eq!(
+            mode_for_command(&editor_command_id("enter-visual-block")),
+            Some(editor_mode_id("visual-block"))
+        );
+    }
+
+    #[test]
+    fn test_mode_for_command_visual_exit() {
+        assert_eq!(
+            mode_for_command(&editor_command_id("exit-visual")),
+            Some(editor_mode_id("normal"))
+        );
+    }
+
+    #[test]
+    fn test_mode_for_command_insert_entry() {
+        assert_eq!(
+            mode_for_command(&editor_command_id("enter-insert")),
+            Some(editor_mode_id("insert"))
+        );
+        assert_eq!(
+            mode_for_command(&editor_command_id("enter-insert-after")),
+            Some(editor_mode_id("insert"))
+        );
+        assert_eq!(
+            mode_for_command(&editor_command_id("open-line-below")),
+            Some(editor_mode_id("insert"))
+        );
+    }
+
+    #[test]
+    fn test_mode_for_command_insert_exit() {
+        assert_eq!(
+            mode_for_command(&editor_command_id("exit-insert")),
+            Some(editor_mode_id("normal"))
+        );
+    }
+
+    #[test]
+    fn test_mode_for_command_change_enters_insert() {
+        assert_eq!(
+            mode_for_command(&editor_command_id("change-line")),
+            Some(editor_mode_id("insert"))
+        );
+        assert_eq!(
+            mode_for_command(&editor_command_id("change-to-end-of-line")),
+            Some(editor_mode_id("insert"))
+        );
+    }
+
+    #[test]
+    fn test_mode_for_command_unknown_returns_none() {
+        assert_eq!(mode_for_command(&editor_command_id("cursor-up")), None);
+        assert_eq!(mode_for_command(&editor_command_id("delete-line")), None);
+        assert_eq!(mode_for_command(&test_command_id("some-command")), None);
+    }
+
+    #[test]
+    fn test_mode_for_command_non_editor_module() {
+        let other_cmd = CommandId::new(ModuleId::new("other"), "enter-visual");
+        assert_eq!(mode_for_command(&other_cmd), None);
     }
 }


### PR DESCRIPTION
…#242)

Visual Mode Implementation:
- Add Visual, VisualLine, VisualBlock mode variants to EditorMode
- Implement entry/exit commands (v, V, Ctrl-V, Esc)
- Add selection manipulation: SwapAnchor (o), Toggle commands
- Implement ReselectLast (gv) with LastVisualSelection tracking
- Add visual operators: delete (d), yank (y), change (c)
- Add indent/dedent selection (>, <)

Architecture:
- Commands in modules/editor follow mechanism vs policy
- Mode transitions handled by event loop mode_for_command()
- Selection state tracked via kernel Selection API
- LastVisualSelection persisted in AppState for gv

Note: mode_for_command() is a known policy-in-mechanism violation, tracked for refactor in #282.

Testing:
- 51 unit tests covering all commands and operators
- Line-mode deletion bug fixed during review
- 100% pass rate, zero warnings

Closes #242, Defers #282, Parts of #150
