### PR TITLE
fix(keymap): use vim-style prefix lookup and explicit editor mode IDs…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ## [Unreleased] - v0.9.0-dev
 
+### Fixed
+
+- **E2E Test Infrastructure** ([#308](https://github.com/ds1sqe/reovim/issues/308))
+  - Fixed keymap lookup to use vim-style prefix handling (wait for longer bindings like `dd` when `d` is pressed)
+  - Fixed mode ID references in keymap module to use explicit `editor:` prefix (`editor:normal`, `editor:insert`, etc.)
+  - Enables 12 of 28 operator E2E tests to pass
+
 ### Refactored
 
 - **File Splitting Epic Phase 1-3** ([Epic #304](https://github.com/ds1sqe/reovim/issues/304))

--- a/modules/keymap/src/insert.rs
+++ b/modules/keymap/src/insert.rs
@@ -11,91 +11,91 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
         // Exit insert mode
         // ====================================================================
         KeybindingRegistration::new("<Esc>", "exit-insert")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("mode")
             .with_description("Exit insert mode"),
         KeybindingRegistration::new("<C-c>", "exit-insert")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("mode")
             .with_description("Exit insert mode (Ctrl-C)"),
         KeybindingRegistration::new("<C-[>", "exit-insert")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("mode")
             .with_description("Exit insert mode (Ctrl-[)"),
         // ====================================================================
         // Navigation in insert mode
         // ====================================================================
         KeybindingRegistration::new("<Left>", "cursor-left")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move cursor left"),
         KeybindingRegistration::new("<Right>", "cursor-right")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move cursor right"),
         KeybindingRegistration::new("<Up>", "cursor-up")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move cursor up"),
         KeybindingRegistration::new("<Down>", "cursor-down")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move cursor down"),
         KeybindingRegistration::new("<Home>", "line-start")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move to start of line"),
         KeybindingRegistration::new("<End>", "line-end")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("motion")
             .with_description("Move to end of line"),
         // ====================================================================
         // Deletion in insert mode
         // ====================================================================
         KeybindingRegistration::new("<BS>", "delete-char-before")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Delete character before cursor"),
         KeybindingRegistration::new("<Del>", "delete-char")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Delete character under cursor"),
         KeybindingRegistration::new("<C-h>", "delete-char-before")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Delete character before cursor"),
         KeybindingRegistration::new("<C-w>", "delete-word-before")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Delete word before cursor"),
         KeybindingRegistration::new("<C-u>", "delete-to-bol")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Delete to start of line"),
         // ====================================================================
         // Insert operations
         // ====================================================================
         KeybindingRegistration::new("<CR>", "insert-newline")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Insert newline"),
         KeybindingRegistration::new("<Tab>", "insert-tab")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("edit")
             .with_description("Insert tab/indent"),
         // ====================================================================
         // Completion
         // ====================================================================
         KeybindingRegistration::new("<C-n>", "completion-next")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("completion")
             .with_description("Next completion"),
         KeybindingRegistration::new("<C-p>", "completion-prev")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("completion")
             .with_description("Previous completion"),
         KeybindingRegistration::new("<C-Space>", "completion-trigger")
-            .with_modes(&["insert"])
+            .with_modes(&["editor:insert"])
             .with_category("completion")
             .with_description("Trigger completion"),
     ]

--- a/modules/keymap/src/normal.rs
+++ b/modules/keymap/src/normal.rs
@@ -14,312 +14,312 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
         // Movement - hjkl
         // ====================================================================
         KeybindingRegistration::new("h", "cursor-left")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor left"),
         KeybindingRegistration::new("j", "cursor-down")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor down"),
         KeybindingRegistration::new("k", "cursor-up")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor up"),
         KeybindingRegistration::new("l", "cursor-right")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor right"),
         // ====================================================================
         // Display line movement (gj/gk)
         // ====================================================================
         KeybindingRegistration::new("gj", "cursor-display-down")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor down one display line"),
         KeybindingRegistration::new("gk", "cursor-display-up")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move cursor up one display line"),
         // ====================================================================
         // Word motions
         // ====================================================================
         KeybindingRegistration::new("w", "word-forward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to next word"),
         KeybindingRegistration::new("b", "word-backward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to previous word"),
         KeybindingRegistration::new("e", "word-end")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to end of word"),
         KeybindingRegistration::new("W", "word-forward-big")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to next WORD"),
         KeybindingRegistration::new("B", "word-backward-big")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to previous WORD"),
         KeybindingRegistration::new("E", "word-end-big")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to end of WORD"),
         KeybindingRegistration::new("ge", "word-end-backward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to end of previous word"),
         KeybindingRegistration::new("gE", "word-end-backward-big")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to end of previous WORD"),
         // ====================================================================
         // Line motions
         // ====================================================================
         KeybindingRegistration::new("0", "line-start")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to start of line"),
         KeybindingRegistration::new("$", "line-end")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to end of line"),
         KeybindingRegistration::new("^", "first-non-blank")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Move to first non-blank character"),
         // ====================================================================
         // Document motions
         // ====================================================================
         KeybindingRegistration::new("gg", "document-start")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Go to start of document"),
         KeybindingRegistration::new("G", "document-end")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("motion")
             .with_description("Go to end of document"),
         // ====================================================================
         // Mode switching
         // ====================================================================
         KeybindingRegistration::new("i", "enter-insert")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter insert mode"),
         KeybindingRegistration::new("a", "enter-insert-after")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter insert mode after cursor"),
         KeybindingRegistration::new("A", "enter-insert-eol")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter insert mode at end of line"),
         KeybindingRegistration::new("I", "enter-insert-bol")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter insert mode at start of line"),
         KeybindingRegistration::new("o", "open-line-below")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Open line below and enter insert mode"),
         KeybindingRegistration::new("O", "open-line-above")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Open line above and enter insert mode"),
         KeybindingRegistration::new("v", "enter-visual")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter visual mode"),
         KeybindingRegistration::new("V", "enter-visual-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter visual line mode"),
         KeybindingRegistration::new("<C-v>", "enter-visual-block")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter visual block mode"),
         KeybindingRegistration::new(":", "enter-command")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mode")
             .with_description("Enter command mode"),
         // ====================================================================
         // Operators (enter operator-pending mode)
         // ====================================================================
         KeybindingRegistration::new("d", "enter-delete-operator")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Delete operator"),
         KeybindingRegistration::new("y", "enter-yank-operator")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Yank operator"),
         KeybindingRegistration::new("c", "enter-change-operator")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Change operator"),
         KeybindingRegistration::new(">", "enter-indent-operator")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Indent operator"),
         KeybindingRegistration::new("<", "enter-dedent-operator")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Dedent operator"),
         // ====================================================================
         // Line operators (immediate)
         // ====================================================================
         KeybindingRegistration::new("dd", "delete-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Delete line"),
         KeybindingRegistration::new("yy", "yank-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Yank line"),
         KeybindingRegistration::new("cc", "change-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Change line"),
         KeybindingRegistration::new("Y", "yank-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Yank line (alias)"),
         KeybindingRegistration::new("D", "delete-to-eol")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Delete to end of line"),
         KeybindingRegistration::new("C", "change-to-eol")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("operator")
             .with_description("Change to end of line"),
         // ====================================================================
         // Single character operations
         // ====================================================================
         KeybindingRegistration::new("x", "delete-char")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Delete character under cursor"),
         KeybindingRegistration::new("X", "delete-char-before")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Delete character before cursor"),
         KeybindingRegistration::new("r", "replace-char")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Replace character"),
         KeybindingRegistration::new("~", "toggle-case")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Toggle case"),
         // ====================================================================
         // Undo/Redo
         // ====================================================================
         KeybindingRegistration::new("u", "undo")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("history")
             .with_description("Undo"),
         KeybindingRegistration::new("<C-r>", "redo")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("history")
             .with_description("Redo"),
         // ====================================================================
         // Paste
         // ====================================================================
         KeybindingRegistration::new("p", "paste-after")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("clipboard")
             .with_description("Paste after cursor"),
         KeybindingRegistration::new("P", "paste-before")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("clipboard")
             .with_description("Paste before cursor"),
         // ====================================================================
         // Scroll
         // ====================================================================
         KeybindingRegistration::new("<C-u>", "scroll-half-up")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll half page up"),
         KeybindingRegistration::new("<C-d>", "scroll-half-down")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll half page down"),
         KeybindingRegistration::new("<C-b>", "scroll-page-up")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll page up"),
         KeybindingRegistration::new("<C-f>", "scroll-page-down")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll page down"),
         KeybindingRegistration::new("zz", "scroll-center")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Center cursor line"),
         KeybindingRegistration::new("zt", "scroll-top")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll cursor line to top"),
         KeybindingRegistration::new("zb", "scroll-bottom")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("scroll")
             .with_description("Scroll cursor line to bottom"),
         // ====================================================================
         // Search
         // ====================================================================
         KeybindingRegistration::new("/", "search-forward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search forward"),
         KeybindingRegistration::new("?", "search-backward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search backward"),
         KeybindingRegistration::new("n", "search-next")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Next search result"),
         KeybindingRegistration::new("N", "search-prev")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Previous search result"),
         KeybindingRegistration::new("*", "search-word-forward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search word under cursor forward"),
         KeybindingRegistration::new("#", "search-word-backward")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search word under cursor backward"),
         // ====================================================================
         // Window
         // ====================================================================
         KeybindingRegistration::new("<C-w>", "enter-window-mode")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("window")
             .with_description("Enter window mode"),
         // ====================================================================
         // Marks
         // ====================================================================
         KeybindingRegistration::new("m", "set-mark")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mark")
             .with_description("Set mark"),
         KeybindingRegistration::new("'", "goto-mark-line")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mark")
             .with_description("Go to mark (line)"),
         KeybindingRegistration::new("`", "goto-mark-exact")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("mark")
             .with_description("Go to mark (exact position)"),
         // ====================================================================
         // Join
         // ====================================================================
         KeybindingRegistration::new("J", "join-lines")
-            .with_modes(&["normal"])
+            .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Join lines"),
     ]

--- a/modules/keymap/src/operator_pending.rs
+++ b/modules/keymap/src/operator_pending.rs
@@ -14,232 +14,232 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
         // Exit operator-pending mode
         // ====================================================================
         KeybindingRegistration::new("<Esc>", "exit-operator-pending")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("mode")
             .with_description("Cancel operator"),
         KeybindingRegistration::new("<C-c>", "exit-operator-pending")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("mode")
             .with_description("Cancel operator"),
         // ====================================================================
         // Motions (complete the operator)
         // ====================================================================
         KeybindingRegistration::new("h", "motion-left")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Left motion"),
         KeybindingRegistration::new("j", "motion-down")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Down motion"),
         KeybindingRegistration::new("k", "motion-up")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Up motion"),
         KeybindingRegistration::new("l", "motion-right")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Right motion"),
         KeybindingRegistration::new("w", "motion-word-forward")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Word forward motion"),
         KeybindingRegistration::new("b", "motion-word-backward")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Word backward motion"),
         KeybindingRegistration::new("e", "motion-word-end")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Word end motion"),
         KeybindingRegistration::new("W", "motion-word-forward-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("WORD forward motion"),
         KeybindingRegistration::new("B", "motion-word-backward-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("WORD backward motion"),
         KeybindingRegistration::new("E", "motion-word-end-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("WORD end motion"),
         KeybindingRegistration::new("ge", "motion-word-end-backward")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Word end backward motion"),
         KeybindingRegistration::new("gE", "motion-word-end-backward-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("WORD end backward motion"),
         KeybindingRegistration::new("0", "motion-line-start")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Line start motion"),
         KeybindingRegistration::new("$", "motion-line-end")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Line end motion"),
         KeybindingRegistration::new("^", "motion-first-non-blank")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("First non-blank motion"),
         KeybindingRegistration::new("gg", "motion-document-start")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Document start motion"),
         KeybindingRegistration::new("G", "motion-document-end")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("motion")
             .with_description("Document end motion"),
         // ====================================================================
         // Text objects - inner
         // ====================================================================
         KeybindingRegistration::new("iw", "textobjects:inner-word")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner word"),
         KeybindingRegistration::new("iW", "textobjects:inner-word-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner WORD"),
         KeybindingRegistration::new("i\"", "textobjects:inner-double-quote")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner double quotes"),
         KeybindingRegistration::new("i'", "textobjects:inner-single-quote")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner single quotes"),
         KeybindingRegistration::new("i`", "textobjects:inner-backtick")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner backticks"),
         KeybindingRegistration::new("i(", "textobjects:inner-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner parentheses"),
         KeybindingRegistration::new("i)", "textobjects:inner-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner parentheses"),
         KeybindingRegistration::new("ib", "textobjects:inner-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner block (parentheses)"),
         KeybindingRegistration::new("i[", "textobjects:inner-bracket")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner brackets"),
         KeybindingRegistration::new("i]", "textobjects:inner-bracket")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner brackets"),
         KeybindingRegistration::new("i{", "textobjects:inner-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner braces"),
         KeybindingRegistration::new("i}", "textobjects:inner-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner braces"),
         KeybindingRegistration::new("iB", "textobjects:inner-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner Block (braces)"),
         KeybindingRegistration::new("i<", "textobjects:inner-angle")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner angle brackets"),
         KeybindingRegistration::new("i>", "textobjects:inner-angle")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner angle brackets"),
         KeybindingRegistration::new("it", "textobjects:inner-tag")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner tag"),
         KeybindingRegistration::new("is", "textobjects:inner-sentence")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner sentence"),
         KeybindingRegistration::new("ip", "textobjects:inner-paragraph")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Inner paragraph"),
         // ====================================================================
         // Text objects - around
         // ====================================================================
         KeybindingRegistration::new("aw", "textobjects:around-word")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around word"),
         KeybindingRegistration::new("aW", "textobjects:around-word-big")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around WORD"),
         KeybindingRegistration::new("a\"", "textobjects:around-double-quote")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around double quotes"),
         KeybindingRegistration::new("a'", "textobjects:around-single-quote")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around single quotes"),
         KeybindingRegistration::new("a`", "textobjects:around-backtick")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around backticks"),
         KeybindingRegistration::new("a(", "textobjects:around-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around parentheses"),
         KeybindingRegistration::new("a)", "textobjects:around-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around parentheses"),
         KeybindingRegistration::new("ab", "textobjects:around-paren")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around block (parentheses)"),
         KeybindingRegistration::new("a[", "textobjects:around-bracket")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around brackets"),
         KeybindingRegistration::new("a]", "textobjects:around-bracket")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around brackets"),
         KeybindingRegistration::new("a{", "textobjects:around-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around braces"),
         KeybindingRegistration::new("a}", "textobjects:around-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around braces"),
         KeybindingRegistration::new("aB", "textobjects:around-brace")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around Block (braces)"),
         KeybindingRegistration::new("a<", "textobjects:around-angle")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around angle brackets"),
         KeybindingRegistration::new("a>", "textobjects:around-angle")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around angle brackets"),
         KeybindingRegistration::new("at", "textobjects:around-tag")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around tag"),
         KeybindingRegistration::new("as", "textobjects:around-sentence")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around sentence"),
         KeybindingRegistration::new("ap", "textobjects:around-paragraph")
-            .with_modes(&["operator-pending"])
+            .with_modes(&["editor:operator-pending"])
             .with_category("textobj")
             .with_description("Around paragraph"),
     ]

--- a/modules/keymap/src/visual.rs
+++ b/modules/keymap/src/visual.rs
@@ -11,168 +11,168 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
         // Exit visual mode
         // ====================================================================
         KeybindingRegistration::new("<Esc>", "exit-visual")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("mode")
             .with_description("Exit visual mode"),
         KeybindingRegistration::new("<C-c>", "exit-visual")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("mode")
             .with_description("Exit visual mode"),
         // ====================================================================
         // Movement (extends selection)
         // ====================================================================
         KeybindingRegistration::new("h", "cursor-left")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend selection left"),
         KeybindingRegistration::new("j", "cursor-down")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend selection down"),
         KeybindingRegistration::new("k", "cursor-up")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend selection up"),
         KeybindingRegistration::new("l", "cursor-right")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend selection right"),
         KeybindingRegistration::new("w", "word-forward")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to next word"),
         KeybindingRegistration::new("b", "word-backward")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to previous word"),
         KeybindingRegistration::new("e", "word-end")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to end of word"),
         KeybindingRegistration::new("0", "line-start")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to start of line"),
         KeybindingRegistration::new("$", "line-end")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to end of line"),
         KeybindingRegistration::new("gg", "document-start")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to start of document"),
         KeybindingRegistration::new("G", "document-end")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("motion")
             .with_description("Extend to end of document"),
         // ====================================================================
         // Selection operations
         // ====================================================================
         KeybindingRegistration::new("o", "visual-swap-anchor")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("selection")
             .with_description("Swap cursor and anchor"),
         KeybindingRegistration::new("O", "visual-swap-corner")
-            .with_modes(&["visual-block"])
+            .with_modes(&["editor:visual-block"])
             .with_category("selection")
             .with_description("Swap cursor to opposite corner"),
         // ====================================================================
         // Mode switching within visual
         // ====================================================================
         KeybindingRegistration::new("v", "toggle-visual-char")
-            .with_modes(&["visual-line", "visual-block"])
+            .with_modes(&["editor:visual-line", "editor:visual-block"])
             .with_category("mode")
             .with_description("Switch to character-wise visual"),
         KeybindingRegistration::new("V", "toggle-visual-line")
-            .with_modes(&["visual", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-block"])
             .with_category("mode")
             .with_description("Switch to line-wise visual"),
         KeybindingRegistration::new("<C-v>", "toggle-visual-block")
-            .with_modes(&["visual", "visual-line"])
+            .with_modes(&["editor:visual", "editor:visual-line"])
             .with_category("mode")
             .with_description("Switch to block-wise visual"),
         // ====================================================================
         // Operators on selection
         // ====================================================================
         KeybindingRegistration::new("d", "delete-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Delete selection"),
         KeybindingRegistration::new("y", "yank-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Yank selection"),
         KeybindingRegistration::new("c", "change-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Change selection"),
         KeybindingRegistration::new("x", "delete-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Delete selection (alias)"),
         KeybindingRegistration::new(">", "indent-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Indent selection"),
         KeybindingRegistration::new("<", "dedent-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Dedent selection"),
         KeybindingRegistration::new("~", "toggle-case-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Toggle case of selection"),
         KeybindingRegistration::new("u", "lowercase-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Lowercase selection"),
         KeybindingRegistration::new("U", "uppercase-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("operator")
             .with_description("Uppercase selection"),
         // ====================================================================
         // Join
         // ====================================================================
         KeybindingRegistration::new("J", "join-selection")
-            .with_modes(&["visual", "visual-line"])
+            .with_modes(&["editor:visual", "editor:visual-line"])
             .with_category("edit")
             .with_description("Join selected lines"),
         // ====================================================================
         // Enter command mode with selection
         // ====================================================================
         KeybindingRegistration::new(":", "command-with-selection")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("mode")
             .with_description("Enter command mode with selection range"),
         // ====================================================================
         // Blocked keys (explicit no-op) - Issue #145
         // ====================================================================
         KeybindingRegistration::new("i", "visual-noop")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("blocked")
             .with_description("No-op (insert key blocked in visual mode)"),
         KeybindingRegistration::new("a", "visual-noop")
-            .with_modes(&["visual", "visual-line", "visual-block"])
+            .with_modes(&["editor:visual", "editor:visual-line", "editor:visual-block"])
             .with_category("blocked")
             .with_description("No-op (append key blocked in visual mode)"),
         // ====================================================================
         // Visual insert commands (I/A) - Issue #145
         // ====================================================================
         KeybindingRegistration::new("I", "visual-insert-start")
-            .with_modes(&["visual", "visual-line"])
+            .with_modes(&["editor:visual", "editor:visual-line"])
             .with_category("mode")
             .with_description("Exit visual, move to line start, enter insert"),
         KeybindingRegistration::new("A", "visual-insert-end")
-            .with_modes(&["visual", "visual-line"])
+            .with_modes(&["editor:visual", "editor:visual-line"])
             .with_category("mode")
             .with_description("Exit visual, move to line end, enter insert"),
         // Block mode I/A - Issue #146
         KeybindingRegistration::new("I", "block-insert-start")
-            .with_modes(&["visual-block"])
+            .with_modes(&["editor:visual-block"])
             .with_category("mode")
             .with_description("Insert at block left column on all lines"),
         KeybindingRegistration::new("A", "block-insert-end")
-            .with_modes(&["visual-block"])
+            .with_modes(&["editor:visual-block"])
             .with_category("mode")
             .with_description("Append at block right column on all lines"),
     ]

--- a/runner/src/server/registry/keymap.rs
+++ b/runner/src/server/registry/keymap.rs
@@ -202,9 +202,14 @@ impl KeymapRegistry {
     /// Look up a key sequence in a mode.
     ///
     /// Returns:
-    /// - `Found(cmd)` if the sequence exactly matches a binding
-    /// - `Prefix` if the sequence is a prefix of one or more bindings
+    /// - `Found(cmd)` if the sequence exactly matches a binding AND is NOT a prefix of any longer binding
+    /// - `Prefix` if the sequence is a prefix of one or more longer bindings (even if it also matches exactly)
     /// - `NotFound` if the sequence doesn't match anything
+    ///
+    /// This implements vim-style "wait for more keys" behavior:
+    /// - `d` is both an exact match (enter-delete-operator) and a prefix of `dd` (delete-line)
+    /// - We return `Prefix` so the user can type `dd` to delete a line
+    /// - If the user wanted just `d`, they can press another motion like `dw`
     #[must_use]
     pub fn lookup(&self, mode: &ModeId, keys: &KeySequence) -> KeyLookupResult {
         profile_scope!("keymap_lookup", "runner::keymap");
@@ -213,14 +218,18 @@ impl KeymapRegistry {
             return KeyLookupResult::NotFound;
         };
 
-        // Check for exact match first
-        if let Some(entry) = mode_entries.get(keys) {
-            return KeyLookupResult::Found(entry.command.clone());
+        let exact_match = mode_entries.get(keys);
+        let is_prefix = Self::is_prefix_of_any(mode_entries, keys);
+
+        // Vim-style: if this is a prefix of something longer, wait for more keys
+        // even if it's also an exact match (e.g., 'd' is both d-> and dd)
+        if is_prefix {
+            return KeyLookupResult::Prefix;
         }
 
-        // Check if this is a prefix of any binding
-        if Self::is_prefix_of_any(mode_entries, keys) {
-            return KeyLookupResult::Prefix;
+        // Not a prefix - return exact match if found
+        if let Some(entry) = exact_match {
+            return KeyLookupResult::Found(entry.command.clone());
         }
 
         KeyLookupResult::NotFound
@@ -373,12 +382,12 @@ mod tests {
         registry.register_str(mode.clone(), "g", test_command("goto"));
         registry.register_str(mode.clone(), "gg", test_command("goto-top"));
 
-        // Single `g` is an exact match (not prefix)
+        // Single `g` is a prefix of `gg`, so we return Prefix (vim-style wait for more keys)
         let g = KeySequence::parse("g").unwrap();
         let result = registry.lookup(&mode, &g);
-        assert!(result.is_found());
+        assert!(result.is_prefix());
 
-        // `gg` is also an exact match
+        // `gg` is an exact match with no longer prefix
         let gg = KeySequence::parse("gg").unwrap();
         let result = registry.lookup(&mode, &gg);
         assert!(result.is_found());


### PR DESCRIPTION
… (#308)

Fixed two issues blocking E2E test enablement:

1. Keymap lookup now returns Prefix when key sequence could extend to longer binding (e.g., 'd' returns Prefix when 'dd' exists), enabling vim-style multi-key commands to work correctly.

2. Keymap module now uses explicit editor: prefix for mode references (editor:normal, editor:insert, etc.) since modes are defined by the editor module, not the keymap module.

Changes:
- runner/src/server/registry/keymap.rs: Prefix takes precedence over exact match
- modules/keymap/src/*.rs: All mode references now use editor: prefix

Refs #308, Parts of #307
