### PR TITLE
feat(operators): add operator-motion combinations (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- Register selection prefix (`"a`) - specify register for yank/delete/paste (#333)
+  - `"ayy` yanks line into register 'a'
+  - `"ap` pastes from register 'a'
+  - `"add` deletes line into register 'a'
+  - Supports a-z, A-Z (append), 0-9, special registers
+
+- Search commands now functional (#335)
+  - `/pattern<Enter>` - Forward search
+  - `?pattern<Enter>` - Backward search
+  - `n` / `N` - Next/previous match
+  - `*` / `#` - Search word under cursor
+
+- Operator-motion combinations (#336)
+  - `dw`, `db`, `d$`, `dj`, `dk`, `dgg`, `dG` - Delete with motion
+  - `cw`, `cb`, `c$`, `cj`, `ck` - Change with motion (enters insert mode)
+  - `yw`, `yb`, `y$`, `yj`, `yk` - Yank with motion
+  - Escape cancels pending operator
+  - Full operator-pending mode support
+
 ### Changed
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "reovim-module-keymap",
  "reovim-module-layout",
  "reovim-module-motions",
+ "reovim-module-operators",
  "reovim-module-undotree",
  "reovim-protocol",
  "serde",

--- a/lib/drivers/command/src/context.rs
+++ b/lib/drivers/command/src/context.rs
@@ -34,6 +34,11 @@ pub struct CommandContext {
     /// Set by the runner before dispatching commands that may need
     /// filesystem access (e.g., `:w`, `:e`).
     vfs: Option<Arc<dyn VfsDriver>>,
+    /// Current mode name (e.g., "normal", "operator-pending").
+    ///
+    /// Set by the runner before dispatching commands. Commands can use
+    /// this to adjust their behavior based on the current mode.
+    mode_name: Option<String>,
 }
 
 impl std::fmt::Debug for CommandContext {
@@ -41,6 +46,7 @@ impl std::fmt::Debug for CommandContext {
         f.debug_struct("CommandContext")
             .field("args", &self.args)
             .field("vfs", &self.vfs.as_ref().map(|_| "<VfsDriver>"))
+            .field("mode_name", &self.mode_name)
             .finish()
     }
 }
@@ -157,6 +163,36 @@ impl CommandContext {
     pub fn vfs(&self) -> Option<&Arc<dyn VfsDriver>> {
         self.vfs.as_ref()
     }
+
+    /// Set the current mode name.
+    ///
+    /// Called by the runner before dispatching commands. Commands can
+    /// use `mode_name()` to adjust behavior based on the current mode.
+    pub fn set_mode_name(&mut self, mode: impl Into<String>) {
+        self.mode_name = Some(mode.into());
+    }
+
+    /// Get the current mode name.
+    ///
+    /// Returns the mode name (e.g., "normal", "operator-pending", "insert").
+    /// Commands can use this to adjust behavior. For example, motion commands
+    /// return `CommandResult::OperatorRange` in operator-pending mode instead
+    /// of moving the cursor.
+    #[must_use]
+    pub fn mode_name(&self) -> Option<&str> {
+        self.mode_name.as_deref()
+    }
+
+    /// Check if the current mode is operator-pending.
+    ///
+    /// Convenience method for motion commands to check if they should return
+    /// a range instead of moving the cursor.
+    #[must_use]
+    pub fn is_operator_pending(&self) -> bool {
+        self.mode_name
+            .as_ref()
+            .is_some_and(|m| m == "operator-pending")
+    }
 }
 
 #[cfg(test)]
@@ -251,5 +287,30 @@ mod tests {
         let ctx = CommandContext::new().with_vfs(vfs);
         let debug_str = format!("{ctx:?}");
         assert!(debug_str.contains("<VfsDriver>"));
+    }
+
+    #[test]
+    fn test_command_context_mode_name_none_by_default() {
+        let ctx = CommandContext::new();
+        assert!(ctx.mode_name().is_none());
+    }
+
+    #[test]
+    fn test_command_context_set_mode_name() {
+        let mut ctx = CommandContext::new();
+        ctx.set_mode_name("operator-pending");
+        assert_eq!(ctx.mode_name(), Some("operator-pending"));
+    }
+
+    #[test]
+    fn test_command_context_is_operator_pending() {
+        let mut ctx = CommandContext::new();
+        assert!(!ctx.is_operator_pending());
+
+        ctx.set_mode_name("operator-pending");
+        assert!(ctx.is_operator_pending());
+
+        ctx.set_mode_name("normal");
+        assert!(!ctx.is_operator_pending());
     }
 }

--- a/lib/drivers/command/src/result/mod.rs
+++ b/lib/drivers/command/src/result/mod.rs
@@ -117,6 +117,18 @@ pub enum CommandResult {
     /// the last visual selection. The runner handles the actual restoration
     /// by looking up the saved selection and entering the appropriate visual mode.
     ReselectVisual,
+    /// Command requests entering operator-pending mode with a specific operator.
+    ///
+    /// Enter-operator commands (enter-delete-operator, enter-yank-operator, etc.)
+    /// return this to indicate operator-pending mode should be entered with the
+    /// specified operator waiting for a motion. The runner handles setting the
+    /// pending operator state and pushing operator-pending mode.
+    EnterOperatorPending {
+        /// The operator ID (e.g., "delete", "yank", "change").
+        operator_id: &'static str,
+        /// Optional register for the operation.
+        register: Option<char>,
+    },
     /// Command requests a visual-block insert operation.
     ///
     /// Visual-block commands (I, A in visual-block mode) return this to
@@ -251,6 +263,12 @@ impl CommandResult {
         matches!(self, Self::BlockInsertAction(_))
     }
 
+    /// Check if the result is entering operator-pending mode.
+    #[must_use]
+    pub const fn is_enter_operator_pending(&self) -> bool {
+        matches!(self, Self::EnterOperatorPending { .. })
+    }
+
     /// Create an operator range result for text object commands.
     #[must_use]
     pub const fn operator_range(start: Position, end: Position, is_linewise: bool) -> Self {
@@ -258,6 +276,15 @@ impl CommandResult {
             start,
             end,
             is_linewise,
+        }
+    }
+
+    /// Create an enter-operator-pending result.
+    #[must_use]
+    pub const fn enter_operator_pending(operator_id: &'static str, register: Option<char>) -> Self {
+        Self::EnterOperatorPending {
+            operator_id,
+            register,
         }
     }
 }

--- a/modules/editor/src/command/cursor.rs
+++ b/modules/editor/src/command/cursor.rs
@@ -53,27 +53,35 @@ impl CommandHandler for CursorUp {
         };
 
         let count = args.count().unwrap_or(1);
-        let (old_pos, new_pos) = {
+        let buffer = buffer_arc.read();
+        let old_pos = buffer.position();
+
+        // Calculate new line (saturating sub to handle boundary)
+        let new_line = old_pos.line.saturating_sub(count);
+
+        // If already at top, no-op
+        if new_line == old_pos.line && old_pos.line == 0 {
+            return CommandResult::Success;
+        }
+
+        // Get line length for column clamping
+        let line_len = buffer.line_len(new_line).unwrap_or(0);
+        let new_col = old_pos.column.min(line_len);
+        let new_pos = Position::new(new_line, new_col);
+        drop(buffer);
+
+        // In operator-pending mode, return range for the operator
+        // j/k motions are linewise
+        if args.is_operator_pending() {
+            // k moves up, so new_pos.line < old_pos.line
+            return CommandResult::operator_range(new_pos, old_pos, true);
+        }
+
+        // Normal mode: move cursor
+        {
             let mut buffer = buffer_arc.write();
-            let old_pos = buffer.position();
-
-            // Calculate new line (saturating sub to handle boundary)
-            let new_line = old_pos.line.saturating_sub(count);
-
-            // If already at top, no-op
-            if new_line == old_pos.line && old_pos.line == 0 {
-                return CommandResult::Success;
-            }
-
-            // Get line length for column clamping
-            let line_len = buffer.line_len(new_line).unwrap_or(0);
-            let new_col = old_pos.column.min(line_len);
-
-            let new_pos = Position::new(new_line, new_col);
             buffer.set_position(new_pos);
-            drop(buffer);
-            (old_pos, new_pos)
-        };
+        }
 
         // Emit CursorMoved event (buffer lock released)
         ctx.event_bus.emit(CursorMoved {
@@ -120,29 +128,37 @@ impl CommandHandler for CursorDown {
         };
 
         let count = args.count().unwrap_or(1);
-        let (old_pos, new_pos) = {
+        let buffer = buffer_arc.read();
+        let old_pos = buffer.position();
+        let line_count = buffer.line_count();
+
+        // Calculate new line (clamped to last line)
+        let max_line = line_count.saturating_sub(1);
+        let new_line = (old_pos.line + count).min(max_line);
+
+        // If already at bottom, no-op
+        if new_line == old_pos.line && old_pos.line == max_line {
+            return CommandResult::Success;
+        }
+
+        // Get line length for column clamping
+        let line_len = buffer.line_len(new_line).unwrap_or(0);
+        let new_col = old_pos.column.min(line_len);
+        let new_pos = Position::new(new_line, new_col);
+        drop(buffer);
+
+        // In operator-pending mode, return range for the operator
+        // j/k motions are linewise
+        if args.is_operator_pending() {
+            // j moves down, so old_pos.line < new_pos.line
+            return CommandResult::operator_range(old_pos, new_pos, true);
+        }
+
+        // Normal mode: move cursor
+        {
             let mut buffer = buffer_arc.write();
-            let old_pos = buffer.position();
-            let line_count = buffer.line_count();
-
-            // Calculate new line (clamped to last line)
-            let max_line = line_count.saturating_sub(1);
-            let new_line = (old_pos.line + count).min(max_line);
-
-            // If already at bottom, no-op
-            if new_line == old_pos.line && old_pos.line == max_line {
-                return CommandResult::Success;
-            }
-
-            // Get line length for column clamping
-            let line_len = buffer.line_len(new_line).unwrap_or(0);
-            let new_col = old_pos.column.min(line_len);
-
-            let new_pos = Position::new(new_line, new_col);
             buffer.set_position(new_pos);
-            drop(buffer);
-            (old_pos, new_pos)
-        };
+        }
 
         // Emit CursorMoved event (buffer lock released)
         ctx.event_bus.emit(CursorMoved {
@@ -189,23 +205,32 @@ impl CommandHandler for CursorLeft {
         };
 
         let count = args.count().unwrap_or(1);
-        let (old_pos, new_pos) = {
+        let buffer = buffer_arc.read();
+        let old_pos = buffer.position();
+
+        // Calculate new column (saturating sub to handle boundary)
+        let new_col = old_pos.column.saturating_sub(count);
+
+        // If already at left edge, no-op
+        if new_col == old_pos.column && old_pos.column == 0 {
+            return CommandResult::Success;
+        }
+
+        let new_pos = Position::new(old_pos.line, new_col);
+        drop(buffer);
+
+        // In operator-pending mode, return range for the operator
+        // h/l motions are characterwise
+        if args.is_operator_pending() {
+            // h moves left, so new_pos.column < old_pos.column
+            return CommandResult::operator_range(new_pos, old_pos, false);
+        }
+
+        // Normal mode: move cursor
+        {
             let mut buffer = buffer_arc.write();
-            let old_pos = buffer.position();
-
-            // Calculate new column (saturating sub to handle boundary)
-            let new_col = old_pos.column.saturating_sub(count);
-
-            // If already at left edge, no-op
-            if new_col == old_pos.column && old_pos.column == 0 {
-                return CommandResult::Success;
-            }
-
-            let new_pos = Position::new(old_pos.line, new_col);
             buffer.set_position(new_pos);
-            drop(buffer);
-            (old_pos, new_pos)
-        };
+        }
 
         // Emit CursorMoved event (buffer lock released)
         ctx.event_bus.emit(CursorMoved {
@@ -252,31 +277,40 @@ impl CommandHandler for CursorRight {
         };
 
         let count = args.count().unwrap_or(1);
-        let (old_pos, new_pos) = {
+        let buffer = buffer_arc.read();
+        let old_pos = buffer.position();
+
+        // Get current line length for boundary check
+        let line_len = buffer.line_len(old_pos.line).unwrap_or(0);
+
+        // In normal mode, cursor can't go past the last character.
+        // For a line of length N, valid columns are 0..N-1.
+        // An empty line has max_col 0, but we can still be at col 0.
+        let max_col = line_len.saturating_sub(1);
+
+        // Calculate new column (clamped to max valid position)
+        let new_col = (old_pos.column + count).min(max_col);
+
+        // If already at right edge, no-op
+        if new_col == old_pos.column && old_pos.column == max_col {
+            return CommandResult::Success;
+        }
+
+        let new_pos = Position::new(old_pos.line, new_col);
+        drop(buffer);
+
+        // In operator-pending mode, return range for the operator
+        // h/l motions are characterwise
+        if args.is_operator_pending() {
+            // l moves right, so old_pos.column < new_pos.column
+            return CommandResult::operator_range(old_pos, new_pos, false);
+        }
+
+        // Normal mode: move cursor
+        {
             let mut buffer = buffer_arc.write();
-            let old_pos = buffer.position();
-
-            // Get current line length for boundary check
-            let line_len = buffer.line_len(old_pos.line).unwrap_or(0);
-
-            // In normal mode, cursor can't go past the last character.
-            // For a line of length N, valid columns are 0..N-1.
-            // An empty line has max_col 0, but we can still be at col 0.
-            let max_col = line_len.saturating_sub(1);
-
-            // Calculate new column (clamped to max valid position)
-            let new_col = (old_pos.column + count).min(max_col);
-
-            // If already at right edge, no-op
-            if new_col == old_pos.column && old_pos.column == max_col {
-                return CommandResult::Success;
-            }
-
-            let new_pos = Position::new(old_pos.line, new_col);
             buffer.set_position(new_pos);
-            drop(buffer);
-            (old_pos, new_pos)
-        };
+        }
 
         // Emit CursorMoved event (buffer lock released)
         ctx.event_bus.emit(CursorMoved {

--- a/modules/editor/src/command/delete.rs
+++ b/modules/editor/src/command/delete.rs
@@ -155,11 +155,10 @@ impl Command for DeleteLine {
     }
 
     fn args(&self) -> Vec<ArgSpec> {
-        vec![ArgSpec::optional(
-            "count",
-            ArgKind::Count,
-            "Number of lines to delete",
-        )]
+        vec![
+            ArgSpec::optional("count", ArgKind::Count, "Number of lines to delete"),
+            ArgSpec::optional("register", ArgKind::Register, "Target register"),
+        ]
     }
 }
 
@@ -186,6 +185,21 @@ impl CommandHandler for DeleteLine {
         if lines_to_delete == 0 {
             return CommandResult::Success;
         }
+
+        // Collect deleted text for register
+        let mut deleted_text = String::new();
+        for i in 0..lines_to_delete {
+            let line_idx = start_line + i;
+            if let Some(line) = buffer.line(line_idx) {
+                deleted_text.push_str(line);
+                deleted_text.push('\n');
+            }
+        }
+
+        // Store in register (use specified or unnamed)
+        let content = RegisterContent::linewise(deleted_text);
+        let register = args.register();
+        ctx.registers.write().set_by_name(register, content);
 
         // Delete range: from start of first line to start of line after deleted range
         let start = Position::new(start_line, 0);
@@ -244,6 +258,14 @@ impl Command for DeleteToEndOfLine {
     fn description(&self) -> &'static str {
         "Delete to end of line"
     }
+
+    fn args(&self) -> Vec<ArgSpec> {
+        vec![ArgSpec::optional(
+            "register",
+            ArgKind::Register,
+            "Target register",
+        )]
+    }
 }
 
 impl CommandHandler for DeleteToEndOfLine {
@@ -263,6 +285,17 @@ impl CommandHandler for DeleteToEndOfLine {
         if pos.column >= line_len {
             return CommandResult::Success;
         }
+
+        // Get text to delete for register
+        let deleted_text = buffer
+            .line(pos.line)
+            .map(|line| line[pos.column..].to_string())
+            .unwrap_or_default();
+
+        // Store in register (use specified or unnamed)
+        let content = RegisterContent::characterwise(deleted_text);
+        let register = args.register();
+        ctx.registers.write().set_by_name(register, content);
 
         // Delete from cursor to end of line (not including newline)
         let chars_to_delete = line_len - pos.column;
@@ -293,11 +326,10 @@ impl Command for ChangeLine {
     }
 
     fn args(&self) -> Vec<ArgSpec> {
-        vec![ArgSpec::optional(
-            "count",
-            ArgKind::Count,
-            "Number of lines to change",
-        )]
+        vec![
+            ArgSpec::optional("count", ArgKind::Count, "Number of lines to change"),
+            ArgSpec::optional("register", ArgKind::Register, "Target register"),
+        ]
     }
 }
 
@@ -345,9 +377,10 @@ impl CommandHandler for ChangeLine {
         }
         deleted_text.push('\n'); // Linewise content ends with newline
 
-        // Store in register as linewise
+        // Store in register (use specified or unnamed)
         let content = RegisterContent::linewise(deleted_text);
-        ctx.registers.write().set(content);
+        let register = args.register();
+        ctx.registers.write().set_by_name(register, content);
 
         // For cc: if changing multiple lines, delete all but first, then clear first
         // Single line: just clear the content
@@ -443,6 +476,14 @@ impl Command for ChangeToEndOfLine {
     fn description(&self) -> &'static str {
         "Change to end of line"
     }
+
+    fn args(&self) -> Vec<ArgSpec> {
+        vec![ArgSpec::optional(
+            "register",
+            ArgKind::Register,
+            "Target register",
+        )]
+    }
 }
 
 impl CommandHandler for ChangeToEndOfLine {
@@ -472,9 +513,10 @@ impl CommandHandler for ChangeToEndOfLine {
             .map(|line| line[pos.column..].to_string())
             .unwrap_or_default();
 
-        // Store in register as characterwise
+        // Store in register (use specified or unnamed)
         let content = RegisterContent::characterwise(deleted_text);
-        ctx.registers.write().set(content);
+        let register = args.register();
+        ctx.registers.write().set_by_name(register, content);
 
         // Delete from cursor to end of line (not including newline)
         let chars_to_delete = line_len - pos.column;

--- a/modules/editor/src/command/mod.rs
+++ b/modules/editor/src/command/mod.rs
@@ -29,6 +29,7 @@ mod file;
 mod insert_edit;
 mod mode;
 mod mode_entry;
+mod operators;
 mod paste;
 mod replace;
 mod undo;
@@ -43,8 +44,14 @@ pub use {
     display_line::{CursorDisplayDown, CursorDisplayUp},
     file::WriteBufferCommand,
     insert_edit::{InsertNewline, InsertTab},
-    mode::{EnterInsertMode, EnterInsertModeAppend, EnterWindowMode, ExitToNormal},
+    mode::{
+        EnterInsertMode, EnterInsertModeAppend, EnterWindowMode, ExitOperatorPending, ExitToNormal,
+    },
     mode_entry::{EnterInsertEndOfLine, EnterInsertFirstNonBlank, OpenLineAbove, OpenLineBelow},
+    operators::{
+        EnterChangeOperator, EnterDedentOperator, EnterDeleteOperator, EnterIndentOperator,
+        EnterYankOperator,
+    },
     paste::{PasteAfter, PasteBefore},
     replace::{JoinLines, RepeatDot, ReplaceCharStart},
     undo::{RedoCommand, UndoCommand},
@@ -80,9 +87,16 @@ pub fn all_commands() -> Vec<Box<dyn CommandHandler>> {
         Box::new(OpenLineAbove),
         Box::new(ExitToNormal),
         Box::new(EnterWindowMode),
+        Box::new(ExitOperatorPending),
         // Insert mode edits
         Box::new(InsertNewline),
         Box::new(InsertTab),
+        // Enter operator commands
+        Box::new(EnterDeleteOperator),
+        Box::new(EnterYankOperator),
+        Box::new(EnterChangeOperator),
+        Box::new(EnterIndentOperator),
+        Box::new(EnterDedentOperator),
         // Delete operations
         Box::new(DeleteChar),
         Box::new(DeleteCharBefore),
@@ -138,6 +152,7 @@ pub fn mode_commands() -> Vec<Box<dyn CommandHandler>> {
         Box::new(OpenLineAbove),
         Box::new(ExitToNormal),
         Box::new(EnterWindowMode),
+        Box::new(ExitOperatorPending),
     ]
 }
 
@@ -323,9 +338,10 @@ mod tests {
     #[test]
     fn test_all_commands_count() {
         let cmds = all_commands();
-        // 4 cursor + 2 display + 8 mode + 2 insert-edit + 5 delete + 1 yank + 2 paste
-        // + 2 change + 2 undo + 1 replace_char + 1 repeat + 1 write = 31
-        assert_eq!(cmds.len(), 31);
+        // 4 cursor + 2 display + 9 mode + 2 insert-edit + 5 enter-operator
+        // + 5 delete + 1 yank + 2 paste + 2 change + 2 undo + 1 replace_char
+        // + 1 repeat + 1 write = 37
+        assert_eq!(cmds.len(), 37);
     }
 
     #[test]
@@ -343,7 +359,7 @@ mod tests {
     #[test]
     fn test_mode_commands_count() {
         let cmds = mode_commands();
-        assert_eq!(cmds.len(), 8);
+        assert_eq!(cmds.len(), 9);
     }
 
     // =========================================================================

--- a/modules/editor/src/command/mode.rs
+++ b/modules/editor/src/command/mode.rs
@@ -138,3 +138,32 @@ impl CommandHandler for EnterWindowMode {
         CommandResult::ModeAction(ModeAction::Push("window".to_string()))
     }
 }
+
+/// Exit operator-pending mode (Escape cancels the operator).
+///
+/// This command is called when the user presses Escape while in operator-pending
+/// mode. It clears the pending operator state and returns to normal mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExitOperatorPending;
+
+impl Command for ExitOperatorPending {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "exit-operator-pending")
+    }
+
+    fn description(&self) -> &'static str {
+        "Cancel pending operator and return to normal mode"
+    }
+}
+
+impl CommandHandler for ExitOperatorPending {
+    fn execute(&self, ctx: &mut KernelContext, _args: &CommandContext) -> CommandResult {
+        // Emit mode change event
+        ctx.event_bus
+            .emit(ModeChanged::with_mode_id("operator-pending", EditorMode::NORMAL_ID));
+
+        // Return mode action to pop operator-pending mode off the stack
+        // The event loop will clear the pending operator state
+        CommandResult::ModeAction(ModeAction::Pop)
+    }
+}

--- a/modules/editor/src/command/operators.rs
+++ b/modules/editor/src/command/operators.rs
@@ -1,0 +1,247 @@
+//! Enter-operator commands for operator-pending mode.
+//!
+//! Provides commands that enter operator-pending mode with a specific operator:
+//! - `EnterDeleteOperator` (d)
+//! - `EnterYankOperator` (y)
+//! - `EnterChangeOperator` (c)
+//! - `EnterIndentOperator` (>)
+//! - `EnterDedentOperator` (<)
+
+use {
+    reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
+    reovim_kernel::api::v1::{CommandId, KernelContext},
+};
+
+use super::super::mode::EDITOR_MODULE;
+
+/// Enter delete operator-pending mode (d).
+///
+/// Sets the pending operator to "delete" and enters operator-pending mode,
+/// waiting for a motion to determine the range to delete.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterDeleteOperator;
+
+impl Command for EnterDeleteOperator {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-delete-operator")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter delete operator-pending mode"
+    }
+}
+
+impl CommandHandler for EnterDeleteOperator {
+    fn execute(&self, _ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let register = args.register();
+        CommandResult::enter_operator_pending("delete", register)
+    }
+}
+
+/// Enter yank operator-pending mode (y).
+///
+/// Sets the pending operator to "yank" and enters operator-pending mode,
+/// waiting for a motion to determine the range to yank.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterYankOperator;
+
+impl Command for EnterYankOperator {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-yank-operator")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter yank operator-pending mode"
+    }
+}
+
+impl CommandHandler for EnterYankOperator {
+    fn execute(&self, _ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let register = args.register();
+        CommandResult::enter_operator_pending("yank", register)
+    }
+}
+
+/// Enter change operator-pending mode (c).
+///
+/// Sets the pending operator to "change" and enters operator-pending mode,
+/// waiting for a motion to determine the range to change. After deletion,
+/// the editor enters insert mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterChangeOperator;
+
+impl Command for EnterChangeOperator {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-change-operator")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter change operator-pending mode"
+    }
+}
+
+impl CommandHandler for EnterChangeOperator {
+    fn execute(&self, _ctx: &mut KernelContext, args: &CommandContext) -> CommandResult {
+        let register = args.register();
+        CommandResult::enter_operator_pending("change", register)
+    }
+}
+
+/// Enter indent operator-pending mode (>).
+///
+/// Sets the pending operator to "indent" and enters operator-pending mode,
+/// waiting for a motion to determine the range to indent.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterIndentOperator;
+
+impl Command for EnterIndentOperator {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-indent-operator")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter indent operator-pending mode"
+    }
+}
+
+impl CommandHandler for EnterIndentOperator {
+    fn execute(&self, _ctx: &mut KernelContext, _args: &CommandContext) -> CommandResult {
+        CommandResult::enter_operator_pending("indent", None)
+    }
+}
+
+/// Enter dedent operator-pending mode (<).
+///
+/// Sets the pending operator to "dedent" and enters operator-pending mode,
+/// waiting for a motion to determine the range to dedent.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterDedentOperator;
+
+impl Command for EnterDedentOperator {
+    fn id(&self) -> CommandId {
+        CommandId::new(EDITOR_MODULE, "enter-dedent-operator")
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter dedent operator-pending mode"
+    }
+}
+
+impl CommandHandler for EnterDedentOperator {
+    fn execute(&self, _ctx: &mut KernelContext, _args: &CommandContext) -> CommandResult {
+        CommandResult::enter_operator_pending("dedent", None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enter_delete_operator_id() {
+        let cmd = EnterDeleteOperator;
+        assert_eq!(cmd.id().name(), "enter-delete-operator");
+    }
+
+    #[test]
+    fn test_enter_yank_operator_id() {
+        let cmd = EnterYankOperator;
+        assert_eq!(cmd.id().name(), "enter-yank-operator");
+    }
+
+    #[test]
+    fn test_enter_change_operator_id() {
+        let cmd = EnterChangeOperator;
+        assert_eq!(cmd.id().name(), "enter-change-operator");
+    }
+
+    #[test]
+    fn test_enter_indent_operator_id() {
+        let cmd = EnterIndentOperator;
+        assert_eq!(cmd.id().name(), "enter-indent-operator");
+    }
+
+    #[test]
+    fn test_enter_dedent_operator_id() {
+        let cmd = EnterDedentOperator;
+        assert_eq!(cmd.id().name(), "enter-dedent-operator");
+    }
+
+    #[test]
+    fn test_enter_delete_operator_returns_enter_operator_pending() {
+        let mut ctx = KernelContext::default();
+        let args = CommandContext::new();
+        let result = EnterDeleteOperator.execute(&mut ctx, &args);
+
+        assert!(result.is_enter_operator_pending());
+        if let CommandResult::EnterOperatorPending {
+            operator_id,
+            register,
+        } = result
+        {
+            assert_eq!(operator_id, "delete");
+            assert_eq!(register, None);
+        } else {
+            panic!("Expected EnterOperatorPending result");
+        }
+    }
+
+    #[test]
+    fn test_enter_yank_operator_returns_enter_operator_pending() {
+        let mut ctx = KernelContext::default();
+        let args = CommandContext::new();
+        let result = EnterYankOperator.execute(&mut ctx, &args);
+
+        assert!(result.is_enter_operator_pending());
+        if let CommandResult::EnterOperatorPending {
+            operator_id,
+            register,
+        } = result
+        {
+            assert_eq!(operator_id, "yank");
+            assert_eq!(register, None);
+        } else {
+            panic!("Expected EnterOperatorPending result");
+        }
+    }
+
+    #[test]
+    fn test_enter_change_operator_returns_enter_operator_pending() {
+        let mut ctx = KernelContext::default();
+        let args = CommandContext::new();
+        let result = EnterChangeOperator.execute(&mut ctx, &args);
+
+        assert!(result.is_enter_operator_pending());
+        if let CommandResult::EnterOperatorPending {
+            operator_id,
+            register,
+        } = result
+        {
+            assert_eq!(operator_id, "change");
+            assert_eq!(register, None);
+        } else {
+            panic!("Expected EnterOperatorPending result");
+        }
+    }
+
+    #[test]
+    fn test_enter_delete_operator_with_register() {
+        use reovim_driver_command::ArgValue;
+
+        let mut ctx = KernelContext::default();
+        let mut args = CommandContext::new();
+        args.set("register", ArgValue::Register('a'));
+        let result = EnterDeleteOperator.execute(&mut ctx, &args);
+
+        if let CommandResult::EnterOperatorPending {
+            operator_id,
+            register,
+        } = result
+        {
+            assert_eq!(operator_id, "delete");
+            assert_eq!(register, Some('a'));
+        } else {
+            panic!("Expected EnterOperatorPending result");
+        }
+    }
+}

--- a/modules/editor/src/command/paste.rs
+++ b/modules/editor/src/command/paste.rs
@@ -30,11 +30,10 @@ impl Command for PasteAfter {
     }
 
     fn args(&self) -> Vec<ArgSpec> {
-        vec![ArgSpec::optional(
-            "count",
-            ArgKind::Count,
-            "Number of times to paste",
-        )]
+        vec![
+            ArgSpec::optional("count", ArgKind::Count, "Number of times to paste"),
+            ArgSpec::optional("register", ArgKind::Register, "Source register"),
+        ]
     }
 }
 
@@ -48,11 +47,16 @@ impl CommandHandler for PasteAfter {
         };
 
         let count = args.count().unwrap_or(1);
+        let register = args.register();
 
-        // Get register content
+        // Get register content (use specified or unnamed)
         let content = {
             let registers = ctx.registers.read();
-            registers.get().clone()
+            registers.get_by_name(register).cloned()
+        };
+
+        let Some(content) = content else {
+            return CommandResult::Success; // Empty register
         };
 
         if content.is_empty() {
@@ -141,11 +145,10 @@ impl Command for PasteBefore {
     }
 
     fn args(&self) -> Vec<ArgSpec> {
-        vec![ArgSpec::optional(
-            "count",
-            ArgKind::Count,
-            "Number of times to paste",
-        )]
+        vec![
+            ArgSpec::optional("count", ArgKind::Count, "Number of times to paste"),
+            ArgSpec::optional("register", ArgKind::Register, "Source register"),
+        ]
     }
 }
 
@@ -159,11 +162,16 @@ impl CommandHandler for PasteBefore {
         };
 
         let count = args.count().unwrap_or(1);
+        let register = args.register();
 
-        // Get register content
+        // Get register content (use specified or unnamed)
         let content = {
             let registers = ctx.registers.read();
-            registers.get().clone()
+            registers.get_by_name(register).cloned()
+        };
+
+        let Some(content) = content else {
+            return CommandResult::Success; // Empty register
         };
 
         if content.is_empty() {

--- a/modules/editor/src/command/yank.rs
+++ b/modules/editor/src/command/yank.rs
@@ -26,11 +26,10 @@ impl Command for YankLine {
     }
 
     fn args(&self) -> Vec<ArgSpec> {
-        vec![ArgSpec::optional(
-            "count",
-            ArgKind::Count,
-            "Number of lines to yank",
-        )]
+        vec![
+            ArgSpec::optional("count", ArgKind::Count, "Number of lines to yank"),
+            ArgSpec::optional("register", ArgKind::Register, "Target register"),
+        ]
     }
 }
 
@@ -64,9 +63,10 @@ impl CommandHandler for YankLine {
         }
         drop(buffer);
 
-        // Store in unnamed register as linewise
+        // Store in register (use specified register or unnamed)
         let content = RegisterContent::linewise(yanked);
-        ctx.registers.write().set(content);
+        let register = args.register();
+        ctx.registers.write().set_by_name(register, content);
 
         CommandResult::Success
     }

--- a/modules/keymap/src/normal.rs
+++ b/modules/keymap/src/normal.rs
@@ -269,19 +269,19 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
         // ====================================================================
         // Search
         // ====================================================================
-        KeybindingRegistration::new("/", "search-forward")
+        KeybindingRegistration::new("/", "motions:search-forward")
             .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search forward"),
-        KeybindingRegistration::new("?", "search-backward")
+        KeybindingRegistration::new("?", "motions:search-backward")
             .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Search backward"),
-        KeybindingRegistration::new("n", "search-next")
+        KeybindingRegistration::new("n", "motions:search-next")
             .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Next search result"),
-        KeybindingRegistration::new("N", "search-prev")
+        KeybindingRegistration::new("N", "motions:search-prev")
             .with_modes(&["editor:normal"])
             .with_category("search")
             .with_description("Previous search result"),

--- a/modules/motions/src/line.rs
+++ b/modules/motions/src/line.rs
@@ -21,6 +21,9 @@ use super::MOTIONS_MODULE;
 // =============================================================================
 
 /// Execute a line position motion and update cursor position.
+///
+/// In operator-pending mode, returns an `OperatorRange` instead of moving the cursor.
+/// Line position motions (`0`, `$`, `^`) are characterwise.
 #[allow(clippy::cast_possible_truncation)]
 fn execute_line_position(
     ctx: &KernelContext,
@@ -35,24 +38,40 @@ fn execute_line_position(
         return CommandResult::error("Buffer not found");
     };
 
-    let (old_pos, new_pos) = {
-        let mut buffer = buffer_arc.write();
-        let cursor = Cursor::new(buffer.position());
-        let old_pos = cursor.position;
+    let buffer = buffer_arc.read();
+    let cursor = Cursor::new(buffer.position());
+    let old_pos = cursor.position;
 
-        let motion = Motion::LinePosition(position);
-        let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, 1) else {
-            return CommandResult::Success; // No-op if motion fails
-        };
-
-        if new_pos == old_pos {
-            return CommandResult::Success; // No movement
-        }
-
-        buffer.set_position(new_pos);
+    let motion = Motion::LinePosition(position);
+    let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, 1) else {
         drop(buffer);
-        (old_pos, new_pos)
+        return CommandResult::Success; // No-op if motion fails
     };
+
+    if new_pos == old_pos {
+        drop(buffer);
+        return CommandResult::Success; // No movement
+    }
+
+    drop(buffer);
+
+    // In operator-pending mode, return range for the operator
+    if args.is_operator_pending() {
+        // Determine range direction - start should be before end
+        let (start, range_end) = if new_pos.column >= old_pos.column {
+            (old_pos, new_pos)
+        } else {
+            (new_pos, old_pos)
+        };
+        // Line position motions are characterwise
+        return CommandResult::operator_range(start, range_end, false);
+    }
+
+    // Normal mode: move cursor
+    {
+        let mut buffer = buffer_arc.write();
+        buffer.set_position(new_pos);
+    }
 
     ctx.event_bus.emit(CursorMoved {
         buffer_id: buffer_id.as_usize() as u64,
@@ -64,6 +83,9 @@ fn execute_line_position(
 }
 
 /// Execute a jump line motion and update cursor position.
+///
+/// In operator-pending mode, returns an `OperatorRange` instead of moving the cursor.
+/// Document motions (`gg`, `G`) are linewise.
 #[allow(clippy::cast_possible_truncation)]
 fn execute_jump_line(
     ctx: &KernelContext,
@@ -78,24 +100,40 @@ fn execute_jump_line(
         return CommandResult::error("Buffer not found");
     };
 
-    let (old_pos, new_pos) = {
-        let mut buffer = buffer_arc.write();
-        let cursor = Cursor::new(buffer.position());
-        let old_pos = cursor.position;
+    let buffer = buffer_arc.read();
+    let cursor = Cursor::new(buffer.position());
+    let old_pos = cursor.position;
 
-        let motion = Motion::JumpLine(target_line);
-        let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, 1) else {
-            return CommandResult::Success; // No-op if motion fails
-        };
-
-        if new_pos == old_pos {
-            return CommandResult::Success; // No movement
-        }
-
-        buffer.set_position(new_pos);
+    let motion = Motion::JumpLine(target_line);
+    let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, 1) else {
         drop(buffer);
-        (old_pos, new_pos)
+        return CommandResult::Success; // No-op if motion fails
     };
+
+    if new_pos == old_pos {
+        drop(buffer);
+        return CommandResult::Success; // No movement
+    }
+
+    drop(buffer);
+
+    // In operator-pending mode, return range for the operator
+    if args.is_operator_pending() {
+        // Determine range direction - start line should be before end line
+        let (start, range_end) = if new_pos.line >= old_pos.line {
+            (old_pos, new_pos)
+        } else {
+            (new_pos, old_pos)
+        };
+        // Document motions are linewise
+        return CommandResult::operator_range(start, range_end, true);
+    }
+
+    // Normal mode: move cursor
+    {
+        let mut buffer = buffer_arc.write();
+        buffer.set_position(new_pos);
+    }
 
     ctx.event_bus.emit(CursorMoved {
         buffer_id: buffer_id.as_usize() as u64,

--- a/modules/motions/src/word.rs
+++ b/modules/motions/src/word.rs
@@ -22,6 +22,9 @@ use super::MOTIONS_MODULE;
 // =============================================================================
 
 /// Execute a word motion and update cursor position.
+///
+/// In operator-pending mode, returns an `OperatorRange` instead of moving the cursor.
+/// Word motions are characterwise.
 #[allow(clippy::cast_possible_truncation)]
 fn execute_word_motion(
     ctx: &KernelContext,
@@ -45,23 +48,39 @@ fn execute_word_motion(
         end,
     };
 
-    let (old_pos, new_pos) = {
-        let mut buffer = buffer_arc.write();
-        let cursor = Cursor::new(buffer.position());
-        let old_pos = cursor.position;
+    let buffer = buffer_arc.read();
+    let cursor = Cursor::new(buffer.position());
+    let old_pos = cursor.position;
 
-        let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, count) else {
-            return CommandResult::Success; // No-op if motion fails
-        };
-
-        if new_pos == old_pos {
-            return CommandResult::Success; // No movement
-        }
-
-        buffer.set_position(new_pos);
+    let Some(new_pos) = MotionEngine::calculate(&buffer, &cursor, motion, count) else {
         drop(buffer);
-        (old_pos, new_pos)
+        return CommandResult::Success; // No-op if motion fails
     };
+
+    if new_pos == old_pos {
+        drop(buffer);
+        return CommandResult::Success; // No movement
+    }
+
+    drop(buffer);
+
+    // In operator-pending mode, return range for the operator
+    if args.is_operator_pending() {
+        // Determine range direction - start should be before end
+        let (start, range_end) = if direction == Direction::Forward {
+            (old_pos, new_pos)
+        } else {
+            (new_pos, old_pos)
+        };
+        // Word motions are characterwise
+        return CommandResult::operator_range(start, range_end, false);
+    }
+
+    // Normal mode: move cursor
+    {
+        let mut buffer = buffer_arc.write();
+        buffer.set_position(new_pos);
+    }
 
     // Emit CursorMoved event
     ctx.event_bus.emit(CursorMoved {

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -31,6 +31,7 @@ reovim-driver-vfs = { path = "../lib/drivers/vfs" }
 reovim-module-keymap = { path = "../modules/keymap" }
 reovim-module-editor = { path = "../modules/editor" }
 reovim-module-motions = { path = "../modules/motions" }
+reovim-module-operators = { path = "../modules/operators" }
 
 # Layout module for window management
 reovim-module-layout = { path = "../modules/layout" }

--- a/runner/src/server/app/mod.rs
+++ b/runner/src/server/app/mod.rs
@@ -18,6 +18,8 @@ pub use {
     visual::LastVisualSelection,
 };
 
+// Re-export PendingOperator (defined in this file, not a submodule)
+
 use {
     crate::{UndoRegistry, server::window::WindowRegistry},
     reovim_arch::sync::RwLock,
@@ -159,6 +161,57 @@ pub struct AppState {
     /// which window displays it, which buffer's tree is shown,
     /// and navigation state within the tree.
     pub undotree_state: UndotreeState,
+
+    /// Pending operator waiting for a motion.
+    ///
+    /// When a user presses an operator key (d, y, c) in normal mode,
+    /// the operator is stored here until a motion key is pressed to
+    /// complete the operation. The motion provides the text range,
+    /// then the operator is executed on that range.
+    pub pending_operator: Option<PendingOperator>,
+}
+
+/// Information about a pending operator waiting for a motion.
+///
+/// In vim, operators like `d`, `y`, `c` wait for a motion to define
+/// the text range they operate on. This struct captures the operator
+/// and any modifiers (count, register) while waiting.
+#[derive(Debug, Clone)]
+pub struct PendingOperator {
+    /// Operator ID: "delete", "yank", or "change".
+    pub operator_id: &'static str,
+
+    /// Count applied to the operator (e.g., `2dw` applies operator twice).
+    pub count: usize,
+
+    /// Target register for the operation.
+    pub register: Option<char>,
+}
+
+impl PendingOperator {
+    /// Create a new pending operator.
+    #[must_use]
+    pub const fn new(operator_id: &'static str) -> Self {
+        Self {
+            operator_id,
+            count: 1,
+            register: None,
+        }
+    }
+
+    /// Set the count for this operator.
+    #[must_use]
+    pub const fn with_count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+
+    /// Set the register for this operator.
+    #[must_use]
+    pub const fn with_register(mut self, register: Option<char>) -> Self {
+        self.register = register;
+        self
+    }
 }
 
 impl AppState {
@@ -188,6 +241,7 @@ impl AppState {
             last_visual_selection: None,
             windows: WindowRegistry::new(),
             undotree_state: UndotreeState::new(),
+            pending_operator: None,
         }
     }
 
@@ -250,6 +304,38 @@ impl AppState {
     #[must_use]
     pub const fn pending_char(&self) -> Option<&PendingCharOp> {
         self.pending_char.as_ref()
+    }
+
+    // ========================================================================
+    // Pending Operator Methods (for operator-motion combinations)
+    // ========================================================================
+
+    /// Set a pending operator that's waiting for a motion.
+    ///
+    /// Called when an operator key (d, y, c) is pressed in normal mode.
+    /// The operator waits for a motion to provide the text range.
+    pub const fn set_pending_operator(&mut self, op: PendingOperator) {
+        self.pending_operator = Some(op);
+    }
+
+    /// Take the pending operator, clearing it.
+    ///
+    /// Returns `Some(op)` if there was a pending operator, `None` otherwise.
+    /// Called when a motion provides a range to complete the operation.
+    pub const fn take_pending_operator(&mut self) -> Option<PendingOperator> {
+        self.pending_operator.take()
+    }
+
+    /// Check if there is a pending operator.
+    #[must_use]
+    pub const fn has_pending_operator(&self) -> bool {
+        self.pending_operator.is_some()
+    }
+
+    /// Get a reference to the pending operator, if any.
+    #[must_use]
+    pub const fn pending_operator(&self) -> Option<&PendingOperator> {
+        self.pending_operator.as_ref()
     }
 
     // ========================================================================

--- a/runner/src/server/event_loop/mod.rs
+++ b/runner/src/server/event_loop/mod.rs
@@ -14,6 +14,7 @@
 
 mod char_handler;
 mod error;
+mod operator_handler;
 mod search_handler;
 mod undotree_handler;
 mod visual_handler;
@@ -101,6 +102,19 @@ pub struct EventLoop<F: InputFallbackHandler<AppState>> {
     ///
     /// Reset after command execution or when leaving normal mode.
     pending_count: Option<usize>,
+
+    /// Pending register for the next command.
+    ///
+    /// In Vim, typing `"a` before a command specifies the register to use.
+    /// The `"` key enters "waiting for register" state, and the next character
+    /// selects the register. The register is then passed to the command via
+    /// `CommandContext`.
+    ///
+    /// States:
+    /// - `None`: No register prefix
+    /// - `Some('"')`: Waiting for register character (sentinel)
+    /// - `Some('a'..'z')`: Register selected, apply to next command
+    pending_register: Option<char>,
 }
 
 impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
@@ -148,6 +162,7 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             last_error: None,
             pending_mode_change,
             pending_count: None,
+            pending_register: None,
         }
     }
 
@@ -230,6 +245,18 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             return;
         }
 
+        // Check for register prefix waiting for character
+        if self.is_waiting_for_register() {
+            self.handle_register_char(key);
+            return;
+        }
+
+        // Check for register prefix start (") in normal/visual mode
+        if self.is_register_prefix(&key) {
+            self.pending_register = Some('"'); // Sentinel: waiting for char
+            return;
+        }
+
         // Check for count prefix (digits 1-9, or 0 if already have count) in normal mode
         // Digits without modifiers accumulate as a count prefix
         if self.is_count_digit(&key) {
@@ -259,10 +286,22 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                     ctx.set("count", reovim_driver_command::ArgValue::Count(count));
                 }
 
+                // Set register in context if we have a pending register
+                if let Some(reg) = self.pending_register.take() {
+                    // Only set if it's an actual register, not the sentinel
+                    if reg != '"' {
+                        ctx.set("register", reovim_driver_command::ArgValue::Register(reg));
+                    }
+                }
+
                 // Set buffer_id in context if we have an active buffer
                 if let Some(buffer_id) = self.app.active_buffer {
                     ctx.set_buffer_id(buffer_id);
                 }
+
+                // Set current mode name in context for commands that need to
+                // adjust behavior based on mode (e.g., motions in operator-pending)
+                ctx.set_mode_name(mode.name());
 
                 // Save visual selection if currently in visual mode (for gv command).
                 // We check the current mode rather than hardcoding command names that exit visual.
@@ -357,6 +396,7 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
     }
 
     /// Handle command execution result.
+    #[allow(clippy::too_many_lines)]
     fn handle_command_result(&mut self, result: CommandResult) {
         use reovim_driver_command::CharWaitOp;
 
@@ -451,16 +491,12 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                 end,
                 is_linewise,
             } => {
-                // Text object command returned a range for the pending operator.
+                // Motion/text-object returned a range for the pending operator.
                 // Execute the pending operator (d, y, c) with this range.
-                tracing::debug!(
-                    ?start,
-                    ?end,
-                    is_linewise,
-                    "OperatorRange received from text object"
-                );
-                // TODO: Execute pending operator with range
-                // For now, just clear error state
+                tracing::debug!(?start, ?end, is_linewise, "OperatorRange received");
+
+                // Execute the pending operator
+                self.execute_pending_operator(start, end, is_linewise);
                 self.last_error = None;
             }
             CommandResult::ReselectVisual => {
@@ -473,6 +509,30 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
                 // Visual-block insert (I/A in visual-block mode) wants to insert
                 // text across multiple lines. Full implementation TBD.
                 tracing::debug!(?action, "BlockInsertAction requested");
+                self.last_error = None;
+            }
+            CommandResult::EnterOperatorPending {
+                operator_id,
+                register,
+            } => {
+                // Enter-operator commands (d, y, c) request operator-pending mode.
+                // Set pending operator state and push operator-pending mode.
+                use crate::server::app::PendingOperator;
+
+                let count = self.pending_count.take().unwrap_or(1);
+                let pending = PendingOperator::new(operator_id)
+                    .with_count(count)
+                    .with_register(register);
+                self.app.set_pending_operator(pending);
+
+                // Push operator-pending mode onto the stack
+                let mode_id = ModeId::new(
+                    reovim_kernel::api::v1::ModuleId::new("editor"),
+                    "operator-pending",
+                );
+                self.app.mode_stack.push(mode_id);
+
+                tracing::debug!(operator_id, ?register, count, "Entered operator-pending mode");
                 self.last_error = None;
             }
         }
@@ -498,9 +558,19 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             }
             ModeAction::Pop => {
                 // Pop the current mode from the stack.
+                // If popping from operator-pending mode, clear pending operator state.
+                let was_operator_pending = self.app.current_mode().name() == "operator-pending";
+
                 if let Some(popped) = self.app.mode_stack.pop() {
                     tracing::info!(mode = %popped, "Popped mode from stack");
                 }
+
+                // Clear pending operator if we were in operator-pending mode
+                if was_operator_pending {
+                    self.app.take_pending_operator();
+                    tracing::debug!("Cleared pending operator state on mode pop");
+                }
+
                 self.last_error = None;
             }
             ModeAction::Set(mode_name) => {
@@ -675,6 +745,77 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             // Prevent overflow by capping at MAX_INSERT_COUNT
             let new_count = current.saturating_mul(10).saturating_add(digit);
             self.pending_count = Some(new_count.min(crate::server::app::MAX_INSERT_COUNT));
+        }
+    }
+
+    // ========================================================================
+    // Register Prefix Handling (for "ayy, "ap, etc.)
+    // ========================================================================
+
+    /// Check if a key is the register prefix (`"`).
+    ///
+    /// In Vim, `"` starts a register selection. Only valid in normal/visual modes
+    /// and without modifiers.
+    fn is_register_prefix(&self, key: &KeyEvent) -> bool {
+        use reovim_driver_input::KeyCode;
+
+        // Only in normal or visual modes
+        let mode_name = self.app.current_mode().name();
+        if mode_name != "normal" && !mode_name.starts_with("visual") {
+            return false;
+        }
+
+        // No modifiers allowed for register prefix
+        if !key.modifiers.is_empty() {
+            return false;
+        }
+
+        // Check if it's the register prefix key
+        matches!(key.code, KeyCode::Char('"'))
+    }
+
+    /// Check if we're waiting for a register character.
+    ///
+    /// Returns true if `pending_register` is the sentinel value `"`.
+    fn is_waiting_for_register(&self) -> bool {
+        self.pending_register == Some('"')
+    }
+
+    /// Handle the register character after `"` was pressed.
+    ///
+    /// Valid registers: a-z, A-Z (append), 0-9, ", +, *, and more.
+    fn handle_register_char(&mut self, key: KeyEvent) {
+        use reovim_driver_input::KeyCode;
+
+        // Handle escape - cancel register selection
+        if key.code == KeyCode::Escape {
+            self.pending_register = None;
+            self.app.clear_pending_keys();
+            return;
+        }
+
+        // Extract character from key event
+        let KeyCode::Char(c) = key.code else {
+            // Non-character keys cancel register selection
+            self.pending_register = None;
+            self.set_error("Invalid register");
+            return;
+        };
+
+        // Validate register character
+        // Valid: a-z, A-Z (append), 0-9, " (unnamed), + (clipboard), * (selection)
+        if c.is_ascii_alphabetic()
+            || c.is_ascii_digit()
+            || c == '"'
+            || c == '+'
+            || c == '*'
+            || c == '_'
+            || c == '-'
+        {
+            self.pending_register = Some(c);
+        } else {
+            self.pending_register = None;
+            self.set_error("Invalid register");
         }
     }
 
@@ -1092,5 +1233,141 @@ mod tests {
 
         // In insert mode, digits are not count prefixes
         assert!(!event_loop.is_count_digit(&KeyEvent::new(KeyCode::Char('3'))));
+    }
+
+    // =========================================================================
+    // Register Prefix Tests
+    // =========================================================================
+
+    #[test]
+    fn test_is_register_prefix_in_normal_mode() {
+        let event_loop = create_test_event_loop();
+
+        // " is the register prefix
+        assert!(event_loop.is_register_prefix(&KeyEvent::new(KeyCode::Char('"'))));
+
+        // Other characters are not register prefix
+        assert!(!event_loop.is_register_prefix(&KeyEvent::new(KeyCode::Char('a'))));
+        assert!(!event_loop.is_register_prefix(&KeyEvent::new(KeyCode::Char('1'))));
+    }
+
+    #[test]
+    fn test_is_register_prefix_with_modifiers() {
+        use reovim_driver_input::Modifiers;
+
+        let event_loop = create_test_event_loop();
+
+        // " with modifiers is not register prefix
+        let ctrl_quote = KeyEvent::with_modifiers(KeyCode::Char('"'), Modifiers::CTRL);
+        assert!(!event_loop.is_register_prefix(&ctrl_quote));
+    }
+
+    #[test]
+    fn test_is_register_prefix_in_insert_mode() {
+        let kernel = KernelContext::default();
+        let insert_mode = ModeId::new(ModuleId::new("editor"), "insert");
+        let app = AppState::new(kernel, insert_mode);
+        let event_loop = EventLoop::new(
+            app,
+            ModeRegistry::new(),
+            CommandRegistry::new(),
+            KeymapRegistry::new(),
+            NoOpFallback,
+        );
+
+        // In insert mode, " is not a register prefix
+        assert!(!event_loop.is_register_prefix(&KeyEvent::new(KeyCode::Char('"'))));
+    }
+
+    #[test]
+    fn test_is_waiting_for_register() {
+        let mut event_loop = create_test_event_loop();
+
+        // Initially not waiting
+        assert!(!event_loop.is_waiting_for_register());
+
+        // Set sentinel
+        event_loop.pending_register = Some('"');
+        assert!(event_loop.is_waiting_for_register());
+
+        // Set actual register
+        event_loop.pending_register = Some('a');
+        assert!(!event_loop.is_waiting_for_register());
+    }
+
+    #[test]
+    fn test_handle_register_char_valid() {
+        let mut event_loop = create_test_event_loop();
+        event_loop.pending_register = Some('"'); // Waiting for char
+
+        // Valid register char 'a'
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('a')));
+        assert_eq!(event_loop.pending_register, Some('a'));
+    }
+
+    #[test]
+    fn test_handle_register_char_uppercase() {
+        let mut event_loop = create_test_event_loop();
+        event_loop.pending_register = Some('"');
+
+        // Uppercase for append
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('A')));
+        assert_eq!(event_loop.pending_register, Some('A'));
+    }
+
+    #[test]
+    fn test_handle_register_char_digit() {
+        let mut event_loop = create_test_event_loop();
+        event_loop.pending_register = Some('"');
+
+        // Numbered registers
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('0')));
+        assert_eq!(event_loop.pending_register, Some('0'));
+    }
+
+    #[test]
+    fn test_handle_register_char_special() {
+        let mut event_loop = create_test_event_loop();
+
+        // Test + (clipboard)
+        event_loop.pending_register = Some('"');
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('+')));
+        assert_eq!(event_loop.pending_register, Some('+'));
+
+        // Test * (selection)
+        event_loop.pending_register = Some('"');
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('*')));
+        assert_eq!(event_loop.pending_register, Some('*'));
+
+        // Test " (unnamed)
+        event_loop.pending_register = Some('"');
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('"')));
+        assert_eq!(event_loop.pending_register, Some('"'));
+    }
+
+    #[test]
+    fn test_handle_register_char_escape_cancels() {
+        let mut event_loop = create_test_event_loop();
+        event_loop.pending_register = Some('"');
+
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Escape));
+        assert!(event_loop.pending_register.is_none());
+    }
+
+    #[test]
+    fn test_handle_register_char_invalid() {
+        let mut event_loop = create_test_event_loop();
+        event_loop.pending_register = Some('"');
+
+        // Invalid register char (e.g., %)
+        event_loop.handle_register_char(KeyEvent::new(KeyCode::Char('%')));
+        assert!(event_loop.pending_register.is_none());
+        assert!(event_loop.last_error().is_some());
+    }
+
+    #[test]
+    fn test_pending_register_initially_none() {
+        let event_loop = create_test_event_loop();
+        assert!(event_loop.pending_register.is_none());
     }
 }

--- a/runner/src/server/event_loop/operator_handler.rs
+++ b/runner/src/server/event_loop/operator_handler.rs
@@ -1,0 +1,114 @@
+//! Operator execution handling.
+//!
+//! Handles execution of pending operators (d, y, c) when a motion returns a range.
+
+use {
+    super::EventLoop,
+    crate::server::AppState,
+    reovim_kernel::api::v1::{ModeId, ModuleId, Position},
+    reovim_module_operators::{
+        ChangeOperator, DeleteOperator, Operator, OperatorContext, Range, YankOperator,
+    },
+};
+
+impl<F: reovim_driver_input::InputFallbackHandler<AppState>> EventLoop<F> {
+    /// Execute the pending operator with the given range.
+    ///
+    /// Called when a motion command returns `CommandResult::OperatorRange`.
+    /// This takes the pending operator state, executes the operator on the range,
+    /// handles undo recording, and returns to normal mode.
+    pub(super) fn execute_pending_operator(
+        &mut self,
+        start: Position,
+        end: Position,
+        is_linewise: bool,
+    ) {
+        // Take the pending operator - this clears the state
+        let Some(pending) = self.app.take_pending_operator() else {
+            tracing::warn!("OperatorRange received but no pending operator");
+            return;
+        };
+
+        // Get the active buffer
+        let Some(buffer_id) = self.app.active_buffer else {
+            tracing::warn!("No active buffer for operator execution");
+            return;
+        };
+
+        // Create the range (normalize it so start <= end)
+        let range = if is_linewise {
+            Range::linewise(start, end).normalized()
+        } else {
+            Range::new(start, end).normalized()
+        };
+
+        // Skip empty ranges (no-op)
+        if range.is_empty() && !is_linewise {
+            tracing::debug!("Empty range, skipping operator");
+            self.pop_operator_pending_mode();
+            return;
+        }
+
+        // Get the operator
+        let operator: Box<dyn Operator> = match pending.operator_id {
+            "delete" => Box::new(DeleteOperator),
+            "yank" => Box::new(YankOperator),
+            "change" => Box::new(ChangeOperator),
+            // TODO: Add indent/dedent operators
+            unknown => {
+                tracing::warn!(operator = unknown, "Unknown operator");
+                self.pop_operator_pending_mode();
+                return;
+            }
+        };
+
+        // Execute the operator
+        // Note: we need to use an unsafe trick here because OperatorContext holds &KernelContext
+        // but KernelContext is inside self.app. We work around this by creating the context
+        // just for the execute call.
+        let operator_result = {
+            let mut op_ctx = OperatorContext {
+                kernel: &self.app.kernel,
+                buffer_id,
+                register: pending.register,
+                count: pending.count,
+            };
+            operator.execute(&mut op_ctx, range)
+        };
+
+        match operator_result {
+            Ok(()) => {
+                tracing::debug!(
+                    operator = pending.operator_id,
+                    ?range,
+                    "Operator executed successfully"
+                );
+
+                // For change operator, enter insert mode
+                if pending.operator_id == "change" {
+                    let insert_mode = ModeId::new(ModuleId::new("editor"), "insert");
+                    self.app.mode_stack.set(insert_mode);
+                    tracing::debug!("Entered insert mode after change operator");
+                } else {
+                    // For other operators, just pop back to normal mode
+                    self.pop_operator_pending_mode();
+                }
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "Operator execution failed");
+                self.last_error = Some(format!("Operator failed: {err}"));
+                self.pop_operator_pending_mode();
+            }
+        }
+    }
+
+    /// Pop operator-pending mode and return to normal mode.
+    fn pop_operator_pending_mode(&mut self) {
+        // Pop should return to normal mode (the mode before operator-pending)
+        self.app.mode_stack.pop();
+        tracing::debug!(
+            mode = %self.app.current_mode(),
+            "Returned from operator-pending mode"
+        );
+    }
+}

--- a/runner/src/server/rpc/handlers/input.rs
+++ b/runner/src/server/rpc/handlers/input.rs
@@ -154,6 +154,10 @@ pub fn input_keys(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
                         cmd_ctx.set("count", reovim_driver_command::ArgValue::Count(count));
                     }
 
+                    // Set current mode name in context for commands that need to
+                    // adjust behavior based on mode (e.g., motions in operator-pending)
+                    cmd_ctx.set_mode_name(mode_name);
+
                     // Execute the command
                     if let Some(cmd_result) = ctx.session.execute_command(cmd_id, &cmd_ctx).await {
                         ctx.session.handle_command_result(cmd_result).await;

--- a/runner/src/server/session/session.rs
+++ b/runner/src/server/session/session.rs
@@ -353,6 +353,18 @@ impl Session {
                 tracing::info!(?action, "Block insert action requested (session)");
                 None
             }
+            CommandResult::EnterOperatorPending {
+                operator_id,
+                register,
+            } => {
+                // Enter-operator-pending actions are handled by the event loop.
+                tracing::info!(
+                    operator_id,
+                    ?register,
+                    "Enter operator-pending action requested (session)"
+                );
+                None
+            }
         }
     }
 


### PR DESCRIPTION
Implement vim-style operator-motion combinations (dw, cw, yw, etc.) where an operator key (d, c, y) followed by a motion determines the text range to operate on.

- Add PendingOperator state to track waiting operators
- Create enter-operator commands (d, y, c, >, <)
- Add mode context to CommandContext for operator-pending detection
- Update motion commands to return ranges in operator-pending mode
- Wire event loop to execute pending operator with range
- Add escape cancellation to exit operator-pending mode
- Shortcut commands (D, C, Y) already implemented

Closes #336