### PR TITLE
test(e2e): enable 32 passing integration tests (#309-#314)

### DIFF
--- a/runner/tests/cursor_movement.rs
+++ b/runner/tests/cursor_movement.rs
@@ -1,4 +1,9 @@
 //! Cursor movement tests (hjkl, 0$, gg/G, w/b/e).
+//!
+//! **Status**: 10 tests enabled, 7 tests require additional features
+//! (count prefix handling, motions like $, ^, w, e, G).
+//!
+//! Run `cargo test --ignored` to run the remaining ignored tests.
 
 mod common;
 use common::IntegrationTest;
@@ -8,7 +13,6 @@ use common::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_j_moves_down() {
     let result = IntegrationTest::new()
         .await
@@ -20,7 +24,6 @@ async fn test_j_moves_down() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_k_moves_up() {
     let result = IntegrationTest::new()
         .await
@@ -32,7 +35,6 @@ async fn test_k_moves_up() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_l_moves_right() {
     let result = IntegrationTest::new()
         .await
@@ -44,7 +46,6 @@ async fn test_l_moves_right() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_h_moves_left() {
     let result = IntegrationTest::new()
         .await
@@ -84,7 +85,6 @@ async fn test_dollar_moves_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_0_moves_to_bol() {
     let result = IntegrationTest::new()
         .await
@@ -112,7 +112,6 @@ async fn test_caret_moves_to_first_nonblank() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_gg_moves_to_first_line() {
     let result = IntegrationTest::new()
         .await
@@ -164,7 +163,6 @@ async fn test_w_moves_to_next_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_b_moves_to_prev_word() {
     let result = IntegrationTest::new()
         .await
@@ -192,7 +190,6 @@ async fn test_e_moves_to_end_of_word() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_j_at_last_line() {
     let result = IntegrationTest::new()
         .await
@@ -204,7 +201,6 @@ async fn test_j_at_last_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_h_at_bol() {
     let result = IntegrationTest::new()
         .await
@@ -216,7 +212,6 @@ async fn test_h_at_bol() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_l_at_eol() {
     let result = IntegrationTest::new()
         .await

--- a/runner/tests/edge_cases.rs
+++ b/runner/tests/edge_cases.rs
@@ -1,4 +1,9 @@
 //! Edge case tests (empty buffer, Unicode, boundaries).
+//!
+//! **Status**: 9 tests enabled, 1 test requires additional features
+//! (Unicode insert handling).
+//!
+//! Run `cargo test --ignored` to run the remaining ignored tests.
 
 mod common;
 use common::IntegrationTest;
@@ -8,7 +13,6 @@ use common::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_dd_empty_buffer() {
     let result = IntegrationTest::new()
         .await
@@ -20,7 +24,6 @@ async fn test_dd_empty_buffer() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_x_empty_buffer() {
     let result = IntegrationTest::new()
         .await
@@ -32,7 +35,6 @@ async fn test_x_empty_buffer() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_yy_empty_buffer() {
     let result = IntegrationTest::new()
         .await
@@ -48,7 +50,6 @@ async fn test_yy_empty_buffer() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_dd_emoji_line() {
     let result = IntegrationTest::new()
         .await
@@ -60,7 +61,6 @@ async fn test_dd_emoji_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_yy_cjk_line() {
     let result = IntegrationTest::new()
         .await
@@ -88,7 +88,6 @@ async fn test_insert_unicode() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_dd_single_char() {
     let result = IntegrationTest::new()
         .await
@@ -100,7 +99,6 @@ async fn test_dd_single_char() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_x_single_char() {
     let result = IntegrationTest::new()
         .await
@@ -116,7 +114,6 @@ async fn test_x_single_char() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_dd_line_with_tabs() {
     let result = IntegrationTest::new()
         .await
@@ -128,7 +125,6 @@ async fn test_dd_line_with_tabs() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_yy_line_with_trailing_spaces() {
     let result = IntegrationTest::new()
         .await

--- a/runner/tests/multi_client_tests.rs
+++ b/runner/tests/multi_client_tests.rs
@@ -1,4 +1,9 @@
 //! Multi-client concurrent tests.
+//!
+//! **Status**: 1 test enabled, 2 tests require additional features
+//! (buffer sharing between clients).
+//!
+//! Run `cargo test --ignored` to run the remaining ignored tests.
 
 mod common;
 use common::MultiClientTest;
@@ -37,7 +42,6 @@ async fn test_clients_see_changes() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_three_clients_concurrent() {
     MultiClientTest::with_clients(3)
         .await

--- a/runner/tests/registers.rs
+++ b/runner/tests/registers.rs
@@ -1,4 +1,9 @@
 //! Register tests (unnamed, named, yank types).
+//!
+//! **Status**: 1 test enabled, 4 tests require additional features
+//! (register content query API).
+//!
+//! Run `cargo test --ignored` to run the remaining ignored tests.
 
 mod common;
 use common::IntegrationTest;
@@ -57,7 +62,6 @@ async fn test_named_register_a() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_named_register_paste() {
     let result = IntegrationTest::new()
         .await

--- a/runner/tests/search.rs
+++ b/runner/tests/search.rs
@@ -1,10 +1,9 @@
 //! Search integration tests (/, ?, n, N, *, #).
 //!
-//! **NOTE**: These tests are currently ignored because the server requires
-//! modules to be loaded for key bindings to function. The server follows
-//! a "mechanism vs policy" design where modules provide the actual editing
-//! behavior. Run with `cargo test --ignored` to run these tests when
-//! module loading is configured.
+//! **Status**: 3 tests enabled, 12 tests require additional features
+//! (search command mode, n/N commands).
+//!
+//! Run `cargo test --ignored` to run the remaining ignored tests.
 
 mod common;
 use common::IntegrationTest;
@@ -147,7 +146,6 @@ async fn test_search_word_forward() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_search_word_backward() {
     let result = IntegrationTest::new()
         .await
@@ -209,7 +207,6 @@ async fn test_search_regex_pattern() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_search_regex_word_boundary() {
     let result = IntegrationTest::new()
         .await
@@ -226,7 +223,6 @@ async fn test_search_regex_word_boundary() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_search_not_found() {
     let result = IntegrationTest::new()
         .await

--- a/runner/tests/undo_redo.rs
+++ b/runner/tests/undo_redo.rs
@@ -1,10 +1,11 @@
 //! Undo/redo tests (u, Ctrl-R).
+//!
+//! **Status**: All 8 tests enabled and passing.
 
 mod common;
 use common::IntegrationTest;
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_undo_delete_line() {
     let result = IntegrationTest::new()
         .await
@@ -16,7 +17,6 @@ async fn test_undo_delete_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_redo_after_undo() {
     let result = IntegrationTest::new()
         .await
@@ -28,7 +28,6 @@ async fn test_redo_after_undo() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_multiple_undo() {
     let result = IntegrationTest::new()
         .await
@@ -40,7 +39,6 @@ async fn test_multiple_undo() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_undo_insert() {
     let result = IntegrationTest::new()
         .await
@@ -52,7 +50,6 @@ async fn test_undo_insert() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_multiple_redo() {
     let result = IntegrationTest::new()
         .await
@@ -64,7 +61,6 @@ async fn test_multiple_redo() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_undo_change_word() {
     let result = IntegrationTest::new()
         .await
@@ -76,7 +72,6 @@ async fn test_undo_change_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_undo_nothing_to_undo() {
     // Undo on fresh buffer should not crash
     let result = IntegrationTest::new()
@@ -89,7 +84,6 @@ async fn test_undo_nothing_to_undo() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_redo_nothing_to_redo() {
     // Redo without prior undo should not crash
     let result = IntegrationTest::new()


### PR DESCRIPTION
## Summary
- Enable 32 E2E tests that now pass after keymap infrastructure fixes
- Tests cover cursor movement, search, undo/redo, edge cases, registers, multi-client

## Changes by Issue

| Issue | Tests Enabled | Tests Ignored | Category |
|-------|---------------|---------------|----------|
| #309 | 10 | 7 | Cursor movement (hjkl, gg, 0, b) |
| #310 | 3 | 12 | Search (#, word boundary, not found) |
| #311 | 8 | 0 | Undo/redo (all passing) |
| #312 | 9 | 1 | Edge cases (empty, Unicode, tabs) |
| #313 | 1 | 4 | Registers (named paste) |
| #314 | 1 | 2 | Multi-client (concurrent connections) |

**Total: 32 enabled, 26 remain ignored** (require count prefix, motions, register API)

## Test plan
- [x] `./scripts/check.sh` passes
- [x] All 32 enabled tests pass
- [x] Ignored tests documented with reason

Refs #309, #310, #311, #312, #313, #314, Parts of #307