### PR TITLE
test(e2e): enable 9 more tests after upstream rebase (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Changed
 
+- E2E tests: Enable 9 more tests after upstream changes (#308)
+  - operators.rs: 19 enabled (was 12), 9 ignored
+  - search.rs: 5 enabled (was 3), 10 ignored
+  - Updated ignore messages to reference specific issues
+
 ### Fixed
 
 ### Removed

--- a/runner/tests/operators.rs
+++ b/runner/tests/operators.rs
@@ -1,7 +1,7 @@
 //! Operator integration tests (delete, yank, paste, change).
 //!
-//! **Status**: 12 tests enabled, 16 tests require additional features
-//! (operator-pending mode, count prefix handling).
+//! **Status**: 19 tests enabled, 9 tests require additional features
+//! ($ motion, operator-motion with j/w/b motions, paste before P).
 //!
 //! Run `cargo test --ignored` to run the remaining ignored tests.
 
@@ -57,7 +57,6 @@ async fn test_dd_last_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_5dd_count_delete() {
     let result = IntegrationTest::new()
         .await
@@ -91,7 +90,6 @@ async fn test_x_middle_of_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_x_at_eol() {
     let result = IntegrationTest::new()
         .await
@@ -103,7 +101,6 @@ async fn test_x_at_eol() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_3x_count_delete() {
     let result = IntegrationTest::new()
         .await
@@ -115,7 +112,7 @@ async fn test_3x_count_delete() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires w motion to return range in operator-pending mode"]
 async fn test_dw_delete_word() {
     let result = IntegrationTest::new()
         .await
@@ -127,7 +124,7 @@ async fn test_dw_delete_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires $ motion (#340)"]
 async fn test_d_dollar_delete_to_eol() {
     let result = IntegrationTest::new()
         .await
@@ -139,7 +136,7 @@ async fn test_d_dollar_delete_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires j motion to return range in operator-pending mode"]
 async fn test_dj_delete_two_lines() {
     let result = IntegrationTest::new()
         .await
@@ -151,7 +148,7 @@ async fn test_dj_delete_two_lines() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires b motion to return range in operator-pending mode"]
 async fn test_db_delete_backward_word() {
     let result = IntegrationTest::new()
         .await
@@ -189,7 +186,7 @@ async fn test_yy_p_multiline() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires j motion to return range in operator-pending mode"]
 async fn test_yj_yank_two_lines() {
     let result = IntegrationTest::new()
         .await
@@ -212,7 +209,6 @@ async fn test_yw_yank_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_2yy_yank_count() {
     let result = IntegrationTest::new()
         .await
@@ -228,7 +224,6 @@ async fn test_2yy_yank_count() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_dd_p_paste_after() {
     let result = IntegrationTest::new()
         .await
@@ -240,7 +235,7 @@ async fn test_dd_p_paste_after() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires P (paste before) fix"]
 async fn test_dd_upper_p_paste_before() {
     let result = IntegrationTest::new()
         .await
@@ -263,7 +258,6 @@ async fn test_yw_p_paste_char() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_2p_paste_multiple() {
     let result = IntegrationTest::new()
         .await
@@ -290,7 +284,7 @@ async fn test_paste_preserves_register() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires w motion to return range in operator-pending mode"]
 async fn test_cw_change_word() {
     let result = IntegrationTest::new()
         .await
@@ -303,7 +297,7 @@ async fn test_cw_change_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires $ motion (#340)"]
 async fn test_c_dollar_change_to_eol() {
     let result = IntegrationTest::new()
         .await
@@ -315,7 +309,6 @@ async fn test_c_dollar_change_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_cc_change_line() {
     let result = IntegrationTest::new()
         .await
@@ -327,7 +320,7 @@ async fn test_cc_change_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires w motion + count support in operator-pending mode"]
 async fn test_2cw_change_count() {
     let result = IntegrationTest::new()
         .await

--- a/runner/tests/search.rs
+++ b/runner/tests/search.rs
@@ -1,7 +1,7 @@
 //! Search integration tests (/, ?, n, N, *, #).
 //!
-//! **Status**: 3 tests enabled, 12 tests require additional features
-//! (search command mode, n/N commands).
+//! **Status**: 5 tests enabled, 10 tests require additional features
+//! (command-line mode for / and ? search patterns).
 //!
 //! Run `cargo test --ignored` to run the remaining ignored tests.
 
@@ -13,7 +13,7 @@ use common::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_forward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -25,7 +25,7 @@ async fn test_search_forward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_forward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -37,7 +37,7 @@ async fn test_search_forward_multiline() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_forward_wrap() {
     let result = IntegrationTest::new()
         .await
@@ -55,7 +55,7 @@ async fn test_search_forward_wrap() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for ? search (#338)"]
 async fn test_search_backward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -69,7 +69,7 @@ async fn test_search_backward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for ? search (#338)"]
 async fn test_search_backward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -86,7 +86,7 @@ async fn test_search_backward_multiline() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_next() {
     let result = IntegrationTest::new()
         .await
@@ -100,7 +100,7 @@ async fn test_search_next() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_next_multiple() {
     let result = IntegrationTest::new()
         .await
@@ -114,7 +114,7 @@ async fn test_search_next_multiple() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_previous() {
     let result = IntegrationTest::new()
         .await
@@ -133,7 +133,6 @@ async fn test_search_previous() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_search_word_forward() {
     let result = IntegrationTest::new()
         .await
@@ -159,7 +158,6 @@ async fn test_search_word_backward() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_search_word_with_n() {
     let result = IntegrationTest::new()
         .await
@@ -177,7 +175,7 @@ async fn test_search_word_with_n() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_cancel_with_escape() {
     let result = IntegrationTest::new()
         .await
@@ -194,7 +192,7 @@ async fn test_search_cancel_with_escape() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
+#[ignore = "requires command-line mode for / search (#338)"]
 async fn test_search_regex_pattern() {
     let result = IntegrationTest::new()
         .await


### PR DESCRIPTION
After rebasing onto upstream with operator-motion combinations (#336), enable tests that now pass.

Operator tests (runners/tests/operators.rs):
- Enable 7 tests: 5dd, x_at_eol, 3x, 2yy, dd_p, 2p, cc_change_line
- Now 19 enabled, 9 ignored
- Update ignore messages with specific issues:
  - d$/c$ need $ motion (#340)
  - dw/cw/db/dj/yj need motion ranges in operator-pending mode
  - P (paste before) needs fix

Search tests (runners/tests/search.rs):
- Enable 2 tests: search_word_forward, search_word_with_n
- Now 5 enabled, 10 ignored
- Update ignore messages to reference command-line mode (#338)

Refs #308, Parts of #307