### PR TITLE
feat(ffi): add FFI module loading mechanism (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,23 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
   - Example C module at `examples/c-module/`
   - Modules can be written in C, Haskell, or any FFI-compatible language
 
+- **Haskell FFI Module Support** (Issue #294)
+  - Example Haskell module at `examples/haskell-module/`
+  - GHC RTS initialization via `__attribute__((constructor))` in `rts_shim.c`
+  - Pointer-based FFI alternatives for GHC limitations:
+    - `reovim_module_api_version_ptr()` - GHC can't export static symbols
+    - `reovim_module_probe()` via pointer - GHC can't return structs by value
+  - Module loader fallback support (`runner/src/server/module/loading/loader.rs`):
+    - Tries static symbol first, then pointer-based function
+  - Haskell FFI bindings library:
+    - `Reovim.FFI.Types` - Storable instances for FFI types
+    - `Reovim.FFI.Version` - Version constants and compatibility
+    - `Reovim.FFI.Probe` - ProbeBuilder pattern
+    - `Reovim.FFI.Logging` - Kernel logging imports
+    - `Reovim.Module` - ReovimModule typeclass with exception-safe wrappers
+  - Documentation at `docs/architecture/ffi/haskell.md`
+  - Demo script: `examples/haskell-module/demo.sh`
+
 - **Basic Window Management** (Issue #276)
   - **WindowRegistry** (`runner/src/server/window.rs`):
     - `WindowState` struct for per-window cursor position and scroll offset

--- a/docs/architecture/ffi/haskell.md
+++ b/docs/architecture/ffi/haskell.md
@@ -1,0 +1,300 @@
+# Haskell FFI Guide
+
+This document covers Haskell-specific details for writing reovim modules.
+For the general FFI interface, see [overview.md](overview.md).
+
+## GHC Runtime System
+
+The GHC Runtime System (RTS) must be initialized before any Haskell code
+executes. This is critical because reovim's module loader calls probe
+functions before the module's `entry()` function.
+
+### The Problem
+
+1. Loader calls `dlopen()` to load the shared library
+2. Loader calls `reovim_module_api_version_ptr()` to check version
+3. Loader calls `reovim_module_probe()` to get metadata
+4. **At this point, GHC RTS is NOT initialized!**
+5. Haskell code panics: "RTS is not initialised; call hs_init() first"
+
+### The Solution: Constructor Attribute
+
+Use GCC's `__attribute__((constructor))` to initialize the RTS when the
+library is loaded, before any other function is called:
+
+```c
+// rts_shim.c
+#include <stddef.h>
+#include <HsFFI.h>
+
+static void reovim_rts_init(void) __attribute__((constructor));
+static void reovim_rts_init(void)
+{
+    static char *argv[] = { "reovim-haskell-module", NULL };
+    static char **argv_ = argv;
+    static int argc = 1;
+    hs_init(&argc, &argv_);
+}
+
+static void reovim_rts_exit(void) __attribute__((destructor));
+static void reovim_rts_exit(void)
+{
+    hs_exit();
+}
+```
+
+The constructor runs automatically when `dlopen()` loads the library,
+ensuring the RTS is ready before any Haskell functions are called.
+
+### Limitations
+
+- **No RTS reinit**: GHC does not support reinitializing the RTS after
+  `hs_exit()`. Once a Haskell module is unloaded, it cannot be reloaded
+  in the same process.
+- **One RTS per process**: Multiple Haskell modules share the same RTS.
+
+## FFI Signature Alternatives
+
+GHC has limitations on FFI signatures that require alternative entry points.
+
+### Return by Pointer
+
+GHC cannot return structs by value from FFI functions. Instead of:
+
+```c
+ReovimModuleProbe reovim_module_probe(void);  // GHC cannot do this
+```
+
+Use a pointer-based signature:
+
+```c
+void reovim_module_probe(ReovimModuleProbe* out);  // GHC can do this
+```
+
+The reovim loader supports both signatures, trying return-by-value first,
+then falling back to pointer-based.
+
+### Static Symbol Export
+
+GHC cannot export static data symbols. Instead of:
+
+```c
+const ReovimVersion REOVIM_MODULE_API_VERSION;  // GHC cannot do this
+```
+
+Use a function that writes to a pointer:
+
+```c
+void reovim_module_api_version_ptr(ReovimVersion* out);  // GHC can do this
+```
+
+## Type Mappings
+
+| C Type | Haskell Type | Notes |
+|--------|--------------|-------|
+| `uint8_t` | `Word8` | |
+| `uint32_t` | `Word32` | |
+| `int32_t` | `Int32` | |
+| `size_t` | `CSize` (Word) | |
+| `const char*` | `CString` | Null-terminated |
+| `void*` | `Ptr ()` | Opaque pointer |
+| `uint8_t[64]` | `ByteString` | Fixed-size, stored inline |
+
+### Storable Instances
+
+All FFI structs need `Storable` instances for marshalling:
+
+```haskell
+instance Storable ReovimVersion where
+    sizeOf _ = 12  -- 3 * 4 bytes
+    alignment _ = 4
+    peek ptr = ReovimVersion
+        <$> peekByteOff ptr 0   -- major
+        <*> peekByteOff ptr 4   -- minor
+        <*> peekByteOff ptr 8   -- patch
+    poke ptr (ReovimVersion maj min pat) = do
+        pokeByteOff ptr 0 maj
+        pokeByteOff ptr 4 min
+        pokeByteOff ptr 8 pat
+```
+
+## Exception Safety
+
+Haskell exceptions must NOT escape across the FFI boundary. All exported
+functions must catch exceptions and convert them to return codes:
+
+```haskell
+safeFFI :: IO Int32 -> IO Int32
+safeFFI action = action `catch` handleException
+  where
+    handleException :: SomeException -> IO Int32
+    handleException e = do
+        logError $ "Haskell exception: " ++ show e
+        return returnPanic  -- -2
+```
+
+## Module Structure
+
+A Haskell module should follow this structure:
+
+```
+my-module/
+├── MyModule.hs           # Module implementation + FFI exports
+├── Reovim/
+│   ├── FFI.hs            # FFI bindings library
+│   ├── FFI/
+│   │   ├── Types.hs      # Core FFI types
+│   │   ├── Version.hs    # Version constants
+│   │   ├── Probe.hs      # ProbeBuilder
+│   │   └── Logging.hs    # Kernel logging imports
+│   └── Module.hs         # ReovimModule typeclass
+├── rts_shim.c            # GHC RTS init/exit
+├── my-module.cabal       # Cabal package
+└── Makefile              # Build targets
+```
+
+## Cabal Configuration
+
+Use `foreign-library` for the shared library component:
+
+```cabal
+foreign-library my-module
+    type:             native-shared
+    lib-version-info: 1:0:0
+
+    other-modules:    MyModule
+    c-sources:        rts_shim.c
+    build-depends:
+        base >= 4.16 && < 5,
+        bytestring >= 0.11 && < 0.13,
+        my-module-ffi-lib
+    default-language: GHC2021
+    ghc-options:      -fPIC
+```
+
+Key points:
+- `type: native-shared` produces a `.so` file
+- `c-sources: rts_shim.c` includes the RTS init shim
+- `-fPIC` is required for shared libraries
+
+## Entry Point Implementation
+
+```haskell
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module MyModule where
+
+import Foreign
+import Foreign.C
+import Reovim.FFI
+import Reovim.Module
+
+-- Module state (managed via StablePtr)
+data MyModuleState = MyModuleState
+    { msInitialized :: !Bool
+    }
+
+-- API version (pointer-based for GHC compatibility)
+foreign export ccall "reovim_module_api_version_ptr"
+    hsApiVersionPtr :: Ptr ReovimVersion -> IO ()
+
+hsApiVersionPtr :: Ptr ReovimVersion -> IO ()
+hsApiVersionPtr ptr = poke ptr apiVersion
+
+-- Probe (pointer-based for GHC compatibility)
+foreign export ccall "reovim_module_probe"
+    hsModuleProbe :: Ptr ReovimModuleProbe -> IO ()
+
+hsModuleProbe :: Ptr ReovimModuleProbe -> IO ()
+hsModuleProbe ptr = poke ptr myProbe
+  where
+    myProbe = buildProbe $ do
+        setId "my-module"
+        setName "My Module"
+        setVersion (1, 0, 0)
+        setApiVersion (0, 2, 0)
+
+-- Entry (creates StablePtr to module state)
+foreign export ccall "reovim_module_entry"
+    hsModuleEntry :: IO (Ptr ())
+
+hsModuleEntry :: IO (Ptr ())
+hsModuleEntry = do
+    logDebug "Creating module instance"
+    let state = MyModuleState { msInitialized = False }
+    stablePtr <- newStablePtr state
+    return $ castStablePtrToPtr stablePtr
+
+-- Init
+foreign export ccall "reovim_module_init"
+    hsModuleInit :: Ptr () -> Ptr () -> IO Int32
+
+hsModuleInit :: Ptr () -> Ptr () -> IO Int32
+hsModuleInit modulePtr _ctxPtr = safeFFI $ do
+    state <- deRefStablePtr (castPtrToStablePtr modulePtr)
+    logInfo "Module initializing"
+    -- Update state...
+    return 0  -- Success
+
+-- Exit
+foreign export ccall "reovim_module_exit"
+    hsModuleExit :: Ptr () -> IO Int32
+
+hsModuleExit :: Ptr () -> IO Int32
+hsModuleExit modulePtr = safeFFI $ do
+    _state <- deRefStablePtr (castPtrToStablePtr modulePtr)
+    logInfo "Module exiting"
+    return 0  -- Success
+
+-- Destroy (frees StablePtr)
+foreign export ccall "reovim_module_destroy"
+    hsModuleDestroy :: Ptr () -> IO ()
+
+hsModuleDestroy :: Ptr () -> IO ()
+hsModuleDestroy modulePtr = do
+    freeStablePtr (castPtrToStablePtr modulePtr :: StablePtr MyModuleState)
+```
+
+## Building
+
+```bash
+# Build
+cabal build flib:my-module
+
+# Find the library
+find dist-newstyle -name "*.so*" -type f
+
+# Test loading
+reovim cli load /path/to/libmy-module.so.1.0.0
+```
+
+## Logging
+
+Kernel logging functions are imported via FFI:
+
+```haskell
+foreign import ccall unsafe "reovim_log_info"
+    c_reovim_log_info :: CString -> IO ()
+
+logInfo :: String -> IO ()
+logInfo msg = withCString msg c_reovim_log_info
+```
+
+For standalone testing (without reovim), provide stub implementations in
+`rts_shim.c`:
+
+```c
+void reovim_log_info(const char *msg) {
+    fprintf(stderr, "[INFO] %s\n", msg);
+}
+```
+
+## Example Module
+
+See `examples/haskell-module/` for a complete working example.
+
+## References
+
+- [GHC User's Guide - Shared Libraries](https://downloads.haskell.org/ghc/latest/docs/users_guide/shared_libs.html)
+- [GHC User's Guide - FFI](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/ffi.html)
+- [Well-Typed Blog - Building Plugins as Haskell Shared Libs](https://well-typed.com/blog/2009/05/buildings-plugins-as-haskell-shared-libs/)

--- a/examples/haskell-module/.gitignore
+++ b/examples/haskell-module/.gitignore
@@ -1,0 +1,34 @@
+# Cabal build artifacts
+dist-newstyle/
+dist/
+
+# Stack build artifacts
+.stack-work/
+
+# GHC interface files
+*.hi
+*.dyn_hi
+*.o
+*.dyn_o
+
+# Shared libraries (built artifacts)
+*.so
+*.so.*
+*.dylib
+*.dll
+
+# Static libraries
+*.a
+
+# Stub files
+*_stub.h
+
+# Cabal sandbox
+.cabal-sandbox/
+cabal.sandbox.config
+
+# Editor files
+*~
+*.swp
+.vscode/
+.idea/

--- a/examples/haskell-module/ExampleModule.hs
+++ b/examples/haskell-module/ExampleModule.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : ExampleModule
+-- Description : Example reovim module in Haskell
+--
+-- This module demonstrates how to implement a reovim module in Haskell.
+-- It exports all 6 required entry points using the C calling convention.
+--
+-- = Building
+--
+-- @
+-- make
+-- @
+--
+-- = Entry Points
+--
+-- The module exports these symbols:
+--
+-- * @REOVIM_MODULE_API_VERSION@ - Static API version
+-- * @reovim_module_probe@ - Return module metadata
+-- * @reovim_module_entry@ - Create module instance
+-- * @reovim_module_init@ - Initialize module
+-- * @reovim_module_exit@ - Cleanup module
+-- * @reovim_module_destroy@ - Free module memory
+
+module ExampleModule where
+
+import Control.Exception (SomeException, catch)
+import Data.Int (Int32)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Foreign.Ptr (Ptr, nullPtr)
+import Foreign.StablePtr
+    ( StablePtr
+    , newStablePtr
+    , freeStablePtr
+    , deRefStablePtr
+    , castStablePtrToPtr
+    , castPtrToStablePtr
+    )
+import Foreign.Marshal.Alloc (malloc, free)
+import Foreign.Storable (poke)
+
+import System.IO.Unsafe (unsafePerformIO)
+
+import Reovim.FFI
+import Reovim.Module
+
+-- | Module state
+data ExampleState = ExampleState
+    { stateInitialized :: !(IORef Bool)
+    , stateCounter :: !(IORef Int)
+    }
+
+-- | Create initial module state
+newExampleState :: IO ExampleState
+newExampleState = ExampleState
+    <$> newIORef False
+    <*> newIORef 0
+
+-- | Module metadata
+exampleProbe :: ReovimModuleProbe
+exampleProbe = buildProbe $
+    newProbe
+        & withId "example-haskell"
+        & withName "Example Haskell Module"
+        & withVersion 1 0 0
+        & withRustcVersion "GHC"
+  where
+    (&) = flip ($)
+
+instance ReovimModule ExampleState where
+    moduleProbe _ = exampleProbe
+
+    moduleInit state _ctx = do
+        -- Fun greeting sequence
+        logInfo "==================================="
+        logInfo "  Hello, Reovim!"
+        logInfo "  I am a Haskell module!"
+        logInfo "  Functional programming FTW!"
+        logInfo "==================================="
+
+        -- Check ABI compatibility
+        compatible <- checkKernelCompatibility
+        if not compatible
+            then do
+                logError "ABI version mismatch"
+                return returnFailed
+            else do
+                writeIORef (stateInitialized state) True
+                writeIORef (stateCounter state) 42
+                logDebug "Counter initialized to 42"
+                logInfo "Module ready!"
+                return returnSuccess
+
+    moduleExit state = do
+        logInfo "Example Haskell module exiting"
+        writeIORef (stateInitialized state) False
+        writeIORef (stateCounter state) 0
+        return returnSuccess
+
+-- ============================================================================
+-- FFI Entry Points
+-- ============================================================================
+
+-- | Static API version symbol
+--
+-- The loader reads this before calling any functions.
+-- We export a pointer to a statically allocated version struct.
+foreign export ccall "reovim_module_api_version_ptr"
+    apiVersionPtr :: IO (Ptr ReovimVersion)
+
+{-# NOINLINE apiVersionStorage #-}
+apiVersionStorage :: IORef (Maybe (Ptr ReovimVersion))
+apiVersionStorage = unsafePerformIO $ newIORef Nothing
+  where
+    -- Safe use of unsafePerformIO for one-time initialization
+    {-# NOINLINE unsafePerformIO #-}
+    unsafePerformIO = System.IO.Unsafe.unsafePerformIO
+
+apiVersionPtr :: IO (Ptr ReovimVersion)
+apiVersionPtr = do
+    existing <- readIORef apiVersionStorage
+    case existing of
+        Just ptr -> return ptr
+        Nothing -> do
+            ptr <- malloc
+            poke ptr apiVersion
+            writeIORef apiVersionStorage (Just ptr)
+            return ptr
+
+-- Note: REOVIM_MODULE_API_VERSION as a static data export is complex in Haskell.
+-- The loader should also support reading via reovim_module_api_version_ptr().
+
+-- | Return module metadata via pointer
+--
+-- The C ABI expects probe returned by value, but GHC can't do that.
+-- We allocate and fill a buffer instead. The caller is responsible
+-- for providing the buffer (or we malloc one).
+foreign export ccall "reovim_module_probe"
+    hsModuleProbe :: Ptr ReovimModuleProbe -> IO ()
+
+hsModuleProbe :: Ptr ReovimModuleProbe -> IO ()
+hsModuleProbe ptr = poke ptr exampleProbe
+
+-- | Create module instance
+--
+-- Allocates state and wraps in StablePtr to prevent GC.
+foreign export ccall "reovim_module_entry"
+    hsModuleEntry :: IO (Ptr ())
+
+hsModuleEntry :: IO (Ptr ())
+hsModuleEntry = safeFFI' $ do
+    logDebug "Creating Haskell module instance"
+    state <- newExampleState
+    newModulePtr state
+  where
+    safeFFI' action = action `catch` \(_ :: SomeException) -> return nullPtr
+
+-- | Initialize module
+foreign export ccall "reovim_module_init"
+    hsModuleInit :: Ptr () -> Ptr () -> IO Int32
+
+hsModuleInit :: Ptr () -> Ptr () -> IO Int32
+hsModuleInit modulePtr ctxPtr = safeFFI $ do
+    result <- withModulePtr modulePtr $ \(state :: ExampleState) ->
+        moduleInit state ctxPtr
+    case result of
+        Just r -> return r
+        Nothing -> do
+            logError "Module init called with null pointer"
+            return returnFailed
+
+-- | Cleanup module
+foreign export ccall "reovim_module_exit"
+    hsModuleExit :: Ptr () -> IO Int32
+
+hsModuleExit :: Ptr () -> IO Int32
+hsModuleExit modulePtr = safeFFI $ do
+    result <- withModulePtr modulePtr $ \(state :: ExampleState) ->
+        moduleExit state
+    case result of
+        Just r -> return r
+        Nothing -> do
+            logError "Module exit called with null pointer"
+            return returnFailed
+
+-- | Free module memory
+foreign export ccall "reovim_module_destroy"
+    hsModuleDestroy :: Ptr () -> IO ()
+
+hsModuleDestroy :: Ptr () -> IO ()
+hsModuleDestroy modulePtr = safeFFIVoid $ do
+    logDebug "Destroying Haskell module instance"
+    freeModulePtr modulePtr
+
+-- | Check if hot reload is supported
+foreign export ccall "reovim_module_supports_hot_reload"
+    hsModuleSupportsHotReload :: Ptr () -> IO Int32
+
+hsModuleSupportsHotReload :: Ptr () -> IO Int32
+hsModuleSupportsHotReload _ = return 0  -- Not supported
+
+-- | Save state for hot reload (not supported)
+foreign export ccall "reovim_module_save_state"
+    hsModuleSaveState :: Ptr () -> Ptr (Ptr ()) -> Ptr Int -> IO Int32
+
+hsModuleSaveState :: Ptr () -> Ptr (Ptr ()) -> Ptr Int -> IO Int32
+hsModuleSaveState _ _ _ = return 1  -- No state to save
+
+-- | Restore state after hot reload (not supported)
+foreign export ccall "reovim_module_restore_state"
+    hsModuleRestoreState :: Ptr () -> Ptr () -> Int -> IO Int32
+
+hsModuleRestoreState :: Ptr () -> Ptr () -> Int -> IO Int32
+hsModuleRestoreState _ _ _ = return returnFailed  -- Not supported
+
+-- | Free state buffer (not supported)
+foreign export ccall "reovim_module_free_state"
+    hsModuleFreeState :: Ptr () -> Int -> IO ()
+
+hsModuleFreeState :: Ptr () -> Int -> IO ()
+hsModuleFreeState _ _ = return ()  -- Nothing to free

--- a/examples/haskell-module/LICENSE
+++ b/examples/haskell-module/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 reovim contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/haskell-module/Makefile
+++ b/examples/haskell-module/Makefile
@@ -1,0 +1,101 @@
+# Makefile for reovim Haskell example module
+#
+# Targets:
+#   make        - Build the shared library
+#   make test   - Run FFI safety tests
+#   make check  - Verify exported symbols
+#   make clean  - Remove build artifacts
+#   make help   - Show this help
+
+.PHONY: all build test check clean help install
+
+# Default target
+all: build
+
+# Build the shared library using cabal
+build:
+	@echo "Building Haskell module..."
+	cabal build all
+	@echo ""
+	@echo "Build complete. Library location:"
+	@find dist-newstyle -name "libexample-haskell*.so" -o \
+	      -name "libexample-haskell*.dylib" -o \
+	      -name "example-haskell*.dll" 2>/dev/null | head -1 || \
+	    echo "  (library will be in dist-newstyle/)"
+
+# Run FFI safety tests
+test: build
+	@echo "Running FFI safety tests..."
+	cabal run test-ffi-safety
+
+# Verify exported symbols match requirements
+check: build
+	@echo "Checking exported symbols..."
+	@LIB=$$(find dist-newstyle -name "libexample-haskell*.so" -o \
+	        -name "libexample-haskell*.dylib" 2>/dev/null | head -1); \
+	if [ -z "$$LIB" ]; then \
+	    echo "ERROR: Shared library not found. Run 'make build' first."; \
+	    exit 1; \
+	fi; \
+	echo "Library: $$LIB"; \
+	echo ""; \
+	echo "Required symbols:"; \
+	echo "-----------------"; \
+	MISSING=0; \
+	for sym in reovim_module_probe reovim_module_entry reovim_module_init \
+	           reovim_module_exit reovim_module_destroy; do \
+	    if nm -D "$$LIB" 2>/dev/null | grep -q "$$sym" || \
+	       nm "$$LIB" 2>/dev/null | grep -q "$$sym"; then \
+	        echo "[OK] $$sym"; \
+	    else \
+	        echo "[MISSING] $$sym"; \
+	        MISSING=1; \
+	    fi; \
+	done; \
+	echo ""; \
+	echo "Optional symbols:"; \
+	echo "-----------------"; \
+	for sym in reovim_module_supports_hot_reload reovim_module_save_state \
+	           reovim_module_restore_state reovim_module_free_state \
+	           reovim_module_api_version_ptr; do \
+	    if nm -D "$$LIB" 2>/dev/null | grep -q "$$sym" || \
+	       nm "$$LIB" 2>/dev/null | grep -q "$$sym"; then \
+	        echo "[OK] $$sym"; \
+	    else \
+	        echo "[--] $$sym (not exported)"; \
+	    fi; \
+	done; \
+	echo ""; \
+	if [ $$MISSING -eq 1 ]; then \
+	    echo "ERROR: Missing required symbols!"; \
+	    exit 1; \
+	fi; \
+	echo "All required symbols found!"
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	cabal clean
+	rm -rf dist-newstyle
+
+# Install to user's modules directory (example)
+install: build check
+	@echo "To install, copy the shared library to your reovim modules directory:"
+	@LIB=$$(find dist-newstyle -name "libexample-haskell*.so" -o \
+	        -name "libexample-haskell*.dylib" 2>/dev/null | head -1); \
+	echo "  cp $$LIB ~/.config/reovim/modules/"
+
+# Show help
+help:
+	@echo "Reovim Haskell Module - Build Targets"
+	@echo ""
+	@echo "  make          Build the shared library"
+	@echo "  make test     Run FFI safety tests"
+	@echo "  make check    Verify exported symbols"
+	@echo "  make clean    Remove build artifacts"
+	@echo "  make install  Show install instructions"
+	@echo "  make help     Show this help"
+	@echo ""
+	@echo "Prerequisites:"
+	@echo "  - GHC 9.4+ with cabal-install"
+	@echo "  - reovim with FFI support (#290)"

--- a/examples/haskell-module/README.md
+++ b/examples/haskell-module/README.md
@@ -1,0 +1,256 @@
+# Haskell Module Example
+
+This directory contains an example reovim module written in Haskell, demonstrating how to use the FFI bindings to extend reovim.
+
+## Prerequisites
+
+- **GHC 9.4+** with the `base` and `bytestring` packages
+- **cabal-install 3.0+**
+- **reovim** with FFI support (requires #290)
+
+### Installing GHC
+
+```bash
+# Using ghcup (recommended)
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+ghcup install ghc 9.4
+ghcup set ghc 9.4
+
+# Verify installation
+ghc --version
+cabal --version
+```
+
+## Building
+
+```bash
+# Build the shared library
+make
+
+# Or using cabal directly
+cabal build all
+```
+
+## Testing
+
+```bash
+# Run FFI safety tests
+make test
+
+# Verify exported symbols
+make check
+```
+
+## Project Structure
+
+```
+examples/haskell-module/
+  Reovim/
+    FFI.hs              # Re-exports all FFI modules
+    FFI/
+      Types.hs          # ReovimVersion, ReovimModuleProbe (Storable)
+      Version.hs        # Version constants (ABI 1.0.0, API 0.2.0)
+      Probe.hs          # ModuleProbe builder pattern
+      Logging.hs        # reovim_log_* foreign imports
+    Module.hs           # ReovimModule typeclass, exception-safe wrappers
+  ExampleModule.hs      # Working example with all entry points
+  TestFFISafety.hs      # FFI safety tests
+  example-module.cabal  # Package definition
+  Makefile              # Build instructions
+  README.md             # This file
+```
+
+## Writing Your Own Module
+
+### 1. Define Module State
+
+```haskell
+data MyModuleState = MyModuleState
+    { stateConfig :: IORef Config
+    , stateCache :: IORef (Map String Value)
+    }
+```
+
+### 2. Create Module Probe
+
+```haskell
+import Reovim.FFI
+
+myProbe :: ReovimModuleProbe
+myProbe = buildProbe $
+    newProbe
+        & withId "my-module"
+        & withName "My Haskell Module"
+        & withVersion 1 0 0
+  where
+    (&) = flip ($)
+```
+
+### 3. Implement ReovimModule Typeclass
+
+```haskell
+import Reovim.Module
+
+instance ReovimModule MyModuleState where
+    moduleProbe _ = myProbe
+
+    moduleInit state _ctx = do
+        logInfo "My module initializing"
+        -- Initialize your state here
+        return returnSuccess
+
+    moduleExit state = do
+        logInfo "My module exiting"
+        -- Cleanup here
+        return returnSuccess
+```
+
+### 4. Export FFI Entry Points
+
+```haskell
+foreign export ccall "reovim_module_probe"
+    hsModuleProbe :: IO ReovimModuleProbe
+
+hsModuleProbe :: IO ReovimModuleProbe
+hsModuleProbe = return myProbe
+
+foreign export ccall "reovim_module_entry"
+    hsModuleEntry :: IO (Ptr ())
+
+hsModuleEntry :: IO (Ptr ())
+hsModuleEntry = do
+    state <- newMyModuleState
+    newModulePtr state
+
+foreign export ccall "reovim_module_init"
+    hsModuleInit :: Ptr () -> Ptr () -> IO Int32
+
+hsModuleInit modulePtr ctxPtr = safeFFI $ do
+    result <- withModulePtr modulePtr $ \(state :: MyModuleState) ->
+        moduleInit state ctxPtr
+    return $ fromMaybe returnFailed result
+
+-- ... similarly for exit and destroy
+```
+
+## Entry Points Reference
+
+| Symbol | Signature | Purpose |
+|--------|-----------|---------|
+| `reovim_module_probe` | `() -> ReovimModuleProbe` | Return module metadata |
+| `reovim_module_entry` | `() -> Ptr ()` | Create module instance |
+| `reovim_module_init` | `Ptr () -> Ptr () -> Int32` | Initialize module |
+| `reovim_module_exit` | `Ptr () -> Int32` | Cleanup module |
+| `reovim_module_destroy` | `Ptr () -> ()` | Free module memory |
+
+### Return Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Defer (try again later) |
+| `-1` | Failed |
+| `-2` | Panic (exception occurred) |
+
+## Exception Handling
+
+**Critical**: Haskell exceptions must never escape to C code. Use the `safeFFI` wrapper:
+
+```haskell
+import Reovim.Module (safeFFI, returnPanic)
+
+-- Exceptions are caught and converted to -2
+hsModuleInit ptr ctx = safeFFI $ do
+    -- Your code here, exceptions are safe
+    return returnSuccess
+```
+
+## Memory Management
+
+### StablePtr Usage
+
+Module state must be wrapped in `StablePtr` to prevent GC:
+
+```haskell
+import Reovim.Module (newModulePtr, freeModulePtr, withModulePtr)
+
+-- In entry():
+ptr <- newModulePtr myState
+
+-- In init/exit:
+withModulePtr ptr $ \state -> do
+    -- Use state
+    return result
+
+-- In destroy():
+freeModulePtr ptr
+```
+
+### Memory Ownership Rules
+
+1. **Haskell-allocated**: Use `StablePtr`, free with `freeStablePtr`
+2. **Strings to C**: Use `withCString` (temporary) or `newCString` (caller frees)
+3. **Never store ctx pointer**: The context in `init()` is only valid during that call
+
+## Debugging
+
+### Enable Debug Logging
+
+```haskell
+import Reovim.FFI.Logging
+
+moduleInit state ctx = do
+    logDebug "Entering init"
+    -- ...
+    logDebug "Init complete"
+    return returnSuccess
+```
+
+### Check Exported Symbols
+
+```bash
+# List all exported symbols
+nm -D dist-newstyle/.../libexample-haskell.so | grep reovim
+
+# Verify specific symbols
+make check
+```
+
+## Known Limitations
+
+1. **Static data export**: `REOVIM_MODULE_API_VERSION` as a static symbol is complex in Haskell. Use `reovim_module_api_version_ptr()` instead.
+
+2. **Hot reload**: Not supported in this example. Implementing `save_state`/`restore_state` requires serialization.
+
+3. **GHC RTS overhead**: Each Haskell module loads its own GHC runtime (~10MB memory).
+
+4. **Callback latency**: GHC's garbage collector may pause briefly. Keep callbacks fast (<1ms).
+
+## Troubleshooting
+
+### "undefined symbol: reovim_log_info"
+
+The module is being tested standalone. These symbols are provided by reovim at load time.
+
+### "cannot find -lHSrts"
+
+GHC libraries not found. Ensure GHC is properly installed:
+
+```bash
+ghc-pkg list rts
+```
+
+### Module loads but init fails
+
+Check ABI compatibility:
+
+```haskell
+compatible <- checkKernelCompatibility
+unless compatible $ logError "ABI mismatch"
+```
+
+## Related
+
+- [FFI Overview](../../docs/architecture/ffi/overview.md)
+- [C Module Example](../c-module/)
+- Issue: #294

--- a/examples/haskell-module/Reovim/FFI.hs
+++ b/examples/haskell-module/Reovim/FFI.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- |
+-- Module      : Reovim.FFI
+-- Description : Re-exports all FFI types and functions
+--
+-- This module provides a convenient single import for all FFI bindings
+-- needed to write reovim modules in Haskell.
+--
+-- = Usage
+--
+-- @
+-- import Reovim.FFI
+--
+-- myProbe :: ReovimModuleProbe
+-- myProbe = simpleProbe "my-module" "My Module" (1, 0, 0)
+-- @
+--
+-- = ABI Compatibility
+--
+-- This module is compiled against:
+--
+-- * ABI Version: 1.0.0
+-- * API Version: 0.2.0
+--
+-- Modules must check compatibility before using kernel services.
+
+module Reovim.FFI
+    ( -- * Types
+      module Reovim.FFI.Types
+      -- * Version
+    , module Reovim.FFI.Version
+      -- * Probe Builder
+    , module Reovim.FFI.Probe
+      -- * Logging
+    , module Reovim.FFI.Logging
+      -- * Kernel Services
+    , reovimAbiIsCompatible
+    ) where
+
+import Reovim.FFI.Types
+import Reovim.FFI.Version
+import Reovim.FFI.Probe
+import Reovim.FFI.Logging
+
+-- | Check if two ABI versions are compatible
+--
+-- This is a pure Haskell implementation matching the kernel's logic.
+-- We don't call the C function because GHC FFI can't pass structs by value.
+reovimAbiIsCompatible :: ReovimVersion -> ReovimVersion -> Bool
+reovimAbiIsCompatible = isCompatible

--- a/examples/haskell-module/Reovim/FFI/Logging.hs
+++ b/examples/haskell-module/Reovim/FFI/Logging.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- |
+-- Module      : Reovim.FFI.Logging
+-- Description : Logging functions via kernel services
+--
+-- This module provides safe Haskell wrappers around the reovim kernel's
+-- logging services. All functions handle NULL gracefully.
+
+module Reovim.FFI.Logging
+    ( -- * Logging Functions (String)
+      logInfo
+    , logWarn
+    , logError
+    , logDebug
+      -- * Logging Functions (ByteString)
+    , logInfoBS
+    , logWarnBS
+    , logErrorBS
+    , logDebugBS
+      -- * Low-level C Imports
+    , c_reovim_log_info
+    , c_reovim_log_warn
+    , c_reovim_log_error
+    , c_reovim_log_debug
+    ) where
+
+import Foreign.C.String (CString, withCString)
+import qualified Data.ByteString.Char8 as BS8
+import Data.ByteString (ByteString)
+
+-- | Foreign imports for kernel logging services
+-- All functions handle NULL msg gracefully (no-op)
+foreign import ccall unsafe "reovim_log_info"
+    c_reovim_log_info :: CString -> IO ()
+
+foreign import ccall unsafe "reovim_log_warn"
+    c_reovim_log_warn :: CString -> IO ()
+
+foreign import ccall unsafe "reovim_log_error"
+    c_reovim_log_error :: CString -> IO ()
+
+foreign import ccall unsafe "reovim_log_debug"
+    c_reovim_log_debug :: CString -> IO ()
+
+-- | Log an info-level message
+logInfo :: String -> IO ()
+logInfo msg = withCString msg c_reovim_log_info
+
+-- | Log a warning-level message
+logWarn :: String -> IO ()
+logWarn msg = withCString msg c_reovim_log_warn
+
+-- | Log an error-level message
+logError :: String -> IO ()
+logError msg = withCString msg c_reovim_log_error
+
+-- | Log a debug-level message
+logDebug :: String -> IO ()
+logDebug msg = withCString msg c_reovim_log_debug
+
+-- | ByteString variants for efficiency
+logInfoBS :: ByteString -> IO ()
+logInfoBS msg = BS8.useAsCString msg c_reovim_log_info
+
+logWarnBS :: ByteString -> IO ()
+logWarnBS msg = BS8.useAsCString msg c_reovim_log_warn
+
+logErrorBS :: ByteString -> IO ()
+logErrorBS msg = BS8.useAsCString msg c_reovim_log_error
+
+logDebugBS :: ByteString -> IO ()
+logDebugBS msg = BS8.useAsCString msg c_reovim_log_debug

--- a/examples/haskell-module/Reovim/FFI/Probe.hs
+++ b/examples/haskell-module/Reovim/FFI/Probe.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Reovim.FFI.Probe
+-- Description : ModuleProbe builder pattern
+--
+-- This module provides a fluent builder API for constructing ReovimModuleProbe
+-- structs with proper string truncation and validation.
+
+module Reovim.FFI.Probe
+    ( -- * Builder Type
+      ProbeBuilder
+      -- * Builder Functions
+    , newProbe
+    , withId
+    , withName
+    , withVersion
+    , withApiVersion
+    , withRustcVersion
+    , withRequiredDep
+    , withOptionalDep
+    , buildProbe
+      -- * Quick Builders
+    , simpleProbe
+    ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Word (Word32)
+
+import Reovim.FFI.Types
+    ( ReovimModuleProbe(..)
+    , ReovimVersion(..)
+    , emptyProbe
+    , maxIdLength
+    , maxNameLength
+    , maxRustcVersionLength
+    , maxDeps
+    , maxDepIdLength
+    )
+import Reovim.FFI.Version (apiVersion)
+
+-- | Builder state for constructing a probe
+newtype ProbeBuilder = ProbeBuilder { unBuilder :: ReovimModuleProbe }
+
+-- | Start building a new probe
+newProbe :: ProbeBuilder
+newProbe = ProbeBuilder emptyProbe
+
+-- | Set the module ID (truncated to 63 chars)
+withId :: ByteString -> ProbeBuilder -> ProbeBuilder
+withId id_ (ProbeBuilder p) = ProbeBuilder $ p
+    { probeId = truncateString (maxIdLength - 1) id_ }
+
+-- | Set the module display name (truncated to 127 chars)
+withName :: ByteString -> ProbeBuilder -> ProbeBuilder
+withName name (ProbeBuilder p) = ProbeBuilder $ p
+    { probeName = truncateString (maxNameLength - 1) name }
+
+-- | Set the module version
+withVersion :: Word32 -> Word32 -> Word32 -> ProbeBuilder -> ProbeBuilder
+withVersion major minor patch (ProbeBuilder p) = ProbeBuilder $ p
+    { probeVersion = ReovimVersion major minor patch }
+
+-- | Set the required API version (defaults to current API version)
+withApiVersion :: Word32 -> Word32 -> Word32 -> ProbeBuilder -> ProbeBuilder
+withApiVersion major minor patch (ProbeBuilder p) = ProbeBuilder $ p
+    { probeApiVersion = ReovimVersion major minor patch }
+
+-- | Set the compiler version string (truncated to 63 chars)
+withRustcVersion :: ByteString -> ProbeBuilder -> ProbeBuilder
+withRustcVersion ver (ProbeBuilder p) = ProbeBuilder $ p
+    { probeRustcVersion = truncateString (maxRustcVersionLength - 1) ver }
+
+-- | Add a required dependency (max 8, each truncated to 63 chars)
+withRequiredDep :: ByteString -> ProbeBuilder -> ProbeBuilder
+withRequiredDep dep (ProbeBuilder p) = ProbeBuilder $ p
+    { probeRequiredDeps = take maxDeps $
+        probeRequiredDeps p ++ [truncateString (maxDepIdLength - 1) dep]
+    }
+
+-- | Add an optional dependency (max 8, each truncated to 63 chars)
+withOptionalDep :: ByteString -> ProbeBuilder -> ProbeBuilder
+withOptionalDep dep (ProbeBuilder p) = ProbeBuilder $ p
+    { probeOptionalDeps = take maxDeps $
+        probeOptionalDeps p ++ [truncateString (maxDepIdLength - 1) dep]
+    }
+
+-- | Finalize and extract the probe
+buildProbe :: ProbeBuilder -> ReovimModuleProbe
+buildProbe (ProbeBuilder p) = p
+    { probeApiVersion = if probeApiVersion p == ReovimVersion 0 0 0
+                        then apiVersion
+                        else probeApiVersion p
+    }
+
+-- | Create a simple probe with just ID, name, and version
+simpleProbe :: ByteString  -- ^ Module ID
+            -> ByteString  -- ^ Module name
+            -> (Word32, Word32, Word32)  -- ^ Version (major, minor, patch)
+            -> ReovimModuleProbe
+simpleProbe id_ name (major, minor, patch) = buildProbe $
+    newProbe
+        & withId id_
+        & withName name
+        & withVersion major minor patch
+  where
+    -- Flip function application for builder pattern
+    (&) = flip ($)
+
+-- | Helper to truncate a ByteString to a maximum length
+truncateString :: Int -> ByteString -> ByteString
+truncateString maxLen = BS.take maxLen

--- a/examples/haskell-module/Reovim/FFI/Types.hs
+++ b/examples/haskell-module/Reovim/FFI/Types.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- |
+-- Module      : Reovim.FFI.Types
+-- Description : FFI-safe types matching reovim C ABI
+--
+-- This module defines Haskell types that match the C structs defined in
+-- reovim.h. All types have Storable instances for FFI interop.
+--
+-- ABI Version: 1.0.0
+-- API Version: 0.2.0
+
+module Reovim.FFI.Types
+    ( -- * Version
+      ReovimVersion(..)
+    , versionToTuple
+    , versionFromTuple
+      -- * Module Probe
+    , ReovimModuleProbe(..)
+    , emptyProbe
+      -- * Constants
+    , maxIdLength
+    , maxNameLength
+    , maxRustcVersionLength
+    , maxDeps
+    , maxDepIdLength
+    , probeSize
+    ) where
+
+import Data.Word (Word8, Word32)
+import Foreign.Storable (Storable(..))
+import Foreign.Ptr (Ptr, plusPtr)
+import Foreign.Marshal.Array (pokeArray, peekArray)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+-- | Buffer size constants matching reovim.h
+maxIdLength :: Int
+maxIdLength = 64
+
+maxNameLength :: Int
+maxNameLength = 128
+
+maxRustcVersionLength :: Int
+maxRustcVersionLength = 64
+
+maxDeps :: Int
+maxDeps = 8
+
+maxDepIdLength :: Int
+maxDepIdLength = 64
+
+-- | Total size of ReovimModuleProbe struct (1308 bytes)
+probeSize :: Int
+probeSize = 1308
+
+-- | Semantic version representation.
+--
+-- Size: 12 bytes
+-- Alignment: 4 bytes
+data ReovimVersion = ReovimVersion
+    { versionMajor :: !Word32
+    , versionMinor :: !Word32
+    , versionPatch :: !Word32
+    } deriving (Eq, Show)
+
+versionToTuple :: ReovimVersion -> (Word32, Word32, Word32)
+versionToTuple (ReovimVersion maj min_ pat) = (maj, min_, pat)
+
+versionFromTuple :: (Word32, Word32, Word32) -> ReovimVersion
+versionFromTuple (maj, min_, pat) = ReovimVersion maj min_ pat
+
+instance Storable ReovimVersion where
+    sizeOf _ = 12
+    alignment _ = 4
+
+    peek ptr = do
+        maj <- peekByteOff ptr 0
+        min_ <- peekByteOff ptr 4
+        pat <- peekByteOff ptr 8
+        return $ ReovimVersion maj min_ pat
+
+    poke ptr (ReovimVersion maj min_ pat) = do
+        pokeByteOff ptr 0 maj
+        pokeByteOff ptr 4 min_
+        pokeByteOff ptr 8 pat
+
+-- | FFI-safe module metadata for discovery.
+--
+-- Size: 1308 bytes
+-- Alignment: 4 bytes
+--
+-- Layout:
+--   id[64]                    offset 0
+--   name[128]                 offset 64
+--   version (12 bytes)        offset 192
+--   api_version (12 bytes)    offset 204
+--   rustc_version[64]         offset 216
+--   required_deps_count (1)   offset 280
+--   required_deps[8][64]      offset 281
+--   optional_deps_count (1)   offset 793
+--   optional_deps[8][64]      offset 794
+--   Total: 1306 bytes + 2 padding = 1308 bytes
+data ReovimModuleProbe = ReovimModuleProbe
+    { probeId :: !ByteString           -- ^ Module ID (max 63 chars + nul)
+    , probeName :: !ByteString         -- ^ Display name (max 127 chars + nul)
+    , probeVersion :: !ReovimVersion   -- ^ Module version
+    , probeApiVersion :: !ReovimVersion -- ^ Required API version
+    , probeRustcVersion :: !ByteString -- ^ Compiler version (max 63 chars + nul)
+    , probeRequiredDeps :: ![ByteString] -- ^ Required dependency IDs (max 8)
+    , probeOptionalDeps :: ![ByteString] -- ^ Optional dependency IDs (max 8)
+    } deriving (Eq, Show)
+
+-- | Empty probe with default values
+emptyProbe :: ReovimModuleProbe
+emptyProbe = ReovimModuleProbe
+    { probeId = BS.empty
+    , probeName = BS.empty
+    , probeVersion = ReovimVersion 0 0 0
+    , probeApiVersion = ReovimVersion 0 2 0
+    , probeRustcVersion = BS.empty
+    , probeRequiredDeps = []
+    , probeOptionalDeps = []
+    }
+
+-- | Helper to write a ByteString to a fixed-size buffer with null termination
+pokeFixedString :: Ptr Word8 -> Int -> ByteString -> IO ()
+pokeFixedString ptr maxLen bs = do
+    let truncated = BS.take (maxLen - 1) bs
+        padded = truncated <> BS.replicate (maxLen - BS.length truncated) 0
+    pokeArray ptr (BS.unpack padded)
+
+-- | Helper to read a null-terminated string from a fixed-size buffer
+peekFixedString :: Ptr Word8 -> Int -> IO ByteString
+peekFixedString ptr maxLen = do
+    bytes <- peekArray maxLen ptr
+    return $ BS.pack $ takeWhile (/= 0) bytes
+
+-- | Helper to write dependency array
+pokeDepsArray :: Ptr Word8 -> Int -> Int -> [ByteString] -> IO ()
+pokeDepsArray ptr maxDepsCount depSize deps = do
+    let truncatedDeps = take maxDepsCount deps
+        paddedDeps = truncatedDeps ++ replicate (maxDepsCount - length truncatedDeps) BS.empty
+    mapM_ (\(i, dep) -> pokeFixedString (ptr `plusPtr` (i * depSize)) depSize dep)
+          (zip [0..] paddedDeps)
+
+-- | Helper to read dependency array
+peekDepsArray :: Ptr Word8 -> Int -> Int -> Int -> IO [ByteString]
+peekDepsArray ptr count maxDepsCount depSize = do
+    let actualCount = min count maxDepsCount
+    mapM (\i -> peekFixedString (ptr `plusPtr` (i * depSize)) depSize) [0..actualCount-1]
+
+instance Storable ReovimModuleProbe where
+    sizeOf _ = probeSize
+    alignment _ = 4
+
+    peek ptr = do
+        -- id[64] at offset 0
+        id_ <- peekFixedString (plusPtr ptr 0) maxIdLength
+        -- name[128] at offset 64
+        name <- peekFixedString (plusPtr ptr 64) maxNameLength
+        -- version at offset 192
+        version <- peek (plusPtr ptr 192)
+        -- api_version at offset 204
+        apiVersion <- peek (plusPtr ptr 204)
+        -- rustc_version[64] at offset 216
+        rustcVersion <- peekFixedString (plusPtr ptr 216) maxRustcVersionLength
+        -- required_deps_count at offset 280
+        reqCount <- peekByteOff ptr 280 :: IO Word8
+        -- required_deps[8][64] at offset 281
+        reqDeps <- peekDepsArray (plusPtr ptr 281) (fromIntegral reqCount) maxDeps maxDepIdLength
+        -- optional_deps_count at offset 793
+        optCount <- peekByteOff ptr 793 :: IO Word8
+        -- optional_deps[8][64] at offset 794
+        optDeps <- peekDepsArray (plusPtr ptr 794) (fromIntegral optCount) maxDeps maxDepIdLength
+
+        return $ ReovimModuleProbe id_ name version apiVersion rustcVersion reqDeps optDeps
+
+    poke ptr probe = do
+        -- Zero the entire struct first
+        pokeArray (plusPtr ptr 0 :: Ptr Word8) (replicate probeSize 0)
+
+        -- id[64] at offset 0
+        pokeFixedString (plusPtr ptr 0) maxIdLength (probeId probe)
+        -- name[128] at offset 64
+        pokeFixedString (plusPtr ptr 64) maxNameLength (probeName probe)
+        -- version at offset 192
+        poke (plusPtr ptr 192) (probeVersion probe)
+        -- api_version at offset 204
+        poke (plusPtr ptr 204) (probeApiVersion probe)
+        -- rustc_version[64] at offset 216
+        pokeFixedString (plusPtr ptr 216) maxRustcVersionLength (probeRustcVersion probe)
+        -- required_deps_count at offset 280
+        pokeByteOff ptr 280 (fromIntegral (length (probeRequiredDeps probe)) :: Word8)
+        -- required_deps[8][64] at offset 281
+        pokeDepsArray (plusPtr ptr 281) maxDeps maxDepIdLength (probeRequiredDeps probe)
+        -- optional_deps_count at offset 793
+        pokeByteOff ptr 793 (fromIntegral (length (probeOptionalDeps probe)) :: Word8)
+        -- optional_deps[8][64] at offset 794
+        pokeDepsArray (plusPtr ptr 794) maxDeps maxDepIdLength (probeOptionalDeps probe)

--- a/examples/haskell-module/Reovim/FFI/Version.hs
+++ b/examples/haskell-module/Reovim/FFI/Version.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- |
+-- Module      : Reovim.FFI.Version
+-- Description : Version constants and compatibility checking
+--
+-- This module provides the ABI and API version constants that must match
+-- the reovim kernel's expectations, along with compatibility checking.
+
+module Reovim.FFI.Version
+    ( -- * ABI Version (binary compatibility)
+      abiVersion
+    , abiVersionMajor
+    , abiVersionMinor
+    , abiVersionPatch
+      -- * API Version (semantic compatibility)
+    , apiVersion
+    , apiVersionMajor
+    , apiVersionMinor
+    , apiVersionPatch
+      -- * Version Creation
+    , makeVersion
+      -- * Compatibility Checking
+    , isCompatible
+      -- * Kernel Services
+    , getKernelAbiVersion
+    , checkKernelCompatibility
+    ) where
+
+import Data.Word (Word32)
+import Foreign.Ptr (Ptr)
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Storable (peek, poke)
+
+import Reovim.FFI.Types (ReovimVersion(..))
+
+-- | ABI version constants (binary compatibility)
+-- Must match REOVIM_ABI_VERSION_* in reovim.h
+abiVersionMajor, abiVersionMinor, abiVersionPatch :: Word32
+abiVersionMajor = 1
+abiVersionMinor = 0
+abiVersionPatch = 0
+
+-- | The ABI version this module is compiled against
+abiVersion :: ReovimVersion
+abiVersion = ReovimVersion abiVersionMajor abiVersionMinor abiVersionPatch
+
+-- | API version constants (semantic compatibility)
+-- Must match REOVIM_API_VERSION_* in reovim.h
+apiVersionMajor, apiVersionMinor, apiVersionPatch :: Word32
+apiVersionMajor = 0
+apiVersionMinor = 2
+apiVersionPatch = 0
+
+-- | The API version this module requires
+apiVersion :: ReovimVersion
+apiVersion = ReovimVersion apiVersionMajor apiVersionMinor apiVersionPatch
+
+-- | Create a version from components
+makeVersion :: Word32 -> Word32 -> Word32 -> ReovimVersion
+makeVersion = ReovimVersion
+
+-- | Check if two versions are compatible.
+--
+-- Compatibility rules (same as reovim_abi_is_compatible):
+-- - Major version must match exactly
+-- - Required minor must be <= provided minor
+-- - Patch version is ignored
+isCompatible :: ReovimVersion  -- ^ Required version
+             -> ReovimVersion  -- ^ Provided version
+             -> Bool
+isCompatible required provided =
+    versionMajor required == versionMajor provided &&
+    versionMinor required <= versionMinor provided
+
+-- | Foreign import for kernel's ABI version function (via pointer)
+--
+-- The C function returns struct by value, but GHC FFI requires pointer.
+-- We use a wrapper that fills a pre-allocated buffer.
+foreign import ccall unsafe "reovim_abi_version_ptr"
+    c_reovim_abi_version_ptr :: Ptr ReovimVersion -> IO ()
+
+-- | Get the kernel's ABI version
+--
+-- Note: This requires the reovim kernel to provide reovim_abi_version_ptr,
+-- or you can skip this check since the loader verifies compatibility.
+getKernelAbiVersion :: IO ReovimVersion
+getKernelAbiVersion = alloca $ \ptr -> do
+    -- Initialize with known version in case the call fails
+    poke ptr abiVersion
+    c_reovim_abi_version_ptr ptr
+    peek ptr
+
+-- | Check if the kernel's ABI is compatible with our requirements
+--
+-- Note: The module loader already checks API version compatibility
+-- before calling init(), so this is optional but recommended for
+-- additional safety.
+checkKernelCompatibility :: IO Bool
+checkKernelCompatibility = do
+    kernelVersion <- getKernelAbiVersion
+    return $ isCompatible abiVersion kernelVersion
+
+-- | Alternative: Skip runtime check, trust loader's version verification
+--
+-- The loader reads REOVIM_MODULE_API_VERSION before loading, so if
+-- we reach init(), we know versions are compatible.
+checkKernelCompatibilitySimple :: IO Bool
+checkKernelCompatibilitySimple = return True

--- a/examples/haskell-module/Reovim/Module.hs
+++ b/examples/haskell-module/Reovim/Module.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      : Reovim.Module
+-- Description : High-level module implementation helpers
+--
+-- This module provides the ReovimModule typeclass and utilities for
+-- implementing reovim modules in Haskell with proper exception handling
+-- and StablePtr management.
+--
+-- = Exception Safety
+--
+-- All exported FFI functions are wrapped in exception handlers to prevent
+-- Haskell exceptions from escaping to C (which would be undefined behavior).
+-- Exceptions are caught and converted to the -2 (panic) return code.
+--
+-- = Memory Management
+--
+-- Module state is wrapped in a StablePtr to prevent GC collection while
+-- the C code holds a reference. The StablePtr must be freed in destroy().
+
+module Reovim.Module
+    ( -- * Module Typeclass
+      ReovimModule(..)
+      -- * Exception-Safe Wrappers
+    , safeFFI
+    , safeFFIVoid
+      -- * StablePtr Utilities
+    , newModulePtr
+    , freeModulePtr
+    , withModulePtr
+      -- * Return Codes
+    , returnSuccess
+    , returnDefer
+    , returnFailed
+    , returnPanic
+      -- * GHC RTS Management
+    , initRTS
+    , exitRTS
+    ) where
+
+import Control.Exception (SomeException, catch)
+import Data.Int (Int32)
+import Foreign.Ptr (Ptr, nullPtr)
+import Foreign.StablePtr
+    ( StablePtr
+    , newStablePtr
+    , freeStablePtr
+    , deRefStablePtr
+    , castStablePtrToPtr
+    , castPtrToStablePtr
+    )
+import Foreign.C.String (CString)
+
+import Reovim.FFI.Types (ReovimModuleProbe)
+import Reovim.FFI.Logging (logError)
+
+-- | Return codes for module lifecycle functions
+returnSuccess, returnDefer, returnFailed, returnPanic :: Int32
+returnSuccess = 0   -- ^ Operation succeeded
+returnDefer   = 1   -- ^ Defer, try again later (like Linux EPROBE_DEFER)
+returnFailed  = -1  -- ^ Operation failed
+returnPanic   = -2  -- ^ Panic/exception occurred
+
+-- | Typeclass for reovim modules
+--
+-- Implement this typeclass to define your module's behavior.
+-- The default implementations handle common cases.
+class ReovimModule a where
+    -- | Return module metadata for discovery
+    moduleProbe :: a -> ReovimModuleProbe
+
+    -- | Initialize the module
+    --
+    -- Called after entry(). The context pointer is currently opaque.
+    -- Return 0 for success, 1 to defer, -1 for failure.
+    moduleInit :: a -> Ptr () -> IO Int32
+    moduleInit _ _ = return returnSuccess
+
+    -- | Cleanup before unload
+    --
+    -- Called before destroy(). Release any resources here.
+    -- Return 0 for success, -1 for error.
+    moduleExit :: a -> IO Int32
+    moduleExit _ = return returnSuccess
+
+    -- | Check if hot reload is supported
+    moduleSupportsHotReload :: a -> Bool
+    moduleSupportsHotReload _ = False
+
+    -- | Save state for hot reload
+    --
+    -- Return Nothing if no state to save.
+    moduleSaveState :: a -> IO (Maybe (Ptr (), Int))
+    moduleSaveState _ = return Nothing
+
+    -- | Restore state after hot reload
+    --
+    -- Return True on success, False on failure.
+    moduleRestoreState :: a -> Ptr () -> Int -> IO Bool
+    moduleRestoreState _ _ _ = return False
+
+-- | Wrap an IO action that returns Int32, catching all exceptions
+--
+-- Exceptions are logged and converted to returnPanic (-2).
+safeFFI :: IO Int32 -> IO Int32
+safeFFI action = action `catch` handleException
+  where
+    handleException :: SomeException -> IO Int32
+    handleException e = do
+        logError $ "Haskell exception: " ++ show e
+        return returnPanic
+
+-- | Wrap a void IO action, catching all exceptions
+--
+-- Exceptions are logged but cannot affect return value.
+safeFFIVoid :: IO () -> IO ()
+safeFFIVoid action = action `catch` handleException
+  where
+    handleException :: SomeException -> IO ()
+    handleException e = logError $ "Haskell exception: " ++ show e
+
+-- | Create a new StablePtr for module state and return as opaque Ptr
+newModulePtr :: a -> IO (Ptr ())
+newModulePtr state = do
+    stablePtr <- newStablePtr state
+    return $ castStablePtrToPtr stablePtr
+
+-- | Free a module's StablePtr
+freeModulePtr :: Ptr () -> IO ()
+freeModulePtr ptr
+    | ptr == nullPtr = return ()
+    | otherwise = freeStablePtr (castPtrToStablePtr ptr :: StablePtr ())
+
+-- | Safely access module state from an opaque Ptr
+--
+-- Returns Nothing if the pointer is null.
+withModulePtr :: Ptr () -> (a -> IO b) -> IO (Maybe b)
+withModulePtr ptr action
+    | ptr == nullPtr = return Nothing
+    | otherwise = do
+        let stablePtr = castPtrToStablePtr ptr :: StablePtr a
+        state <- deRefStablePtr stablePtr
+        result <- action state
+        return (Just result)
+
+-- | Initialize the GHC runtime system
+--
+-- This must be called before any Haskell code runs.
+-- Safe to call multiple times (GHC tracks init count).
+foreign import ccall "hs_init"
+    c_hs_init :: Ptr (Ptr CString) -> Ptr (Ptr CString) -> IO ()
+
+-- | Shutdown the GHC runtime system
+--
+-- Must be called after all Haskell code is done.
+-- Must balance hs_init calls.
+foreign import ccall "hs_exit"
+    c_hs_exit :: IO ()
+
+-- | Initialize the GHC RTS (safe wrapper)
+initRTS :: IO ()
+initRTS = c_hs_init nullPtr nullPtr
+
+-- | Exit the GHC RTS (safe wrapper)
+exitRTS :: IO ()
+exitRTS = c_hs_exit

--- a/examples/haskell-module/Setup.hs
+++ b/examples/haskell-module/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/examples/haskell-module/TestFFISafety.hs
+++ b/examples/haskell-module/TestFFISafety.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      : TestFFISafety
+-- Description : FFI safety tests for Haskell module bindings
+--
+-- This module provides tests for critical FFI boundary conditions:
+--
+-- * Exception handling at FFI boundary
+-- * StablePtr round-trip correctness
+-- * NULL pointer handling
+-- * String truncation behavior
+--
+-- = Running Tests
+--
+-- @
+-- make test
+-- @
+
+module Main where
+
+import Control.Exception (SomeException, catch, throwIO, Exception)
+import Control.Monad (unless, when)
+import Data.Int (Int32)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Foreign.Ptr (Ptr, nullPtr)
+import Foreign.StablePtr
+    ( StablePtr
+    , newStablePtr
+    , freeStablePtr
+    , deRefStablePtr
+    , castStablePtrToPtr
+    , castPtrToStablePtr
+    )
+import Foreign.Marshal.Alloc (malloc, free, mallocBytes)
+import Foreign.Storable (peek, poke, sizeOf)
+import System.Exit (exitFailure, exitSuccess)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+
+import Reovim.FFI
+import Reovim.Module
+
+-- | Custom exception for testing
+data TestException = TestException String
+    deriving (Show)
+
+instance Exception TestException
+
+-- | Test result tracking
+data TestResult = TestResult
+    { testName :: String
+    , testPassed :: Bool
+    , testMessage :: String
+    }
+
+-- | Run a test and return result
+runTest :: String -> IO Bool -> IO TestResult
+runTest name action = do
+    result <- action `catch` \(e :: SomeException) ->
+        return False
+    return $ TestResult name result (if result then "OK" else "FAILED")
+
+-- | Assert a condition
+assert :: String -> Bool -> IO ()
+assert msg cond = unless cond $ do
+    putStrLn $ "Assertion failed: " ++ msg
+    throwIO $ TestException msg
+
+-- ============================================================================
+-- Exception Boundary Tests
+-- ============================================================================
+
+-- | Test that safeFFI catches exceptions and returns -2
+testExceptionBoundary :: IO Bool
+testExceptionBoundary = do
+    let throwingAction :: IO Int32
+        throwingAction = throwIO (TestException "test exception")
+
+    result <- safeFFI throwingAction
+    return $ result == returnPanic  -- Should be -2
+
+-- | Test that safeFFIVoid catches exceptions without crashing
+testExceptionBoundaryVoid :: IO Bool
+testExceptionBoundaryVoid = do
+    let throwingAction :: IO ()
+        throwingAction = throwIO (TestException "test exception")
+
+    -- Should not throw, just log
+    safeFFIVoid throwingAction
+    return True  -- If we got here, test passed
+
+-- | Test that nested exceptions are handled
+testNestedExceptions :: IO Bool
+testNestedExceptions = do
+    let nestedThrow :: IO Int32
+        nestedThrow = do
+            _ <- safeFFI (throwIO (TestException "inner"))
+            throwIO (TestException "outer")
+
+    result <- safeFFI nestedThrow
+    return $ result == returnPanic
+
+-- ============================================================================
+-- StablePtr Tests
+-- ============================================================================
+
+-- | Test basic StablePtr round-trip
+testStablePtrRoundTrip :: IO Bool
+testStablePtrRoundTrip = do
+    let testValue = 42 :: Int
+
+    -- Create StablePtr
+    stablePtr <- newStablePtr testValue
+
+    -- Convert to Ptr ()
+    let opaquePtr = castStablePtrToPtr stablePtr
+
+    -- Convert back to StablePtr
+    let recoveredStable = castPtrToStablePtr opaquePtr :: StablePtr Int
+
+    -- Dereference
+    recovered <- deRefStablePtr recoveredStable
+
+    -- Cleanup
+    freeStablePtr stablePtr
+
+    return $ recovered == testValue
+
+-- | Test StablePtr with complex data
+testStablePtrComplex :: IO Bool
+testStablePtrComplex = do
+    -- Create complex state
+    ref1 <- newIORef (100 :: Int)
+    ref2 <- newIORef "hello"
+    let state = (ref1, ref2)
+
+    -- Wrap in StablePtr
+    stablePtr <- newStablePtr state
+
+    -- Convert through opaque pointer
+    let opaquePtr = castStablePtrToPtr stablePtr
+    let recovered = castPtrToStablePtr opaquePtr :: StablePtr (IORef Int, IORef String)
+
+    -- Access state
+    (r1, r2) <- deRefStablePtr recovered
+    v1 <- readIORef r1
+    v2 <- readIORef r2
+
+    -- Modify and verify
+    writeIORef r1 200
+    v1' <- readIORef r1
+
+    -- Cleanup
+    freeStablePtr stablePtr
+
+    return $ v1 == 100 && v2 == "hello" && v1' == 200
+
+-- | Test newModulePtr and freeModulePtr
+testModulePtrHelpers :: IO Bool
+testModulePtrHelpers = do
+    let testData = "module state" :: String
+
+    -- Create module pointer
+    ptr <- newModulePtr testData
+
+    -- Access via withModulePtr
+    result <- withModulePtr ptr $ \(s :: String) -> return s
+
+    -- Cleanup
+    freeModulePtr ptr
+
+    return $ result == Just testData
+
+-- | Test that freeModulePtr handles null safely
+testFreeNullPtr :: IO Bool
+testFreeNullPtr = do
+    -- Should not crash
+    freeModulePtr nullPtr
+    return True
+
+-- ============================================================================
+-- NULL Pointer Handling Tests
+-- ============================================================================
+
+-- | Test withModulePtr with null pointer
+testWithNullPtr :: IO Bool
+testWithNullPtr = do
+    result <- withModulePtr nullPtr $ \(_ :: Int) -> return 42
+    return $ result == Nothing
+
+-- ============================================================================
+-- Type Tests
+-- ============================================================================
+
+-- | Test ReovimVersion Storable instance
+testVersionStorable :: IO Bool
+testVersionStorable = do
+    let version = ReovimVersion 1 2 3
+
+    -- Allocate and write
+    ptr <- malloc :: IO (Ptr ReovimVersion)
+    poke ptr version
+
+    -- Read back
+    read_version <- peek ptr
+
+    -- Cleanup
+    free ptr
+
+    return $ read_version == version
+
+-- | Test ReovimModuleProbe Storable instance
+testProbeStorable :: IO Bool
+testProbeStorable = do
+    let probe = buildProbe $
+            newProbe
+                & withId "test-id"
+                & withName "Test Module"
+                & withVersion 1 2 3
+                & withRequiredDep "dep1"
+                & withOptionalDep "opt1"
+          where (&) = flip ($)
+
+    -- Allocate and write
+    ptr <- mallocBytes probeSize :: IO (Ptr ReovimModuleProbe)
+    poke ptr probe
+
+    -- Read back
+    read_probe <- peek ptr
+
+    -- Cleanup
+    free ptr
+
+    -- Compare fields
+    return $ probeId read_probe == probeId probe
+          && probeName read_probe == probeName probe
+          && probeVersion read_probe == probeVersion probe
+          && probeRequiredDeps read_probe == probeRequiredDeps probe
+
+-- | Test string truncation in probe builder
+testStringTruncation :: IO Bool
+testStringTruncation = do
+    -- Create string longer than max ID length (64)
+    let longId = BS8.pack $ replicate 100 'x'
+    let probe = buildProbe $ newProbe & withId longId
+          where (&) = flip ($)
+
+    -- ID should be truncated to 63 chars (64 - 1 for null)
+    return $ BS.length (probeId probe) == 63
+
+-- | Test max dependencies limit
+testMaxDependencies :: IO Bool
+testMaxDependencies = do
+    -- Try to add more than 8 dependencies
+    let probe = buildProbe $
+            newProbe
+                & withRequiredDep "dep1"
+                & withRequiredDep "dep2"
+                & withRequiredDep "dep3"
+                & withRequiredDep "dep4"
+                & withRequiredDep "dep5"
+                & withRequiredDep "dep6"
+                & withRequiredDep "dep7"
+                & withRequiredDep "dep8"
+                & withRequiredDep "dep9"  -- Should be ignored
+                & withRequiredDep "dep10" -- Should be ignored
+          where (&) = flip ($)
+
+    -- Should only have 8 dependencies
+    return $ length (probeRequiredDeps probe) == 8
+
+-- ============================================================================
+-- Version Compatibility Tests
+-- ============================================================================
+
+-- | Test version compatibility logic
+testVersionCompatibility :: IO Bool
+testVersionCompatibility = do
+    let v100 = ReovimVersion 1 0 0
+        v110 = ReovimVersion 1 1 0
+        v120 = ReovimVersion 1 2 0
+        v200 = ReovimVersion 2 0 0
+
+    -- Same version is compatible
+    let test1 = isCompatible v100 v100
+
+    -- Higher minor is compatible
+    let test2 = isCompatible v100 v110
+
+    -- Lower minor is not compatible
+    let test3 = not $ isCompatible v120 v100
+
+    -- Different major is not compatible
+    let test4 = not $ isCompatible v100 v200
+
+    return $ test1 && test2 && test3 && test4
+
+-- ============================================================================
+-- Main Test Runner
+-- ============================================================================
+
+main :: IO ()
+main = do
+    putStrLn "Running FFI Safety Tests"
+    putStrLn "========================"
+    putStrLn ""
+
+    results <- sequence
+        [ runTest "Exception boundary (Int32)" testExceptionBoundary
+        , runTest "Exception boundary (void)" testExceptionBoundaryVoid
+        , runTest "Nested exceptions" testNestedExceptions
+        , runTest "StablePtr round-trip" testStablePtrRoundTrip
+        , runTest "StablePtr complex data" testStablePtrComplex
+        , runTest "Module pointer helpers" testModulePtrHelpers
+        , runTest "Free null pointer" testFreeNullPtr
+        , runTest "withModulePtr null" testWithNullPtr
+        , runTest "Version Storable" testVersionStorable
+        , runTest "Probe Storable" testProbeStorable
+        , runTest "String truncation" testStringTruncation
+        , runTest "Max dependencies" testMaxDependencies
+        , runTest "Version compatibility" testVersionCompatibility
+        ]
+
+    putStrLn ""
+    putStrLn "Results:"
+    putStrLn "--------"
+
+    mapM_ printResult results
+
+    let passed = length $ filter testPassed results
+    let total = length results
+
+    putStrLn ""
+    putStrLn $ "Passed: " ++ show passed ++ "/" ++ show total
+
+    if passed == total
+        then do
+            putStrLn "All tests passed!"
+            exitSuccess
+        else do
+            putStrLn "Some tests failed!"
+            exitFailure
+
+printResult :: TestResult -> IO ()
+printResult (TestResult name passed msg) =
+    putStrLn $ "[" ++ status ++ "] " ++ name
+  where
+    status = if passed then "PASS" else "FAIL"

--- a/examples/haskell-module/demo.sh
+++ b/examples/haskell-module/demo.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Fun demo: Haskell FFI Module for Reovim
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../.."
+
+MODULE_PATH="$SCRIPT_DIR/dist-newstyle/build/x86_64-linux/ghc-9.4.8/reovim-example-module-1.0.0/f/example-haskell/build/example-haskell/libexample-haskell.so.1.0.0"
+REOVIM="./target/release/reovim"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo -e "${PURPLE}"
+cat << 'EOF'
+  _    _           _        _ _   _____ _____ ___
+ | |  | |         | |      | | | |  ___|  ___|_ _|
+ | |__| | __ _ ___| | _____| | | | |_  | |_   | |
+ |  __  |/ _` / __| |/ / _ \ | | |  _| |  _|  | |
+ | |  | | (_| \__ \   <  __/ | | | |   | |   _| |_
+ |_|  |_|\__,_|___/_|\_\___|_|_| |_|   |_|  |_____|
+EOF
+echo -e "${NC}"
+echo -e "${CYAN}     Haskell FFI Module Demo for Reovim${NC}"
+echo ""
+
+# Check if module is built
+if [ ! -f "$MODULE_PATH" ]; then
+    echo -e "${YELLOW}Building Haskell module...${NC}"
+    cd "$SCRIPT_DIR"
+    cabal build flib:example-haskell 2>&1 | tail -3
+    cd "$SCRIPT_DIR/../.."
+    echo ""
+fi
+
+# Check for running server
+PORT=$($REOVIM cli list 2>/dev/null | grep -o '127.0.0.1:[0-9]*' | head -1 | cut -d: -f2 || true)
+
+if [ -z "$PORT" ]; then
+    echo -e "${YELLOW}Starting reovim server...${NC}"
+    $REOVIM server --no-defaults 2>&1 &
+    sleep 2
+    PORT=$($REOVIM cli list 2>/dev/null | grep -o '127.0.0.1:[0-9]*' | head -1 | cut -d: -f2)
+fi
+
+echo -e "${GREEN}Server on port $PORT${NC}"
+echo ""
+
+# Fun message sequence via load/unload
+echo -e "${BLUE}=== Load/Unload Animation ===${NC}"
+echo ""
+
+for word in "  Hello" "  Reovim!" "  I" "  am" "  a" "  Haskell" "  module!"; do
+    $REOVIM cli --tcp 127.0.0.1:$PORT unload example-haskell >/dev/null 2>&1 || true
+    $REOVIM cli --tcp 127.0.0.1:$PORT load "$MODULE_PATH" >/dev/null 2>&1
+    echo -e "${GREEN}$word${NC}"
+    sleep 0.25
+done
+
+echo ""
+
+# Show final state
+echo -e "${CYAN}Loaded modules:${NC}"
+$REOVIM cli --tcp 127.0.0.1:$PORT modules 2>&1
+
+echo ""
+echo -e "${PURPLE}Haskell module loaded ${GREEN}7 times${PURPLE}!${NC}"
+echo -e "${CYAN}Functional programming meets systems programming.${NC}"

--- a/examples/haskell-module/example-module.cabal
+++ b/examples/haskell-module/example-module.cabal
@@ -1,0 +1,67 @@
+cabal-version:      3.0
+name:               reovim-example-module
+version:            1.0.0
+synopsis:           Example reovim module in Haskell
+description:
+    An example module demonstrating how to write reovim modules in Haskell
+    using the FFI bindings. This module exports all required entry points
+    and can be loaded by the reovim module loader.
+license:            MIT
+license-file:       LICENSE
+author:             reovim contributors
+build-type:         Simple
+extra-doc-files:    README.md
+
+-- Common settings for all components
+common warnings
+    ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates
+                 -Wincomplete-uni-patterns -Wmissing-export-lists
+                 -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+
+-- The FFI library providing Haskell bindings to reovim
+library
+    import:           warnings
+    exposed-modules:
+        Reovim.FFI
+        Reovim.FFI.Types
+        Reovim.FFI.Version
+        Reovim.FFI.Probe
+        Reovim.FFI.Logging
+        Reovim.Module
+    build-depends:
+        base >= 4.16 && < 5,
+        bytestring >= 0.11 && < 0.13
+    hs-source-dirs:   .
+    default-language: GHC2021
+
+-- The example module as a shared library
+-- Note: Building as foreign library requires special handling
+foreign-library example-haskell
+    type:             native-shared
+    lib-version-info: 1:0:0
+
+    if os(windows)
+        options: standalone
+        mod-def-file: ExampleModule.def
+
+    other-modules:    ExampleModule
+    c-sources:        rts_shim.c
+    build-depends:
+        base >= 4.16 && < 5,
+        bytestring >= 0.11 && < 0.13,
+        reovim-example-module
+    hs-source-dirs:   .
+    default-language: GHC2021
+    ghc-options:      -fPIC
+
+-- FFI safety test executable
+executable test-ffi-safety
+    import:           warnings
+    main-is:          TestFFISafety.hs
+    build-depends:
+        base >= 4.16 && < 5,
+        bytestring >= 0.11 && < 0.13,
+        reovim-example-module
+    hs-source-dirs:   .
+    c-sources:        test_stubs.c
+    default-language: GHC2021

--- a/examples/haskell-module/rts_shim.c
+++ b/examples/haskell-module/rts_shim.c
@@ -1,0 +1,84 @@
+/**
+ * GHC Runtime System Initialization Shim
+ *
+ * This file provides automatic initialization and cleanup of the GHC
+ * Runtime System (RTS) when the shared library is loaded/unloaded.
+ *
+ * The GHC RTS must be initialized before ANY Haskell code can execute.
+ * Since reovim's module loader calls probe functions before entry(),
+ * we use GCC's constructor/destructor attributes to ensure the RTS
+ * is ready when dlopen() returns.
+ *
+ * References:
+ * - https://downloads.haskell.org/ghc/latest/docs/users_guide/shared_libs.html
+ * - https://well-typed.com/blog/2009/05/buildings-plugins-as-haskell-shared-libs/
+ */
+
+#include <stddef.h>  /* for NULL */
+#include <stdio.h>   /* for fprintf */
+#include <HsFFI.h>
+
+/**
+ * Initialize GHC RTS when library is loaded.
+ *
+ * The __attribute__((constructor)) causes this function to be called
+ * automatically when the shared library is loaded via dlopen(), before
+ * dlopen() returns to the caller.
+ *
+ * This ensures the RTS is initialized before reovim calls any FFI
+ * functions like reovim_module_probe or reovim_module_api_version_ptr.
+ */
+static void reovim_rts_init(void) __attribute__((constructor));
+static void reovim_rts_init(void)
+{
+    /* Dummy argc/argv for hs_init - required but not used */
+    static char *argv[] = { "reovim-haskell-module", NULL };
+    static char **argv_ = argv;
+    static int argc = 1;
+
+    hs_init(&argc, &argv_);
+}
+
+/**
+ * Shutdown GHC RTS when library is unloaded.
+ *
+ * The __attribute__((destructor)) causes this function to be called
+ * automatically when the shared library is unloaded via dlclose(),
+ * or when the process exits.
+ *
+ * Note: GHC does not support reinitializing the RTS after hs_exit().
+ * Once a Haskell module is unloaded, it cannot be reloaded in the
+ * same process.
+ */
+static void reovim_rts_exit(void) __attribute__((destructor));
+static void reovim_rts_exit(void)
+{
+    hs_exit();
+}
+
+/*
+ * Logging stubs - these should be provided by the reovim kernel.
+ * For standalone testing, we provide no-op implementations.
+ *
+ * TODO: Issue #305 - Implement proper kernel logging FFI exports
+ */
+
+void reovim_log_trace(const char *msg) {
+    fprintf(stderr, "[TRACE] %s\n", msg);
+}
+
+void reovim_log_debug(const char *msg) {
+    fprintf(stderr, "[DEBUG] %s\n", msg);
+}
+
+void reovim_log_info(const char *msg) {
+    fprintf(stderr, "[INFO] %s\n", msg);
+}
+
+void reovim_log_warn(const char *msg) {
+    fprintf(stderr, "[WARN] %s\n", msg);
+}
+
+void reovim_log_error(const char *msg) {
+    fprintf(stderr, "[ERROR] %s\n", msg);
+}

--- a/examples/haskell-module/test_stubs.c
+++ b/examples/haskell-module/test_stubs.c
@@ -1,0 +1,49 @@
+/*
+ * test_stubs.c - Stub implementations for FFI safety tests
+ *
+ * These stubs allow the test executable to link without reovim.
+ * They provide no-op implementations of kernel services.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Logging stubs - just print to stdout for testing */
+void reovim_log_info(const char* msg) {
+    if (msg) printf("[INFO] %s\n", msg);
+}
+
+void reovim_log_warn(const char* msg) {
+    if (msg) printf("[WARN] %s\n", msg);
+}
+
+void reovim_log_error(const char* msg) {
+    if (msg) printf("[ERROR] %s\n", msg);
+}
+
+void reovim_log_debug(const char* msg) {
+    if (msg) printf("[DEBUG] %s\n", msg);
+}
+
+/* Version struct */
+typedef struct ReovimVersion {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+} ReovimVersion;
+
+/* Version stub - fills provided buffer with ABI version */
+void reovim_abi_version_ptr(ReovimVersion* out) {
+    if (out) {
+        out->major = 1;
+        out->minor = 0;
+        out->patch = 0;
+    }
+}
+
+/* Compatibility check stub */
+bool reovim_abi_is_compatible(ReovimVersion required, ReovimVersion provided) {
+    return required.major == provided.major &&
+           required.minor <= provided.minor;
+}

--- a/runner/src/server/module/loading/handle.rs
+++ b/runner/src/server/module/loading/handle.rs
@@ -23,6 +23,12 @@ pub type InitFn = unsafe extern "C" fn(*mut c_void, *const c_void) -> i32;
 pub type ExitFn = unsafe extern "C" fn(*mut c_void) -> i32;
 pub type DestroyFn = unsafe extern "C" fn(*mut c_void);
 
+// Alternative FFI types for languages that can't return structs by value (e.g., Haskell)
+/// Alternative probe function that fills a pre-allocated buffer.
+pub type ProbePtrFn = unsafe extern "C" fn(*mut ModuleProbe);
+/// Alternative API version function that fills a pre-allocated buffer.
+pub type ApiVersionPtrFn = unsafe extern "C" fn(*mut Version);
+
 // Hot reload FFI types
 pub type SupportsHotReloadFn = unsafe extern "C" fn(*const c_void) -> i32;
 pub type SaveStateFn = unsafe extern "C" fn(*const c_void, *mut *mut u8, *mut usize) -> i32;

--- a/runner/src/server/module/loading/loader.rs
+++ b/runner/src/server/module/loading/loader.rs
@@ -10,14 +10,16 @@ use std::{
 
 use {
     libloading::{Library, Symbol},
-    reovim_kernel::api::v1::{API_VERSION, Module, ModuleError, ModuleId, Version, is_compatible},
+    reovim_kernel::api::v1::{
+        API_VERSION, Module, ModuleError, ModuleId, ModuleProbe, Version, is_compatible,
+    },
 };
 
 use super::{
     discovery::{default_search_paths, discover_modules, find_module},
     handle::{
-        DestroyFn, EntryFn, ExitFn, FfiSymbols, FreeStateFn, InitFn, ModuleHandle, ProbeFn,
-        RestoreStateFn, SaveStateFn, SupportsHotReloadFn,
+        ApiVersionPtrFn, DestroyFn, EntryFn, ExitFn, FfiSymbols, FreeStateFn, InitFn, ModuleHandle,
+        ProbeFn, ProbePtrFn, RestoreStateFn, SaveStateFn, SupportsHotReloadFn,
     },
 };
 
@@ -122,14 +124,26 @@ impl ModuleLoader {
             // 1. Load shared library
             let library = Library::new(path).map_err(|e| ModuleError::LoadFailed(e.to_string()))?;
 
-            // 2. Check API version FIRST (static symbol, fast)
-            // NOTE: Macro generates `pub static`, so Symbol returns a reference
-            let api_version: Symbol<&'static Version> =
-                library
-                    .get(b"REOVIM_MODULE_API_VERSION")
-                    .map_err(|e| ModuleError::NoEntryPoint(e.to_string()))?;
-
-            let module_api = **api_version; // Double dereference: Symbol -> & -> Version
+            // 2. Check API version FIRST
+            // Try static symbol first (fast), then fallback to pointer function (Haskell)
+            let module_api = if let Ok(api_version) =
+                library.get::<&'static Version>(b"REOVIM_MODULE_API_VERSION")
+            {
+                // NOTE: Macro generates `pub static`, so Symbol returns a reference
+                **api_version // Double dereference: Symbol -> & -> Version
+            } else if let Ok(api_version_ptr_fn) =
+                library.get::<ApiVersionPtrFn>(b"reovim_module_api_version_ptr")
+            {
+                // Fallback for languages that can't export static data (e.g., Haskell)
+                let mut version = Version::new(0, 0, 0);
+                api_version_ptr_fn(&raw mut version);
+                version
+            } else {
+                return Err(ModuleError::NoEntryPoint(
+                    "neither REOVIM_MODULE_API_VERSION nor reovim_module_api_version_ptr found"
+                        .to_string(),
+                ));
+            };
 
             // is_compatible(required, provided) - module requires, kernel provides
             if !is_compatible(module_api, API_VERSION) {
@@ -140,11 +154,18 @@ impl ModuleLoader {
             }
 
             // 3. Get module probe (metadata without instantiation)
-            let probe_fn: Symbol<ProbeFn> = library
-                .get(b"reovim_module_probe")
-                .map_err(|e| ModuleError::NoEntryPoint(e.to_string()))?;
-
-            let probe = probe_fn();
+            // Try return-by-value first, then fallback to pointer (Haskell)
+            let probe = if let Ok(probe_fn) = library.get::<ProbeFn>(b"reovim_module_probe") {
+                probe_fn()
+            } else if let Ok(probe_ptr_fn) = library.get::<ProbePtrFn>(b"reovim_module_probe") {
+                // Fallback for languages that can't return structs by value (e.g., Haskell)
+                // SAFETY: ModuleProbe is repr(C) and all-zero is a valid state
+                let mut probe: ModuleProbe = std::mem::zeroed();
+                probe_ptr_fn(&raw mut probe);
+                probe
+            } else {
+                return Err(ModuleError::NoEntryPoint("reovim_module_probe not found".to_string()));
+            };
             let id = ModuleId::from_string(probe.id_str().to_owned());
 
             // 4. Check if already loaded


### PR DESCRIPTION
Add FFI driver crate for external module support, enabling modules written in C, Haskell, or any FFI-compatible language.

- New reovim-driver-ffi crate with cdylib output
- C header file (reovim.h) documenting stable ABI contract
- ABI version 1.0.0 with struct layout guarantees:
  - ReovimVersion: 12 bytes (3 x u32)
  - ReovimModuleProbe: 1308 bytes (fixed-size metadata)
- FFI service wrappers: reovim_log_*, reovim_abi_*
- Architecture documentation at docs/architecture/ffi/overview.md
- Example C module implementation at examples/c-module/

Closes #290
