### PR TITLE
feat(editor): add unicode-aware display line calculations and count s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,34 @@ For legacy crate changes (`lib/core`, `lib/sys`, plugins), see [CHANGELOG-archiv
 
 ### Added
 
+- **Deferred Enhancements from #233/#234** ([Issue #248](https://github.com/ds1sqe/reovim/issues/248))
+  - **Unicode-Aware Display Line Calculations** (`modules/editor/src/display_lines.rs`):
+    - Tab width support with contextual expansion based on `tabstop` option
+    - CJK double-width character handling via `unicode-width` crate
+    - New functions: `display_width_unicode()`, `display_line_count_unicode()`, `display_position_unicode()`, `buffer_col_from_display_col_unicode()`
+    - 46 comprehensive unit tests covering edge cases
+  - **Autoindent for o/O Commands** (`modules/editor/src/command/mode_entry.rs`):
+    - `OpenLineBelow` and `OpenLineAbove` now preserve current line indentation
+    - `get_line_indent()` helper extracts leading whitespace (tabs and spaces)
+    - Respects `autoindent` option from buffer-scoped OptionRegistry
+  - **Smart Indent for Enter Key** (`modules/editor/src/command/insert_edit.rs`):
+    - `InsertNewline` command applies autoindent in insert mode
+    - New lines inherit indentation from current line
+  - **Count Support Infrastructure** (`runner/src/server/app/repeat.rs`):
+    - `InsertEntryType` enum: `Inline`, `OpenBelow`, `OpenAbove`
+    - `RepeatState` extended with count tracking and entry type
+    - Count validation: zero becomes 1, capped at 999 to prevent denial-of-service
+    - 15+ unit tests for count handling
+  - **Count Prefix Handling** (`runner/src/server/event_loop/mod.rs`):
+    - Vim-style count accumulation (1-9 starts count, 0 continues)
+    - Mode-aware: only active in normal/visual modes
+    - `handle_insert_mode_exit()` handles text repetition based on entry type
+  - **Unicode-Aware gj/gk Commands** (`modules/editor/src/command/display_line.rs`):
+    - `CursorDisplayDown` and `CursorDisplayUp` now use unicode-aware display calculations
+    - Proper handling of tabs and CJK characters in wrapped line navigation
+    - Retrieves `tabstop` option from buffer-scoped OptionRegistry
+  - Deferred to E2E epic #307: Integration tests for 3i/5o count features
+
 - **Visual Mode Key Blocking** (Issue #145)
   - Explicit no-op bindings for `i`/`a` keys in all visual modes (prevent fallthrough)
   - `I` command in visual/visual-line modes: move to first non-blank, enter insert

--- a/modules/editor/Cargo.toml
+++ b/modules/editor/Cargo.toml
@@ -16,6 +16,7 @@ reovim-driver-display = { path = "../../lib/drivers/display" }
 reovim-driver-input = { path = "../../lib/drivers/input" }
 reovim-driver-vfs = { path = "../../lib/drivers/vfs" }
 reovim-module-operators = { path = "../operators" }
+unicode-width = "0.2"
 
 [lints]
 workspace = true

--- a/modules/editor/src/command/display_line.rs
+++ b/modules/editor/src/command/display_line.rs
@@ -3,15 +3,30 @@
 //! Provides cursor movement based on display (visual) lines rather than buffer lines.
 //! When text wraps across multiple terminal lines, gj/gk move one visual line
 //! rather than one buffer line.
+//!
+//! These commands are unicode-aware and handle:
+//! - Tab characters (expand based on `tabstop` setting)
+//! - CJK double-width characters (take 2 display columns)
 
 use {
     reovim_driver_command::{
         ArgKind, ArgSpec, Command, CommandContext, CommandHandler, CommandResult,
     },
-    reovim_kernel::api::v1::{CommandId, KernelContext, Position, events::CursorMoved},
+    reovim_kernel::api::v1::{
+        CommandId, KernelContext, OptionScopeId, Position, events::CursorMoved,
+    },
 };
 
 use super::super::{display_lines, mode::EDITOR_MODULE};
+
+/// Get the tabstop setting for a buffer.
+fn get_tabstop(ctx: &KernelContext, buffer_id: reovim_kernel::api::v1::BufferId) -> usize {
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    ctx.options
+        .get("tabstop", OptionScopeId::Buffer(buffer_id))
+        .and_then(|v| v.as_int())
+        .map_or(8, |n| n.max(1) as usize)
+}
 
 /// Move cursor down one display line (gj).
 ///
@@ -52,8 +67,9 @@ impl CommandHandler for CursorDisplayDown {
 
         // Terminal width: use 80 as default
         // Note: In the future, this could be retrieved from session state
-        // or passed through CommandContext. See issue #248 for tracking.
+        // or passed through CommandContext.
         let terminal_width = 80;
+        let tabstop = get_tabstop(ctx, buffer_id);
 
         let count = args.count().unwrap_or(1);
         let (old_pos, new_pos) = {
@@ -63,10 +79,16 @@ impl CommandHandler for CursorDisplayDown {
 
             // Get current line content
             let current_line = buffer.line(old_pos.line).unwrap_or("");
+
+            // Use unicode-aware functions for proper tab and CJK handling
             let display_lines_in_current =
-                display_lines::display_line_count(current_line, terminal_width);
-            let (current_display_line, display_col) =
-                display_lines::display_position(old_pos.column, terminal_width);
+                display_lines::display_line_count_unicode(current_line, terminal_width, tabstop);
+            let (current_display_line, display_col) = display_lines::display_position_unicode(
+                current_line,
+                old_pos.column,
+                terminal_width,
+                tabstop,
+            );
 
             // Calculate how many display lines we can move within this buffer line
             let remaining_display_lines =
@@ -75,8 +97,12 @@ impl CommandHandler for CursorDisplayDown {
             let new_pos = if count <= remaining_display_lines {
                 // Stay on same buffer line, move to next display line
                 let target_display_line = current_display_line + count;
-                let new_col =
-                    display_lines::buffer_column(target_display_line, display_col, terminal_width);
+                let target_display_col = target_display_line * terminal_width + display_col;
+                let new_col = display_lines::buffer_col_from_display_col_unicode(
+                    current_line,
+                    target_display_col,
+                    tabstop,
+                );
                 // Clamp to line length
                 let line_len = current_line.chars().count();
                 let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
@@ -88,15 +114,17 @@ impl CommandHandler for CursorDisplayDown {
 
                 while lines_to_move > 0 && new_line < line_count {
                     let line = buffer.line(new_line).unwrap_or("");
-                    let display_count = display_lines::display_line_count(line, terminal_width);
+                    let display_count =
+                        display_lines::display_line_count_unicode(line, terminal_width, tabstop);
 
                     if lines_to_move <= display_count {
                         // Target is within this line
                         let target_display = lines_to_move - 1;
-                        let new_col = display_lines::buffer_column(
-                            target_display,
-                            display_col,
-                            terminal_width,
+                        let target_display_col = target_display * terminal_width + display_col;
+                        let new_col = display_lines::buffer_col_from_display_col_unicode(
+                            line,
+                            target_display_col,
+                            tabstop,
                         );
                         let line_len = line.chars().count();
                         let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
@@ -118,11 +146,18 @@ impl CommandHandler for CursorDisplayDown {
                 // Reached end of buffer - go to last line, last display line
                 let last_line = line_count.saturating_sub(1);
                 let last_content = buffer.line(last_line).unwrap_or("");
-                let last_display_count =
-                    display_lines::display_line_count(last_content, terminal_width);
+                let last_display_count = display_lines::display_line_count_unicode(
+                    last_content,
+                    terminal_width,
+                    tabstop,
+                );
                 let target_display = last_display_count.saturating_sub(1);
-                let new_col =
-                    display_lines::buffer_column(target_display, display_col, terminal_width);
+                let target_display_col = target_display * terminal_width + display_col;
+                let new_col = display_lines::buffer_col_from_display_col_unicode(
+                    last_content,
+                    target_display_col,
+                    tabstop,
+                );
                 let line_len = last_content.chars().count();
                 let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
                 Position::new(last_line, clamped_col)
@@ -182,8 +217,9 @@ impl CommandHandler for CursorDisplayUp {
 
         // Terminal width: use 80 as default
         // Note: In the future, this could be retrieved from session state
-        // or passed through CommandContext. See issue #248 for tracking.
+        // or passed through CommandContext.
         let terminal_width = 80;
+        let tabstop = get_tabstop(ctx, buffer_id);
 
         let count = args.count().unwrap_or(1);
         let (old_pos, new_pos) = {
@@ -192,14 +228,24 @@ impl CommandHandler for CursorDisplayUp {
 
             // Get current line content
             let current_line = buffer.line(old_pos.line).unwrap_or("");
-            let (current_display_line, display_col) =
-                display_lines::display_position(old_pos.column, terminal_width);
+
+            // Use unicode-aware functions for proper tab and CJK handling
+            let (current_display_line, display_col) = display_lines::display_position_unicode(
+                current_line,
+                old_pos.column,
+                terminal_width,
+                tabstop,
+            );
 
             let new_pos = if count <= current_display_line {
                 // Stay on same buffer line, move to previous display line
                 let target_display_line = current_display_line - count;
-                let new_col =
-                    display_lines::buffer_column(target_display_line, display_col, terminal_width);
+                let target_display_col = target_display_line * terminal_width + display_col;
+                let new_col = display_lines::buffer_col_from_display_col_unicode(
+                    current_line,
+                    target_display_col,
+                    tabstop,
+                );
                 // Clamp to line length
                 let line_len = current_line.chars().count();
                 let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
@@ -212,15 +258,17 @@ impl CommandHandler for CursorDisplayUp {
                 while lines_to_move > 0 && new_line > 0 {
                     new_line -= 1;
                     let line = buffer.line(new_line).unwrap_or("");
-                    let display_count = display_lines::display_line_count(line, terminal_width);
+                    let display_count =
+                        display_lines::display_line_count_unicode(line, terminal_width, tabstop);
 
                     if lines_to_move <= display_count {
                         // Target is within this line (from bottom)
                         let target_display = display_count - lines_to_move;
-                        let new_col = display_lines::buffer_column(
-                            target_display,
-                            display_col,
-                            terminal_width,
+                        let target_display_col = target_display * terminal_width + display_col;
+                        let new_col = display_lines::buffer_col_from_display_col_unicode(
+                            line,
+                            target_display_col,
+                            tabstop,
                         );
                         let line_len = line.chars().count();
                         let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
@@ -240,7 +288,11 @@ impl CommandHandler for CursorDisplayUp {
 
                 // Reached beginning of buffer - go to first line, first display line
                 let first_content = buffer.line(0).unwrap_or("");
-                let new_col = display_lines::buffer_column(0, display_col, terminal_width);
+                let new_col = display_lines::buffer_col_from_display_col_unicode(
+                    first_content,
+                    display_col,
+                    tabstop,
+                );
                 let line_len = first_content.chars().count();
                 let clamped_col = new_col.min(line_len.saturating_sub(1).max(0));
                 Position::new(0, clamped_col)

--- a/modules/editor/src/command/insert_edit.rs
+++ b/modules/editor/src/command/insert_edit.rs
@@ -9,7 +9,7 @@ use {
     reovim_kernel::api::v1::{CommandId, KernelContext, OptionScopeId},
 };
 
-use super::super::mode::EDITOR_MODULE;
+use super::{super::mode::EDITOR_MODULE, mode_entry::get_line_indent};
 
 /// Insert a newline at cursor position (Enter in insert mode).
 #[derive(Debug, Clone, Copy, Default)]
@@ -34,10 +34,33 @@ impl CommandHandler for InsertNewline {
             return CommandResult::error("Buffer not found");
         };
 
+        // Check autoindent option
+        let autoindent = ctx
+            .options
+            .get("autoindent", OptionScopeId::Buffer(buffer_id))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         let mut buffer = buffer_arc.write();
+        let pos = buffer.position();
+
+        // Get indent from current line if autoindent is enabled
+        let indent = if autoindent {
+            buffer
+                .line(pos.line)
+                .map(|line| get_line_indent(line).to_owned())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
         let cursor_before = buffer.position();
-        // Insert newline splits the line at cursor position
-        let edit = buffer.insert("\n");
+
+        // Insert newline + indent (splits the line at cursor position)
+        let insert_text = format!("\n{indent}");
+        let edit = buffer.insert(&insert_text);
+
+        // Cursor is now at end of indent on new line
         let cursor_after = buffer.position();
         drop(buffer);
 

--- a/modules/editor/src/command/mode_entry.rs
+++ b/modules/editor/src/command/mode_entry.rs
@@ -8,10 +8,33 @@
 
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
-    reovim_kernel::api::v1::{CommandId, KernelContext, Position, events::ModeChanged},
+    reovim_kernel::api::v1::{
+        CommandId, KernelContext, OptionScopeId, Position, events::ModeChanged,
+    },
 };
 
 use super::super::mode::{EDITOR_MODULE, EditorMode};
+
+/// Extract the leading whitespace (indent) from a line.
+///
+/// Returns a string slice containing only the leading whitespace characters.
+/// This preserves the exact mix of tabs and spaces.
+///
+/// # Example
+///
+/// ```ignore
+/// assert_eq!(get_line_indent("    hello"), "    ");
+/// assert_eq!(get_line_indent("\t\thello"), "\t\t");
+/// assert_eq!(get_line_indent("hello"), "");
+/// ```
+#[must_use]
+pub fn get_line_indent(line: &str) -> &str {
+    let non_ws_pos = line
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map_or(line.len(), |(i, _)| i);
+    &line[..non_ws_pos]
+}
 
 /// Enter insert mode at first non-blank character (I).
 #[derive(Debug, Clone, Copy, Default)]
@@ -109,8 +132,25 @@ impl CommandHandler for OpenLineBelow {
             return CommandResult::error("Buffer not found");
         };
 
+        // Check autoindent option
+        let autoindent = ctx
+            .options
+            .get("autoindent", OptionScopeId::Buffer(buffer_id))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         let mut buffer = buffer_arc.write();
         let pos = buffer.position();
+
+        // Get indent from current line if autoindent is enabled
+        let indent = if autoindent {
+            buffer
+                .line(pos.line)
+                .map(|line| get_line_indent(line).to_owned())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
 
         // Move to end of current line
         let line_len = buffer.line_len(pos.line).unwrap_or(0);
@@ -118,9 +158,12 @@ impl CommandHandler for OpenLineBelow {
 
         // Capture cursor before insert (after move to end of line)
         let cursor_before = buffer.position();
-        // Insert newline (creates new line below)
-        let edit = buffer.insert("\n");
-        // Cursor is now at start of new line
+
+        // Insert newline + indent
+        let insert_text = format!("\n{indent}");
+        let edit = buffer.insert(&insert_text);
+
+        // Cursor is now at end of indent on new line
         let cursor_after = buffer.position();
         drop(buffer);
 
@@ -154,19 +197,39 @@ impl CommandHandler for OpenLineAbove {
             return CommandResult::error("Buffer not found");
         };
 
+        // Check autoindent option
+        let autoindent = ctx
+            .options
+            .get("autoindent", OptionScopeId::Buffer(buffer_id))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         let mut buffer = buffer_arc.write();
         let pos = buffer.position();
+
+        // Get indent from current line if autoindent is enabled
+        let indent = if autoindent {
+            buffer
+                .line(pos.line)
+                .map(|line| get_line_indent(line).to_owned())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
 
         // Move to start of current line
         buffer.set_position(Position::new(pos.line, 0));
 
         // Capture cursor before insert
         let cursor_before = buffer.position();
-        // Insert newline before current line content
-        let edit = buffer.insert("\n");
 
-        // Move cursor up to the new empty line
-        buffer.set_position(Position::new(pos.line, 0));
+        // Insert indent + newline before current line content
+        let insert_text = format!("{indent}\n");
+        let edit = buffer.insert(&insert_text);
+
+        // Move cursor to end of indent on the new line (which is now at pos.line)
+        let indent_len = indent.chars().count();
+        buffer.set_position(Position::new(pos.line, indent_len));
         let cursor_after = buffer.position();
         drop(buffer);
 
@@ -174,5 +237,45 @@ impl CommandHandler for OpenLineAbove {
             .emit(ModeChanged::with_mode_id("normal", EditorMode::INSERT_ID));
 
         CommandResult::edit_action(buffer_id, edit, cursor_before, cursor_after)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_line_indent_spaces() {
+        assert_eq!(get_line_indent("    hello"), "    ");
+        assert_eq!(get_line_indent("  world"), "  ");
+    }
+
+    #[test]
+    fn test_get_line_indent_tabs() {
+        assert_eq!(get_line_indent("\t\thello"), "\t\t");
+        assert_eq!(get_line_indent("\tworld"), "\t");
+    }
+
+    #[test]
+    fn test_get_line_indent_mixed() {
+        assert_eq!(get_line_indent("\t  hello"), "\t  ");
+        assert_eq!(get_line_indent("  \thello"), "  \t");
+    }
+
+    #[test]
+    fn test_get_line_indent_no_indent() {
+        assert_eq!(get_line_indent("hello"), "");
+        assert_eq!(get_line_indent("world"), "");
+    }
+
+    #[test]
+    fn test_get_line_indent_empty() {
+        assert_eq!(get_line_indent(""), "");
+    }
+
+    #[test]
+    fn test_get_line_indent_whitespace_only() {
+        assert_eq!(get_line_indent("    "), "    ");
+        assert_eq!(get_line_indent("\t\t"), "\t\t");
     }
 }

--- a/modules/editor/src/display_lines.rs
+++ b/modules/editor/src/display_lines.rs
@@ -10,12 +10,28 @@
 //! buffer primitives, but how to interpret "display lines" based on terminal
 //! width is up to the editor module.
 //!
+//! # Tab Handling
+//!
+//! Tabs are contextual - their display width depends on the current column:
+//! - Tab at column 0 with tabstop=4 takes 4 columns (advances to column 4)
+//! - Tab at column 2 with tabstop=4 takes 2 columns (advances to column 4)
+//! - Formula: `tab_width = tabstop - (column % tabstop)`
+//!
+//! # CJK / Unicode Width
+//!
+//! East Asian characters (CJK) typically render as 2 columns ("fullwidth").
+//! This module uses the `unicode-width` crate to determine character widths:
+//! - ASCII and most Latin characters: 1 column
+//! - CJK ideographs, fullwidth forms: 2 columns
+//! - Combining marks, zero-width chars: 0 columns
+//!
 //! # Limitations
 //!
 //! Current implementation:
-//! - Assumes 1 column per character (no CJK double-width support)
-//! - Assumes tabs render as 1 column (actual tab width not considered)
 //! - Simple division-based wrapping (no word wrap)
+//! - Terminal must support Unicode for CJK to display correctly
+
+use unicode_width::UnicodeWidthChar;
 
 /// Calculate number of display lines for a buffer line.
 ///
@@ -119,6 +135,376 @@ pub const fn buffer_column(
     display_line * terminal_width + display_column
 }
 
+// ============================================================================
+// Tab-aware display calculations
+// ============================================================================
+
+/// Calculate display width of a line accounting for tabs.
+///
+/// Each tab character expands to fill until the next tab stop. The width
+/// depends on the current display column position.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `tabstop` - Tab stop width (typically 4 or 8)
+///
+/// # Returns
+///
+/// Total display width in columns
+///
+/// # Example
+///
+/// ```ignore
+/// // "a\tb" with tabstop=4: 'a' (1) + tab (3 to reach col 4) + 'b' (1) = 5
+/// assert_eq!(display_width_with_tabs("a\tb", 4), 5);
+/// ```
+#[must_use]
+pub fn display_width_with_tabs(line: &str, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1); // Prevent division by zero
+    let mut display_col = 0;
+
+    for c in line.chars() {
+        if c == '\t' {
+            // Advance to next tab stop
+            let tab_width = tabstop - (display_col % tabstop);
+            display_col += tab_width;
+        } else {
+            display_col += 1;
+        }
+    }
+
+    display_col
+}
+
+/// Calculate number of display lines for a buffer line, accounting for tabs.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `terminal_width` - Terminal width in columns
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Number of display lines (minimum 1)
+#[must_use]
+pub fn display_line_count_with_tabs(line: &str, terminal_width: usize, tabstop: usize) -> usize {
+    if terminal_width == 0 {
+        return 1;
+    }
+
+    let width = display_width_with_tabs(line, tabstop);
+    if width == 0 {
+        return 1;
+    }
+
+    width.div_ceil(terminal_width)
+}
+
+/// Get display position for a buffer column, accounting for tabs.
+///
+/// Calculates which display line and column a buffer column falls on,
+/// properly handling tab expansion.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `buffer_col` - Column position in the buffer (character index, 0-indexed)
+/// * `terminal_width` - Terminal width in columns
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Tuple of (`display_line_index`, `column_within_display_line`)
+#[must_use]
+pub fn display_position_with_tabs(
+    line: &str,
+    buffer_col: usize,
+    terminal_width: usize,
+    tabstop: usize,
+) -> (usize, usize) {
+    let tabstop = tabstop.max(1);
+    if terminal_width == 0 {
+        // Fallback: calculate display column without wrapping
+        let display_col = display_col_from_buffer_col(line, buffer_col, tabstop);
+        return (0, display_col);
+    }
+
+    let display_col = display_col_from_buffer_col(line, buffer_col, tabstop);
+    let display_line = display_col / terminal_width;
+    let col_in_line = display_col % terminal_width;
+
+    (display_line, col_in_line)
+}
+
+/// Convert buffer column to display column, accounting for tabs.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `buffer_col` - Column position in buffer (character index)
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Display column position
+#[must_use]
+pub fn display_col_from_buffer_col(line: &str, buffer_col: usize, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1);
+    let mut display_col = 0;
+
+    for (i, c) in line.chars().enumerate() {
+        if i >= buffer_col {
+            break;
+        }
+        if c == '\t' {
+            let tab_width = tabstop - (display_col % tabstop);
+            display_col += tab_width;
+        } else {
+            display_col += 1;
+        }
+    }
+
+    display_col
+}
+
+/// Convert display column to buffer column, accounting for tabs.
+///
+/// Given a target display column, finds the buffer column (character index)
+/// that corresponds to that display position.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `target_display_col` - Target display column
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Buffer column (character index)
+#[must_use]
+pub fn buffer_col_from_display_col(line: &str, target_display_col: usize, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1);
+    let mut display_col = 0;
+    let mut buffer_col = 0;
+
+    for c in line.chars() {
+        if display_col >= target_display_col {
+            break;
+        }
+
+        let char_width = if c == '\t' {
+            tabstop - (display_col % tabstop)
+        } else {
+            1
+        };
+
+        // Check if we'd overshoot
+        if display_col + char_width > target_display_col {
+            // We're inside a tab or at the target
+            break;
+        }
+
+        display_col += char_width;
+        buffer_col += 1;
+    }
+
+    buffer_col
+}
+
+// ============================================================================
+// Unicode-aware display calculations (tabs + CJK)
+// ============================================================================
+
+/// Get the display width of a single character.
+///
+/// Returns the number of terminal columns the character occupies:
+/// - Tab: contextual (use `char_display_width_at` instead)
+/// - Most characters: 1 column
+/// - CJK / fullwidth: 2 columns
+/// - Combining marks, zero-width: 0 columns
+#[must_use]
+pub fn char_display_width(c: char) -> usize {
+    if c == '\t' {
+        // Tab width is contextual - caller should use char_display_width_at
+        1
+    } else {
+        c.width().unwrap_or(0)
+    }
+}
+
+/// Get the display width of a character at a specific column.
+///
+/// Handles both tabs (contextual width) and Unicode characters (intrinsic width).
+#[must_use]
+pub fn char_display_width_at(c: char, display_col: usize, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1);
+    if c == '\t' {
+        tabstop - (display_col % tabstop)
+    } else {
+        c.width().unwrap_or(0)
+    }
+}
+
+/// Calculate display width of a line accounting for tabs and Unicode width.
+///
+/// This is the most comprehensive width function - it handles:
+/// - Tab expansion based on column position
+/// - CJK double-width characters
+/// - Combining marks (width 0)
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `tabstop` - Tab stop width (typically 4 or 8)
+///
+/// # Returns
+///
+/// Total display width in columns
+#[must_use]
+pub fn display_width_unicode(line: &str, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1);
+    let mut display_col = 0;
+
+    for c in line.chars() {
+        display_col += char_display_width_at(c, display_col, tabstop);
+    }
+
+    display_col
+}
+
+/// Calculate number of display lines for a buffer line, with full Unicode support.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `terminal_width` - Terminal width in columns
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Number of display lines (minimum 1)
+#[must_use]
+pub fn display_line_count_unicode(line: &str, terminal_width: usize, tabstop: usize) -> usize {
+    if terminal_width == 0 {
+        return 1;
+    }
+
+    let width = display_width_unicode(line, tabstop);
+    if width == 0 {
+        return 1;
+    }
+
+    width.div_ceil(terminal_width)
+}
+
+/// Convert buffer column to display column, with full Unicode support.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `buffer_col` - Column position in buffer (character index)
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Display column position
+#[must_use]
+pub fn display_col_from_buffer_col_unicode(line: &str, buffer_col: usize, tabstop: usize) -> usize {
+    let tabstop = tabstop.max(1);
+    let mut display_col = 0;
+
+    for (i, c) in line.chars().enumerate() {
+        if i >= buffer_col {
+            break;
+        }
+        display_col += char_display_width_at(c, display_col, tabstop);
+    }
+
+    display_col
+}
+
+/// Convert display column to buffer column, with full Unicode support.
+///
+/// Given a target display column, finds the buffer column (character index)
+/// that corresponds to that display position. If the target falls inside
+/// a wide character (like CJK), returns the buffer column of that character.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `target_display_col` - Target display column
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Buffer column (character index)
+#[must_use]
+pub fn buffer_col_from_display_col_unicode(
+    line: &str,
+    target_display_col: usize,
+    tabstop: usize,
+) -> usize {
+    let tabstop = tabstop.max(1);
+    let mut display_col = 0;
+    let mut buffer_col = 0;
+
+    for c in line.chars() {
+        if display_col >= target_display_col {
+            break;
+        }
+
+        let char_width = char_display_width_at(c, display_col, tabstop);
+
+        // Check if we'd overshoot (landing inside a wide char)
+        if display_col + char_width > target_display_col {
+            // We're inside a wide character - stay at this buffer column
+            break;
+        }
+
+        display_col += char_width;
+        buffer_col += 1;
+    }
+
+    buffer_col
+}
+
+/// Get display position for a buffer column, with full Unicode support.
+///
+/// Calculates which display line and column a buffer column falls on,
+/// properly handling tab expansion and CJK characters.
+///
+/// # Arguments
+///
+/// * `line` - The buffer line content
+/// * `buffer_col` - Column position in the buffer (character index, 0-indexed)
+/// * `terminal_width` - Terminal width in columns
+/// * `tabstop` - Tab stop width
+///
+/// # Returns
+///
+/// Tuple of (`display_line_index`, `column_within_display_line`)
+#[must_use]
+pub fn display_position_unicode(
+    line: &str,
+    buffer_col: usize,
+    terminal_width: usize,
+    tabstop: usize,
+) -> (usize, usize) {
+    let tabstop = tabstop.max(1);
+    if terminal_width == 0 {
+        let display_col = display_col_from_buffer_col_unicode(line, buffer_col, tabstop);
+        return (0, display_col);
+    }
+
+    let display_col = display_col_from_buffer_col_unicode(line, buffer_col, tabstop);
+    let display_line = display_col / terminal_width;
+    let col_in_line = display_col % terminal_width;
+
+    (display_line, col_in_line)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +577,318 @@ mod tests {
             let (dl, dc) = display_position(col, 80);
             assert_eq!(buffer_column(dl, dc, 80), col);
         }
+    }
+
+    // ========================================================================
+    // Tab-aware function tests
+    // ========================================================================
+
+    #[test]
+    fn test_display_width_with_tabs_basic() {
+        // "a\tb" with tabstop=4: 'a'(1) + tab(3 to col 4) + 'b'(1) = 5
+        assert_eq!(display_width_with_tabs("a\tb", 4), 5);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_double_tab() {
+        // "\t\t" with tabstop=8: tab(8) + tab(8) = 16
+        assert_eq!(display_width_with_tabs("\t\t", 8), 16);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_at_start() {
+        // Tab at column 0 with tabstop=4 takes full 4 columns
+        assert_eq!(display_width_with_tabs("\t", 4), 4);
+        assert_eq!(display_width_with_tabs("\tx", 4), 5);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_contextual() {
+        // Tab at column 2 with tabstop=4 takes 2 columns (to reach 4)
+        assert_eq!(display_width_with_tabs("ab\t", 4), 4);
+        // Tab at column 3 with tabstop=4 takes 1 column (to reach 4)
+        assert_eq!(display_width_with_tabs("abc\t", 4), 4);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_only_char() {
+        // Single tab is the only character
+        assert_eq!(display_width_with_tabs("\t", 4), 4);
+        assert_eq!(display_width_with_tabs("\t", 8), 8);
+        assert_eq!(display_width_with_tabs("\t", 2), 2);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_consecutive() {
+        // Multiple consecutive tabs at different positions
+        assert_eq!(display_width_with_tabs("\t\t\t", 4), 12); // 4 + 4 + 4
+        assert_eq!(display_width_with_tabs("x\t\t", 4), 8); // 1 + 3 + 4
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_mixed() {
+        // Mixed tabs and spaces
+        assert_eq!(display_width_with_tabs("  \t", 4), 4); // 2 + 2
+        assert_eq!(display_width_with_tabs("\t  ", 4), 6); // 4 + 2
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_various_tabstops() {
+        let line = "x\ty";
+        // tabstop=1: each tab advances by 1
+        assert_eq!(display_width_with_tabs(line, 1), 3); // 1 + 1 + 1
+        // tabstop=2: x(1) + tab(1 to reach col 2) + y(1) = 3
+        assert_eq!(display_width_with_tabs(line, 2), 3);
+        // tabstop=4: x(1) + tab(3 to reach col 4) + y(1) = 5
+        assert_eq!(display_width_with_tabs(line, 4), 5);
+        // tabstop=8: x(1) + tab(7 to reach col 8) + y(1) = 9
+        assert_eq!(display_width_with_tabs(line, 8), 9);
+        // tabstop=16: x(1) + tab(15 to reach col 16) + y(1) = 17
+        assert_eq!(display_width_with_tabs(line, 16), 17);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_zero_tabstop() {
+        // Zero tabstop should be treated as 1 (prevent division by zero)
+        assert_eq!(display_width_with_tabs("a\tb", 0), 3);
+    }
+
+    #[test]
+    fn test_display_width_with_tabs_empty() {
+        assert_eq!(display_width_with_tabs("", 4), 0);
+    }
+
+    #[test]
+    fn test_display_line_count_with_tabs() {
+        // Line with tabs that causes wrapping
+        let line = "\t\t\t"; // 12 columns with tabstop=4
+        assert_eq!(display_line_count_with_tabs(line, 10, 4), 2);
+        assert_eq!(display_line_count_with_tabs(line, 12, 4), 1);
+        assert_eq!(display_line_count_with_tabs(line, 6, 4), 2);
+    }
+
+    #[test]
+    fn test_display_col_from_buffer_col() {
+        let line = "a\tb";
+        // Buffer col 0 (before 'a') = display col 0
+        assert_eq!(display_col_from_buffer_col(line, 0, 4), 0);
+        // Buffer col 1 (after 'a', before tab) = display col 1
+        assert_eq!(display_col_from_buffer_col(line, 1, 4), 1);
+        // Buffer col 2 (after tab, before 'b') = display col 4
+        assert_eq!(display_col_from_buffer_col(line, 2, 4), 4);
+        // Buffer col 3 (after 'b') = display col 5
+        assert_eq!(display_col_from_buffer_col(line, 3, 4), 5);
+    }
+
+    #[test]
+    fn test_buffer_col_from_display_col() {
+        let line = "a\tb";
+        // Display col 0 = buffer col 0 (at 'a')
+        assert_eq!(buffer_col_from_display_col(line, 0, 4), 0);
+        // Display col 1 = buffer col 1 (after 'a', at start of tab)
+        assert_eq!(buffer_col_from_display_col(line, 1, 4), 1);
+        // Display col 2,3 = buffer col 1 (inside tab, can't land here)
+        assert_eq!(buffer_col_from_display_col(line, 2, 4), 1);
+        assert_eq!(buffer_col_from_display_col(line, 3, 4), 1);
+        // Display col 4 = buffer col 2 (at 'b')
+        assert_eq!(buffer_col_from_display_col(line, 4, 4), 2);
+        // Display col 5 = buffer col 3 (after 'b')
+        assert_eq!(buffer_col_from_display_col(line, 5, 4), 3);
+    }
+
+    #[test]
+    fn test_display_position_with_tabs() {
+        let line = "a\tb";
+        // Buffer col 2 (at 'b') = display col 4, on display line 0 for 80-col terminal
+        assert_eq!(display_position_with_tabs(line, 2, 80, 4), (0, 4));
+    }
+
+    #[test]
+    fn test_display_position_with_tabs_wrapped() {
+        // Create a line that wraps with tabs
+        let line = "\t\t\t"; // 12 display columns with tabstop=4
+        // Buffer col 0 = display col 0, display line 0
+        assert_eq!(display_position_with_tabs(line, 0, 10, 4), (0, 0));
+        // Buffer col 1 = display col 4 (after first tab), still line 0
+        assert_eq!(display_position_with_tabs(line, 1, 10, 4), (0, 4));
+        // Buffer col 2 = display col 8 (after second tab), still line 0
+        assert_eq!(display_position_with_tabs(line, 2, 10, 4), (0, 8));
+        // Buffer col 3 = display col 12, wraps to line 1, col 2
+        assert_eq!(display_position_with_tabs(line, 3, 10, 4), (1, 2));
+    }
+
+    #[test]
+    fn test_tab_roundtrip() {
+        // Test that buffer_col -> display_col -> buffer_col round-trips
+        let line = "abc\tdef\tghi";
+        for buffer_col in 0..=line.chars().count() {
+            let display_col = display_col_from_buffer_col(line, buffer_col, 4);
+            let back = buffer_col_from_display_col(line, display_col, 4);
+            assert_eq!(back, buffer_col, "Roundtrip failed for buffer_col={buffer_col}");
+        }
+    }
+
+    #[test]
+    fn test_tab_at_end_of_line() {
+        let line = "hello\t";
+        // "hello" = 5 cols, tab at col 5 with tabstop=4 advances to col 8 (width 3)
+        assert_eq!(display_width_with_tabs(line, 4), 8);
+    }
+
+    // ========================================================================
+    // Unicode-aware function tests (CJK + tabs)
+    // ========================================================================
+
+    #[test]
+    fn test_char_display_width_ascii() {
+        assert_eq!(char_display_width('a'), 1);
+        assert_eq!(char_display_width('Z'), 1);
+        assert_eq!(char_display_width(' '), 1);
+        assert_eq!(char_display_width('!'), 1);
+    }
+
+    #[test]
+    fn test_char_display_width_cjk() {
+        // CJK ideographs are double-width
+        assert_eq!(char_display_width('中'), 2);
+        assert_eq!(char_display_width('日'), 2);
+        assert_eq!(char_display_width('本'), 2);
+        assert_eq!(char_display_width('語'), 2);
+    }
+
+    #[test]
+    fn test_char_display_width_fullwidth() {
+        // Fullwidth ASCII variants
+        assert_eq!(char_display_width('Ａ'), 2); // Fullwidth A
+        assert_eq!(char_display_width('１'), 2); // Fullwidth 1
+    }
+
+    #[test]
+    fn test_char_display_width_combining() {
+        // Combining marks have width 0
+        assert_eq!(char_display_width('\u{0301}'), 0); // Combining acute accent
+        assert_eq!(char_display_width('\u{0308}'), 0); // Combining diaeresis
+    }
+
+    #[test]
+    fn test_display_width_unicode_ascii() {
+        assert_eq!(display_width_unicode("Hello", 4), 5);
+        assert_eq!(display_width_unicode("Hello World", 4), 11);
+    }
+
+    #[test]
+    fn test_display_width_unicode_cjk() {
+        // 5 CJK characters = 10 display columns
+        assert_eq!(display_width_unicode("中文测试字", 4), 10);
+        // 3 CJK = 6 columns
+        assert_eq!(display_width_unicode("日本語", 4), 6);
+    }
+
+    #[test]
+    fn test_display_width_unicode_mixed() {
+        // "Hello中文" = 5 + 4 = 9 columns
+        assert_eq!(display_width_unicode("Hello中文", 4), 9);
+        // "a中b" = 1 + 2 + 1 = 4 columns
+        assert_eq!(display_width_unicode("a中b", 4), 4);
+    }
+
+    #[test]
+    fn test_display_width_unicode_with_tabs() {
+        // "a\t中" with tabstop=4: a(1) + tab(3) + 中(2) = 6
+        assert_eq!(display_width_unicode("a\t中", 4), 6);
+        // "\t中" with tabstop=4: tab(4) + 中(2) = 6
+        assert_eq!(display_width_unicode("\t中", 4), 6);
+    }
+
+    #[test]
+    fn test_display_width_unicode_combining() {
+        // "é" as e + combining accent = 1 + 0 = 1
+        assert_eq!(display_width_unicode("e\u{0301}", 4), 1);
+        // "naïve" with combining diaeresis
+        assert_eq!(display_width_unicode("nai\u{0308}ve", 4), 5);
+    }
+
+    #[test]
+    fn test_display_width_unicode_tabs_and_cjk_integration() {
+        // Critical integration test: tabs + CJK in same line
+        // "中\t日" with tabstop=4: 中(2) + tab(2 to reach 4) + 日(2) = 6
+        assert_eq!(display_width_unicode("中\t日", 4), 6);
+        // "a中\tb" with tabstop=4: a(1) + 中(2) + tab(1 to reach 4) + b(1) = 5
+        assert_eq!(display_width_unicode("a中\tb", 4), 5);
+    }
+
+    #[test]
+    fn test_display_col_from_buffer_col_unicode_cjk() {
+        let line = "a中b";
+        // Buffer col 0 = display col 0
+        assert_eq!(display_col_from_buffer_col_unicode(line, 0, 4), 0);
+        // Buffer col 1 (after 'a') = display col 1
+        assert_eq!(display_col_from_buffer_col_unicode(line, 1, 4), 1);
+        // Buffer col 2 (after '中') = display col 3 (1 + 2)
+        assert_eq!(display_col_from_buffer_col_unicode(line, 2, 4), 3);
+        // Buffer col 3 (after 'b') = display col 4
+        assert_eq!(display_col_from_buffer_col_unicode(line, 3, 4), 4);
+    }
+
+    #[test]
+    fn test_buffer_col_from_display_col_unicode_cjk() {
+        let line = "a中b";
+        // Display col 0 = buffer col 0
+        assert_eq!(buffer_col_from_display_col_unicode(line, 0, 4), 0);
+        // Display col 1 = buffer col 1 (at '中')
+        assert_eq!(buffer_col_from_display_col_unicode(line, 1, 4), 1);
+        // Display col 2 = buffer col 1 (inside '中', can't land here)
+        assert_eq!(buffer_col_from_display_col_unicode(line, 2, 4), 1);
+        // Display col 3 = buffer col 2 (at 'b')
+        assert_eq!(buffer_col_from_display_col_unicode(line, 3, 4), 2);
+        // Display col 4 = buffer col 3 (after 'b')
+        assert_eq!(buffer_col_from_display_col_unicode(line, 4, 4), 3);
+    }
+
+    #[test]
+    fn test_display_position_unicode_cjk() {
+        let line = "a中b";
+        // Buffer col 2 (at 'b') = display col 3
+        assert_eq!(display_position_unicode(line, 2, 80, 4), (0, 3));
+    }
+
+    #[test]
+    fn test_unicode_roundtrip_cjk() {
+        let line = "Hello中文World";
+        for buffer_col in 0..=line.chars().count() {
+            let display_col = display_col_from_buffer_col_unicode(line, buffer_col, 4);
+            let back = buffer_col_from_display_col_unicode(line, display_col, 4);
+            assert_eq!(back, buffer_col, "Roundtrip failed for buffer_col={buffer_col}");
+        }
+    }
+
+    #[test]
+    fn test_unicode_roundtrip_tabs_and_cjk() {
+        let line = "a\t中\tb";
+        for buffer_col in 0..=line.chars().count() {
+            let display_col = display_col_from_buffer_col_unicode(line, buffer_col, 4);
+            let back = buffer_col_from_display_col_unicode(line, display_col, 4);
+            assert_eq!(back, buffer_col, "Roundtrip failed for buffer_col={buffer_col}");
+        }
+    }
+
+    #[test]
+    fn test_cursor_never_lands_inside_wide_char() {
+        let line = "中"; // Single CJK char, 2 columns wide
+        // Display col 0 = buffer col 0 (at start of '中')
+        assert_eq!(buffer_col_from_display_col_unicode(line, 0, 4), 0);
+        // Display col 1 = buffer col 0 (inside '中', stays at start)
+        assert_eq!(buffer_col_from_display_col_unicode(line, 1, 4), 0);
+        // Display col 2 = buffer col 1 (after '中')
+        assert_eq!(buffer_col_from_display_col_unicode(line, 2, 4), 1);
+    }
+
+    #[test]
+    fn test_display_line_count_unicode() {
+        // CJK text that wraps
+        let line = "中文中文中"; // 5 chars * 2 = 10 columns
+        assert_eq!(display_line_count_unicode(line, 8, 4), 2); // 10 / 8 = 2
+        assert_eq!(display_line_count_unicode(line, 10, 4), 1); // 10 / 10 = 1
+        assert_eq!(display_line_count_unicode(line, 4, 4), 3); // 10 / 4 = 3
     }
 }

--- a/runner/src/server/app/mod.rs
+++ b/runner/src/server/app/mod.rs
@@ -12,7 +12,7 @@ mod visual;
 
 pub use {
     char_ops::{CharWaitState, FindType, LastFind, PendingCharOp},
-    repeat::{PendingEditBatch, RepeatState},
+    repeat::{InsertEntryType, MAX_INSERT_COUNT, PendingEditBatch, RepeatState},
     search::{SearchDirection, SearchState},
     undotree::{DiffPreviewLine, UndotreeRenderLine, UndotreeState},
     visual::LastVisualSelection,

--- a/runner/src/server/app/repeat.rs
+++ b/runner/src/server/app/repeat.rs
@@ -96,6 +96,24 @@ impl PendingEditBatch {
 // Repeat Infrastructure
 // ============================================================================
 
+/// Maximum insert count to prevent denial-of-service (e.g., `999999i` would be very slow).
+pub const MAX_INSERT_COUNT: usize = 999;
+
+/// Type of command that entered insert mode.
+///
+/// Used by the repeat system to know how to repeat text on exit.
+/// For example, "3o" opens a line and repeats text on 2 more new lines on exit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InsertEntryType {
+    /// Normal insert (i, a, I, A) - repeat text inline.
+    #[default]
+    Inline,
+    /// Open line below (o) - repeat text on new lines below.
+    OpenBelow,
+    /// Open line above (O) - repeat text on new lines above.
+    OpenAbove,
+}
+
 /// State for the repeat command (`.`).
 ///
 /// Tracks the last repeatable command so that `.` can re-execute it.
@@ -114,19 +132,89 @@ pub struct RepeatState {
 
     /// Whether we're currently accumulating insert text.
     pub accumulating: bool,
+
+    /// Count for insert mode entry (e.g., `3i` means repeat text 3 times).
+    ///
+    /// Defaults to 1. Set when entering insert mode with a count prefix.
+    /// Used by `ExitToNormal` to repeat the accumulated text.
+    insert_count: usize,
+
+    /// Type of command that entered insert mode.
+    ///
+    /// Used to determine how to repeat text on exit:
+    /// - `Inline`: repeat text at cursor (i, a, I, A)
+    /// - `OpenBelow`: repeat text on new lines below (o)
+    /// - `OpenAbove`: repeat text on new lines above (O)
+    insert_entry_type: InsertEntryType,
 }
 
 impl RepeatState {
     /// Create a new empty repeat state.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            insert_count: 1,
+            ..Self::default()
+        }
     }
 
-    /// Start accumulating insert mode text.
-    pub fn start_accumulating(&mut self) {
+    /// Start accumulating insert mode text with an optional count and entry type.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Repeat count for insert mode (e.g., 3 for `3i`).
+    ///   Values of 0 default to 1. Values above `MAX_INSERT_COUNT` are capped.
+    /// * `entry_type` - How insert mode was entered (affects how text is repeated).
+    pub fn start_accumulating_with_count_and_type(
+        &mut self,
+        count: usize,
+        entry_type: InsertEntryType,
+    ) {
         self.accumulating = true;
         self.insert_text.clear();
+        self.set_insert_count(count);
+        self.insert_entry_type = entry_type;
+    }
+
+    /// Start accumulating insert mode text with an optional count.
+    ///
+    /// Uses `InsertEntryType::Inline` by default.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Repeat count for insert mode (e.g., 3 for `3i`).
+    ///   Values of 0 default to 1. Values above `MAX_INSERT_COUNT` are capped.
+    pub fn start_accumulating_with_count(&mut self, count: usize) {
+        self.start_accumulating_with_count_and_type(count, InsertEntryType::Inline);
+    }
+
+    /// Start accumulating insert mode text (count defaults to 1, inline entry).
+    pub fn start_accumulating(&mut self) {
+        self.start_accumulating_with_count(1);
+    }
+
+    /// Get the insert entry type.
+    #[must_use]
+    pub const fn get_insert_entry_type(&self) -> InsertEntryType {
+        self.insert_entry_type
+    }
+
+    /// Set the insert count with validation.
+    ///
+    /// - Count of 0 is treated as 1 (no repetition)
+    /// - Count above `MAX_INSERT_COUNT` is capped
+    pub fn set_insert_count(&mut self, count: usize) {
+        self.insert_count = if count == 0 {
+            1
+        } else {
+            count.min(MAX_INSERT_COUNT)
+        };
+    }
+
+    /// Get the current insert count.
+    #[must_use]
+    pub const fn get_insert_count(&self) -> usize {
+        self.insert_count
     }
 
     /// Add text to the insert accumulator.
@@ -153,6 +241,8 @@ impl RepeatState {
         self.last_command = None;
         self.insert_text.clear();
         self.accumulating = false;
+        self.insert_count = 1;
+        self.insert_entry_type = InsertEntryType::Inline;
     }
 }
 
@@ -226,12 +316,129 @@ mod tests {
     fn test_repeat_state_clear() {
         let mut state = RepeatState::new();
         state.record_command("change");
-        state.start_accumulating();
+        state.start_accumulating_with_count(5);
         state.accumulate_insert("text");
 
         state.clear();
         assert!(state.last_command.is_none());
         assert!(state.insert_text.is_empty());
         assert!(!state.accumulating);
+        assert_eq!(state.get_insert_count(), 1);
+    }
+
+    #[test]
+    fn test_repeat_state_insert_count_default() {
+        let state = RepeatState::new();
+        assert_eq!(state.get_insert_count(), 1);
+    }
+
+    #[test]
+    fn test_repeat_state_set_insert_count() {
+        let mut state = RepeatState::new();
+        state.set_insert_count(3);
+        assert_eq!(state.get_insert_count(), 3);
+    }
+
+    #[test]
+    fn test_repeat_state_insert_count_zero_becomes_one() {
+        let mut state = RepeatState::new();
+        state.set_insert_count(0);
+        assert_eq!(state.get_insert_count(), 1);
+    }
+
+    #[test]
+    fn test_repeat_state_insert_count_capped() {
+        let mut state = RepeatState::new();
+        state.set_insert_count(1000);
+        assert_eq!(state.get_insert_count(), MAX_INSERT_COUNT);
+
+        state.set_insert_count(10000);
+        assert_eq!(state.get_insert_count(), MAX_INSERT_COUNT);
+    }
+
+    #[test]
+    fn test_repeat_state_insert_count_max_accepted() {
+        let mut state = RepeatState::new();
+        state.set_insert_count(MAX_INSERT_COUNT);
+        assert_eq!(state.get_insert_count(), MAX_INSERT_COUNT);
+    }
+
+    #[test]
+    fn test_repeat_state_start_accumulating_with_count() {
+        let mut state = RepeatState::new();
+        state.start_accumulating_with_count(5);
+        assert!(state.accumulating);
+        assert!(state.insert_text.is_empty());
+        assert_eq!(state.get_insert_count(), 5);
+    }
+
+    #[test]
+    fn test_repeat_state_sequential_inserts_reset_count() {
+        let mut state = RepeatState::new();
+
+        // First insert with count 3
+        state.start_accumulating_with_count(3);
+        state.accumulate_insert("hello");
+        state.stop_accumulating();
+        assert_eq!(state.get_insert_count(), 3);
+
+        // Second insert without explicit count
+        state.start_accumulating();
+        assert_eq!(state.get_insert_count(), 1);
+    }
+
+    // =========================================================================
+    // Insert Entry Type Tests
+    // =========================================================================
+
+    #[test]
+    fn test_insert_entry_type_default() {
+        let state = RepeatState::new();
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::Inline);
+    }
+
+    #[test]
+    fn test_start_accumulating_with_count_and_type_inline() {
+        let mut state = RepeatState::new();
+        state.start_accumulating_with_count_and_type(3, InsertEntryType::Inline);
+        assert!(state.accumulating);
+        assert_eq!(state.get_insert_count(), 3);
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::Inline);
+    }
+
+    #[test]
+    fn test_start_accumulating_with_count_and_type_open_below() {
+        let mut state = RepeatState::new();
+        state.start_accumulating_with_count_and_type(5, InsertEntryType::OpenBelow);
+        assert!(state.accumulating);
+        assert_eq!(state.get_insert_count(), 5);
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::OpenBelow);
+    }
+
+    #[test]
+    fn test_start_accumulating_with_count_and_type_open_above() {
+        let mut state = RepeatState::new();
+        state.start_accumulating_with_count_and_type(2, InsertEntryType::OpenAbove);
+        assert!(state.accumulating);
+        assert_eq!(state.get_insert_count(), 2);
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::OpenAbove);
+    }
+
+    #[test]
+    fn test_clear_resets_entry_type() {
+        let mut state = RepeatState::new();
+        state.start_accumulating_with_count_and_type(5, InsertEntryType::OpenBelow);
+        state.clear();
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::Inline);
+    }
+
+    #[test]
+    fn test_start_accumulating_without_type_defaults_to_inline() {
+        let mut state = RepeatState::new();
+        // First set it to something else
+        state.start_accumulating_with_count_and_type(3, InsertEntryType::OpenBelow);
+        // Then start accumulating with just count
+        state.start_accumulating_with_count(5);
+        assert_eq!(state.get_insert_entry_type(), InsertEntryType::Inline);
     }
 }

--- a/runner/src/server/event_loop/mod.rs
+++ b/runner/src/server/event_loop/mod.rs
@@ -92,6 +92,15 @@ pub struct EventLoop<F: InputFallbackHandler<AppState>> {
     /// stores the target here, and we apply it after command execution.
     /// This enables event-driven mode transitions without hardcoded command names.
     pending_mode_change: Arc<Mutex<Option<ModeId>>>,
+
+    /// Pending count for the next command.
+    ///
+    /// In Vim, typing "3i" enters insert mode and repeats the text 3 times on exit.
+    /// Digits pressed in normal mode (without modifiers) accumulate here until
+    /// a non-digit command key is pressed.
+    ///
+    /// Reset after command execution or when leaving normal mode.
+    pending_count: Option<usize>,
 }
 
 impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
@@ -138,6 +147,7 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             key_reader: None,
             last_error: None,
             pending_mode_change,
+            pending_count: None,
         }
     }
 
@@ -199,11 +209,12 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
     ///
     /// This is the core dispatch logic:
     /// 0. Check for char-wait state (find-char commands)
-    /// 1. Add key to pending sequence
-    /// 2. Look up in keymap
-    /// 3. If found: execute command
-    /// 4. If prefix: wait for more keys
-    /// 5. If not found: delegate to fallback handler
+    /// 1. Check for count prefix (digits in normal mode)
+    /// 2. Add key to pending sequence
+    /// 3. Look up in keymap
+    /// 4. If found: execute command
+    /// 5. If prefix: wait for more keys
+    /// 6. If not found: delegate to fallback handler
     fn handle_key(&mut self, key: KeyEvent) {
         profile_scope!("handle_key", "runner::event_loop");
 
@@ -216,6 +227,13 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
         // Check for pending character operation (f/F/t/T or r waiting for character)
         if self.app.has_pending_char() {
             self.handle_pending_char(key);
+            return;
+        }
+
+        // Check for count prefix (digits 1-9, or 0 if already have count) in normal mode
+        // Digits without modifiers accumulate as a count prefix
+        if self.is_count_digit(&key) {
+            self.accumulate_count_digit(&key);
             return;
         }
 
@@ -232,8 +250,14 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                 // (any command breaks insert mode batching)
                 self.app.flush_pending_edits();
 
-                // Build command context (TODO: parse count/register from pending keys)
+                // Build command context with count from pending_count
                 let mut ctx = CommandContext::new();
+
+                // Set count in context if we have a pending count
+                let command_count = self.pending_count.take();
+                if let Some(count) = command_count {
+                    ctx.set("count", reovim_driver_command::ArgValue::Count(count));
+                }
 
                 // Set buffer_id in context if we have an active buffer
                 if let Some(buffer_id) = self.app.active_buffer {
@@ -248,6 +272,9 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                     self.save_visual_selection_if_active();
                 }
 
+                // Track current mode before command for insert mode detection
+                let mode_before = self.app.current_mode().clone();
+
                 // Clear pending mode change before command execution
                 if let Ok(mut guard) = self.pending_mode_change.lock() {
                     *guard = None;
@@ -260,9 +287,39 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                     // Handle mode transition from ModeChanged events
                     // Commands emit ModeChanged::with_mode_id() which sets pending_mode_change.
                     // This event-driven approach replaces hardcoded mode_for_command() mapping.
-                    if let Ok(mut guard) = self.pending_mode_change.lock()
-                        && let Some(new_mode) = guard.take()
-                    {
+                    //
+                    // Extract mode change from mutex before processing to avoid borrow issues
+                    let new_mode = self
+                        .pending_mode_change
+                        .lock()
+                        .ok()
+                        .and_then(|mut guard| guard.take());
+
+                    if let Some(new_mode) = new_mode {
+                        // Check if entering insert mode - start accumulation with count
+                        if new_mode.name() == "insert" && mode_before.name() != "insert" {
+                            use crate::server::app::InsertEntryType;
+
+                            let insert_count = command_count.unwrap_or(1);
+
+                            // Determine entry type based on command
+                            let entry_type = if cmd_id.name() == "open-line-below" {
+                                InsertEntryType::OpenBelow
+                            } else if cmd_id.name() == "open-line-above" {
+                                InsertEntryType::OpenAbove
+                            } else {
+                                InsertEntryType::Inline
+                            };
+
+                            self.app
+                                .repeat_state
+                                .start_accumulating_with_count_and_type(insert_count, entry_type);
+                        }
+                        // Check if exiting insert mode - handle text repetition
+                        else if mode_before.name() == "insert" && new_mode.name() != "insert" {
+                            self.handle_insert_mode_exit();
+                        }
+
                         self.app.mode_stack.set(new_mode);
                     }
                 } else {
@@ -566,6 +623,118 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
     pub fn keymap_registry_mut(&mut self) -> &mut KeymapRegistry {
         &mut self.keymap_registry
     }
+
+    // ========================================================================
+    // Count Prefix Handling (for 3i, 5o, etc.)
+    // ========================================================================
+
+    /// Check if a key is a count digit.
+    ///
+    /// In Vim, digits 1-9 start a count, and 0 continues an existing count.
+    /// This only applies in normal/visual modes and only without modifiers.
+    fn is_count_digit(&self, key: &KeyEvent) -> bool {
+        use reovim_driver_input::KeyCode;
+
+        // Only in normal or visual modes (not insert, not operator-pending, etc.)
+        let mode_name = self.app.current_mode().name();
+        if mode_name != "normal" && !mode_name.starts_with("visual") {
+            return false;
+        }
+
+        // No modifiers allowed for count digits
+        if !key.modifiers.is_empty() {
+            return false;
+        }
+
+        // Check if it's a digit
+        match key.code {
+            KeyCode::Char(c) => {
+                if c.is_ascii_digit() {
+                    // 1-9 can start a count, 0 can only continue
+                    c != '0' || self.pending_count.is_some()
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Accumulate a digit into the pending count.
+    ///
+    /// Called when `is_count_digit` returns true. Multiplies existing count
+    /// by 10 and adds the new digit.
+    fn accumulate_count_digit(&mut self, key: &KeyEvent) {
+        use reovim_driver_input::KeyCode;
+
+        if let KeyCode::Char(c) = key.code
+            && let Some(digit) = c.to_digit(10)
+        {
+            let digit = digit as usize;
+            let current = self.pending_count.unwrap_or(0);
+            // Prevent overflow by capping at MAX_INSERT_COUNT
+            let new_count = current.saturating_mul(10).saturating_add(digit);
+            self.pending_count = Some(new_count.min(crate::server::app::MAX_INSERT_COUNT));
+        }
+    }
+
+    // ========================================================================
+    // Insert Mode Exit Handling
+    // ========================================================================
+
+    /// Handle insert mode exit (repeat accumulated text if count > 1).
+    ///
+    /// Behavior depends on how insert mode was entered:
+    /// - `Inline` (i/a/I/A): "3ihello<Esc>" inserts "hellohellohello"
+    /// - `OpenBelow` (o): "3ohello<Esc>" creates 3 lines each with "hello"
+    /// - `OpenAbove` (O): "3Ohello<Esc>" creates 3 lines each with "hello"
+    fn handle_insert_mode_exit(&mut self) {
+        use crate::server::app::InsertEntryType;
+
+        // Stop accumulating and get the count and entry type
+        self.app.repeat_state.stop_accumulating();
+        let count = self.app.repeat_state.get_insert_count();
+        let entry_type = self.app.repeat_state.get_insert_entry_type();
+
+        // If count > 1, repeat the accumulated text
+        if count > 1 {
+            let text = self.app.repeat_state.insert_text.clone();
+            if !text.is_empty() {
+                // Get the active buffer
+                if let Some(buffer_id) = self.app.active_buffer
+                    && let Some(buffer_arc) = self.app.kernel.buffers.get(buffer_id)
+                {
+                    let mut buffer = buffer_arc.write();
+                    let cursor_before = buffer.position();
+
+                    // Build the repeat text based on entry type
+                    let repeat_text = match entry_type {
+                        InsertEntryType::Inline => {
+                            // Repeat text inline (e.g., "3itest" -> "testtesttest")
+                            text.repeat(count - 1)
+                        }
+                        InsertEntryType::OpenBelow | InsertEntryType::OpenAbove => {
+                            // Repeat text on new lines (e.g., "3otest" -> 3 lines with "test")
+                            // Format: newline + text, repeated (count-1) times
+                            format!("\n{text}").repeat(count - 1)
+                        }
+                    };
+
+                    let edit = buffer.insert(&repeat_text);
+                    let cursor_after = buffer.position();
+                    drop(buffer);
+
+                    // Record the edit for undo
+                    self.app.undo_registry.record(
+                        buffer_id,
+                        vec![edit],
+                        cursor_before,
+                        cursor_after,
+                    );
+                }
+            }
+        }
+    }
 }
 
 impl<F: InputFallbackHandler<AppState>> std::fmt::Debug for EventLoop<F> {
@@ -828,4 +997,100 @@ mod tests {
 
     // Note: mode_for_command tests and helpers removed as part of Epic #284.
     // Mode transitions are now event-driven via ModeChanged events with target_mode.
+
+    // =========================================================================
+    // Count Prefix Tests
+    // =========================================================================
+
+    #[test]
+    fn test_is_count_digit_in_normal_mode() {
+        let event_loop = create_test_event_loop();
+
+        // 1-9 can start a count
+        assert!(event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('1'))));
+        assert!(event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('5'))));
+        assert!(event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('9'))));
+
+        // 0 cannot start a count (it's "go to beginning of line")
+        assert!(!event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('0'))));
+
+        // Letters are not count digits
+        assert!(!event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('a'))));
+        assert!(!event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('i'))));
+    }
+
+    #[test]
+    fn test_is_count_digit_with_modifiers() {
+        use reovim_driver_input::Modifiers;
+
+        let event_loop = create_test_event_loop();
+
+        // Digits with modifiers are not count digits
+        let ctrl_1 = KeyEvent::with_modifiers(KeyCode::Char('1'), Modifiers::CTRL);
+        assert!(!event_loop.is_count_digit(&ctrl_1));
+
+        let alt_5 = KeyEvent::with_modifiers(KeyCode::Char('5'), Modifiers::ALT);
+        assert!(!event_loop.is_count_digit(&alt_5));
+    }
+
+    #[test]
+    fn test_is_count_digit_zero_continues_count() {
+        let mut event_loop = create_test_event_loop();
+
+        // Set a pending count
+        event_loop.pending_count = Some(3);
+
+        // Now 0 can continue the count
+        assert!(event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('0'))));
+    }
+
+    #[test]
+    fn test_accumulate_count_digit() {
+        let mut event_loop = create_test_event_loop();
+
+        // Accumulate "123"
+        event_loop.accumulate_count_digit(&KeyEvent::new(KeyCode::Char('1')));
+        assert_eq!(event_loop.pending_count, Some(1));
+
+        event_loop.accumulate_count_digit(&KeyEvent::new(KeyCode::Char('2')));
+        assert_eq!(event_loop.pending_count, Some(12));
+
+        event_loop.accumulate_count_digit(&KeyEvent::new(KeyCode::Char('3')));
+        assert_eq!(event_loop.pending_count, Some(123));
+    }
+
+    #[test]
+    fn test_accumulate_count_digit_capped() {
+        let mut event_loop = create_test_event_loop();
+
+        // Set a high count and try to exceed MAX_INSERT_COUNT
+        event_loop.pending_count = Some(990);
+        event_loop.accumulate_count_digit(&KeyEvent::new(KeyCode::Char('9')));
+
+        // Should be capped at MAX_INSERT_COUNT (999)
+        assert_eq!(event_loop.pending_count, Some(crate::server::app::MAX_INSERT_COUNT));
+    }
+
+    #[test]
+    fn test_pending_count_initially_none() {
+        let event_loop = create_test_event_loop();
+        assert!(event_loop.pending_count.is_none());
+    }
+
+    #[test]
+    fn test_count_digit_in_insert_mode_not_counted() {
+        let kernel = KernelContext::default();
+        let insert_mode = ModeId::new(ModuleId::new("editor"), "insert");
+        let app = AppState::new(kernel, insert_mode);
+        let event_loop = EventLoop::new(
+            app,
+            ModeRegistry::new(),
+            CommandRegistry::new(),
+            KeymapRegistry::new(),
+            NoOpFallback,
+        );
+
+        // In insert mode, digits are not count prefixes
+        assert!(!event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('3'))));
+    }
 }

--- a/runner/src/server/mod.rs
+++ b/runner/src/server/mod.rs
@@ -170,7 +170,7 @@ use {
     reovim_driver_vfs::{StandardVfs, VfsDriver},
     reovim_kernel::api::v1::{
         EventBus, KernelContext, MarkBank, ModeId, Module, ModuleContext, ModuleId, MotionEngine,
-        OptionRegistry, RegisterBank, TextObjectEngine,
+        OptionRegistry, OptionScope, OptionSpec, OptionValue, RegisterBank, TextObjectEngine,
     },
     reovim_module_editor::{EditorMode, command::all_commands},
     reovim_module_keymap::KeymapModule,
@@ -765,6 +765,9 @@ const fn fallback_default_mode() -> ModeId {
 /// Unlike `KernelContext::default()` which uses stubs, this creates
 /// a fully functional kernel context suitable for actual editing.
 fn real_kernel_context() -> KernelContext {
+    let option_registry = Arc::new(OptionRegistry::new());
+    register_default_options(&option_registry);
+
     KernelContext::new(
         Arc::new(EventBus::new()),
         Arc::new(SimpleBufferManager::new()),
@@ -772,8 +775,43 @@ fn real_kernel_context() -> KernelContext {
         Arc::new(TextObjectEngine),
         Arc::new(RwLock::new(RegisterBank::new())),
         Arc::new(RwLock::new(MarkBank::new())),
-        Arc::new(OptionRegistry::new()),
+        option_registry,
     )
+}
+
+/// Register default editor options.
+///
+/// These options are registered at startup and available to all modules.
+/// Following mechanism vs policy: the registry (mechanism) is in kernel,
+/// the option definitions (policy) are here in the runner.
+fn register_default_options(registry: &OptionRegistry) {
+    // Indentation options
+    let _ = registry.register(
+        OptionSpec::new(
+            "autoindent",
+            "Copy indent from current line when starting new line",
+            OptionValue::bool(true),
+        )
+        .with_short("ai")
+        .with_scope(OptionScope::Buffer),
+    );
+
+    let _ = registry.register(
+        OptionSpec::new(
+            "smartindent",
+            "Smart autoindenting for C-like languages",
+            OptionValue::bool(false),
+        )
+        .with_short("si")
+        .with_scope(OptionScope::Buffer),
+    );
+
+    // Tab options (for display line calculations)
+    let _ = registry.register(
+        OptionSpec::new("tabstop", "Number of spaces that a tab counts for", OptionValue::int(8))
+            .with_short("ts")
+            .with_scope(OptionScope::Buffer),
+    );
 }
 
 /// Create the standard VFS for file operations.


### PR DESCRIPTION
…upport (#248)

Implements deferred enhancements from #233/#234:

Unicode-Aware Display Lines:
- Tab width support with contextual expansion (tabstop option)
- CJK double-width character handling via unicode-width crate
- New functions: display_width_unicode(), display_line_count_unicode(), display_position_unicode(), buffer_col_from_display_col_unicode()
- 46 comprehensive unit tests

Autoindent Infrastructure:
- o/O commands preserve current line indentation
- Enter key applies autoindent in insert mode
- get_line_indent() helper extracts leading whitespace
- Respects autoindent option from buffer-scoped OptionRegistry

Count Support:
- InsertEntryType enum: Inline, OpenBelow, OpenAbove
- RepeatState extended with count tracking
- Vim-style count prefix parsing (1-9 start, 0 continues)
- Count capped at 999 to prevent denial-of-service
- handle_insert_mode_exit() handles text repetition

Unicode-Aware gj/gk:
- CursorDisplayDown/Up use unicode-aware calculations
- Proper tab and CJK handling in wrapped line navigation

Closes #248
Parts of Epic #150
