### PR TITLE
feat(editor): visual mode key blocking and block insert (#145, #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Visual Mode Key Blocking** (Issue #145)
+  - Explicit no-op bindings for `i`/`a` keys in all visual modes (prevent fallthrough)
+  - `I` command in visual/visual-line modes: move to first non-blank, enter insert
+  - `A` command in visual/visual-line modes: move to end of line, enter insert
+  - `I`/`A` in visual-block mode: explicit no-op (deferred to #146 for block insert)
+  - New commands: `VisualNoOp`, `VisualInsertStart`, `VisualInsertEnd`
+  - 11 unit tests for new command behavior
+
 - **FFI Module Loading Mechanism** (Issue #290)
   - New `reovim-driver-ffi` crate for external module support
   - C header file `lib/drivers/ffi/include/reovim.h` for external modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,17 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
   - Explicit no-op bindings for `i`/`a` keys in all visual modes (prevent fallthrough)
   - `I` command in visual/visual-line modes: move to first non-blank, enter insert
   - `A` command in visual/visual-line modes: move to end of line, enter insert
-  - `I`/`A` in visual-block mode: explicit no-op (deferred to #146 for block insert)
   - New commands: `VisualNoOp`, `VisualInsertStart`, `VisualInsertEnd`
   - 11 unit tests for new command behavior
+
+- **Visual-Block Insert Mode** (Issue #146)
+  - `I` in visual-block mode: insert at left column of block on all selected lines
+  - `A` in visual-block mode: append at right column of block on all selected lines
+  - Text typed after `I`/`A` is applied to all lines in the block on exit
+  - New commands: `BlockInsertStart`, `BlockInsertEnd`
+  - New `CommandResult::BlockInsertAction` variant for callback pattern
+  - New `BlockInsertState` in `AppState` for tracking block bounds
+  - Runner detects insert mode exit and applies accumulated text to all block lines
 
 - **FFI Module Loading Mechanism** (Issue #290)
   - New `reovim-driver-ffi` crate for external module support

--- a/lib/drivers/command/src/lib.rs
+++ b/lib/drivers/command/src/lib.rs
@@ -75,8 +75,8 @@ pub use context::CommandContext;
 
 // Re-export result types
 pub use result::{
-    CommandResult, EditAction, ModeAction, SearchAction, SearchDirection, UndoAction,
-    UndotreeAction, WindowAction,
+    BlockInsertAction, CommandResult, EditAction, ModeAction, SearchAction, SearchDirection,
+    UndoAction, UndotreeAction, WindowAction,
 };
 
 // Re-export traits

--- a/lib/drivers/command/src/result.rs
+++ b/lib/drivers/command/src/result.rs
@@ -165,6 +165,55 @@ pub enum ModeAction {
 }
 
 // ============================================================================
+// Block Insert Action Type
+// ============================================================================
+
+/// Block insert action intent returned by visual-block `I`/`A` commands.
+///
+/// Commands return this to initiate block insert mode, where text typed in
+/// insert mode is applied to all lines in the block selection upon exit.
+///
+/// # Example
+///
+/// ```ignore
+/// fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+///     // User pressed `I` in visual-block mode
+///     CommandResult::BlockInsertAction(BlockInsertAction::InsertStart {
+///         start_line: 2,
+///         end_line: 5,
+///         column: 10,
+///     })
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockInsertAction {
+    /// Insert at the start column of each line in the block (`I` in visual-block).
+    ///
+    /// When insert mode exits, accumulated text is inserted at `column` on each
+    /// line from `start_line` to `end_line` inclusive.
+    InsertStart {
+        /// First line of the block (0-indexed).
+        start_line: usize,
+        /// Last line of the block (0-indexed, inclusive).
+        end_line: usize,
+        /// Column where text will be inserted (left edge of block).
+        column: usize,
+    },
+    /// Insert at the end column of each line in the block (`A` in visual-block).
+    ///
+    /// When insert mode exits, accumulated text is inserted after `column` on each
+    /// line from `start_line` to `end_line` inclusive.
+    InsertEnd {
+        /// First line of the block (0-indexed).
+        start_line: usize,
+        /// Last line of the block (0-indexed, inclusive).
+        end_line: usize,
+        /// Column after which text will be inserted (right edge of block + 1).
+        column: usize,
+    },
+}
+
+// ============================================================================
 // Edit Action Type
 // ============================================================================
 
@@ -329,6 +378,12 @@ pub enum CommandResult {
     /// the last visual selection. The runner handles the actual restoration
     /// by looking up the saved selection and entering the appropriate visual mode.
     ReselectVisual,
+    /// Command requests block insert mode (`I`/`A` in visual-block).
+    ///
+    /// Visual-block `I`/`A` commands return this to initiate block insert mode.
+    /// The runner stores the block bounds and enters insert mode. When insert
+    /// mode exits, the accumulated text is applied to all lines in the block.
+    BlockInsertAction(BlockInsertAction),
 }
 
 impl CommandResult {
@@ -448,6 +503,12 @@ impl CommandResult {
     #[must_use]
     pub const fn is_reselect_visual(&self) -> bool {
         matches!(self, Self::ReselectVisual)
+    }
+
+    /// Check if the result is a block insert action.
+    #[must_use]
+    pub const fn is_block_insert_action(&self) -> bool {
+        matches!(self, Self::BlockInsertAction(_))
     }
 
     /// Create an operator range result for text object commands.
@@ -867,6 +928,100 @@ mod tests {
             let result = CommandResult::ModeAction(action);
             assert!(result.is_mode_action());
             assert!(!result.is_window_action());
+        }
+    }
+
+    // ========================================================================
+    // BlockInsertAction Tests
+    // ========================================================================
+
+    #[test]
+    fn test_block_insert_action_insert_start() {
+        let action = BlockInsertAction::InsertStart {
+            start_line: 2,
+            end_line: 5,
+            column: 10,
+        };
+
+        assert_eq!(
+            action,
+            BlockInsertAction::InsertStart {
+                start_line: 2,
+                end_line: 5,
+                column: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn test_block_insert_action_insert_end() {
+        let action = BlockInsertAction::InsertEnd {
+            start_line: 0,
+            end_line: 3,
+            column: 15,
+        };
+
+        assert_eq!(
+            action,
+            BlockInsertAction::InsertEnd {
+                start_line: 0,
+                end_line: 3,
+                column: 15,
+            }
+        );
+    }
+
+    #[test]
+    fn test_block_insert_action_inequality() {
+        let start = BlockInsertAction::InsertStart {
+            start_line: 0,
+            end_line: 2,
+            column: 5,
+        };
+        let end = BlockInsertAction::InsertEnd {
+            start_line: 0,
+            end_line: 2,
+            column: 5,
+        };
+
+        assert_ne!(start, end);
+    }
+
+    #[test]
+    fn test_command_result_block_insert_action() {
+        let action = BlockInsertAction::InsertStart {
+            start_line: 1,
+            end_line: 4,
+            column: 8,
+        };
+        let result = CommandResult::BlockInsertAction(action);
+
+        assert!(result.is_block_insert_action());
+        assert!(!result.is_success());
+        assert!(!result.is_error());
+        assert!(!result.is_quit());
+        assert!(!result.is_mode_action());
+        assert!(!result.is_window_action());
+    }
+
+    #[test]
+    fn test_block_insert_action_all_variants() {
+        let variants = [
+            BlockInsertAction::InsertStart {
+                start_line: 0,
+                end_line: 0,
+                column: 0,
+            },
+            BlockInsertAction::InsertEnd {
+                start_line: 0,
+                end_line: 0,
+                column: 0,
+            },
+        ];
+
+        for action in variants {
+            let result = CommandResult::BlockInsertAction(action);
+            assert!(result.is_block_insert_action());
         }
     }
 }

--- a/modules/editor/src/visual.rs
+++ b/modules/editor/src/visual.rs
@@ -764,6 +764,139 @@ impl CommandHandler for DedentSelection {
 }
 
 // =============================================================================
+// Visual Mode Key Blocking Commands
+// =============================================================================
+
+/// Explicit no-op for keys that should be blocked in visual mode.
+///
+/// In Vim, certain keys (`i`, `a`) are intentionally blocked in visual mode.
+/// Rather than relying on missing bindings, we bind them to explicit no-ops
+/// for clarity and defensive programming.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VisualNoOp;
+
+impl Command for VisualNoOp {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "visual-noop")
+    }
+
+    fn description(&self) -> &'static str {
+        "No-op command for blocked visual mode keys"
+    }
+}
+
+impl CommandHandler for VisualNoOp {
+    fn execute(&self, _ctx: &mut KernelContext, _args: &CommandContext) -> CommandResult {
+        // Intentional no-op - key is explicitly blocked
+        CommandResult::Success
+    }
+}
+
+/// Enter insert mode at first non-blank character (`I` in visual char/line mode).
+///
+/// In Vim's visual and visual-line modes, pressing `I` clears the selection,
+/// moves the cursor to the first non-blank character of the current line,
+/// and enters insert mode.
+///
+/// Note: Visual-block `I` (block insert) is handled by a different command
+/// in issue #146.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VisualInsertStart;
+
+impl Command for VisualInsertStart {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "visual-insert-start")
+    }
+
+    fn description(&self) -> &'static str {
+        "Exit visual mode, move to first non-blank, enter insert mode"
+    }
+}
+
+impl CommandHandler for VisualInsertStart {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        {
+            let mut buffer = buffer_arc.write();
+
+            // Clear selection first
+            buffer.selection_mut().clear();
+
+            // Find first non-blank character on current line
+            let pos = buffer.position();
+            let first_non_blank = buffer
+                .line(pos.line)
+                .map_or(0, |line| line.chars().position(|c| !c.is_whitespace()).unwrap_or(0));
+
+            buffer.set_position(Position::new(pos.line, first_non_blank));
+        }
+
+        // Emit mode change to Insert
+        ctx.event_bus
+            .emit(ModeChanged::with_mode_id("visual", EditorMode::INSERT_ID));
+
+        CommandResult::Success
+    }
+}
+
+/// Enter insert mode at end of line (`A` in visual char/line mode).
+///
+/// In Vim's visual and visual-line modes, pressing `A` clears the selection,
+/// moves the cursor to the end of the current line, and enters insert mode.
+///
+/// Note: Visual-block `A` (block append) is handled by a different command
+/// in issue #146.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VisualInsertEnd;
+
+impl Command for VisualInsertEnd {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "visual-insert-end")
+    }
+
+    fn description(&self) -> &'static str {
+        "Exit visual mode, move to end of line, enter insert mode"
+    }
+}
+
+impl CommandHandler for VisualInsertEnd {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        {
+            let mut buffer = buffer_arc.write();
+
+            // Clear selection first
+            buffer.selection_mut().clear();
+
+            // Move cursor to end of current line
+            let pos = buffer.position();
+            let line_len = buffer.line_len(pos.line).unwrap_or(0);
+            buffer.set_position(Position::new(pos.line, line_len));
+        }
+
+        // Emit mode change to Insert
+        ctx.event_bus
+            .emit(ModeChanged::with_mode_id("visual", EditorMode::INSERT_ID));
+
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 
@@ -807,13 +940,24 @@ pub fn visual_operator_commands() -> Vec<Box<dyn CommandHandler>> {
     ]
 }
 
-/// Get all visual mode commands (entry + exit + selection + operators).
+/// Get all visual mode key blocking commands.
+#[must_use]
+pub fn visual_key_blocking_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![
+        Box::new(VisualNoOp),
+        Box::new(VisualInsertStart),
+        Box::new(VisualInsertEnd),
+    ]
+}
+
+/// Get all visual mode commands (entry + exit + selection + operators + key blocking).
 #[must_use]
 pub fn visual_commands() -> Vec<Box<dyn CommandHandler>> {
     let mut cmds = visual_entry_commands();
     cmds.extend(visual_exit_commands());
     cmds.extend(visual_selection_commands());
     cmds.extend(visual_operator_commands());
+    cmds.extend(visual_key_blocking_commands());
     cmds
 }
 
@@ -1222,7 +1366,7 @@ mod tests {
     #[test]
     fn test_visual_commands_count() {
         let cmds = visual_commands();
-        assert_eq!(cmds.len(), 14); // 3 entry + 1 exit + 5 selection + 5 operators
+        assert_eq!(cmds.len(), 17); // 3 entry + 1 exit + 5 selection + 5 operators + 3 key blocking
     }
 
     #[test]
@@ -1523,5 +1667,185 @@ mod tests {
         let buffer = buffer_arc.read();
         assert_eq!(buffer.line_count(), 1);
         assert_eq!(buffer.lines()[0], "line three");
+    }
+
+    // ========================================================================
+    // Key Blocking Command Tests - Issue #145
+    // ========================================================================
+
+    #[test]
+    fn test_visual_noop_command_id() {
+        let cmd = VisualNoOp;
+        assert_eq!(cmd.id().name(), "visual-noop");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_visual_noop_returns_success() {
+        let mut ctx = create_test_context();
+        let args = CommandContext::new();
+
+        // Should succeed even without a buffer
+        let result = VisualNoOp.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+    }
+
+    #[test]
+    fn test_visual_insert_start_command_id() {
+        let cmd = VisualInsertStart;
+        assert_eq!(cmd.id().name(), "visual-insert-start");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_visual_insert_end_command_id() {
+        let cmd = VisualInsertEnd;
+        assert_eq!(cmd.id().name(), "visual-insert-end");
+        assert_eq!(cmd.id().module(), &EDITOR_MODULE);
+    }
+
+    #[test]
+    fn test_visual_insert_start_clears_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate selection
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+            buffer.set_position(Position::new(0, 4));
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = VisualInsertStart.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Selection should be cleared
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_visual_insert_start_moves_to_first_nonblank() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("    hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Start at position 10 (in "world")
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer.set_position(Position::new(0, 10));
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 10), SelectionMode::Character);
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = VisualInsertStart.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Cursor should be at first non-blank (position 4)
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.position(), Position::new(0, 4));
+    }
+
+    #[test]
+    fn test_visual_insert_start_empty_line() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("   "); // Only whitespace
+        let buffer_id = ctx.buffers.register(buffer);
+
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer.set_position(Position::new(0, 2));
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 2), SelectionMode::Character);
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = VisualInsertStart.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Cursor should be at position 0 (no non-blank found)
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.position(), Position::new(0, 0));
+    }
+
+    #[test]
+    fn test_visual_insert_end_clears_selection() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Activate selection
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+            buffer.set_position(Position::new(0, 4));
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = VisualInsertEnd.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Selection should be cleared
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert!(!buffer.selection().is_active());
+    }
+
+    #[test]
+    fn test_visual_insert_end_moves_to_eol() {
+        let mut ctx = create_test_context();
+        let buffer = Buffer::from_string("hello world");
+        let buffer_id = ctx.buffers.register(buffer);
+
+        // Start at position 0
+        {
+            let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+            let mut buffer = buffer_arc.write();
+            buffer.set_position(Position::new(0, 0));
+            buffer
+                .selection_mut()
+                .start(Position::new(0, 0), SelectionMode::Character);
+        }
+
+        let mut args = CommandContext::new();
+        args.set_buffer_id(buffer_id);
+
+        let result = VisualInsertEnd.execute(&mut ctx, &args);
+        assert_eq!(result, CommandResult::Success);
+
+        // Cursor should be at end of line (position 11)
+        let buffer_arc = ctx.buffers.get(buffer_id).unwrap();
+        let buffer = buffer_arc.read();
+        assert_eq!(buffer.position(), Position::new(0, 11));
+    }
+
+    #[test]
+    fn test_visual_key_blocking_commands_count() {
+        let cmds = visual_key_blocking_commands();
+        assert_eq!(cmds.len(), 3); // VisualNoOp, VisualInsertStart, VisualInsertEnd
     }
 }

--- a/modules/editor/src/visual.rs
+++ b/modules/editor/src/visual.rs
@@ -19,7 +19,9 @@
 //! - `c` changes selection (delete + insert mode)
 
 use {
-    reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
+    reovim_driver_command::{
+        BlockInsertAction, Command, CommandContext, CommandHandler, CommandResult,
+    },
     reovim_kernel::api::v1::{
         CommandId, KernelContext, Position, SelectionMode, events::ModeChanged,
     },
@@ -897,6 +899,146 @@ impl CommandHandler for VisualInsertEnd {
 }
 
 // =============================================================================
+// Block Insert Mode Commands (Issue #146)
+// =============================================================================
+
+/// Start block insert at the left column (`I` in visual-block mode).
+///
+/// In Vim's visual-block mode, pressing `I` enters insert mode where text
+/// typed is applied to all lines in the block selection at the left column
+/// when insert mode is exited.
+///
+/// Returns `BlockInsertAction::InsertStart` with the block bounds, which
+/// the runner handles by storing the state and entering insert mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlockInsertStart;
+
+impl Command for BlockInsertStart {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "block-insert-start")
+    }
+
+    fn description(&self) -> &'static str {
+        "Start block insert at left column (I in visual-block)"
+    }
+}
+
+impl CommandHandler for BlockInsertStart {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let (start_line, end_line, column) = {
+            let mut buffer = buffer_arc.write();
+            let selection = buffer.selection();
+
+            // Must have an active block selection
+            if !selection.is_active() || !selection.mode().is_block() {
+                return CommandResult::error("No active block selection");
+            }
+
+            let cursor_pos = buffer.position();
+            let Some((top_left, bottom_right)) = selection.block_bounds(cursor_pos) else {
+                return CommandResult::error("Could not determine block bounds");
+            };
+
+            let start_line = top_left.line;
+            let end_line = bottom_right.line;
+            let column = top_left.column; // Left edge of block
+
+            // Clear selection before entering insert mode
+            buffer.selection_mut().clear();
+
+            // Position cursor at the insert column on the first line
+            buffer.set_position(Position::new(start_line, column));
+            drop(buffer);
+
+            (start_line, end_line, column)
+        };
+
+        // Return block insert action for the runner to handle
+        CommandResult::BlockInsertAction(BlockInsertAction::InsertStart {
+            start_line,
+            end_line,
+            column,
+        })
+    }
+}
+
+/// Start block insert at the right column (`A` in visual-block mode).
+///
+/// In Vim's visual-block mode, pressing `A` enters insert mode where text
+/// typed is applied to all lines in the block selection after the right column
+/// when insert mode is exited.
+///
+/// Returns `BlockInsertAction::InsertEnd` with the block bounds, which
+/// the runner handles by storing the state and entering insert mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlockInsertEnd;
+
+impl Command for BlockInsertEnd {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "block-insert-end")
+    }
+
+    fn description(&self) -> &'static str {
+        "Start block insert after right column (A in visual-block)"
+    }
+}
+
+impl CommandHandler for BlockInsertEnd {
+    fn execute(&self, ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let Some(buffer_id) = args.buffer_id() else {
+            return CommandResult::error("No active buffer");
+        };
+
+        let Some(buffer_arc) = ctx.buffers.get(buffer_id) else {
+            return CommandResult::error("Buffer not found");
+        };
+
+        let (start_line, end_line, column) = {
+            let mut buffer = buffer_arc.write();
+            let selection = buffer.selection();
+
+            // Must have an active block selection
+            if !selection.is_active() || !selection.mode().is_block() {
+                return CommandResult::error("No active block selection");
+            }
+
+            let cursor_pos = buffer.position();
+            let Some((top_left, bottom_right)) = selection.block_bounds(cursor_pos) else {
+                return CommandResult::error("Could not determine block bounds");
+            };
+
+            let start_line = top_left.line;
+            let end_line = bottom_right.line;
+            let column = bottom_right.column + 1; // After right edge of block
+
+            // Clear selection before entering insert mode
+            buffer.selection_mut().clear();
+
+            // Position cursor at the insert column on the first line
+            buffer.set_position(Position::new(start_line, column));
+            drop(buffer);
+
+            (start_line, end_line, column)
+        };
+
+        // Return block insert action for the runner to handle
+        CommandResult::BlockInsertAction(BlockInsertAction::InsertEnd {
+            start_line,
+            end_line,
+            column,
+        })
+    }
+}
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 
@@ -950,7 +1092,13 @@ pub fn visual_key_blocking_commands() -> Vec<Box<dyn CommandHandler>> {
     ]
 }
 
-/// Get all visual mode commands (entry + exit + selection + operators + key blocking).
+/// Get all block insert mode commands (I/A in visual-block).
+#[must_use]
+pub fn visual_block_insert_commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![Box::new(BlockInsertStart), Box::new(BlockInsertEnd)]
+}
+
+/// Get all visual mode commands (entry + exit + selection + operators + key blocking + block insert).
 #[must_use]
 pub fn visual_commands() -> Vec<Box<dyn CommandHandler>> {
     let mut cmds = visual_entry_commands();
@@ -958,6 +1106,7 @@ pub fn visual_commands() -> Vec<Box<dyn CommandHandler>> {
     cmds.extend(visual_selection_commands());
     cmds.extend(visual_operator_commands());
     cmds.extend(visual_key_blocking_commands());
+    cmds.extend(visual_block_insert_commands());
     cmds
 }
 
@@ -1366,7 +1515,7 @@ mod tests {
     #[test]
     fn test_visual_commands_count() {
         let cmds = visual_commands();
-        assert_eq!(cmds.len(), 17); // 3 entry + 1 exit + 5 selection + 5 operators + 3 key blocking
+        assert_eq!(cmds.len(), 19); // 3 entry + 1 exit + 5 selection + 5 operators + 3 key blocking + 2 block insert
     }
 
     #[test]

--- a/modules/keymap/src/visual.rs
+++ b/modules/keymap/src/visual.rs
@@ -144,5 +144,36 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
             .with_modes(&["visual", "visual-line", "visual-block"])
             .with_category("mode")
             .with_description("Enter command mode with selection range"),
+        // ====================================================================
+        // Blocked keys (explicit no-op) - Issue #145
+        // ====================================================================
+        KeybindingRegistration::new("i", "visual-noop")
+            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_category("blocked")
+            .with_description("No-op (insert key blocked in visual mode)"),
+        KeybindingRegistration::new("a", "visual-noop")
+            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_category("blocked")
+            .with_description("No-op (append key blocked in visual mode)"),
+        // ====================================================================
+        // Visual insert commands (I/A) - Issue #145
+        // ====================================================================
+        KeybindingRegistration::new("I", "visual-insert-start")
+            .with_modes(&["visual", "visual-line"])
+            .with_category("mode")
+            .with_description("Exit visual, move to line start, enter insert"),
+        KeybindingRegistration::new("A", "visual-insert-end")
+            .with_modes(&["visual", "visual-line"])
+            .with_category("mode")
+            .with_description("Exit visual, move to line end, enter insert"),
+        // Block mode I/A - no-op until #146 implements block insert
+        KeybindingRegistration::new("I", "visual-noop")
+            .with_modes(&["visual-block"])
+            .with_category("blocked")
+            .with_description("Block insert (not yet implemented, see #146)"),
+        KeybindingRegistration::new("A", "visual-noop")
+            .with_modes(&["visual-block"])
+            .with_category("blocked")
+            .with_description("Block append (not yet implemented, see #146)"),
     ]
 }

--- a/modules/keymap/src/visual.rs
+++ b/modules/keymap/src/visual.rs
@@ -166,14 +166,14 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
             .with_modes(&["visual", "visual-line"])
             .with_category("mode")
             .with_description("Exit visual, move to line end, enter insert"),
-        // Block mode I/A - no-op until #146 implements block insert
-        KeybindingRegistration::new("I", "visual-noop")
+        // Block mode I/A - Issue #146
+        KeybindingRegistration::new("I", "block-insert-start")
             .with_modes(&["visual-block"])
-            .with_category("blocked")
-            .with_description("Block insert (not yet implemented, see #146)"),
-        KeybindingRegistration::new("A", "visual-noop")
+            .with_category("mode")
+            .with_description("Insert at block left column on all lines"),
+        KeybindingRegistration::new("A", "block-insert-end")
             .with_modes(&["visual-block"])
-            .with_category("blocked")
-            .with_description("Block append (not yet implemented, see #146)"),
+            .with_category("mode")
+            .with_description("Append at block right column on all lines"),
     ]
 }

--- a/runner/src/server/app.rs
+++ b/runner/src/server/app.rs
@@ -500,6 +500,91 @@ impl RepeatState {
 }
 
 // ============================================================================
+// Block Insert Mode State
+// ============================================================================
+
+/// State for block insert mode (`I`/`A` in visual-block).
+///
+/// When active, text typed in insert mode is recorded and will be applied
+/// to all lines in the block upon exiting insert mode.
+///
+/// # Block Insert Flow
+///
+/// 1. User selects text with visual-block mode (`<C-v>`)
+/// 2. User presses `I` or `A` to start block insert
+/// 3. This state is populated with block bounds
+/// 4. User types text (shown at cursor on first line)
+/// 5. User exits insert mode (Escape, Ctrl-C, etc.)
+/// 6. Accumulated text is applied to all lines in the block
+/// 7. State is cleared
+#[derive(Debug, Clone, Default)]
+pub struct BlockInsertState {
+    /// Whether block insert is currently active.
+    pub active: bool,
+    /// First line of the block (0-indexed).
+    pub start_line: usize,
+    /// Last line of the block (0-indexed, inclusive).
+    pub end_line: usize,
+    /// Column where text will be inserted (0-indexed).
+    ///
+    /// For `I`, this is the left column of the block.
+    /// For `A`, this is the right column + 1 (after the block).
+    pub column: usize,
+    /// Whether this is an append operation (`A`) vs insert (`I`).
+    pub is_append: bool,
+}
+
+impl BlockInsertState {
+    /// Create a new inactive block insert state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            active: false,
+            start_line: 0,
+            end_line: 0,
+            column: 0,
+            is_append: false,
+        }
+    }
+
+    /// Start a block insert operation.
+    #[allow(clippy::missing_const_for_fn)] // &mut self const fns not stable
+    pub fn start(&mut self, start_line: usize, end_line: usize, column: usize, is_append: bool) {
+        self.active = true;
+        self.start_line = start_line;
+        self.end_line = end_line;
+        self.column = column;
+        self.is_append = is_append;
+    }
+
+    /// Clear the block insert state.
+    #[allow(clippy::missing_const_for_fn)] // &mut self const fns not stable
+    pub fn clear(&mut self) {
+        self.active = false;
+        self.start_line = 0;
+        self.end_line = 0;
+        self.column = 0;
+        self.is_append = false;
+    }
+
+    /// Check if block insert is currently active.
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Get the number of lines in the block.
+    #[must_use]
+    pub const fn line_count(&self) -> usize {
+        if self.active {
+            self.end_line - self.start_line + 1
+        } else {
+            0
+        }
+    }
+}
+
+// ============================================================================
 // Visual Mode Selection Infrastructure
 // ============================================================================
 
@@ -881,6 +966,12 @@ pub struct AppState {
     /// which window displays it, which buffer's tree is shown,
     /// and navigation state within the tree.
     pub undotree_state: UndotreeState,
+
+    /// Block insert state for visual-block `I`/`A` commands.
+    ///
+    /// When block insert is active, text typed in insert mode is recorded
+    /// and applied to all lines in the block when insert mode exits.
+    pub block_insert: BlockInsertState,
 }
 
 impl AppState {
@@ -910,6 +1001,7 @@ impl AppState {
             last_visual_selection: None,
             windows: WindowRegistry::new(),
             undotree_state: UndotreeState::new(),
+            block_insert: BlockInsertState::new(),
         }
     }
 

--- a/runner/src/server/event_loop.rs
+++ b/runner/src/server/event_loop.rs
@@ -274,9 +274,17 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                     // Handle mode transition from ModeChanged events
                     // Commands emit ModeChanged::with_mode_id() which sets pending_mode_change.
                     // This event-driven approach replaces hardcoded mode_for_command() mapping.
-                    if let Ok(mut guard) = self.pending_mode_change.lock()
-                        && let Some(new_mode) = guard.take()
-                    {
+                    let pending_new_mode = self
+                        .pending_mode_change
+                        .lock()
+                        .ok()
+                        .and_then(|mut guard| guard.take());
+                    if let Some(new_mode) = pending_new_mode {
+                        // Check if exiting insert mode with block insert active
+                        let old_mode = self.app.current_mode();
+                        if old_mode.name() == "insert" && self.app.block_insert.is_active() {
+                            self.apply_block_insert_text();
+                        }
                         self.app.mode_stack.set(new_mode);
                     }
                 } else {
@@ -580,6 +588,11 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                 // last visual selection. Handle it here instead of checking
                 // the command name.
                 self.handle_reselect_last();
+            }
+            CommandResult::BlockInsertAction(action) => {
+                // Visual-block I/A commands return this to initiate block insert mode.
+                // Store the block bounds and enter insert mode.
+                self.handle_block_insert_action(action);
             }
         }
     }
@@ -1575,6 +1588,122 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
         // Using the stored mode_id instead of deriving from SelectionMode
         // removes hardcoded "editor" module assumption
         self.app.mode_stack.set(mode_id);
+    }
+
+    /// Handle a block insert action from visual-block I/A commands.
+    ///
+    /// This initiates block insert mode:
+    /// 1. Stores block bounds in `AppState`
+    /// 2. Enters insert mode
+    /// 3. Starts insert text accumulation
+    ///
+    /// When insert mode exits (via Escape, Ctrl-C, etc.), the accumulated text
+    /// will be applied to all lines in the block.
+    fn handle_block_insert_action(&mut self, action: reovim_driver_command::BlockInsertAction) {
+        use {
+            reovim_driver_command::BlockInsertAction,
+            reovim_kernel::api::v1::{ModeId, ModuleId},
+        };
+
+        let (start_line, end_line, column, is_append) = match action {
+            BlockInsertAction::InsertStart {
+                start_line,
+                end_line,
+                column,
+            } => (start_line, end_line, column, false),
+            BlockInsertAction::InsertEnd {
+                start_line,
+                end_line,
+                column,
+            } => (start_line, end_line, column, true),
+        };
+
+        // Store block insert state
+        self.app
+            .block_insert
+            .start(start_line, end_line, column, is_append);
+
+        // Enter insert mode (construct ModeId directly since runner doesn't depend on editor module)
+        let insert_mode_id = ModeId::new(ModuleId::new("editor"), "insert");
+        self.app.mode_stack.set(insert_mode_id);
+
+        // Start accumulating insert text for later application
+        self.app.repeat_state.start_accumulating();
+
+        tracing::debug!(start_line, end_line, column, is_append, "Block insert mode started");
+    }
+
+    /// Apply accumulated block insert text to all lines in the block.
+    ///
+    /// Called when exiting insert mode while block insert is active.
+    /// Applies the text typed on the first line to all lines in the block selection.
+    fn apply_block_insert_text(&mut self) {
+        // Get block insert state
+        let block_insert = &self.app.block_insert;
+        if !block_insert.is_active() {
+            return;
+        }
+
+        let start_line = block_insert.start_line;
+        let end_line = block_insert.end_line;
+        let column = block_insert.column;
+
+        // Get accumulated insert text
+        let insert_text = self.app.repeat_state.insert_text.clone();
+        if insert_text.is_empty() {
+            // No text to apply
+            self.app.block_insert.clear();
+            self.app.repeat_state.stop_accumulating();
+            return;
+        }
+
+        // Get active buffer
+        let Some(buffer_id) = self.app.active_buffer else {
+            self.app.block_insert.clear();
+            self.app.repeat_state.stop_accumulating();
+            return;
+        };
+
+        let Some(buffer_arc) = self.app.kernel.buffers.get(buffer_id) else {
+            self.app.block_insert.clear();
+            self.app.repeat_state.stop_accumulating();
+            return;
+        };
+
+        // Apply text to lines 2..=N (first line already has the text from typing)
+        // Text was already inserted on start_line, so we apply to start_line+1..=end_line
+        let mut buffer = buffer_arc.write();
+        let lines_count = buffer.lines().len();
+
+        for line_num in (start_line + 1)..=end_line {
+            if line_num >= lines_count {
+                break;
+            }
+
+            let line = buffer.lines().get(line_num).map(String::from);
+            if let Some(line) = line {
+                // Calculate insert position - clamp to line length
+                // (for both insert and append, column is the target position)
+                let insert_col = column.min(line.len());
+
+                let pos = Position::new(line_num, insert_col);
+                buffer.insert_at(pos, &insert_text);
+            }
+        }
+        drop(buffer);
+
+        tracing::debug!(
+            start_line,
+            end_line,
+            column,
+            text_len = insert_text.len(),
+            "Applied block insert text to {} lines",
+            end_line - start_line
+        );
+
+        // Clear block insert state
+        self.app.block_insert.clear();
+        self.app.repeat_state.stop_accumulating();
     }
 }
 

--- a/runner/src/server/session/session.rs
+++ b/runner/src/server/session/session.rs
@@ -306,6 +306,11 @@ impl Session {
                 tracing::info!(?action, "Mode action requested (session)");
                 None
             }
+            CommandResult::BlockInsertAction(action) => {
+                // Block insert actions are handled by the runner event loop.
+                tracing::info!(?action, "Block insert action requested (session)");
+                None
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Issue #145**: Add explicit no-op bindings for `i`/`a` in visual modes, implement `I`/`A` commands in visual/visual-line modes
- **Issue #146**: Implement `I`/`A` in visual-block mode with block insert functionality

## Changes

### Issue #145 - Visual Mode Key Blocking
- Explicit no-op bindings for `i`/`a` keys in all visual modes (prevent fallthrough)
- `I` in visual/visual-line: move to first non-blank, enter insert
- `A` in visual/visual-line: move to end of line, enter insert
- New commands: `VisualNoOp`, `VisualInsertStart`, `VisualInsertEnd`

### Issue #146 - Visual-Block Insert Mode
- `I` in visual-block: insert at left column of block on all selected lines
- `A` in visual-block: append at right column of block on all selected lines
- Text typed is applied to all lines in the block on exit
- New commands: `BlockInsertStart`, `BlockInsertEnd`
- New `CommandResult::BlockInsertAction` variant for callback pattern
- New `BlockInsertState` in `AppState` for tracking block bounds

## Test plan

- [ ] Verify `i`/`a` are blocked in visual modes (no fallthrough to insert)
- [ ] Test `I`/`A` in visual mode moves cursor and enters insert
- [ ] Test `I`/`A` in visual-line mode moves cursor and enters insert
- [ ] Test `I` in visual-block inserts text at left column on all lines
- [ ] Test `A` in visual-block appends text at right column on all lines

Closes #145, Closes #146