### PR TITLE
test(e2e): enable all multi-client tests (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - search.rs: 5 enabled (was 3), 10 ignored
   - Updated ignore messages to reference specific issues
 
+- Multi-client tests: Enable all 3 tests (#314)
+  - Add `with_buffer()` to `MultiClientTest` for shared buffer setup
+  - Fix "No active buffer" error in multi-client tests
+
 ### Fixed
 
 ### Removed

--- a/runner/tests/common/multi_client.rs
+++ b/runner/tests/common/multi_client.rs
@@ -1,6 +1,10 @@
 //! Multi-client test utilities for concurrent client testing.
 
-use std::time::Duration;
+use std::{
+    io::Write,
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
 
 use {
     runner::client::common::{ConnectionConfig, RpcClient},
@@ -8,6 +12,9 @@ use {
 };
 
 use super::harness::TestServerHarness;
+
+/// Counter for unique temp file names
+static MULTI_CLIENT_FILE_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Client wrapper for multi-client tests
 pub struct TestClient {
@@ -59,6 +66,7 @@ impl TestClient {
 pub struct MultiClientTest {
     harness: TestServerHarness,
     client_count: usize,
+    initial_content: Option<String>,
 }
 
 impl MultiClientTest {
@@ -69,7 +77,15 @@ impl MultiClientTest {
                 .await
                 .expect("Failed to spawn server"),
             client_count: n,
+            initial_content: None,
         }
+    }
+
+    /// Set initial buffer content (shared by all clients)
+    #[must_use]
+    pub fn with_buffer(mut self, content: &str) -> Self {
+        self.initial_content = Some(content.to_string());
+        self
     }
 
     /// Connect all clients and run test
@@ -94,6 +110,26 @@ impl MultiClientTest {
                 }
             };
             clients.push(TestClient { client, id });
+        }
+
+        // Set up initial buffer via first client (shared by all)
+        if self.initial_content.is_some() || !clients.is_empty() {
+            let temp_path = {
+                let id = MULTI_CLIENT_FILE_COUNTER.fetch_add(1, Ordering::SeqCst);
+                let path = format!("/tmp/reovim-multi-test-{}-{id}.txt", std::process::id());
+                let content = self.initial_content.as_deref().unwrap_or("");
+                let mut file = std::fs::File::create(&path).expect("Failed to create temp file");
+                file.write_all(content.as_bytes())
+                    .expect("Failed to write temp file");
+                path
+            };
+            clients[0]
+                .client
+                .call("buffer/open_file", json!({ "path": &temp_path }))
+                .await
+                .expect("Failed to open buffer file");
+            // Small delay to ensure buffer is ready for other clients
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         test_fn(clients).await;

--- a/runner/tests/multi_client_tests.rs
+++ b/runner/tests/multi_client_tests.rs
@@ -1,18 +1,17 @@
 //! Multi-client concurrent tests.
 //!
-//! **Status**: 1 test enabled, 2 tests require additional features
-//! (buffer sharing between clients).
+//! **Status**: 3 tests enabled.
 //!
-//! Run `cargo test --ignored` to run the remaining ignored tests.
+//! Run `cargo test --test multi_client_tests` to run these tests.
 
 mod common;
 use common::MultiClientTest;
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_two_clients_read_same_buffer() {
     MultiClientTest::with_clients(2)
         .await
+        .with_buffer("")
         .run(|mut clients| async move {
             // Client 0 inserts
             clients[0].send_keys("ihello<Esc>").await.unwrap();
@@ -25,10 +24,10 @@ async fn test_two_clients_read_same_buffer() {
 }
 
 #[tokio::test]
-#[ignore = "requires modules loaded for key bindings"]
 async fn test_clients_see_changes() {
     MultiClientTest::with_clients(2)
         .await
+        .with_buffer("")
         .run(|mut clients| async move {
             // Client 0 makes change
             clients[0].send_keys("iworld<Esc>").await.unwrap();
@@ -45,6 +44,7 @@ async fn test_clients_see_changes() {
 async fn test_three_clients_concurrent() {
     MultiClientTest::with_clients(3)
         .await
+        .with_buffer("")
         .run(|mut clients| async move {
             // All clients should connect successfully
             for (i, client) in clients.iter_mut().enumerate() {


### PR DESCRIPTION
Fix MultiClientTest to support initial buffer setup, enabling all 3 multi-client tests that were previously ignored.

Changes:
- Add with_buffer() method to MultiClientTest for shared buffer setup
- Create temp file and open via buffer/open_file before running test
- Update all 3 tests to use with_buffer("") for empty initial buffer

Tests now passing:
- test_two_clients_read_same_buffer
- test_clients_see_changes
- test_three_clients_concurrent

The "No active buffer" error was caused by clients trying to read/write before any buffer was created. Now the first client opens a buffer that all clients share.

Closes #314, Refs #308, Parts of #307