### PR TITLE
feat(ffi): add Python FFI bindings via PyO3 (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,23 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
   - Example C module at `examples/c-module/`
   - Modules can be written in C, Haskell, or any FFI-compatible language
 
+- **Python FFI Bindings via PyO3** (Issue #293)
+  - New `reovim-driver-ffi-python` crate for Python module support
+  - Optional feature flag: `cargo build --features python`
+  - PyO3 type bindings for kernel types:
+    - `ModuleId`, `Version`, `ProbeResult` - core identity types
+    - `CommandRegistration`, `KeybindingRegistration`, `EventHandlerRegistration` - builder types
+    - `ModuleContext` - init context wrapper
+  - `PythonModule` wrapper implementing all 12 `Module` trait methods
+  - Thread-safe GIL acquisition via `Python::attach()`
+  - Python module discovery (`discover_python_modules()`) and loading (`load_python()`)
+  - Hot reload support with `pickle`-based state serialization
+  - Documentation:
+    - Architecture: `docs/architecture/ffi/python.md`
+    - User guide: `docs/user-guide/python-modules.md`
+  - Example modules: `examples/python-module/hello.py`, `examples/python-module/counter.py`
+  - 34 unit tests covering all type bindings and conversions
+
 - **Basic Window Management** (Issue #276)
   - **WindowRegistry** (`runner/src/server/window.rs`):
     - `WindowState` struct for per-window cursor position and scroll offset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +770,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -898,6 +916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +934,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1004,10 +1089,12 @@ dependencies = [
  "crossterm",
  "futures",
  "libloading",
+ "pyo3",
  "regex",
  "reovim-arch",
  "reovim-driver-command",
  "reovim-driver-display",
+ "reovim-driver-ffi-python",
  "reovim-driver-input",
  "reovim-driver-vfs",
  "reovim-kernel",
@@ -1066,6 +1153,15 @@ name = "reovim-driver-ffi"
 version = "0.9.0-dev"
 dependencies = [
  "libc",
+ "reovim-kernel",
+ "tracing",
+]
+
+[[package]]
+name = "reovim-driver-ffi-python"
+version = "0.9.0-dev"
+dependencies = [
+ "pyo3",
  "reovim-kernel",
  "tracing",
 ]
@@ -1516,6 +1612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1932,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "lib/drivers/log",
     "lib/drivers/trace",
     "lib/drivers/ffi",
+    "lib/drivers/ffi-python",
 
     # Platform abstraction
     "lib/arch",
@@ -98,6 +99,10 @@ reovim-driver-vfs = { path = "./lib/drivers/vfs", version = "0.9.0-dev" }
 reovim-driver-log = { path = "./lib/drivers/log", version = "0.9.0-dev" }
 reovim-driver-trace = { path = "./lib/drivers/trace", version = "0.9.0-dev" }
 reovim-driver-ffi = { path = "./lib/drivers/ffi", version = "0.9.0-dev" }
+reovim-driver-ffi-python = { path = "./lib/drivers/ffi-python", version = "0.9.0-dev" }
+
+# Python FFI
+pyo3 = { version = "0.27", features = ["auto-initialize"] }
 
 # Policy modules
 reovim-module-example = { path = "./modules/example", version = "0.9.0-dev" }

--- a/docs/architecture/ffi/python.md
+++ b/docs/architecture/ffi/python.md
@@ -1,0 +1,299 @@
+# Python FFI Bindings
+
+This document describes the Python FFI bindings for reovim modules via PyO3.
+
+## Overview
+
+Reovim supports writing modules in Python through the `reovim-driver-ffi-python` crate.
+Python modules use the same `Module` trait as Rust modules, with automatic conversion
+between Python and Rust types.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  PYTHON MODULES (~/.local/share/reovim/modules/*.py)        │
+│  class MyModule(Module):                                    │
+│      def init(self, ctx): ...                               │
+│  User-written Python code                                   │
+├─────────────────────────────────────────────────────────────┤
+│  PYTHON BINDINGS (lib/drivers/ffi-python/)                  │
+│  reovim Python package                                      │
+│  #[pyclass] ModuleId, Version, ProbeResult                  │
+│  PyO3 bindings for kernel types                             │
+├─────────────────────────────────────────────────────────────┤
+│  PYTHON MODULE WRAPPER                                      │
+│  PythonModule struct implementing Module trait              │
+│  Delegates to Python methods via PyO3 GIL                   │
+├─────────────────────────────────────────────────────────────┤
+│  MODULE LOADER (runner/src/server/module/loading/)          │
+│  load_python() - Python module loading                      │
+│  discover_python_modules() - .py file detection             │
+│  Unified interface: static/dynamic/python                   │
+├─────────────────────────────────────────────────────────────┤
+│  LIFECYCLE MANAGER (existing)                               │
+│  Same dependency resolution, deferred probing, hot reload   │
+│  No changes needed!                                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Design Decisions
+
+### PyO3 over ctypes
+
+We use PyO3 for Rust-Python interop because:
+- **Type safety**: Automatic conversions with compile-time checks
+- **Memory safety**: Rust's ownership model extends to Python objects
+- **Performance**: Direct function calls, no marshalling overhead
+- **Ergonomics**: Idiomatic Python API with decorators and type hints
+
+### Embedded Python
+
+Python runs in the same process as reovim:
+- **Shared memory**: Direct access to kernel types
+- **Low latency**: No IPC overhead
+- **Full API**: Python modules can use all kernel services
+
+### Unified Module Trait
+
+Python modules implement the same 12-method `Module` trait:
+- **Consistency**: Same lifecycle as Rust modules
+- **Interoperability**: Python modules can depend on Rust modules
+- **Hot reload**: State preservation works across languages
+
+## Module Interface
+
+### Base Class
+
+Python modules inherit from `Module`:
+
+```python
+from reovim import Module, ModuleId, ProbeResult
+
+class MyModule(Module):
+    def id(self) -> ModuleId:
+        return ModuleId("my-module")
+
+    def name(self) -> str:
+        return "My Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        return ProbeResult.Success()
+
+    def exit(self):
+        pass
+```
+
+### Available Types
+
+The `reovim` Python module exports:
+
+| Type | Purpose |
+|------|---------|
+| `Module` | Base class for modules |
+| `ModuleId` | Unique module identifier |
+| `Version` | Semantic version (major, minor, patch) |
+| `ProbeResult` | Init result: `Success`, `Defer(reason)`, `Failed(reason)` |
+| `ModuleContext` | Context passed to `init()` |
+| `CommandRegistration` | Command registration builder |
+| `KeybindingRegistration` | Keybinding registration builder |
+| `EventHandlerRegistration` | Event handler registration builder |
+
+### Method Signatures
+
+| Method | Signature | Required |
+|--------|-----------|----------|
+| `id()` | `() -> ModuleId` | Yes |
+| `name()` | `() -> str` | Yes |
+| `version()` | `() -> tuple[int, int, int]` | Yes |
+| `api_version()` | `() -> Version` | No |
+| `dependencies()` | `() -> list[ModuleId]` | No |
+| `optional_dependencies()` | `() -> list[ModuleId]` | No |
+| `init(ctx)` | `(dict) -> ProbeResult` | Yes |
+| `exit()` | `() -> None` | Yes |
+| `commands()` | `() -> list[CommandRegistration]` | No |
+| `keybindings()` | `() -> list[KeybindingRegistration]` | No |
+| `event_handlers()` | `() -> list[EventHandlerRegistration]` | No |
+| `supports_hot_reload()` | `() -> bool` | No |
+| `save_state()` | `() -> bytes \| None` | No |
+| `restore_state(state)` | `(bytes) -> None` | No |
+
+## Implementation Details
+
+### PythonModule Wrapper
+
+The `PythonModule` struct wraps a Python object and implements `Module`:
+
+```rust
+pub struct PythonModule {
+    /// Python module class instance (Py<PyAny> in Arc for thread safety)
+    py_object: Arc<Py<PyAny>>,
+
+    /// Path to source file (for debugging/hot reload)
+    source_path: Option<String>,
+
+    /// Cached metadata (id, name, version, api_version)
+    metadata: OnceLock<CachedMetadata>,
+}
+```
+
+### GIL Acquisition
+
+All Python calls acquire the Global Interpreter Lock (GIL):
+
+```rust
+fn id(&self) -> ModuleId {
+    self.get_metadata().id.clone()
+}
+
+fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+    Python::attach(|py| {
+        let obj = self.py_object.bind(py);
+        // ... call Python method
+    })
+}
+```
+
+### Thread Safety
+
+`PythonModule` is `Send + Sync` because:
+- `Py<PyAny>` is wrapped in `Arc` for shared ownership
+- All Python calls acquire the GIL before accessing the object
+- Cached metadata uses `OnceLock` for thread-safe initialization
+
+### Module Loading
+
+The loader finds Python modules by:
+
+1. Scanning search paths for `.py` files
+2. Filtering out files starting with `_` (private)
+3. Executing the Python code in a new module namespace
+4. Finding a class that inherits from `Module`
+5. Instantiating the class
+6. Wrapping in `PythonModule`
+
+```rust
+#[cfg(feature = "python")]
+pub fn load_python(&mut self, path: &Path) -> Result<ModuleId, ModuleError> {
+    // ... load Python file, find Module subclass, instantiate
+}
+```
+
+### Registration Types
+
+Registration builders use `Box::leak()` to convert dynamic strings to `&'static str`:
+
+```rust
+impl PyCommandRegistration {
+    pub fn to_kernel(&self) -> v1::CommandRegistration {
+        v1::CommandRegistration {
+            id: Box::leak(self.id.clone().into_boxed_str()),
+            // ...
+        }
+    }
+}
+```
+
+This is acceptable because registrations are typically created once at module load
+and live for the program's lifetime.
+
+## Feature Flag
+
+Python support is optional and controlled by the `python` feature:
+
+```toml
+# runner/Cargo.toml
+[features]
+default = []
+python = ["dep:reovim-driver-ffi-python", "dep:pyo3"]
+```
+
+Build with Python support:
+
+```bash
+cargo build --features python
+```
+
+## Search Paths
+
+Python modules are discovered in the same paths as native modules:
+
+1. `/usr/lib/reovim/modules/` (system, Linux)
+2. `/usr/local/lib/reovim/modules/` (local, Linux)
+3. `~/.local/share/reovim/modules/` (user, XDG)
+
+## Hot Reload
+
+Python modules can support hot reload by implementing:
+
+```python
+def supports_hot_reload(self) -> bool:
+    return True
+
+def save_state(self) -> bytes | None:
+    import pickle
+    return pickle.dumps(self.__dict__)
+
+def restore_state(self, state: bytes):
+    import pickle
+    self.__dict__.update(pickle.loads(state))
+```
+
+State is limited to 16 MiB to prevent memory issues.
+
+## Error Handling
+
+Python exceptions are converted to `ModuleError`:
+
+| Python Exception | ModuleError |
+|------------------|-------------|
+| Syntax error | `LoadFailed` |
+| Import error | `LoadFailed` |
+| Exception in `init()` | `InitFailed` |
+| Exception in `exit()` | `InitFailed` |
+| No Module subclass | `NoEntryPoint` |
+
+## Performance Considerations
+
+### GIL Contention
+
+The GIL is acquired for each method call. For performance:
+- Keep Python code fast
+- Avoid blocking operations in Python
+- Heavy computation should be in Rust modules
+
+### Startup Cost
+
+Python modules have higher startup cost than Rust:
+- Python interpreter initialization
+- Module compilation
+- Object creation
+
+For latency-critical paths, prefer Rust modules.
+
+## Security
+
+### Pickle Deserialization
+
+Hot reload state uses pickle, which can execute arbitrary code.
+Mitigations:
+- State comes from the module itself (not user input)
+- Size limit (16 MiB) prevents memory attacks
+- Document risks in user guide
+
+### Module Sandboxing
+
+Python modules run with full Python capabilities.
+Future work may add:
+- Resource limits
+- Filesystem restrictions
+- Network restrictions
+
+## Related Documentation
+
+- [FFI Overview](./overview.md) - C FFI interface
+- [Module Overview](../modules/overview.md) - Module system architecture
+- [Python Modules User Guide](../../user-guide/python-modules.md) - Writing Python modules

--- a/docs/architecture/modules/overview.md
+++ b/docs/architecture/modules/overview.md
@@ -11,6 +11,21 @@ The module system enables dynamic loading of policy modules. Implemented in Phas
 | `ModuleLoader` | `runner/src/module/loader.rs` | Static + dynamic loading |
 | `ModuleRegistry` | `runner/src/module/registry.rs` | Dependency resolution |
 | `HotReloadManager` | `runner/src/module/hot_reload.rs` | File watching |
+| `PythonModule` | `lib/drivers/ffi-python/` | Python module wrapper |
+
+## Module Types
+
+Reovim supports multiple module types:
+
+| Type | Extension | Build | Feature Flag |
+|------|-----------|-------|--------------|
+| Rust (static) | - | Compile-time | - |
+| Rust (dynamic) | `.so`/`.dylib`/`.dll` | Runtime | - |
+| C/FFI | `.so`/`.dylib`/`.dll` | Runtime | - |
+| Python | `.py` | Runtime | `python` |
+
+All module types implement the same `Module` trait and participate in the
+same lifecycle, dependency resolution, and hot reload system.
 
 ---
 
@@ -173,6 +188,10 @@ impl ModuleLoader {
     // Dynamic loading (runtime)
     pub fn load_dynamic(&mut self, path: &Path) -> Result<ModuleHandle>;
 
+    // Python loading (requires `python` feature)
+    #[cfg(feature = "python")]
+    pub fn load_python(&mut self, path: &Path) -> Result<ModuleId>;
+
     // Search path loading
     pub fn load_by_name(&mut self, name: &str) -> Result<ModuleHandle>;
 }
@@ -186,7 +205,9 @@ impl ModuleLoader {
 ~/.local/share/reovim/modules/
 ```
 
-File extensions: `.so` (Linux), `.dylib` (macOS), `.dll` (Windows)
+File extensions:
+- Native: `.so` (Linux), `.dylib` (macOS), `.dll` (Windows)
+- Python: `.py` (requires `python` feature)
 
 ---
 
@@ -403,3 +424,6 @@ declare_module!(KeymapModule);
 - [Mechanism vs Policy](../contributing/philosophy/mechanism-vs-policy.md) - Design principle
 - [Module-Mode Inheritance](./mode-inheritance.md) - Mode system
 - [Kernel Subsystems](../kernel/overview.md) - Kernel internals
+- [FFI Overview](../ffi/overview.md) - C FFI interface
+- [Python FFI](../ffi/python.md) - Python module bindings
+- [Python Modules User Guide](../../user-guide/python-modules.md) - Writing Python modules

--- a/docs/user-guide/python-modules.md
+++ b/docs/user-guide/python-modules.md
@@ -1,0 +1,466 @@
+# Writing Python Modules for Reovim
+
+This guide explains how to write reovim modules in Python.
+
+## Prerequisites
+
+### Enable Python Support
+
+Reovim must be built with the `python` feature:
+
+```bash
+cargo build --features python
+```
+
+### Python Version
+
+Python 3.11 or later is required.
+
+## Quick Start
+
+### 1. Create a Module File
+
+Create a `.py` file in your modules directory:
+
+```bash
+mkdir -p ~/.local/share/reovim/modules
+touch ~/.local/share/reovim/modules/my_module.py
+```
+
+### 2. Write the Module
+
+```python
+from reovim import Module, ModuleId, ProbeResult
+
+class MyModule(Module):
+    """My custom Python module."""
+
+    def id(self) -> ModuleId:
+        return ModuleId("my-module")
+
+    def name(self) -> str:
+        return "My Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        print(f"Module initialized! Data dir: {ctx['data_dir']}")
+        return ProbeResult.Success()
+
+    def exit(self):
+        print("Module exiting")
+```
+
+### 3. Start Reovim
+
+The module will be discovered and loaded automatically.
+
+## Module Structure
+
+### Required Methods
+
+Every module must implement these methods:
+
+```python
+class MyModule(Module):
+    def id(self) -> ModuleId:
+        """Return unique module identifier (kebab-case recommended)."""
+        return ModuleId("my-module")
+
+    def name(self) -> str:
+        """Return human-readable display name."""
+        return "My Module"
+
+    def version(self) -> tuple[int, int, int]:
+        """Return semantic version as (major, minor, patch)."""
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        """Initialize the module. Called when module is loaded."""
+        return ProbeResult.Success()
+
+    def exit(self):
+        """Clean up the module. Called when module is unloaded."""
+        pass
+```
+
+### Init Context
+
+The `ctx` parameter in `init()` is a dictionary with:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `data_dir` | `str` | Module's data directory path |
+| `cache_dir` | `str` | Module's cache directory path |
+| `optional_deps` | `list[str]` | Loaded optional dependencies |
+
+### ProbeResult
+
+Return one of these from `init()`:
+
+```python
+# Success - module initialized
+return ProbeResult.Success()
+
+# Defer - try again later (dependency not ready)
+return ProbeResult.Defer("waiting for treesitter module")
+
+# Failed - permanent failure
+return ProbeResult.Failed("configuration file not found")
+```
+
+## Dependencies
+
+### Required Dependencies
+
+Declare modules that must be loaded before yours:
+
+```python
+def dependencies(self) -> list[ModuleId]:
+    return [
+        ModuleId("editor"),
+        ModuleId("keymap"),
+    ]
+```
+
+### Optional Dependencies
+
+Declare modules that enhance yours if available:
+
+```python
+def optional_dependencies(self) -> list[ModuleId]:
+    return [
+        ModuleId("lsp"),
+        ModuleId("treesitter"),
+    ]
+```
+
+Check if optional dependencies are loaded:
+
+```python
+def init(self, ctx) -> ProbeResult:
+    if "lsp" in ctx['optional_deps']:
+        self._setup_lsp_integration()
+    return ProbeResult.Success()
+```
+
+## Registrations
+
+### Commands
+
+Register commands that can be invoked:
+
+```python
+from reovim import CommandRegistration
+
+def commands(self) -> list[CommandRegistration]:
+    return [
+        CommandRegistration("my-command")
+            .with_name("My Command")
+            .with_description("Does something useful")
+            .with_category("custom"),
+
+        CommandRegistration("my-operator")
+            .with_name("My Operator")
+            .with_count()      # Accepts count prefix (e.g., 5x)
+            .with_motion()     # Accepts motion (e.g., xw for word)
+            .with_text_modifying(),
+    ]
+```
+
+### Keybindings
+
+Register keybindings that invoke commands:
+
+```python
+from reovim import KeybindingRegistration
+
+def keybindings(self) -> list[KeybindingRegistration]:
+    return [
+        KeybindingRegistration("<C-m>", "my-command")
+            .with_modes(["normal"])
+            .with_description("Run my command")
+            .with_category("custom"),
+
+        KeybindingRegistration("gx", "my-operator")
+            .with_modes(["normal", "visual"])
+            .with_priority(50),  # Lower = higher priority
+    ]
+```
+
+### Event Handlers
+
+Register handlers for editor events:
+
+```python
+from reovim import EventHandlerRegistration
+
+def event_handlers(self) -> list[EventHandlerRegistration]:
+    return [
+        EventHandlerRegistration("BufferChanged")
+            .with_description("Update on buffer change")
+            .with_priority(100),
+
+        EventHandlerRegistration("CursorMoved")
+            .with_once()  # Auto-unsubscribe after first event
+            .with_target("editor"),
+    ]
+```
+
+## Hot Reload
+
+### Enable Hot Reload
+
+Support preserving state when the module is reloaded:
+
+```python
+def supports_hot_reload(self) -> bool:
+    return True
+```
+
+### Save State
+
+Serialize your module's state:
+
+```python
+import pickle
+
+def save_state(self) -> bytes | None:
+    return pickle.dumps({
+        "counter": self._counter,
+        "settings": self._settings,
+    })
+```
+
+### Restore State
+
+Restore state after reload:
+
+```python
+def restore_state(self, state: bytes):
+    data = pickle.loads(state)
+    self._counter = data.get("counter", 0)
+    self._settings = data.get("settings", {})
+```
+
+### Complete Example
+
+```python
+import pickle
+from reovim import Module, ModuleId, ProbeResult
+
+class CounterModule(Module):
+    def __init__(self):
+        super().__init__()
+        self._count = 0
+
+    def id(self) -> ModuleId:
+        return ModuleId("counter")
+
+    def name(self) -> str:
+        return "Counter Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        return ProbeResult.Success()
+
+    def exit(self):
+        pass
+
+    def supports_hot_reload(self) -> bool:
+        return True
+
+    def save_state(self) -> bytes | None:
+        return pickle.dumps({"count": self._count})
+
+    def restore_state(self, state: bytes):
+        data = pickle.loads(state)
+        self._count = data.get("count", 0)
+
+    # Public API
+    def increment(self) -> int:
+        self._count += 1
+        return self._count
+```
+
+## Best Practices
+
+### Keep It Lightweight
+
+Python modules should be thin wrappers. Heavy computation belongs in Rust.
+
+```python
+# Good: Simple coordination
+def init(self, ctx) -> ProbeResult:
+    self._config = load_config(ctx['data_dir'])
+    return ProbeResult.Success()
+
+# Bad: Heavy computation in Python
+def init(self, ctx) -> ProbeResult:
+    self._index = build_massive_index()  # Do this in Rust
+    return ProbeResult.Success()
+```
+
+### Handle Errors Gracefully
+
+Return appropriate `ProbeResult` values:
+
+```python
+def init(self, ctx) -> ProbeResult:
+    try:
+        self._config = load_config()
+    except FileNotFoundError:
+        # Permanent failure - config required
+        return ProbeResult.Failed("config.toml not found")
+    except ConnectionError:
+        # Temporary failure - retry later
+        return ProbeResult.Defer("network unavailable")
+
+    return ProbeResult.Success()
+```
+
+### Use Type Hints
+
+Type hints improve readability and catch errors:
+
+```python
+from reovim import Module, ModuleId, ProbeResult, Version
+
+class MyModule(Module):
+    def id(self) -> ModuleId:
+        return ModuleId("my-module")
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def api_version(self) -> Version:
+        return Version(0, 9, 0)
+```
+
+### Document Your Module
+
+Add docstrings for clarity:
+
+```python
+class MyModule(Module):
+    """
+    My custom module for reovim.
+
+    Features:
+    - Feature A
+    - Feature B
+
+    Configuration:
+        Set MY_OPTION in config.toml
+    """
+
+    def init(self, ctx) -> ProbeResult:
+        """Initialize with optional LSP integration."""
+        ...
+```
+
+## Debugging
+
+### Print Debugging
+
+Use print statements (output goes to reovim's log):
+
+```python
+def init(self, ctx) -> ProbeResult:
+    print(f"MyModule: data_dir = {ctx['data_dir']}")
+    print(f"MyModule: optional_deps = {ctx['optional_deps']}")
+    return ProbeResult.Success()
+```
+
+### Check Logs
+
+View reovim logs:
+
+```bash
+tail -f ~/.local/share/reovim/reovim-*.log
+```
+
+### Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "no Module subclass found" | Class doesn't inherit from `Module` | Add `class MyModule(Module):` |
+| "Python syntax error" | Invalid Python code | Check syntax, run `python -m py_compile file.py` |
+| "cannot instantiate" | Error in `__init__` | Check `__init__` for exceptions |
+
+## Module Locations
+
+Modules are discovered in these directories:
+
+| Path | Description |
+|------|-------------|
+| `/usr/lib/reovim/modules/` | System modules (Linux) |
+| `/usr/local/lib/reovim/modules/` | Local system modules |
+| `~/.local/share/reovim/modules/` | User modules (XDG) |
+
+## API Reference
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `Module` | Base class for Python modules |
+| `ModuleId` | Module identifier (`ModuleId("name")`) |
+| `Version` | Semantic version (`Version(1, 2, 3)`) |
+| `ProbeResult` | Init result (`Success()`, `Defer(reason)`, `Failed(reason)`) |
+| `ModuleContext` | Context with `data_dir`, `cache_dir`, `optional_deps` |
+
+### Registration Types
+
+| Type | Description |
+|------|-------------|
+| `CommandRegistration` | Command registration builder |
+| `KeybindingRegistration` | Keybinding registration builder |
+| `EventHandlerRegistration` | Event handler registration builder |
+
+### CommandRegistration Methods
+
+| Method | Description |
+|--------|-------------|
+| `.with_name(str)` | Set display name |
+| `.with_description(str)` | Set description |
+| `.with_category(str)` | Set category |
+| `.with_count()` | Accept count prefix |
+| `.with_motion()` | Accept motion |
+| `.with_jump()` | Record in jump list |
+| `.with_text_modifying()` | Marks buffer as modified |
+
+### KeybindingRegistration Methods
+
+| Method | Description |
+|--------|-------------|
+| `.with_modes(list[str])` | Set active modes |
+| `.with_description(str)` | Set description |
+| `.with_category(str)` | Set category |
+| `.with_priority(int)` | Set priority (lower = higher) |
+| `.with_disabled()` | Disable by default |
+
+### EventHandlerRegistration Methods
+
+| Method | Description |
+|--------|-------------|
+| `.with_priority(int)` | Set priority |
+| `.with_description(str)` | Set description |
+| `.with_once()` | Auto-unsubscribe after first event |
+| `.with_target(str)` | Set target component |
+
+## Examples
+
+See `examples/python-module/` for complete examples:
+
+- `hello.py` - Minimal hello world module
+- `counter.py` - Hot reload with state preservation
+
+## Related Documentation
+
+- [Python FFI Architecture](../architecture/ffi/python.md)
+- [Module Overview](../architecture/modules/overview.md)
+- [Commands Reference](./commands.md)

--- a/examples/python-module/README.md
+++ b/examples/python-module/README.md
@@ -1,0 +1,135 @@
+# Python Module Examples
+
+This directory contains example Python modules for reovim.
+
+## Prerequisites
+
+Reovim must be built with the `python` feature enabled:
+
+```bash
+cargo build --features python
+```
+
+## Installation
+
+Copy modules to your reovim modules directory:
+
+```bash
+cp *.py ~/.local/share/reovim/modules/
+```
+
+## Examples
+
+### hello.py - Hello World
+
+The simplest possible Python module demonstrating:
+- Module identity (id, name, version)
+- Lifecycle (init, exit)
+
+```python
+from reovim import Module, ModuleId, ProbeResult
+
+class HelloModule(Module):
+    def id(self) -> ModuleId:
+        return ModuleId("hello-python")
+
+    def name(self) -> str:
+        return "Hello Python Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        print(f"Hello from Python! Data dir: {ctx['data_dir']}")
+        return ProbeResult.Success()
+
+    def exit(self):
+        print("Goodbye from Python!")
+```
+
+### counter.py - Hot Reload Support
+
+Demonstrates state preservation across hot reloads using pickle:
+
+```python
+from reovim import Module, ModuleId, ProbeResult
+import pickle
+
+class CounterModule(Module):
+    def __init__(self):
+        super().__init__()
+        self._count = 0
+
+    def supports_hot_reload(self) -> bool:
+        return True
+
+    def save_state(self) -> bytes | None:
+        return pickle.dumps({"count": self._count})
+
+    def restore_state(self, state: bytes):
+        data = pickle.loads(state)
+        self._count = data.get("count", 0)
+```
+
+## Module API Reference
+
+### Required Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `id()` | `ModuleId` | Unique module identifier |
+| `name()` | `str` | Human-readable module name |
+| `version()` | `tuple[int, int, int]` | Semantic version (major, minor, patch) |
+| `init(ctx)` | `ProbeResult` | Initialize the module |
+| `exit()` | `None` | Clean up before unload |
+
+### Optional Methods
+
+| Method | Return Type | Default | Description |
+|--------|-------------|---------|-------------|
+| `api_version()` | `Version` | Current API | Required kernel API version |
+| `dependencies()` | `list[ModuleId]` | `[]` | Required dependencies |
+| `optional_dependencies()` | `list[ModuleId]` | `[]` | Optional dependencies |
+| `supports_hot_reload()` | `bool` | `False` | Whether hot reload is supported |
+| `save_state()` | `bytes \| None` | `None` | Serialize state for hot reload |
+| `restore_state(state)` | `None` | No-op | Restore state after hot reload |
+
+### Registration Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `commands()` | `list[CommandRegistration]` | Commands to register |
+| `keybindings()` | `list[KeybindingRegistration]` | Keybindings to register |
+| `event_handlers()` | `list[EventHandlerRegistration]` | Event handlers to register |
+
+### Available Types
+
+Import from the `reovim` module:
+
+```python
+from reovim import (
+    Module,              # Base class for modules
+    ModuleId,            # Module identifier
+    Version,             # Semantic version
+    ProbeResult,         # Init result (Success, Defer, Failed)
+    ModuleContext,       # Context passed to init()
+    CommandRegistration,       # Command registration builder
+    KeybindingRegistration,    # Keybinding registration builder
+    EventHandlerRegistration,  # Event handler registration builder
+)
+```
+
+## Tips
+
+1. **Keep it simple**: Python modules should be lightweight. Heavy computation should be in Rust.
+
+2. **Handle errors gracefully**: Return `ProbeResult.Defer("reason")` if dependencies aren't ready.
+
+3. **Use pickle carefully**: Only pickle trusted data. The state comes from your own module.
+
+4. **Test locally**: Copy to `~/.local/share/reovim/modules/` and restart reovim.
+
+## More Information
+
+- [Python Modules User Guide](../../docs/user-guide/python-modules.md)
+- [Python FFI Architecture](../../docs/architecture/ffi/python.md)

--- a/examples/python-module/counter.py
+++ b/examples/python-module/counter.py
@@ -1,0 +1,71 @@
+"""
+Counter Module with Hot Reload Support.
+
+Demonstrates:
+- State preservation across hot reload
+- Using pickle for serialization
+- Custom module methods
+
+To install:
+    cp counter.py ~/.local/share/reovim/modules/
+"""
+
+import pickle
+
+from reovim import Module, ModuleId, ProbeResult
+
+
+class CounterModule(Module):
+    """A counter module demonstrating hot reload with state preservation."""
+
+    def __init__(self):
+        super().__init__()
+        self._count = 0
+
+    def id(self) -> ModuleId:
+        return ModuleId("counter-python")
+
+    def name(self) -> str:
+        return "Python Counter Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        print(f"Counter initialized at: {self._count}")
+        return ProbeResult.Success()
+
+    def exit(self):
+        print(f"Counter final value: {self._count}")
+
+    def supports_hot_reload(self) -> bool:
+        return True
+
+    def save_state(self) -> bytes | None:
+        """Serialize module state for hot reload."""
+        return pickle.dumps({"count": self._count})
+
+    def restore_state(self, state: bytes):
+        """Restore module state after hot reload."""
+        data = pickle.loads(state)  # noqa: S301 - trusted internal data
+        self._count = data.get("count", 0)
+        print(f"Counter restored to: {self._count}")
+
+    # Public API for other modules or commands
+    def increment(self) -> int:
+        """Increment the counter and return new value."""
+        self._count += 1
+        return self._count
+
+    def decrement(self) -> int:
+        """Decrement the counter and return new value."""
+        self._count -= 1
+        return self._count
+
+    def get_count(self) -> int:
+        """Get the current counter value."""
+        return self._count
+
+    def reset(self):
+        """Reset the counter to zero."""
+        self._count = 0

--- a/examples/python-module/hello.py
+++ b/examples/python-module/hello.py
@@ -1,0 +1,32 @@
+"""
+Hello World Python Module for reovim.
+
+This is the simplest possible Python module demonstrating:
+- Module identity (id, name, version)
+- Lifecycle (init, exit)
+
+To install:
+    cp hello.py ~/.local/share/reovim/modules/
+"""
+
+from reovim import Module, ModuleId, ProbeResult
+
+
+class HelloModule(Module):
+    """A simple hello world module."""
+
+    def id(self) -> ModuleId:
+        return ModuleId("hello-python")
+
+    def name(self) -> str:
+        return "Hello Python Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        print(f"Hello from Python! Data dir: {ctx['data_dir']}")
+        return ProbeResult.Success()
+
+    def exit(self):
+        print("Goodbye from Python!")

--- a/lib/drivers/ffi-python/Cargo.toml
+++ b/lib/drivers/ffi-python/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "reovim-driver-ffi-python"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Python FFI bindings for reovim modules via PyO3"
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[lib]
+name = "reovim_driver_ffi_python"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+reovim-kernel = { workspace = true }
+# Note: extension-module is NOT used because we embed Python in the runner.
+# If building a standalone Python extension, add extension-module feature.
+pyo3 = { version = "0.27", features = ["auto-initialize"] }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/drivers/ffi-python/README.md
+++ b/lib/drivers/ffi-python/README.md
@@ -1,0 +1,81 @@
+# reovim-driver-ffi-python
+
+Python FFI bindings for reovim modules via PyO3.
+
+## Overview
+
+This crate provides Python bindings that allow writing reovim modules in Python.
+It wraps kernel types (`ModuleId`, `Version`, `ProbeResult`) and provides the
+foundation for Python modules to interact with the reovim module system.
+
+## Architecture
+
+```
+Python Module (my_module.py)
+        │
+        ▼
+┌─────────────────────────┐
+│  ffi-python crate       │
+│  PythonModule wrapper   │
+│  impl Module trait      │
+└─────────────────────────┘
+        │
+        ▼
+┌─────────────────────────┐
+│  ModuleLoader           │
+│  .py detection          │
+└─────────────────────────┘
+```
+
+## Python Types
+
+The following types are exported to Python:
+
+- `Module` - Base class for Python modules
+- `ModuleId` - Unique module identifier
+- `Version` - Semantic version (major, minor, patch)
+- `ProbeResult` - Module initialization result
+
+## Python Usage
+
+```python
+from reovim import Module, ModuleId, ProbeResult
+
+class MyModule(Module):
+    def id(self) -> ModuleId:
+        return ModuleId("my-python-module")
+
+    def name(self) -> str:
+        return "My Python Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        print(f"Initializing with data_dir: {ctx['data_dir']}")
+        return ProbeResult.Success
+
+    def exit(self):
+        print("Goodbye!")
+```
+
+## Requirements
+
+- Python 3.11 or later
+- PyO3 0.27+
+
+## Building
+
+```bash
+cargo build -p reovim-driver-ffi-python
+```
+
+## Testing
+
+```bash
+cargo test -p reovim-driver-ffi-python
+```
+
+## License
+
+AGPL-3.0-only

--- a/lib/drivers/ffi-python/src/lib.rs
+++ b/lib/drivers/ffi-python/src/lib.rs
@@ -1,0 +1,299 @@
+//! Python FFI bindings for reovim modules via `PyO3`.
+//!
+//! This crate provides Python bindings that allow writing reovim modules in Python.
+//! It wraps kernel types (`ModuleId`, `Version`, `ProbeResult`) and provides a
+//! `PythonModule` wrapper that implements the `Module` trait.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Python Module (my_module.py)
+//!         │
+//!         ▼
+//! ┌─────────────────────────┐
+//! │  ffi-python crate       │
+//! │  PythonModule wrapper   │
+//! │  impl Module trait      │
+//! └─────────────────────────┘
+//!         │
+//!         ▼
+//! ┌─────────────────────────┐
+//! │  ModuleLoader           │
+//! │  .py detection          │
+//! └─────────────────────────┘
+//! ```
+//!
+//! # Python Usage
+//!
+//! ```python
+//! from reovim import Module, ModuleId, Version, ProbeResult
+//!
+//! class MyModule(Module):
+//!     def id(self) -> ModuleId:
+//!         return ModuleId("my-python-module")
+//!
+//!     def name(self) -> str:
+//!         return "My Python Module"
+//!
+//!     def version(self) -> tuple[int, int, int]:
+//!         return (1, 0, 0)
+//!
+//!     def init(self, ctx) -> ProbeResult:
+//!         return ProbeResult.Success
+//!
+//!     def exit(self):
+//!         pass
+//! ```
+
+use pyo3::prelude::*;
+
+pub mod module;
+pub mod types;
+
+/// Initialize Python with the `reovim` module registered.
+///
+/// This must be called BEFORE any other Python operations to make
+/// `import reovim` work. Uses `append_to_inittab!` to register the
+/// module as a built-in.
+///
+/// # Panics
+///
+/// Panics if called after Python has already been initialized.
+///
+/// # Example
+///
+/// ```no_run
+/// use reovim_driver_ffi_python::init_python;
+///
+/// // Initialize Python with reovim module
+/// init_python();
+///
+/// // Now Python code can: from reovim import Module
+/// ```
+pub fn init_python() {
+    pyo3::append_to_inittab!(reovim);
+}
+
+pub use {
+    module::{PyModuleContext, PythonModule},
+    types::{
+        PyCommandRegistration, PyEventHandlerRegistration, PyKeybindingRegistration, PyModuleId,
+        PyProbeResult, PyVersion,
+    },
+};
+
+/// Base class for Python modules.
+///
+/// Python modules must inherit from this class and implement the required methods.
+/// This is a marker class - the actual implementation is in Python.
+#[pyclass(name = "Module", module = "reovim", subclass)]
+pub struct PyModuleBase;
+
+// Allow clippy lints that conflict with PyO3 requirements.
+// PyO3 methods must have `&self` or `&mut self` even when not used,
+// and cannot be made `const` since they're called from Python.
+#[allow(
+    clippy::unused_self,
+    clippy::missing_const_for_fn,
+    clippy::new_without_default
+)]
+#[pymethods]
+impl PyModuleBase {
+    #[new]
+    fn new() -> Self {
+        Self
+    }
+
+    /// Unique module identifier.
+    ///
+    /// Override this method to return your module's ID.
+    /// Convention: kebab-case, e.g., "my-module"
+    fn id(&self) -> PyModuleId {
+        PyModuleId::new("unnamed-module")
+    }
+
+    /// Human-readable module name.
+    ///
+    /// Override this method to return your module's display name.
+    fn name(&self) -> &'static str {
+        "Unnamed Module"
+    }
+
+    /// Module version as (major, minor, patch) tuple.
+    ///
+    /// Override this method to return your module's version.
+    fn version(&self) -> (u32, u32, u32) {
+        (0, 0, 0)
+    }
+
+    /// Required API version.
+    ///
+    /// Override to require a specific kernel API version.
+    /// Defaults to the current API version.
+    fn api_version(&self) -> PyVersion {
+        PyVersion::new(
+            reovim_kernel::api::v1::API_VERSION.major,
+            reovim_kernel::api::v1::API_VERSION.minor,
+            reovim_kernel::api::v1::API_VERSION.patch,
+        )
+    }
+
+    /// Required dependencies.
+    ///
+    /// Override to specify modules that must be loaded before this one.
+    fn dependencies(&self) -> Vec<PyModuleId> {
+        Vec::new()
+    }
+
+    /// Optional dependencies.
+    ///
+    /// Override to specify modules that should be loaded before this one if available.
+    fn optional_dependencies(&self) -> Vec<PyModuleId> {
+        Vec::new()
+    }
+
+    /// Initialize the module.
+    ///
+    /// Override this method to perform module initialization.
+    /// Return `ProbeResult.Success` on success, `ProbeResult.Defer(reason)` to retry later,
+    /// or `ProbeResult.Failed(reason)` for permanent failure.
+    #[pyo3(signature = (ctx))]
+    #[allow(unused_variables)]
+    fn init(&mut self, ctx: &Bound<'_, PyAny>) -> PyProbeResult {
+        PyProbeResult::success()
+    }
+
+    /// Clean up the module.
+    ///
+    /// Override this method to perform cleanup before the module is unloaded.
+    fn exit(&mut self) {}
+
+    /// Whether this module supports hot reload.
+    ///
+    /// Override to return `True` if your module can preserve state across reloads.
+    fn supports_hot_reload(&self) -> bool {
+        false
+    }
+
+    /// Save module state for hot reload.
+    ///
+    /// Override to serialize your module's state. Return `None` if no state to save.
+    /// Use `pickle.dumps()` for simple serialization.
+    fn save_state(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    /// Restore module state after hot reload.
+    ///
+    /// Override to deserialize state saved by `save_state()`.
+    #[pyo3(signature = (state))]
+    #[allow(unused_variables)]
+    fn restore_state(&mut self, state: &[u8]) {}
+
+    // ========================================================================
+    // Registrations
+    // ========================================================================
+
+    /// Return command registrations.
+    ///
+    /// Override to register commands that can be invoked by keybindings.
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// def commands(self):
+    ///     return [
+    ///         CommandRegistration("my-command")
+    ///             .with_name("My Command")
+    ///             .with_description("Does something useful")
+    ///     ]
+    /// ```
+    fn commands(&self) -> Vec<PyCommandRegistration> {
+        Vec::new()
+    }
+
+    /// Return keybinding registrations.
+    ///
+    /// Override to register keybindings that invoke commands.
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// def keybindings(self):
+    ///     return [
+    ///         KeybindingRegistration("<C-m>", "my-command")
+    ///             .with_modes(["normal"])
+    ///             .with_description("Run my command")
+    ///     ]
+    /// ```
+    fn keybindings(&self) -> Vec<PyKeybindingRegistration> {
+        Vec::new()
+    }
+
+    /// Return event handler registrations.
+    ///
+    /// Override to register handlers for editor events.
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// def event_handlers(self):
+    ///     return [
+    ///         EventHandlerRegistration("BufferChanged")
+    ///             .with_description("Handle buffer changes")
+    ///     ]
+    /// ```
+    fn event_handlers(&self) -> Vec<PyEventHandlerRegistration> {
+        Vec::new()
+    }
+}
+
+/// The reovim Python module.
+///
+/// Provides types for writing reovim modules in Python:
+/// - `Module` - Base class for Python modules
+/// - `ModuleId` - Unique module identifier
+/// - `Version` - Semantic version
+/// - `ProbeResult` - Initialization result
+/// - `CommandRegistration` - Command registration builder
+/// - `KeybindingRegistration` - Keybinding registration builder
+/// - `EventHandlerRegistration` - Event handler registration builder
+#[pymodule]
+fn reovim(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Base class
+    m.add_class::<PyModuleBase>()?;
+
+    // Core types
+    m.add_class::<PyModuleId>()?;
+    m.add_class::<PyVersion>()?;
+    m.add_class::<PyProbeResult>()?;
+    m.add_class::<PyModuleContext>()?;
+
+    // Registration types
+    m.add_class::<PyCommandRegistration>()?;
+    m.add_class::<PyKeybindingRegistration>()?;
+    m.add_class::<PyEventHandlerRegistration>()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_base_defaults() {
+        let module = PyModuleBase::new();
+        assert_eq!(module.id().as_str(), "unnamed-module");
+        assert_eq!(module.name(), "Unnamed Module");
+        assert_eq!(module.version(), (0, 0, 0));
+        assert!(!module.supports_hot_reload());
+        assert!(module.save_state().is_none());
+        assert!(module.dependencies().is_empty());
+        assert!(module.optional_dependencies().is_empty());
+        // Registration methods default to empty
+        assert!(module.commands().is_empty());
+        assert!(module.keybindings().is_empty());
+        assert!(module.event_handlers().is_empty());
+    }
+}

--- a/lib/drivers/ffi-python/src/module.rs
+++ b/lib/drivers/ffi-python/src/module.rs
@@ -1,0 +1,563 @@
+//! `PythonModule` wrapper implementing the kernel `Module` trait.
+//!
+//! This module provides the bridge between Python module classes and the
+//! Rust module system. `PythonModule` wraps a Python object and implements
+//! the `Module` trait by delegating to Python methods.
+
+use std::sync::{Arc, OnceLock};
+
+use {
+    pyo3::{prelude::*, types::PyDict},
+    reovim_kernel::api::v1::{
+        CommandRegistration, EventHandlerRegistration, KeybindingRegistration, Module,
+        ModuleContext, ModuleError, ModuleId, ProbeResult, Version,
+    },
+    tracing::{debug, error, warn},
+};
+
+use crate::types::{
+    PyCommandRegistration, PyEventHandlerRegistration, PyKeybindingRegistration, PyModuleId,
+    PyProbeResult, PyVersion,
+};
+
+// ============================================================================
+// PyModuleContext - Python-visible context
+// ============================================================================
+
+/// Python-visible module context.
+///
+/// Provides a simplified view of `ModuleContext` for Python modules.
+#[pyclass(name = "ModuleContext", module = "reovim")]
+#[derive(Clone)]
+pub struct PyModuleContext {
+    /// Path to module's data directory.
+    #[pyo3(get)]
+    pub data_dir: String,
+    /// Path to module's cache directory.
+    #[pyo3(get)]
+    pub cache_dir: String,
+    /// Loaded optional dependencies.
+    optional_deps: Vec<String>,
+}
+
+#[pymethods]
+impl PyModuleContext {
+    /// Check if an optional dependency is available.
+    #[must_use]
+    pub fn has_optional_dep(&self, id: &str) -> bool {
+        self.optional_deps.iter().any(|dep| dep == id)
+    }
+
+    /// Get all loaded optional dependencies.
+    #[must_use]
+    pub fn optional_deps(&self) -> Vec<String> {
+        self.optional_deps.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ModuleContext(data_dir='{}', cache_dir='{}')", self.data_dir, self.cache_dir)
+    }
+}
+
+impl PyModuleContext {
+    /// Create from kernel `ModuleContext`.
+    #[must_use]
+    pub fn from_kernel(ctx: &ModuleContext) -> Self {
+        Self {
+            data_dir: ctx.data_dir.to_string_lossy().to_string(),
+            cache_dir: ctx.cache_dir.to_string_lossy().to_string(),
+            optional_deps: ctx
+                .optional_deps()
+                .iter()
+                .map(|id| id.as_str().to_string())
+                .collect(),
+        }
+    }
+}
+
+// ============================================================================
+// Cached Module Metadata
+// ============================================================================
+
+/// Cached identity metadata from Python module.
+///
+/// These values are read once and cached for performance,
+/// since they shouldn't change during the module's lifetime.
+struct CachedMetadata {
+    id: ModuleId,
+    name: String,
+    version: Version,
+    api_version: Version,
+}
+
+// ============================================================================
+// PythonModule
+// ============================================================================
+
+/// A Rust wrapper around a Python module instance.
+///
+/// Implements the kernel `Module` trait by delegating to Python methods.
+/// The GIL is acquired for each method call to Python.
+///
+/// # Thread Safety
+///
+/// `PythonModule` is `Send + Sync` because:
+/// - The `Py<PyAny>` is wrapped in `Arc` for shared ownership
+/// - All Python calls acquire the GIL before accessing the object
+/// - Cached metadata uses `OnceLock` for thread-safe initialization
+///
+/// # Example
+///
+/// ```ignore
+/// use pyo3::prelude::*;
+/// use reovim_driver_ffi_python::PythonModule;
+///
+/// // Load a Python module class and instantiate it
+/// Python::attach(|py| {
+///     let code = r#"
+/// from reovim import Module, ModuleId, ProbeResult
+///
+/// class MyModule(Module):
+///     def id(self):
+///         return ModuleId("my-module")
+///     def name(self):
+///         return "My Module"
+///     def version(self):
+///         return (1, 0, 0)
+///     def init(self, ctx):
+///         return ProbeResult.Success
+///     def exit(self):
+///         pass
+/// "#;
+///     // ... create PythonModule from MyModule instance
+/// });
+/// ```
+pub struct PythonModule {
+    /// The Python module instance.
+    py_object: Arc<Py<PyAny>>,
+    /// Path to the source file (for debugging/hot reload).
+    source_path: Option<String>,
+    /// Cached metadata (populated on first access).
+    metadata: OnceLock<CachedMetadata>,
+}
+
+// SAFETY: Py<PyAny> is thread-safe when accessed through the GIL.
+// All Python calls in PythonModule acquire the GIL first via Python::attach().
+#[allow(unsafe_code)]
+unsafe impl Send for PythonModule {}
+#[allow(unsafe_code)]
+unsafe impl Sync for PythonModule {}
+
+impl PythonModule {
+    /// Create a new `PythonModule` from a Python object.
+    ///
+    /// The object should be an instance of a class that inherits from `Module`.
+    #[must_use]
+    pub fn new(py_object: Py<PyAny>, source_path: Option<String>) -> Self {
+        Self {
+            py_object: Arc::new(py_object),
+            source_path,
+            metadata: OnceLock::new(),
+        }
+    }
+
+    /// Get the source file path if available.
+    #[must_use]
+    pub fn source_path(&self) -> Option<&str> {
+        self.source_path.as_deref()
+    }
+
+    /// Get or initialize cached metadata.
+    fn get_metadata(&self) -> &CachedMetadata {
+        self.metadata.get_or_init(|| self.read_metadata())
+    }
+
+    /// Read metadata from Python object.
+    fn read_metadata(&self) -> CachedMetadata {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+
+            // Read id
+            let id = match obj.call_method0("id") {
+                Ok(result) => {
+                    if let Ok(py_id) = result.extract::<PyModuleId>() {
+                        py_id.0
+                    } else if let Ok(id_str) = result.extract::<String>() {
+                        ModuleId::from_string(id_str)
+                    } else {
+                        warn!("Python module id() returned unexpected type");
+                        ModuleId::from_string("unknown".to_string())
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to call Python module id(): {}", e);
+                    ModuleId::from_string("unknown".to_string())
+                }
+            };
+
+            // Read name
+            let name = match obj.call_method0("name") {
+                Ok(result) => result
+                    .extract::<String>()
+                    .unwrap_or_else(|_| "Unknown".to_string()),
+                Err(e) => {
+                    error!("Failed to call Python module name(): {}", e);
+                    "Unknown".to_string()
+                }
+            };
+
+            // Read version
+            let version = match obj.call_method0("version") {
+                Ok(result) => Self::extract_version(&result).unwrap_or_else(|| {
+                    warn!("Python module version() returned unexpected type");
+                    Version::new(0, 0, 0)
+                }),
+                Err(e) => {
+                    error!("Failed to call Python module version(): {e}");
+                    Version::new(0, 0, 0)
+                }
+            };
+
+            // Read api_version
+            let api_version = obj
+                .call_method0("api_version")
+                .ok()
+                .and_then(|r| Self::extract_version(&r))
+                .unwrap_or(reovim_kernel::api::v1::API_VERSION);
+
+            CachedMetadata {
+                id,
+                name,
+                version,
+                api_version,
+            }
+        })
+    }
+
+    /// Extract a Version from a Python result.
+    fn extract_version(result: &Bound<'_, PyAny>) -> Option<Version> {
+        result.extract::<PyVersion>().map(|v| v.0).ok().or_else(|| {
+            result
+                .extract::<(u32, u32, u32)>()
+                .map(|(major, minor, patch)| Version::new(major, minor, patch))
+                .ok()
+        })
+    }
+
+    /// Extract module IDs from a Python list.
+    fn extract_module_ids(obj: &Bound<'_, PyAny>) -> Vec<ModuleId> {
+        obj.extract::<Vec<PyModuleId>>()
+            .map(|ids| ids.into_iter().map(|id| id.0).collect())
+            .or_else(|_| {
+                obj.extract::<Vec<String>>()
+                    .map(|strings| strings.into_iter().map(ModuleId::from_string).collect())
+            })
+            .unwrap_or_default()
+    }
+}
+
+impl Module for PythonModule {
+    // ========================================================================
+    // Identity (cached)
+    // ========================================================================
+
+    fn id(&self) -> ModuleId {
+        self.get_metadata().id.clone()
+    }
+
+    fn name(&self) -> &'static str {
+        // SAFETY: We leak the string to get a 'static lifetime.
+        // This is acceptable because:
+        // 1. Module names are small and there are few modules
+        // 2. Modules typically live for the entire program lifetime
+        let name = self.get_metadata().name.clone();
+        Box::leak(name.into_boxed_str())
+    }
+
+    fn version(&self) -> Version {
+        self.get_metadata().version
+    }
+
+    fn api_version(&self) -> Version {
+        self.get_metadata().api_version
+    }
+
+    // ========================================================================
+    // Dependencies (not cached - may change between loads)
+    // ========================================================================
+
+    fn dependencies(&self) -> Vec<ModuleId> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("dependencies") {
+                Ok(result) => Self::extract_module_ids(&result),
+                Err(e) => {
+                    debug!("Python module dependencies() failed: {}", e);
+                    Vec::new()
+                }
+            }
+        })
+    }
+
+    fn optional_dependencies(&self) -> Vec<ModuleId> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("optional_dependencies") {
+                Ok(result) => Self::extract_module_ids(&result),
+                Err(e) => {
+                    debug!("Python module optional_dependencies() failed: {}", e);
+                    Vec::new()
+                }
+            }
+        })
+    }
+
+    // ========================================================================
+    // Lifecycle
+    // ========================================================================
+
+    fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            let py_ctx = PyModuleContext::from_kernel(ctx);
+
+            // Convert to Python dict for easier access
+            let ctx_dict = PyDict::new(py);
+            ctx_dict
+                .set_item("data_dir", &py_ctx.data_dir)
+                .expect("set data_dir");
+            ctx_dict
+                .set_item("cache_dir", &py_ctx.cache_dir)
+                .expect("set cache_dir");
+            ctx_dict
+                .set_item("optional_deps", py_ctx.optional_deps())
+                .expect("set optional_deps");
+
+            match obj.call_method1("init", (ctx_dict,)) {
+                Ok(result) => result
+                    .extract::<PyProbeResult>()
+                    .map_or(ProbeResult::Success, |py_result| py_result.to_kernel()),
+                Err(e) => {
+                    error!("Python module init() raised exception: {e}");
+                    ProbeResult::Failed(ModuleError::InitFailed(format!("Python exception: {e}")))
+                }
+            }
+        })
+    }
+
+    fn exit(&mut self) -> Result<(), ModuleError> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("exit") {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("Python module exit() raised exception: {e}");
+                    Err(ModuleError::InitFailed(format!("Python exception: {e}")))
+                }
+            }
+        })
+    }
+
+    // ========================================================================
+    // Registrations
+    // ========================================================================
+
+    fn commands(&self) -> Vec<CommandRegistration> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("commands") {
+                Ok(result) => {
+                    // Try to extract as list of PyCommandRegistration
+                    if let Ok(py_regs) = result.extract::<Vec<PyCommandRegistration>>() {
+                        return py_regs
+                            .iter()
+                            .map(PyCommandRegistration::to_kernel)
+                            .collect();
+                    }
+                    // Fallback: empty list if method returns None or wrong type
+                    if result.is_none() {
+                        return Vec::new();
+                    }
+                    debug!("Python module commands() returned unexpected type for {}", self.id());
+                    Vec::new()
+                }
+                Err(e) => {
+                    // Method not implemented or raised exception - that's OK, use default
+                    debug!("Python module commands() not available: {}", e);
+                    Vec::new()
+                }
+            }
+        })
+    }
+
+    fn keybindings(&self) -> Vec<KeybindingRegistration> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("keybindings") {
+                Ok(result) => {
+                    // Try to extract as list of PyKeybindingRegistration
+                    if let Ok(py_regs) = result.extract::<Vec<PyKeybindingRegistration>>() {
+                        return py_regs
+                            .iter()
+                            .map(PyKeybindingRegistration::to_kernel)
+                            .collect();
+                    }
+                    // Fallback: empty list if method returns None or wrong type
+                    if result.is_none() {
+                        return Vec::new();
+                    }
+                    debug!(
+                        "Python module keybindings() returned unexpected type for {}",
+                        self.id()
+                    );
+                    Vec::new()
+                }
+                Err(e) => {
+                    // Method not implemented or raised exception - that's OK, use default
+                    debug!("Python module keybindings() not available: {}", e);
+                    Vec::new()
+                }
+            }
+        })
+    }
+
+    fn event_handlers(&self) -> Vec<EventHandlerRegistration> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("event_handlers") {
+                Ok(result) => {
+                    // Try to extract as list of PyEventHandlerRegistration
+                    if let Ok(py_regs) = result.extract::<Vec<PyEventHandlerRegistration>>() {
+                        return py_regs
+                            .iter()
+                            .map(PyEventHandlerRegistration::to_kernel)
+                            .collect();
+                    }
+                    // Fallback: empty list if method returns None or wrong type
+                    if result.is_none() {
+                        return Vec::new();
+                    }
+                    debug!(
+                        "Python module event_handlers() returned unexpected type for {}",
+                        self.id()
+                    );
+                    Vec::new()
+                }
+                Err(e) => {
+                    // Method not implemented or raised exception - that's OK, use default
+                    debug!("Python module event_handlers() not available: {}", e);
+                    Vec::new()
+                }
+            }
+        })
+    }
+
+    // ========================================================================
+    // Hot Reload
+    // ========================================================================
+
+    fn supports_hot_reload(&self) -> bool {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            obj.call_method0("supports_hot_reload")
+                .is_ok_and(|result| result.extract::<bool>().unwrap_or(false))
+        })
+    }
+
+    fn save_state(&self) -> Option<Box<[u8]>> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            match obj.call_method0("save_state") {
+                Ok(result) => {
+                    if result.is_none() {
+                        None
+                    } else {
+                        match result.extract::<Vec<u8>>() {
+                            Ok(bytes) => Some(bytes.into_boxed_slice()),
+                            Err(e) => {
+                                warn!("Python module save_state() returned non-bytes: {}", e);
+                                None
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Python module save_state() raised exception: {}", e);
+                    None
+                }
+            }
+        })
+    }
+
+    fn restore_state(&mut self, state: &[u8]) -> Result<(), ModuleError> {
+        Python::attach(|py| {
+            let obj = self.py_object.bind(py);
+            let py_bytes = pyo3::types::PyBytes::new(py, state);
+
+            match obj.call_method1("restore_state", (py_bytes,)) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("Python module restore_state() raised exception: {e}");
+                    Err(ModuleError::InitFailed(format!("restore_state failed: {e}")))
+                }
+            }
+        })
+    }
+}
+
+impl std::fmt::Debug for PythonModule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PythonModule")
+            .field("id", &self.id())
+            .field("source_path", &self.source_path)
+            .finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_py_module_context_from_kernel() {
+        let kernel_ctx = ModuleContext::default();
+        let py_ctx = PyModuleContext::from_kernel(&kernel_ctx);
+
+        assert!(py_ctx.data_dir.contains("reovim-test"));
+        assert!(py_ctx.cache_dir.contains("reovim-test"));
+        assert!(py_ctx.optional_deps().is_empty());
+    }
+
+    #[test]
+    fn test_py_module_context_has_optional_dep() {
+        let py_ctx = PyModuleContext {
+            data_dir: "/tmp/data".to_string(),
+            cache_dir: "/tmp/cache".to_string(),
+            optional_deps: vec!["lsp".to_string(), "treesitter".to_string()],
+        };
+
+        assert!(py_ctx.has_optional_dep("lsp"));
+        assert!(py_ctx.has_optional_dep("treesitter"));
+        assert!(!py_ctx.has_optional_dep("unknown"));
+    }
+
+    #[test]
+    fn test_py_module_context_repr() {
+        let py_ctx = PyModuleContext {
+            data_dir: "/data".to_string(),
+            cache_dir: "/cache".to_string(),
+            optional_deps: vec![],
+        };
+
+        let repr = py_ctx.__repr__();
+        assert!(repr.contains("/data"));
+        assert!(repr.contains("/cache"));
+    }
+
+    // Integration tests with actual Python require the GIL and are tested
+    // via integration tests in runner/tests/
+}

--- a/lib/drivers/ffi-python/src/types.rs
+++ b/lib/drivers/ffi-python/src/types.rs
@@ -1,0 +1,1112 @@
+//! `PyO3` type bindings for kernel types.
+//!
+//! This module provides Python-visible wrappers for kernel types used in module
+//! definitions: `ModuleId`, `Version`, and `ProbeResult`.
+
+use {pyo3::prelude::*, reovim_kernel::api::v1};
+
+// ============================================================================
+// ModuleId
+// ============================================================================
+
+/// Python-visible `ModuleId` wrapper.
+///
+/// Represents a unique module identifier. Use kebab-case names like
+/// "my-module" or "lang-python".
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import ModuleId
+///
+/// id = ModuleId("my-module")
+/// print(id.as_str())  # "my-module"
+/// print(str(id))      # "my-module"
+/// ```
+#[pyclass(name = "ModuleId", module = "reovim")]
+#[derive(Clone)]
+pub struct PyModuleId(pub(crate) v1::ModuleId);
+
+#[pymethods]
+impl PyModuleId {
+    /// Create a new module identifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The module identifier string (kebab-case recommended)
+    #[new]
+    #[must_use]
+    pub fn new(id: &str) -> Self {
+        Self(v1::ModuleId::from_string(id.to_string()))
+    }
+
+    /// Get the identifier as a string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ModuleId('{}')", self.0.as_str())
+    }
+
+    fn __str__(&self) -> &str {
+        self.0.as_str()
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    fn __hash__(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.0.as_str().hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl From<v1::ModuleId> for PyModuleId {
+    fn from(id: v1::ModuleId) -> Self {
+        Self(id)
+    }
+}
+
+impl From<PyModuleId> for v1::ModuleId {
+    fn from(id: PyModuleId) -> Self {
+        id.0
+    }
+}
+
+// ============================================================================
+// Version
+// ============================================================================
+
+/// Python-visible `Version` wrapper.
+///
+/// Represents a semantic version (major, minor, patch).
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import Version
+///
+/// v = Version(1, 2, 3)
+/// print(v.major)  # 1
+/// print(v.minor)  # 2
+/// print(v.patch)  # 3
+/// print(str(v))   # "1.2.3"
+/// ```
+#[pyclass(name = "Version", module = "reovim")]
+#[derive(Clone, Copy)]
+pub struct PyVersion(pub(crate) v1::Version);
+
+// PyO3 methods cannot be `const` since they're called from Python.
+#[allow(clippy::missing_const_for_fn)]
+#[pymethods]
+impl PyVersion {
+    /// Create a new version.
+    ///
+    /// # Arguments
+    ///
+    /// * `major` - Major version (breaking changes)
+    /// * `minor` - Minor version (backwards-compatible additions)
+    /// * `patch` - Patch version (backwards-compatible fixes)
+    #[new]
+    #[must_use]
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self(v1::Version::new(major, minor, patch))
+    }
+
+    /// Major version number.
+    #[getter]
+    #[must_use]
+    pub const fn major(&self) -> u32 {
+        self.0.major
+    }
+
+    /// Minor version number.
+    #[getter]
+    #[must_use]
+    pub const fn minor(&self) -> u32 {
+        self.0.minor
+    }
+
+    /// Patch version number.
+    #[getter]
+    #[must_use]
+    pub const fn patch(&self) -> u32 {
+        self.0.patch
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Version({}, {}, {})", self.0.major, self.0.minor, self.0.patch)
+    }
+
+    fn __str__(&self) -> String {
+        format!("{}.{}.{}", self.0.major, self.0.minor, self.0.patch)
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    fn __lt__(&self, other: &Self) -> bool {
+        self.0 < other.0
+    }
+
+    fn __le__(&self, other: &Self) -> bool {
+        self.0 <= other.0
+    }
+
+    fn __gt__(&self, other: &Self) -> bool {
+        self.0 > other.0
+    }
+
+    fn __ge__(&self, other: &Self) -> bool {
+        self.0 >= other.0
+    }
+
+    fn __hash__(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.0.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl From<v1::Version> for PyVersion {
+    fn from(ver: v1::Version) -> Self {
+        Self(ver)
+    }
+}
+
+impl From<PyVersion> for v1::Version {
+    fn from(ver: PyVersion) -> Self {
+        ver.0
+    }
+}
+
+// ============================================================================
+// ProbeResult
+// ============================================================================
+
+/// Internal representation of probe result variants.
+#[derive(Clone)]
+pub(crate) enum ProbeResultInner {
+    Success,
+    Defer(String),
+    Failed(String),
+}
+
+/// Python-visible `ProbeResult` enum.
+///
+/// Result of module probe/initialization:
+/// - `Success` - Module initialized successfully
+/// - `Defer(reason)` - Retry later (like Linux `-EPROBE_DEFER`)
+/// - `Failed(reason)` - Permanent failure
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import ProbeResult
+///
+/// # Success
+/// result = ProbeResult.Success
+///
+/// # Defer (retry later)
+/// result = ProbeResult.Defer("waiting for treesitter")
+///
+/// # Failed (permanent)
+/// result = ProbeResult.Failed("configuration error")
+/// ```
+#[pyclass(name = "ProbeResult", module = "reovim")]
+#[derive(Clone)]
+pub struct PyProbeResult {
+    pub(crate) inner: ProbeResultInner,
+}
+
+// PyO3 methods cannot be `const` since they're called from Python.
+#[allow(clippy::missing_const_for_fn)]
+#[pymethods]
+impl PyProbeResult {
+    /// Create a success result.
+    ///
+    /// Use this to indicate the module initialized successfully.
+    #[staticmethod]
+    #[pyo3(name = "Success", signature = ())]
+    #[must_use]
+    pub fn success() -> Self {
+        Self {
+            inner: ProbeResultInner::Success,
+        }
+    }
+
+    /// Create a deferred result.
+    ///
+    /// Use this to indicate the module should be retried later.
+    /// This is like Linux's `-EPROBE_DEFER` for driver probing.
+    ///
+    /// # Arguments
+    ///
+    /// * `reason` - Why initialization is being deferred
+    #[staticmethod]
+    #[pyo3(name = "Defer")]
+    #[must_use]
+    pub fn defer(reason: &str) -> Self {
+        Self {
+            inner: ProbeResultInner::Defer(reason.to_string()),
+        }
+    }
+
+    /// Create a failed result.
+    ///
+    /// Use this to indicate a permanent failure that should not be retried.
+    ///
+    /// # Arguments
+    ///
+    /// * `reason` - Why initialization failed
+    #[staticmethod]
+    #[pyo3(name = "Failed")]
+    #[must_use]
+    pub fn failed(reason: &str) -> Self {
+        Self {
+            inner: ProbeResultInner::Failed(reason.to_string()),
+        }
+    }
+
+    /// Check if this is a success result.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(self.inner, ProbeResultInner::Success)
+    }
+
+    /// Check if this is a deferred result.
+    #[must_use]
+    pub fn is_defer(&self) -> bool {
+        matches!(self.inner, ProbeResultInner::Defer(_))
+    }
+
+    /// Check if this is a failed result.
+    #[must_use]
+    pub fn is_failed(&self) -> bool {
+        matches!(self.inner, ProbeResultInner::Failed(_))
+    }
+
+    /// Get the defer reason if this is a deferred result.
+    #[must_use]
+    pub fn defer_reason(&self) -> Option<String> {
+        match &self.inner {
+            ProbeResultInner::Defer(reason) => Some(reason.clone()),
+            _ => None,
+        }
+    }
+
+    /// Get the failure reason if this is a failed result.
+    #[must_use]
+    pub fn failure_reason(&self) -> Option<String> {
+        match &self.inner {
+            ProbeResultInner::Failed(reason) => Some(reason.clone()),
+            _ => None,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.inner {
+            ProbeResultInner::Success => "ProbeResult.Success".to_string(),
+            ProbeResultInner::Defer(reason) => format!("ProbeResult.Defer('{reason}')"),
+            ProbeResultInner::Failed(reason) => format!("ProbeResult.Failed('{reason}')"),
+        }
+    }
+
+    fn __str__(&self) -> String {
+        match &self.inner {
+            ProbeResultInner::Success => "Success".to_string(),
+            ProbeResultInner::Defer(reason) => format!("Defer: {reason}"),
+            ProbeResultInner::Failed(reason) => format!("Failed: {reason}"),
+        }
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        match (&self.inner, &other.inner) {
+            (ProbeResultInner::Success, ProbeResultInner::Success) => true,
+            (ProbeResultInner::Defer(a), ProbeResultInner::Defer(b))
+            | (ProbeResultInner::Failed(a), ProbeResultInner::Failed(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl PyProbeResult {
+    /// Convert to kernel `ProbeResult`.
+    #[must_use]
+    pub fn to_kernel(&self) -> v1::ProbeResult {
+        match &self.inner {
+            ProbeResultInner::Success => v1::ProbeResult::Success,
+            ProbeResultInner::Defer(reason) => v1::ProbeResult::Defer(reason.clone()),
+            ProbeResultInner::Failed(reason) => {
+                v1::ProbeResult::Failed(v1::ModuleError::InitFailed(reason.clone()))
+            }
+        }
+    }
+
+    /// Create from kernel `ProbeResult`.
+    #[must_use]
+    pub fn from_kernel(result: &v1::ProbeResult) -> Self {
+        match result {
+            v1::ProbeResult::Success => Self::success(),
+            v1::ProbeResult::Defer(reason) => Self::defer(reason),
+            v1::ProbeResult::Failed(err) => Self::failed(&err.to_string()),
+        }
+    }
+}
+
+// ============================================================================
+// CommandRegistration
+// ============================================================================
+
+/// Python-visible `CommandRegistration` builder.
+///
+/// Registers a command that can be invoked by keybindings or other commands.
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import CommandRegistration
+///
+/// reg = CommandRegistration("my-command")
+/// reg = reg.with_name("My Command")
+/// reg = reg.with_description("Does something useful")
+/// reg = reg.with_category("edit")
+/// reg = reg.with_count()  # Accepts count prefix like 5j
+/// reg = reg.with_motion()  # Accepts motion like dw
+/// reg = reg.with_text_modifying()  # Modifies buffer text
+/// ```
+// Allow excessive bools - this mirrors the kernel's CommandRegistration struct
+// which has the same boolean flags for command capabilities.
+#[allow(clippy::struct_excessive_bools)]
+#[pyclass(name = "CommandRegistration", module = "reovim")]
+#[derive(Clone)]
+pub struct PyCommandRegistration {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) category: Option<String>,
+    pub(crate) accepts_count: bool,
+    pub(crate) accepts_motion: bool,
+    pub(crate) is_jump: bool,
+    pub(crate) is_text_modifying: bool,
+}
+
+#[pymethods]
+impl PyCommandRegistration {
+    /// Create a new command registration.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique command identifier (e.g., "delete", "yank")
+    #[new]
+    #[must_use]
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            name: String::new(),
+            description: String::new(),
+            category: None,
+            accepts_count: false,
+            accepts_motion: false,
+            is_jump: false,
+            is_text_modifying: false,
+        }
+    }
+
+    /// Set the display name (chainable).
+    #[must_use]
+    pub fn with_name(&self, name: &str) -> Self {
+        let mut new = self.clone();
+        new.name = name.to_string();
+        new
+    }
+
+    /// Set the description (chainable).
+    #[must_use]
+    pub fn with_description(&self, description: &str) -> Self {
+        let mut new = self.clone();
+        new.description = description.to_string();
+        new
+    }
+
+    /// Set the category (chainable).
+    #[must_use]
+    pub fn with_category(&self, category: &str) -> Self {
+        let mut new = self.clone();
+        new.category = Some(category.to_string());
+        new
+    }
+
+    /// Mark command as accepting a count prefix (chainable).
+    #[must_use]
+    pub fn with_count(&self) -> Self {
+        let mut new = self.clone();
+        new.accepts_count = true;
+        new
+    }
+
+    /// Mark command as accepting a motion (chainable).
+    #[must_use]
+    pub fn with_motion(&self) -> Self {
+        let mut new = self.clone();
+        new.accepts_motion = true;
+        new
+    }
+
+    /// Mark command as a jump (recorded in jump list) (chainable).
+    #[must_use]
+    pub fn with_jump(&self) -> Self {
+        let mut new = self.clone();
+        new.is_jump = true;
+        new
+    }
+
+    /// Mark command as text-modifying (chainable).
+    #[must_use]
+    pub fn with_text_modifying(&self) -> Self {
+        let mut new = self.clone();
+        new.is_text_modifying = true;
+        new
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CommandRegistration('{}')", self.id)
+    }
+}
+
+impl PyCommandRegistration {
+    /// Convert to kernel `CommandRegistration`.
+    ///
+    /// Note: This leaks strings to get `&'static str`. This is acceptable
+    /// because commands are typically registered once and live for the
+    /// program's lifetime.
+    #[must_use]
+    pub fn to_kernel(&self) -> v1::CommandRegistration {
+        v1::CommandRegistration {
+            id: Box::leak(self.id.clone().into_boxed_str()),
+            name: Box::leak(self.name.clone().into_boxed_str()),
+            description: Box::leak(self.description.clone().into_boxed_str()),
+            category: self
+                .category
+                .as_ref()
+                .map(|s| Box::leak(s.clone().into_boxed_str()) as &'static str),
+            accepts_count: self.accepts_count,
+            accepts_motion: self.accepts_motion,
+            is_jump: self.is_jump,
+            is_text_modifying: self.is_text_modifying,
+            depends_on: &[],
+            flags: v1::RegistrationFlags::new(),
+        }
+    }
+}
+
+// ============================================================================
+// KeybindingRegistration
+// ============================================================================
+
+/// Python-visible `KeybindingRegistration` builder.
+///
+/// Registers a keybinding that invokes a command.
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import KeybindingRegistration
+///
+/// # Basic keybinding
+/// reg = KeybindingRegistration("dd", "delete-line")
+///
+/// # With options
+/// reg = KeybindingRegistration("<C-w>h", "window-left")
+/// reg = reg.with_modes(["normal"])
+/// reg = reg.with_description("Move to left window")
+/// reg = reg.with_category("window")
+/// reg = reg.with_priority(50)
+/// ```
+#[pyclass(name = "KeybindingRegistration", module = "reovim")]
+#[derive(Clone)]
+pub struct PyKeybindingRegistration {
+    pub(crate) keys: String,
+    pub(crate) command_id: String,
+    pub(crate) modes: Vec<String>,
+    pub(crate) description: String,
+    pub(crate) category: Option<String>,
+    pub(crate) enabled: bool,
+    pub(crate) priority: u32,
+}
+
+#[pymethods]
+impl PyKeybindingRegistration {
+    /// Create a new keybinding registration.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - Key sequence in vim notation (e.g., "dd", "<C-w>h")
+    /// * `command_id` - Command ID to invoke
+    #[new]
+    #[must_use]
+    pub fn new(keys: &str, command_id: &str) -> Self {
+        Self {
+            keys: keys.to_string(),
+            command_id: command_id.to_string(),
+            modes: Vec::new(),
+            description: String::new(),
+            category: None,
+            enabled: true,
+            priority: 100, // Default plugin priority
+        }
+    }
+
+    /// Set active modes (chainable).
+    ///
+    /// Empty list means all modes.
+    #[must_use]
+    pub fn with_modes(&self, modes: Vec<String>) -> Self {
+        let mut new = self.clone();
+        new.modes = modes;
+        new
+    }
+
+    /// Set description (chainable).
+    #[must_use]
+    pub fn with_description(&self, description: &str) -> Self {
+        let mut new = self.clone();
+        new.description = description.to_string();
+        new
+    }
+
+    /// Set category (chainable).
+    #[must_use]
+    pub fn with_category(&self, category: &str) -> Self {
+        let mut new = self.clone();
+        new.category = Some(category.to_string());
+        new
+    }
+
+    /// Disable the keybinding (chainable).
+    #[must_use]
+    pub fn with_disabled(&self) -> Self {
+        let mut new = self.clone();
+        new.enabled = false;
+        new
+    }
+
+    /// Set priority (chainable).
+    ///
+    /// Lower values = higher priority.
+    #[must_use]
+    pub fn with_priority(&self, priority: u32) -> Self {
+        let mut new = self.clone();
+        new.priority = priority;
+        new
+    }
+
+    fn __repr__(&self) -> String {
+        format!("KeybindingRegistration('{}', '{}')", self.keys, self.command_id)
+    }
+}
+
+impl PyKeybindingRegistration {
+    /// Convert to kernel `KeybindingRegistration`.
+    ///
+    /// Note: This leaks strings to get `&'static str`.
+    #[must_use]
+    pub fn to_kernel(&self) -> v1::KeybindingRegistration {
+        let modes: &'static [&'static str] = Box::leak(
+            self.modes
+                .iter()
+                .map(|s| Box::leak(s.clone().into_boxed_str()) as &'static str)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        );
+
+        v1::KeybindingRegistration {
+            keys: Box::leak(self.keys.clone().into_boxed_str()),
+            command_id: Box::leak(self.command_id.clone().into_boxed_str()),
+            modes,
+            description: Box::leak(self.description.clone().into_boxed_str()),
+            category: self
+                .category
+                .as_ref()
+                .map(|s| Box::leak(s.clone().into_boxed_str()) as &'static str),
+            enabled: self.enabled,
+            priority: self.priority,
+            depends_on: &[],
+            flags: v1::RegistrationFlags::new(),
+        }
+    }
+}
+
+// ============================================================================
+// EventHandlerRegistration
+// ============================================================================
+
+/// Python-visible `EventHandlerRegistration` builder.
+///
+/// Registers an event handler for editor events.
+///
+/// # Python Usage
+///
+/// ```python
+/// from reovim import EventHandlerRegistration
+///
+/// reg = EventHandlerRegistration("BufferChanged")
+/// reg = reg.with_priority(50)
+/// reg = reg.with_description("Update syntax highlighting")
+/// reg = reg.with_once()  # One-shot handler
+/// ```
+#[pyclass(name = "EventHandlerRegistration", module = "reovim")]
+#[derive(Clone)]
+pub struct PyEventHandlerRegistration {
+    pub(crate) event_type: String,
+    pub(crate) priority: u32,
+    pub(crate) description: String,
+    pub(crate) once: bool,
+    pub(crate) target_component: Option<String>,
+}
+
+#[pymethods]
+impl PyEventHandlerRegistration {
+    /// Create a new event handler registration.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - Event type name (e.g., `BufferChanged`, `CursorMoved`)
+    #[new]
+    #[must_use]
+    pub fn new(event_type: &str) -> Self {
+        Self {
+            event_type: event_type.to_string(),
+            priority: 100, // Default plugin priority
+            description: String::new(),
+            once: false,
+            target_component: None,
+        }
+    }
+
+    /// Set priority (chainable).
+    ///
+    /// Lower values = called earlier.
+    /// Convention: 0-50 core, 100 plugin, 200+ cleanup.
+    #[must_use]
+    pub fn with_priority(&self, priority: u32) -> Self {
+        let mut new = self.clone();
+        new.priority = priority;
+        new
+    }
+
+    /// Set description (chainable).
+    #[must_use]
+    pub fn with_description(&self, description: &str) -> Self {
+        let mut new = self.clone();
+        new.description = description.to_string();
+        new
+    }
+
+    /// Mark as one-shot handler (chainable).
+    ///
+    /// Handler will auto-unsubscribe after first event.
+    #[must_use]
+    pub fn with_once(&self) -> Self {
+        let mut new = self.clone();
+        new.once = true;
+        new
+    }
+
+    /// Set target component (chainable).
+    #[must_use]
+    pub fn with_target(&self, component: &str) -> Self {
+        let mut new = self.clone();
+        new.target_component = Some(component.to_string());
+        new
+    }
+
+    fn __repr__(&self) -> String {
+        format!("EventHandlerRegistration('{}')", self.event_type)
+    }
+}
+
+impl PyEventHandlerRegistration {
+    /// Convert to kernel `EventHandlerRegistration`.
+    ///
+    /// Note: This leaks strings to get `&'static str`.
+    #[must_use]
+    pub fn to_kernel(&self) -> v1::EventHandlerRegistration {
+        v1::EventHandlerRegistration {
+            event_type: Box::leak(self.event_type.clone().into_boxed_str()),
+            priority: self.priority,
+            description: Box::leak(self.description.clone().into_boxed_str()),
+            once: self.once,
+            target_component: self
+                .target_component
+                .as_ref()
+                .map(|s| Box::leak(s.clone().into_boxed_str()) as &'static str),
+            depends_on: &[],
+            flags: v1::RegistrationFlags::new(),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ModuleId tests
+    #[test]
+    fn test_py_module_id_creation() {
+        let id = PyModuleId::new("test-module");
+        assert_eq!(id.as_str(), "test-module");
+    }
+
+    #[test]
+    fn test_py_module_id_repr() {
+        let id = PyModuleId::new("my-module");
+        assert_eq!(id.__repr__(), "ModuleId('my-module')");
+        assert_eq!(id.__str__(), "my-module");
+    }
+
+    #[test]
+    fn test_py_module_id_equality() {
+        let id1 = PyModuleId::new("test");
+        let id2 = PyModuleId::new("test");
+        let id3 = PyModuleId::new("other");
+        assert!(id1.__eq__(&id2));
+        assert!(!id1.__eq__(&id3));
+    }
+
+    #[test]
+    fn test_py_module_id_hash() {
+        let id1 = PyModuleId::new("test");
+        let id2 = PyModuleId::new("test");
+        assert_eq!(id1.__hash__(), id2.__hash__());
+    }
+
+    #[test]
+    fn test_py_module_id_conversion() {
+        let py_id = PyModuleId::new("test");
+        let kernel_id: v1::ModuleId = py_id.clone().into();
+        let back: PyModuleId = kernel_id.into();
+        assert_eq!(py_id.as_str(), back.as_str());
+    }
+
+    // Version tests
+    #[test]
+    fn test_py_version_creation() {
+        let ver = PyVersion::new(1, 2, 3);
+        assert_eq!(ver.major(), 1);
+        assert_eq!(ver.minor(), 2);
+        assert_eq!(ver.patch(), 3);
+    }
+
+    #[test]
+    fn test_py_version_repr() {
+        let ver = PyVersion::new(1, 2, 3);
+        assert_eq!(ver.__repr__(), "Version(1, 2, 3)");
+        assert_eq!(ver.__str__(), "1.2.3");
+    }
+
+    #[test]
+    fn test_py_version_equality() {
+        let v1 = PyVersion::new(1, 0, 0);
+        let v2 = PyVersion::new(1, 0, 0);
+        let v3 = PyVersion::new(2, 0, 0);
+        assert!(v1.__eq__(&v2));
+        assert!(!v1.__eq__(&v3));
+    }
+
+    #[test]
+    fn test_py_version_ordering() {
+        let v1 = PyVersion::new(1, 0, 0);
+        let v2 = PyVersion::new(1, 1, 0);
+        let v3 = PyVersion::new(2, 0, 0);
+
+        assert!(v1.__lt__(&v2));
+        assert!(v1.__le__(&v2));
+        assert!(v2.__lt__(&v3));
+        assert!(v3.__gt__(&v1));
+        assert!(v3.__ge__(&v1));
+    }
+
+    #[test]
+    fn test_py_version_conversion() {
+        let py_ver = PyVersion::new(1, 2, 3);
+        let kernel_ver: v1::Version = py_ver.into();
+        let back: PyVersion = kernel_ver.into();
+        assert_eq!(py_ver.major(), back.major());
+        assert_eq!(py_ver.minor(), back.minor());
+        assert_eq!(py_ver.patch(), back.patch());
+    }
+
+    // ProbeResult tests
+    #[test]
+    fn test_py_probe_result_success() {
+        let result = PyProbeResult::success();
+        assert!(result.is_success());
+        assert!(!result.is_defer());
+        assert!(!result.is_failed());
+        assert!(result.defer_reason().is_none());
+        assert!(result.failure_reason().is_none());
+    }
+
+    #[test]
+    fn test_py_probe_result_defer() {
+        let result = PyProbeResult::defer("waiting for dependency");
+        assert!(!result.is_success());
+        assert!(result.is_defer());
+        assert!(!result.is_failed());
+        assert_eq!(result.defer_reason(), Some("waiting for dependency".to_string()));
+        assert!(result.failure_reason().is_none());
+    }
+
+    #[test]
+    fn test_py_probe_result_failed() {
+        let result = PyProbeResult::failed("config error");
+        assert!(!result.is_success());
+        assert!(!result.is_defer());
+        assert!(result.is_failed());
+        assert!(result.defer_reason().is_none());
+        assert_eq!(result.failure_reason(), Some("config error".to_string()));
+    }
+
+    #[test]
+    fn test_py_probe_result_repr() {
+        assert_eq!(PyProbeResult::success().__repr__(), "ProbeResult.Success");
+        assert_eq!(PyProbeResult::defer("reason").__repr__(), "ProbeResult.Defer('reason')");
+        assert_eq!(PyProbeResult::failed("error").__repr__(), "ProbeResult.Failed('error')");
+    }
+
+    #[test]
+    fn test_py_probe_result_str() {
+        assert_eq!(PyProbeResult::success().__str__(), "Success");
+        assert_eq!(PyProbeResult::defer("reason").__str__(), "Defer: reason");
+        assert_eq!(PyProbeResult::failed("error").__str__(), "Failed: error");
+    }
+
+    #[test]
+    fn test_py_probe_result_equality() {
+        assert!(PyProbeResult::success().__eq__(&PyProbeResult::success()));
+        assert!(PyProbeResult::defer("a").__eq__(&PyProbeResult::defer("a")));
+        assert!(PyProbeResult::failed("a").__eq__(&PyProbeResult::failed("a")));
+        assert!(!PyProbeResult::success().__eq__(&PyProbeResult::defer("a")));
+        assert!(!PyProbeResult::defer("a").__eq__(&PyProbeResult::defer("b")));
+    }
+
+    #[test]
+    fn test_py_probe_result_to_kernel() {
+        let success = PyProbeResult::success();
+        assert!(matches!(success.to_kernel(), v1::ProbeResult::Success));
+
+        let defer = PyProbeResult::defer("reason");
+        if let v1::ProbeResult::Defer(reason) = defer.to_kernel() {
+            assert_eq!(reason, "reason");
+        } else {
+            panic!("expected Defer");
+        }
+
+        let failed = PyProbeResult::failed("error");
+        if let v1::ProbeResult::Failed(err) = failed.to_kernel() {
+            assert!(err.to_string().contains("error"));
+        } else {
+            panic!("expected Failed");
+        }
+    }
+
+    #[test]
+    fn test_py_probe_result_from_kernel() {
+        let success = PyProbeResult::from_kernel(&v1::ProbeResult::Success);
+        assert!(success.is_success());
+
+        let defer = PyProbeResult::from_kernel(&v1::ProbeResult::Defer("reason".to_string()));
+        assert!(defer.is_defer());
+        assert_eq!(defer.defer_reason(), Some("reason".to_string()));
+
+        let failed = PyProbeResult::from_kernel(&v1::ProbeResult::Failed(
+            v1::ModuleError::InitFailed("error".to_string()),
+        ));
+        assert!(failed.is_failed());
+    }
+
+    // ========================================================================
+    // CommandRegistration tests
+    // ========================================================================
+
+    #[test]
+    fn test_py_command_registration_creation() {
+        let reg = PyCommandRegistration::new("my-command");
+        assert_eq!(reg.id, "my-command");
+        assert!(reg.name.is_empty());
+        assert!(reg.description.is_empty());
+        assert!(reg.category.is_none());
+        assert!(!reg.accepts_count);
+        assert!(!reg.accepts_motion);
+        assert!(!reg.is_jump);
+        assert!(!reg.is_text_modifying);
+    }
+
+    #[test]
+    fn test_py_command_registration_builder() {
+        let reg = PyCommandRegistration::new("delete")
+            .with_name("Delete")
+            .with_description("Delete text")
+            .with_category("edit")
+            .with_count()
+            .with_motion()
+            .with_jump()
+            .with_text_modifying();
+
+        assert_eq!(reg.id, "delete");
+        assert_eq!(reg.name, "Delete");
+        assert_eq!(reg.description, "Delete text");
+        assert_eq!(reg.category, Some("edit".to_string()));
+        assert!(reg.accepts_count);
+        assert!(reg.accepts_motion);
+        assert!(reg.is_jump);
+        assert!(reg.is_text_modifying);
+    }
+
+    #[test]
+    fn test_py_command_registration_repr() {
+        let reg = PyCommandRegistration::new("test-cmd");
+        assert_eq!(reg.__repr__(), "CommandRegistration('test-cmd')");
+    }
+
+    #[test]
+    fn test_py_command_registration_to_kernel() {
+        let reg = PyCommandRegistration::new("yank")
+            .with_name("Yank")
+            .with_description("Copy text")
+            .with_category("edit")
+            .with_count()
+            .with_motion();
+
+        let kernel_reg = reg.to_kernel();
+        assert_eq!(kernel_reg.id, "yank");
+        assert_eq!(kernel_reg.name, "Yank");
+        assert_eq!(kernel_reg.description, "Copy text");
+        assert_eq!(kernel_reg.category, Some("edit"));
+        assert!(kernel_reg.accepts_count);
+        assert!(kernel_reg.accepts_motion);
+        assert!(!kernel_reg.is_jump);
+        assert!(!kernel_reg.is_text_modifying);
+    }
+
+    // ========================================================================
+    // KeybindingRegistration tests
+    // ========================================================================
+
+    #[test]
+    fn test_py_keybinding_registration_creation() {
+        let reg = PyKeybindingRegistration::new("dd", "delete-line");
+        assert_eq!(reg.keys, "dd");
+        assert_eq!(reg.command_id, "delete-line");
+        assert!(reg.modes.is_empty());
+        assert!(reg.description.is_empty());
+        assert!(reg.category.is_none());
+        assert!(reg.enabled);
+        assert_eq!(reg.priority, 100);
+    }
+
+    #[test]
+    fn test_py_keybinding_registration_builder() {
+        let reg = PyKeybindingRegistration::new("<C-w>h", "window-left")
+            .with_modes(vec!["normal".to_string()])
+            .with_description("Move to left window")
+            .with_category("window")
+            .with_priority(50)
+            .with_disabled();
+
+        assert_eq!(reg.keys, "<C-w>h");
+        assert_eq!(reg.command_id, "window-left");
+        assert_eq!(reg.modes, vec!["normal"]);
+        assert_eq!(reg.description, "Move to left window");
+        assert_eq!(reg.category, Some("window".to_string()));
+        assert!(!reg.enabled);
+        assert_eq!(reg.priority, 50);
+    }
+
+    #[test]
+    fn test_py_keybinding_registration_repr() {
+        let reg = PyKeybindingRegistration::new("j", "move-down");
+        assert_eq!(reg.__repr__(), "KeybindingRegistration('j', 'move-down')");
+    }
+
+    #[test]
+    fn test_py_keybinding_registration_to_kernel() {
+        let reg = PyKeybindingRegistration::new("dd", "delete-line")
+            .with_modes(vec!["normal".to_string(), "visual".to_string()])
+            .with_description("Delete entire line")
+            .with_priority(10);
+
+        let kernel_reg = reg.to_kernel();
+        assert_eq!(kernel_reg.keys, "dd");
+        assert_eq!(kernel_reg.command_id, "delete-line");
+        assert_eq!(kernel_reg.modes.len(), 2);
+        assert_eq!(kernel_reg.modes[0], "normal");
+        assert_eq!(kernel_reg.modes[1], "visual");
+        assert_eq!(kernel_reg.description, "Delete entire line");
+        assert!(kernel_reg.enabled);
+        assert_eq!(kernel_reg.priority, 10);
+    }
+
+    // ========================================================================
+    // EventHandlerRegistration tests
+    // ========================================================================
+
+    #[test]
+    fn test_py_event_handler_registration_creation() {
+        let reg = PyEventHandlerRegistration::new("BufferChanged");
+        assert_eq!(reg.event_type, "BufferChanged");
+        assert_eq!(reg.priority, 100);
+        assert!(reg.description.is_empty());
+        assert!(!reg.once);
+        assert!(reg.target_component.is_none());
+    }
+
+    #[test]
+    fn test_py_event_handler_registration_builder() {
+        let reg = PyEventHandlerRegistration::new("CursorMoved")
+            .with_priority(50)
+            .with_description("Track cursor movement")
+            .with_once()
+            .with_target("editor");
+
+        assert_eq!(reg.event_type, "CursorMoved");
+        assert_eq!(reg.priority, 50);
+        assert_eq!(reg.description, "Track cursor movement");
+        assert!(reg.once);
+        assert_eq!(reg.target_component, Some("editor".to_string()));
+    }
+
+    #[test]
+    fn test_py_event_handler_registration_repr() {
+        let reg = PyEventHandlerRegistration::new("ModeChanged");
+        assert_eq!(reg.__repr__(), "EventHandlerRegistration('ModeChanged')");
+    }
+
+    #[test]
+    fn test_py_event_handler_registration_to_kernel() {
+        let reg = PyEventHandlerRegistration::new("BufferWrite")
+            .with_priority(25)
+            .with_description("Auto-save handler")
+            .with_once()
+            .with_target("buffer");
+
+        let kernel_reg = reg.to_kernel();
+        assert_eq!(kernel_reg.event_type, "BufferWrite");
+        assert_eq!(kernel_reg.priority, 25);
+        assert_eq!(kernel_reg.description, "Auto-save handler");
+        assert!(kernel_reg.once);
+        assert_eq!(kernel_reg.target_component, Some("buffer"));
+    }
+}

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -6,6 +6,11 @@ rust-version = "1.92"
 description = "Linux kernel-inspired text editor with mode/command system"
 license = "AGPL-3.0-only"
 
+[features]
+default = []
+# Enable Python module support via PyO3
+python = ["dep:reovim-driver-ffi-python", "dep:pyo3"]
+
 [lib]
 name = "runner"
 path = "src/lib.rs"
@@ -36,6 +41,10 @@ reovim-arch = { path = "../lib/arch" }
 
 # Dynamic library loading for runtime modules
 libloading = "0.8"
+
+# Python module support (optional)
+reovim-driver-ffi-python = { path = "../lib/drivers/ffi-python", optional = true }
+pyo3 = { workspace = true, optional = true }
 
 # Async runtime for multi-threaded server
 tokio = { workspace = true }
@@ -69,6 +78,8 @@ reovim-module-editor = { path = "../modules/editor" }
 # This ensures the cdylib is built when running `cargo test`
 reovim-module-hot-reload-demo = { path = "../modules/hot-reload-demo" }
 tempfile = "3.10"
+# Python FFI driver for e2e tests (provides init_python)
+reovim-driver-ffi-python = { path = "../lib/drivers/ffi-python" }
 
 [lints]
 workspace = true

--- a/runner/src/server/module/loading/discovery.rs
+++ b/runner/src/server/module/loading/discovery.rs
@@ -110,6 +110,58 @@ pub fn find_module(search_paths: &[PathBuf], name: &str) -> Option<PathBuf> {
     None
 }
 
+/// Discover Python module files in search paths.
+///
+/// Scans all search paths for `.py` files.
+#[cfg(feature = "python")]
+#[must_use]
+#[allow(dead_code)] // Public API for external use
+pub fn discover_python_modules(search_paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+
+    for path in search_paths {
+        if !path.exists() {
+            continue;
+        }
+
+        if let Ok(entries) = std::fs::read_dir(path) {
+            for entry in entries.flatten() {
+                let file_path = entry.path();
+                if file_path.extension().is_some_and(|e| e == "py") {
+                    // Skip __pycache__, __init__.py, etc.
+                    if let Some(name) = file_path.file_name().and_then(|n| n.to_str())
+                        && !name.starts_with('_')
+                    {
+                        found.push(file_path);
+                    }
+                }
+            }
+        }
+    }
+
+    found
+}
+
+/// Find a Python module by name in search paths.
+///
+/// Searches for a `.py` file matching the given module name.
+/// Returns the first match found.
+#[cfg(feature = "python")]
+#[must_use]
+#[allow(dead_code)] // Public API for external use
+pub fn find_python_module(search_paths: &[PathBuf], name: &str) -> Option<PathBuf> {
+    let filename = format!("{name}.py");
+
+    for path in search_paths {
+        let full_path = path.join(&filename);
+        if full_path.exists() {
+            return Some(full_path);
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,5 +219,87 @@ mod tests {
     fn test_find_module_not_found() {
         let result = find_module(&[PathBuf::from("/nonexistent")], "fake-module");
         assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // Python Discovery Tests (require python feature)
+    // ========================================================================
+
+    #[cfg(feature = "python")]
+    mod python_tests {
+        use std::io::Write;
+
+        use {super::*, tempfile::TempDir};
+
+        #[test]
+        fn test_discover_python_modules_empty() {
+            let found = super::discover_python_modules(&[]);
+            assert!(found.is_empty());
+        }
+
+        #[test]
+        fn test_discover_python_modules_nonexistent_path() {
+            let found = super::discover_python_modules(&[PathBuf::from("/nonexistent/path")]);
+            assert!(found.is_empty());
+        }
+
+        #[test]
+        fn test_discover_python_modules_finds_py_files() {
+            let temp_dir = TempDir::new().unwrap();
+            let module_path = temp_dir.path().join("my_module.py");
+            std::fs::File::create(&module_path)
+                .unwrap()
+                .write_all(b"# test")
+                .unwrap();
+
+            let found = super::discover_python_modules(&[temp_dir.path().to_path_buf()]);
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0], module_path);
+        }
+
+        #[test]
+        fn test_discover_python_modules_skips_private_files() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Create regular module
+            let module_path = temp_dir.path().join("my_module.py");
+            std::fs::File::create(&module_path)
+                .unwrap()
+                .write_all(b"# test")
+                .unwrap();
+
+            // Create private files that should be skipped
+            std::fs::File::create(temp_dir.path().join("__init__.py"))
+                .unwrap()
+                .write_all(b"")
+                .unwrap();
+            std::fs::File::create(temp_dir.path().join("_private.py"))
+                .unwrap()
+                .write_all(b"")
+                .unwrap();
+
+            let found = super::discover_python_modules(&[temp_dir.path().to_path_buf()]);
+            assert_eq!(found.len(), 1);
+            assert_eq!(found[0], module_path);
+        }
+
+        #[test]
+        fn test_find_python_module_not_found() {
+            let result = super::find_python_module(&[PathBuf::from("/nonexistent")], "fake");
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn test_find_python_module_found() {
+            let temp_dir = TempDir::new().unwrap();
+            let module_path = temp_dir.path().join("my_module.py");
+            std::fs::File::create(&module_path)
+                .unwrap()
+                .write_all(b"# test")
+                .unwrap();
+
+            let result = super::find_python_module(&[temp_dir.path().to_path_buf()], "my_module");
+            assert_eq!(result, Some(module_path));
+        }
     }
 }

--- a/runner/src/server/module/loading/loader.rs
+++ b/runner/src/server/module/loading/loader.rs
@@ -13,6 +13,9 @@ use {
     reovim_kernel::api::v1::{API_VERSION, Module, ModuleError, ModuleId, Version, is_compatible},
 };
 
+#[cfg(feature = "python")]
+use reovim_driver_ffi_python::PythonModule;
+
 use super::{
     discovery::{default_search_paths, discover_modules, find_module},
     handle::{
@@ -291,6 +294,154 @@ impl ModuleLoader {
     pub fn search_paths(&self) -> &[PathBuf] {
         &self.search_paths
     }
+
+    /// Load Python module from path.
+    ///
+    /// Executes the Python file, finds a class inheriting from `Module`,
+    /// instantiates it, and wraps it in `PythonModule`.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Python fails to execute the file
+    /// - No `Module` subclass is found
+    /// - Module with same ID already loaded
+    #[cfg(feature = "python")]
+    pub fn load_python(&mut self, path: &Path) -> Result<ModuleId, ModuleError> {
+        use std::ffi::CString;
+
+        use pyo3::{ffi::c_str, prelude::*, types::PyDict};
+
+        Python::attach(|py| {
+            // 1. Read the Python file
+            let code = std::fs::read_to_string(path).map_err(|e| {
+                ModuleError::LoadFailed(format!("failed to read {}: {e}", path.display()))
+            })?;
+
+            // 2. Create a module name from the file
+            let module_name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("python_module");
+
+            // 3. Convert strings to CString for PyO3 0.27
+            let code_cstring = CString::new(code)
+                .map_err(|e| ModuleError::LoadFailed(format!("invalid Python code: {e}")))?;
+            let filename_cstring = CString::new(path.to_string_lossy().as_bytes())
+                .map_err(|e| ModuleError::LoadFailed(format!("invalid filename: {e}")))?;
+            let module_name_cstring = CString::new(module_name)
+                .map_err(|e| ModuleError::LoadFailed(format!("invalid module name: {e}")))?;
+
+            // 4. Create a new Python module and execute the code in it
+            let py_module = pyo3::types::PyModule::from_code(
+                py,
+                &code_cstring,
+                &filename_cstring,
+                &module_name_cstring,
+            )
+            .map_err(|e| ModuleError::LoadFailed(format!("Python execution failed: {e}")))?;
+
+            // 5. Import our base Module class from the reovim module
+            let reovim_module = py.import(c_str!("reovim")).map_err(|e| {
+                ModuleError::LoadFailed(format!("failed to import reovim module: {e}"))
+            })?;
+            let base_module_class = reovim_module
+                .getattr(c_str!("Module"))
+                .map_err(|e| ModuleError::LoadFailed(format!("failed to get Module class: {e}")))?;
+
+            // 6. Find user's subclass of Module
+            let builtins = py
+                .import(c_str!("builtins"))
+                .map_err(|e| ModuleError::LoadFailed(format!("failed to import builtins: {e}")))?;
+            let issubclass_fn = builtins
+                .getattr(c_str!("issubclass"))
+                .map_err(|e| ModuleError::LoadFailed(format!("failed to get issubclass: {e}")))?;
+            let isinstance_fn = builtins
+                .getattr(c_str!("isinstance"))
+                .map_err(|e| ModuleError::LoadFailed(format!("failed to get isinstance: {e}")))?;
+            let type_class = builtins
+                .getattr(c_str!("type"))
+                .map_err(|e| ModuleError::LoadFailed(format!("failed to get type: {e}")))?;
+
+            let module_dict = py_module.getattr(c_str!("__dict__")).map_err(|e| {
+                ModuleError::LoadFailed(format!("failed to get module __dict__: {e}"))
+            })?;
+            let dict: &Bound<'_, PyDict> = module_dict
+                .cast()
+                .map_err(|e| ModuleError::LoadFailed(format!("__dict__ is not a dict: {e}")))?;
+
+            let mut module_class: Option<Bound<'_, PyAny>> = None;
+            for (key, value) in dict.iter() {
+                let name: String = key
+                    .extract::<String>()
+                    .map_err(|e| ModuleError::LoadFailed(format!("failed to extract key: {e}")))?;
+
+                // Skip private names
+                if name.starts_with('_') {
+                    continue;
+                }
+
+                // Check if it's a class (isinstance(value, type))
+                let is_class: bool = isinstance_fn
+                    .call1((value.clone(), type_class.clone()))
+                    .and_then(|r| r.extract::<bool>())
+                    .unwrap_or(false);
+
+                if !is_class {
+                    continue;
+                }
+
+                // Check if it's a subclass of our Module (but not Module itself)
+                let is_subclass: bool = issubclass_fn
+                    .call1((value.clone(), base_module_class.clone()))
+                    .and_then(|r| r.extract::<bool>())
+                    .unwrap_or(false);
+
+                // Make sure it's not the base Module class itself
+                let is_base = value.is(&base_module_class);
+
+                if is_subclass && !is_base {
+                    module_class = Some(value);
+                    break;
+                }
+            }
+
+            let module_class = module_class.ok_or_else(|| {
+                ModuleError::LoadFailed(format!("no Module subclass found in {}", path.display()))
+            })?;
+
+            // 7. Instantiate the module class
+            let instance = module_class.call0().map_err(|e| {
+                ModuleError::LoadFailed(format!("failed to instantiate module: {e}"))
+            })?;
+
+            // 8. Wrap in PythonModule
+            let python_module =
+                PythonModule::new(instance.unbind(), Some(path.to_string_lossy().to_string()));
+
+            // 9. Register using the existing boxed registration
+            self.register_static_boxed(Box::new(python_module))
+        })
+    }
+
+    /// Load Python module by name (searches paths).
+    ///
+    /// # Errors
+    ///
+    /// Returns error if module not found or loading fails.
+    #[cfg(feature = "python")]
+    pub fn load_python_by_name(&mut self, name: &str) -> Result<ModuleId, ModuleError> {
+        let filename = format!("{name}.py");
+
+        for search_path in &self.search_paths {
+            let full_path = search_path.join(&filename);
+            if full_path.exists() {
+                return self.load_python(&full_path);
+            }
+        }
+
+        Err(ModuleError::NotFound(name.into()))
+    }
 }
 
 #[cfg(test)]
@@ -404,5 +555,119 @@ mod tests {
 
         assert!(!loader.is_empty());
         assert_eq!(loader.len(), 1);
+    }
+
+    // ========================================================================
+    // Python Loading Tests (require python feature + Python runtime)
+    // ========================================================================
+    //
+    // These tests require:
+    // 1. The `python` feature enabled
+    // 2. Python 3.11+ installed
+    // 3. Proper linking against Python library
+    //
+    // All tests are marked #[ignore] because they require Python runtime setup.
+    // Run with: cargo test -p reovim --features python -- --ignored
+
+    #[cfg(feature = "python")]
+    mod python_tests {
+        use std::io::Write;
+
+        use {super::*, tempfile::NamedTempFile};
+
+        /// Test loading a non-existent file.
+        #[test]
+        #[ignore = "requires Python runtime linked"]
+        fn test_load_python_file_not_found() {
+            let mut loader = ModuleLoader::new();
+            let result = loader.load_python(Path::new("/nonexistent/module.py"));
+            assert!(matches!(result, Err(ModuleError::LoadFailed(_))));
+        }
+
+        /// Test loading by name when module doesn't exist.
+        #[test]
+        #[ignore = "requires Python runtime linked"]
+        fn test_load_python_by_name_not_found() {
+            let mut loader = ModuleLoader::new();
+            let result = loader.load_python_by_name("nonexistent-module");
+            assert!(matches!(result, Err(ModuleError::NotFound(_))));
+        }
+
+        /// Test loading an empty Python file (no Module subclass).
+        #[test]
+        #[ignore = "requires Python runtime linked"]
+        fn test_load_python_empty_file() {
+            let mut file = NamedTempFile::with_suffix(".py").unwrap();
+            writeln!(file, "# Empty module").unwrap();
+
+            let mut loader = ModuleLoader::new();
+            let result = loader.load_python(file.path());
+
+            // Should fail because no Module subclass found
+            assert!(
+                matches!(result, Err(ModuleError::LoadFailed(msg)) if msg.contains("no Module subclass"))
+            );
+        }
+
+        /// Test loading a Python file with syntax error.
+        #[test]
+        #[ignore = "requires Python runtime linked"]
+        fn test_load_python_syntax_error() {
+            let mut file = NamedTempFile::with_suffix(".py").unwrap();
+            writeln!(file, "def invalid syntax {{}}").unwrap();
+
+            let mut loader = ModuleLoader::new();
+            let result = loader.load_python(file.path());
+
+            // Should fail with execution error
+            assert!(matches!(result, Err(ModuleError::LoadFailed(_))));
+        }
+
+        /// Full integration test - loads a valid Python module.
+        ///
+        /// Requires:
+        /// 1. Python 3.11+ installed
+        /// 2. The reovim Python module built and importable
+        ///    (set PYTHONPATH to include the built .so file)
+        #[test]
+        #[ignore = "requires Python runtime and reovim module importable"]
+        fn test_load_valid_python_module() {
+            let mut file = NamedTempFile::with_suffix(".py").unwrap();
+            writeln!(
+                file,
+                r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class TestPythonModule(Module):
+    def id(self):
+        return ModuleId("test-python-module")
+
+    def name(self):
+        return "Test Python Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+"#
+            )
+            .unwrap();
+
+            let mut loader = ModuleLoader::new();
+            let result = loader.load_python(file.path());
+
+            assert!(result.is_ok(), "Failed to load: {:?}", result.err());
+            let id = result.unwrap();
+            assert_eq!(id.as_str(), "test-python-module");
+
+            // Verify the module is registered
+            let handle = loader.get(&id);
+            assert!(handle.is_some());
+            assert!(handle.unwrap().is_static()); // Python modules use boxed registration
+        }
     }
 }

--- a/runner/src/server/module/loading/mod.rs
+++ b/runner/src/server/module/loading/mod.rs
@@ -31,3 +31,7 @@ pub use {
     handle::{InitResult, ModuleHandle},
     loader::ModuleLoader,
 };
+
+#[cfg(feature = "python")]
+#[allow(unused_imports)] // Public API exports for Python module discovery
+pub use discovery::{discover_python_modules, find_python_module};

--- a/runner/tests/python_e2e.rs
+++ b/runner/tests/python_e2e.rs
@@ -1,0 +1,617 @@
+//! End-to-end tests for Python module loading.
+//!
+//! These tests verify that Python modules can actually be loaded and executed,
+//! testing the full integration path:
+//! 1. Python runtime initialization
+//! 2. reovim module registration
+//! 3. Python file loading and execution
+//! 4. Module trait method invocation
+//!
+//! # Requirements
+//!
+//! These tests require:
+//! - Python 3.11+ installed on the system
+//! - The `python` feature enabled
+//!
+//! Run with: `cargo test -p reovim --features python python_e2e`
+
+#![cfg(feature = "python")]
+
+use std::{io::Write, sync::Once};
+
+use {
+    reovim_driver_ffi_python::init_python,
+    reovim_kernel::api::v1::{ModuleContext, ModuleError},
+    runner::module::{InitResult, ModuleLoader},
+    tempfile::NamedTempFile,
+};
+
+/// Initialize Python with reovim module registered.
+/// This must be called before any Python operations.
+static INIT: Once = Once::new();
+
+fn ensure_python_initialized() {
+    INIT.call_once(|| {
+        init_python();
+    });
+}
+
+// ============================================================================
+// E2E Tests: Full Python Module Loading
+// ============================================================================
+
+/// Test loading a minimal Python module that implements all required methods.
+#[test]
+fn test_e2e_load_minimal_python_module() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class MinimalModule(Module):
+    def id(self):
+        return ModuleId("minimal-python-module")
+
+    def name(self):
+        return "Minimal Python Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let result = loader.load_python(file.path());
+
+    assert!(result.is_ok(), "Failed to load module: {:?}", result.err());
+    let id = result.unwrap();
+    assert_eq!(id.as_str(), "minimal-python-module");
+
+    // Verify module is registered and accessible
+    let handle = loader.get(&id);
+    assert!(handle.is_some());
+}
+
+/// Test that module trait methods work correctly through FFI.
+#[test]
+fn test_e2e_python_module_trait_methods() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult, Version
+
+class FeatureModule(Module):
+    def id(self):
+        return ModuleId("feature-module")
+
+    def name(self):
+        return "Feature Module"
+
+    def version(self):
+        return (2, 3, 4)
+
+    def api_version(self):
+        return Version(1, 0, 0)
+
+    def dependencies(self):
+        return [ModuleId("dep-one"), ModuleId("dep-two")]
+
+    def optional_dependencies(self):
+        return [ModuleId("optional-dep")]
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+
+    def supports_hot_reload(self):
+        return True
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get(&id).unwrap();
+
+    // Test identity methods
+    assert_eq!(handle.id().as_str(), "feature-module");
+    assert_eq!(handle.name(), "Feature Module");
+
+    let version = handle.version();
+    assert_eq!(version.major, 2);
+    assert_eq!(version.minor, 3);
+    assert_eq!(version.patch, 4);
+
+    // Test dependencies
+    let deps = handle.dependencies();
+    assert_eq!(deps.len(), 2);
+    assert_eq!(deps[0].as_str(), "dep-one");
+    assert_eq!(deps[1].as_str(), "dep-two");
+
+    let opt_deps = handle.optional_dependencies();
+    assert_eq!(opt_deps.len(), 1);
+    assert_eq!(opt_deps[0].as_str(), "optional-dep");
+
+    // Test hot reload support
+    assert!(handle.supports_hot_reload());
+}
+
+/// Test the full module lifecycle: init and exit.
+#[test]
+fn test_e2e_python_module_lifecycle() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class LifecycleModule(Module):
+    def __init__(self):
+        super().__init__()
+        self.initialized = False
+        self.exited = False
+
+    def id(self):
+        return ModuleId("lifecycle-module")
+
+    def name(self):
+        return "Lifecycle Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        self.initialized = True
+        return ProbeResult.Success
+
+    def exit(self):
+        self.exited = True
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get_mut(&id).unwrap();
+
+    // Initialize the module
+    let ctx = ModuleContext::default();
+    let result = handle.init(&ctx);
+    assert!(matches!(result, Ok(InitResult::Success)));
+
+    // Exit the module
+    let exit_result = handle.exit();
+    assert!(exit_result.is_ok());
+}
+
+/// Test deferred initialization.
+#[test]
+fn test_e2e_python_module_deferred_init() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class DeferredModule(Module):
+    def __init__(self):
+        super().__init__()
+        self.init_count = 0
+
+    def id(self):
+        return ModuleId("deferred-module")
+
+    def name(self):
+        return "Deferred Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        self.init_count += 1
+        if self.init_count < 3:
+            return ProbeResult.Defer("waiting for dependency")
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get_mut(&id).unwrap();
+
+    let ctx = ModuleContext::default();
+
+    // First call should defer
+    let result1 = handle.init(&ctx);
+    assert!(matches!(result1, Ok(InitResult::Defer(_))));
+
+    // Second call should also defer
+    let result2 = handle.init(&ctx);
+    assert!(matches!(result2, Ok(InitResult::Defer(_))));
+
+    // Third call should succeed
+    let result3 = handle.init(&ctx);
+    assert!(matches!(result3, Ok(InitResult::Success)));
+}
+
+/// Test failed initialization.
+#[test]
+fn test_e2e_python_module_failed_init() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class FailingModule(Module):
+    def id(self):
+        return ModuleId("failing-module")
+
+    def name(self):
+        return "Failing Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Failed("intentional failure for testing")
+
+    def exit(self):
+        pass
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get_mut(&id).unwrap();
+
+    let ctx = ModuleContext::default();
+    let result = handle.init(&ctx);
+    assert!(result.is_err(), "Expected init to fail: {result:?}");
+}
+
+/// Test command registrations from Python module.
+#[test]
+fn test_e2e_python_module_commands() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult, CommandRegistration
+
+class CommandModule(Module):
+    def id(self):
+        return ModuleId("command-module")
+
+    def name(self):
+        return "Command Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+
+    def commands(self):
+        return [
+            CommandRegistration("my-command")
+                .with_name("My Command")
+                .with_description("Does something useful"),
+            CommandRegistration("another-command")
+        ]
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get(&id).unwrap();
+
+    // Access module trait methods via as_module()
+    let module = handle.as_module().expect("Should be a static module");
+    let commands = module.commands();
+    assert_eq!(commands.len(), 2);
+    assert_eq!(commands[0].id, "my-command");
+    assert_eq!(commands[0].name, "My Command");
+    assert_eq!(commands[0].description, "Does something useful");
+    assert_eq!(commands[1].id, "another-command");
+}
+
+/// Test keybinding registrations from Python module.
+#[test]
+fn test_e2e_python_module_keybindings() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult, KeybindingRegistration
+
+class KeybindingModule(Module):
+    def id(self):
+        return ModuleId("keybinding-module")
+
+    def name(self):
+        return "Keybinding Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+
+    def keybindings(self):
+        return [
+            KeybindingRegistration("<C-m>", "my-command")
+                .with_modes(["normal", "visual"])
+                .with_description("Trigger my command"),
+            KeybindingRegistration("<leader>x", "exit-command")
+        ]
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get(&id).unwrap();
+
+    // Access module trait methods via as_module()
+    let module = handle.as_module().expect("Should be a static module");
+    let keybindings = module.keybindings();
+    assert_eq!(keybindings.len(), 2);
+    assert_eq!(keybindings[0].keys, "<C-m>");
+    assert_eq!(keybindings[0].command_id, "my-command");
+    assert_eq!(keybindings[0].modes, &["normal", "visual"]);
+    assert_eq!(keybindings[0].description, "Trigger my command");
+}
+
+/// Test event handler registrations from Python module.
+#[test]
+fn test_e2e_python_module_event_handlers() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult, EventHandlerRegistration
+
+class EventModule(Module):
+    def id(self):
+        return ModuleId("event-module")
+
+    def name(self):
+        return "Event Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+
+    def event_handlers(self):
+        return [
+            EventHandlerRegistration("BufferChanged")
+                .with_description("React to buffer changes"),
+            EventHandlerRegistration("CursorMoved")
+        ]
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get(&id).unwrap();
+
+    // Access module trait methods via as_module()
+    let module = handle.as_module().expect("Should be a static module");
+    let handlers = module.event_handlers();
+    assert_eq!(handlers.len(), 2);
+    assert_eq!(handlers[0].event_type, "BufferChanged");
+    assert_eq!(handlers[0].description, "React to buffer changes");
+    assert_eq!(handlers[1].event_type, "CursorMoved");
+}
+
+/// Test hot reload state preservation.
+#[test]
+fn test_e2e_python_module_hot_reload() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+import pickle
+from reovim import Module, ModuleId, ProbeResult
+
+class HotReloadModule(Module):
+    def __init__(self):
+        super().__init__()
+        self.counter = 0
+
+    def id(self):
+        return ModuleId("hot-reload-module")
+
+    def name(self):
+        return "Hot Reload Module"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        self.counter += 1
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+
+    def supports_hot_reload(self):
+        return True
+
+    def save_state(self):
+        return pickle.dumps({{"counter": self.counter}})
+
+    def restore_state(self, state):
+        data = pickle.loads(state)
+        self.counter = data.get("counter", 0)
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let id = loader.load_python(file.path()).unwrap();
+    let handle = loader.get_mut(&id).unwrap();
+
+    // Verify hot reload is supported
+    assert!(handle.supports_hot_reload());
+
+    // Initialize
+    let ctx = ModuleContext::default();
+    let init_result = handle.init(&ctx);
+    assert!(init_result.is_ok());
+
+    // Save state
+    let state = handle.save_state();
+    assert!(state.is_some());
+    let state_bytes = state.unwrap();
+    assert!(!state_bytes.is_empty());
+
+    // Restore state (simulates reload)
+    let restore_result = handle.restore_state(&state_bytes);
+    assert!(restore_result.is_ok());
+}
+
+// ============================================================================
+// Error Handling Tests
+// ============================================================================
+
+/// Test that loading a non-existent file fails gracefully.
+#[test]
+fn test_e2e_python_file_not_found() {
+    ensure_python_initialized();
+
+    let mut loader = ModuleLoader::new();
+    let result = loader.load_python(std::path::Path::new("/nonexistent/module.py"));
+
+    assert!(matches!(result, Err(ModuleError::LoadFailed(_))));
+}
+
+/// Test that loading a file without Module subclass fails.
+#[test]
+fn test_e2e_python_no_module_subclass() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r"
+# A Python file without a Module subclass
+def some_function():
+    return 42
+
+class NotAModule:
+    pass
+"
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let result = loader.load_python(file.path());
+
+    assert!(
+        matches!(result, Err(ModuleError::LoadFailed(msg)) if msg.contains("no Module subclass"))
+    );
+}
+
+/// Test that syntax errors are reported correctly.
+#[test]
+fn test_e2e_python_syntax_error() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(file, "def invalid syntax {{}}").unwrap();
+
+    let mut loader = ModuleLoader::new();
+    let result = loader.load_python(file.path());
+
+    assert!(matches!(result, Err(ModuleError::LoadFailed(_))));
+}
+
+/// Test that duplicate module registration fails.
+#[test]
+fn test_e2e_python_duplicate_registration() {
+    ensure_python_initialized();
+
+    let mut file = NamedTempFile::with_suffix(".py").unwrap();
+    writeln!(
+        file,
+        r#"
+from reovim import Module, ModuleId, ProbeResult
+
+class DuplicateModule(Module):
+    def id(self):
+        return ModuleId("duplicate-test-module")
+
+    def name(self):
+        return "Duplicate Test"
+
+    def version(self):
+        return (1, 0, 0)
+
+    def init(self, ctx):
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+"#
+    )
+    .unwrap();
+
+    let mut loader = ModuleLoader::new();
+
+    // First load should succeed
+    let result1 = loader.load_python(file.path());
+    assert!(result1.is_ok());
+
+    // Second load should fail (duplicate ID)
+    let result2 = loader.load_python(file.path());
+    assert!(matches!(result2, Err(ModuleError::LoadFailed(msg)) if msg.contains("already loaded")));
+}

--- a/scripts/e2e-python.sh
+++ b/scripts/e2e-python.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# E2E tests for Python FFI module loading
+#
+# Runs the full integration test suite for Python modules via PyO3.
+# These tests verify that Python modules can actually be loaded and executed.
+#
+# Requirements:
+# - Python 3.11+ installed
+# - pyo3 dependencies satisfied
+#
+# Usage:
+#   ./scripts/e2e-python.sh          # Run all Python e2e tests
+#   ./scripts/e2e-python.sh --verbose # Run with verbose output
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+VERBOSE=""
+for arg in "$@"; do
+    case $arg in
+        --verbose|-v)
+            VERBOSE="-- --nocapture"
+            ;;
+    esac
+done
+
+echo -e "${YELLOW}==> Running Python FFI E2E tests...${NC}"
+
+# Check Python version
+PYTHON_VERSION=$(python3 --version 2>&1 | cut -d' ' -f2)
+PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d'.' -f1)
+PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d'.' -f2)
+
+if [[ "$PYTHON_MAJOR" -lt 3 ]] || [[ "$PYTHON_MAJOR" -eq 3 && "$PYTHON_MINOR" -lt 11 ]]; then
+    echo -e "${RED}Error: Python 3.11+ required, found $PYTHON_VERSION${NC}"
+    exit 1
+fi
+
+echo -e "  Python version: ${GREEN}$PYTHON_VERSION${NC}"
+
+# Run the tests
+echo -e "${YELLOW}==> Building and running tests...${NC}"
+
+if cargo test -p reovim --features python --test python_e2e $VERBOSE; then
+    echo -e "${GREEN}==> All Python E2E tests passed!${NC}"
+else
+    echo -e "${RED}==> Some Python E2E tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Add Python module support allowing reovim modules to be written in Python.

Core Implementation:
- New reovim-driver-ffi-python crate with PyO3 0.27 bindings
- PyModuleId, PyVersion, PyProbeResult type wrappers
- PyCommandRegistration, PyKeybindingRegistration, PyEventHandlerRegistration builders
- PythonModule wrapper implementing all 12 Module trait methods
- Thread-safe GIL acquisition via Python::attach()

Integration:
- ModuleLoader.load_python() and load_python_by_name() methods
- Python module discovery in search paths (.py files)
- init_python() function for registering reovim module in tests
- Optional feature flag: --features python

Testing:
- 34 unit tests covering all type bindings and conversions
- 13 e2e integration tests (runner/tests/python_e2e.rs)
- scripts/e2e-python.sh test runner

Documentation:
- Architecture guide: docs/architecture/ffi/python.md
- User guide: docs/user-guide/python-modules.md
- Example modules: examples/python-module/

Closes: #293
