### PR TITLE
feat(sched): add kernel timer API for delayed and periodic work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - Thread-safe with configurable `max_timers` limit
   - Integrated with Runtime tick cycle and panic safety
 
+- Timer FFI extension for external modules (#343)
+  - `reovim_schedule_delayed()` - C FFI for one-shot timers
+  - `reovim_schedule_periodic()` - C FFI for periodic timers
+  - `reovim_cancel_timer()` - Cancel scheduled timer
+  - `reovim_timer_is_pending()` - Check timer status
+  - `reovim_timer_count()` - Get active timer count
+  - Added timer types to `include/reovim.h`
+
 ### Changed
 
 - E2E tests: Enable 9 more tests after upstream changes (#308)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - Escape cancels pending operator
   - Full operator-pending mode support
 
+- Kernel Timer API for delayed and periodic work scheduling (#343)
+  - `Runtime::schedule_delayed(delay, callback)` - one-shot timer
+  - `Runtime::schedule_periodic(interval, callback)` - repeating timer
+  - RAII `TimerHandle` auto-cancels on drop
+  - Timer wheel implementation with O(1) cancel
+  - Thread-safe with configurable `max_timers` limit
+  - Integrated with Runtime tick cycle and panic safety
+
 ### Changed
 
 - E2E tests: Enable 9 more tests after upstream changes (#308)

--- a/lib/drivers/ffi/build.rs
+++ b/lib/drivers/ffi/build.rs
@@ -14,6 +14,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/types.rs");
     println!("cargo:rerun-if-changed=src/logging.rs");
+    println!("cargo:rerun-if-changed=src/timer.rs");
     println!("cargo:rerun-if-changed=src/version.rs");
     println!("cargo:rerun-if-changed=include/reovim.h");
 }

--- a/lib/drivers/ffi/include/reovim.h
+++ b/lib/drivers/ffi/include/reovim.h
@@ -236,6 +236,108 @@ void reovim_log_error(const char* msg);
 void reovim_log_debug(const char* msg);
 
 /* ============================================================================
+ * Timer Services
+ * ============================================================================
+ *
+ * Schedule delayed and periodic work. Timers fire on the kernel's tick loop.
+ *
+ * IMPORTANT: Timer callbacks must:
+ * - Return quickly (avoid blocking operations)
+ * - Not panic (panics are caught but waste resources)
+ * - Keep user_data valid until the timer fires or is cancelled
+ */
+
+/**
+ * Timer handle returned by scheduling functions.
+ *
+ * Size: 8 bytes
+ * Alignment: 8 bytes
+ *
+ * Check handle.id != 0 to verify the timer was scheduled successfully.
+ */
+typedef struct ReovimTimerHandle {
+    /** Timer ID. 0 indicates a failed/invalid timer. */
+    uint64_t id;
+} ReovimTimerHandle;
+
+/**
+ * Timer callback function type.
+ *
+ * @param user_data  Opaque pointer passed from schedule call
+ */
+typedef void (*ReovimTimerCallback)(void* user_data);
+
+/**
+ * Schedule a one-shot timer.
+ *
+ * The callback will be invoked once after delay_ms milliseconds.
+ *
+ * @param delay_ms   Delay in milliseconds before the callback fires
+ * @param callback   Function to call when the timer fires (may be NULL)
+ * @param user_data  Opaque pointer passed to the callback
+ *
+ * @return Timer handle. Check handle.id != 0 for success.
+ *         Returns null handle (id=0) if:
+ *         - Timer wheel is not initialized
+ *         - Maximum timer limit reached
+ *         - Callback is NULL
+ */
+ReovimTimerHandle reovim_schedule_delayed(
+    uint64_t delay_ms,
+    ReovimTimerCallback callback,
+    void* user_data
+);
+
+/**
+ * Schedule a periodic timer.
+ *
+ * The callback will be invoked repeatedly at interval_ms intervals.
+ *
+ * @param interval_ms  Interval in milliseconds between callback invocations
+ * @param callback     Function to call when the timer fires (may be NULL)
+ * @param user_data    Opaque pointer passed to the callback
+ *
+ * @return Timer handle. Check handle.id != 0 for success.
+ *         Returns null handle (id=0) if:
+ *         - Timer wheel is not initialized
+ *         - Maximum timer limit reached
+ *         - Callback is NULL
+ */
+ReovimTimerHandle reovim_schedule_periodic(
+    uint64_t interval_ms,
+    ReovimTimerCallback callback,
+    void* user_data
+);
+
+/**
+ * Cancel a scheduled timer.
+ *
+ * After cancellation, the timer's callback will not be invoked.
+ * Safe to call on already-cancelled or fired timers.
+ *
+ * @param handle  Timer handle from schedule function
+ *
+ * @return true if timer was found and cancelled, false otherwise
+ */
+bool reovim_cancel_timer(ReovimTimerHandle handle);
+
+/**
+ * Check if a timer is still pending.
+ *
+ * @param handle  Timer handle to check
+ *
+ * @return true if timer is scheduled and hasn't fired yet, false otherwise
+ */
+bool reovim_timer_is_pending(ReovimTimerHandle handle);
+
+/**
+ * Get the number of currently active timers.
+ *
+ * @return Number of pending timers, or 0 if timer wheel not initialized
+ */
+size_t reovim_timer_count(void);
+
+/* ============================================================================
  * Helper Macros
  * ============================================================================ */
 

--- a/lib/drivers/ffi/src/lib.rs
+++ b/lib/drivers/ffi/src/lib.rs
@@ -79,12 +79,18 @@
 //! - New types are added (backwards compatible)
 
 mod logging;
+mod timer;
 mod types;
 mod version;
 
 // Re-export FFI service functions
 pub use {
     logging::{reovim_log_debug, reovim_log_error, reovim_log_info, reovim_log_warn},
+    timer::{
+        ReovimTimerCallback, ReovimTimerHandle, init_timer_wheel, reovim_cancel_timer,
+        reovim_schedule_delayed, reovim_schedule_periodic, reovim_timer_count,
+        reovim_timer_is_pending,
+    },
     version::{ABI_VERSION, reovim_abi_is_compatible, reovim_abi_version},
 };
 

--- a/lib/drivers/ffi/src/timer.rs
+++ b/lib/drivers/ffi/src/timer.rs
@@ -1,0 +1,377 @@
+//! FFI-safe timer functions for external modules.
+//!
+//! These functions allow external modules written in C (or any FFI-compatible
+//! language) to schedule delayed and periodic work through the kernel's timer
+//! infrastructure.
+//!
+//! # Architecture
+//!
+//! The timer FFI uses a global `TimerWheel` that must be initialized by the
+//! main application before modules can schedule timers. If timers are scheduled
+//! before initialization, they fail gracefully with a null handle.
+//!
+//! # Thread Safety
+//!
+//! All timer functions are thread-safe. Multiple threads can schedule, cancel,
+//! and query timers concurrently.
+//!
+//! # Callback Safety
+//!
+//! Timer callbacks are invoked from the kernel's tick loop. Callbacks MUST:
+//! - Return quickly (avoid blocking operations)
+//! - Not panic (panics are caught but waste resources)
+//! - Not call `reovim_cancel_timer` on the currently firing timer
+//!
+//! # C Usage
+//!
+//! ```c
+//! #include <reovim.h>
+//!
+//! void my_callback(void* user_data) {
+//!     int* counter = (int*)user_data;
+//!     (*counter)++;
+//! }
+//!
+//! void schedule_timer(void) {
+//!     int counter = 0;
+//!     ReovimTimerHandle handle = reovim_schedule_delayed(
+//!         1000,  // 1 second delay
+//!         my_callback,
+//!         &counter
+//!     );
+//!
+//!     if (handle.id == 0) {
+//!         reovim_log_error("Failed to schedule timer");
+//!         return;
+//!     }
+//!
+//!     // Timer will fire after 1 second
+//!     // To cancel: reovim_cancel_timer(handle);
+//! }
+//! ```
+
+use std::sync::{Arc, OnceLock};
+
+use reovim_kernel::api::v1::{Priority, TimerWheel};
+
+/// Global timer wheel instance.
+///
+/// This is initialized by the main application during startup.
+/// FFI functions use this to schedule timers.
+static TIMER_WHEEL: OnceLock<Arc<TimerWheel>> = OnceLock::new();
+
+/// Initialize the global timer wheel for FFI access.
+///
+/// This should be called once during application startup, passing the
+/// runtime's timer wheel. After initialization, FFI functions can schedule
+/// timers.
+///
+/// # Panics
+///
+/// Panics if called more than once.
+pub fn init_timer_wheel(wheel: Arc<TimerWheel>) {
+    TIMER_WHEEL
+        .set(wheel)
+        .expect("Timer wheel already initialized");
+}
+
+/// Get the global timer wheel, if initialized.
+fn get_timer_wheel() -> Option<&'static Arc<TimerWheel>> {
+    TIMER_WHEEL.get()
+}
+
+// ============================================================================
+// C-compatible types
+// ============================================================================
+
+/// Opaque timer handle for FFI.
+///
+/// The `id` field is 0 if the timer failed to schedule.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ReovimTimerHandle {
+    /// Timer ID. 0 indicates a failed/invalid timer.
+    pub id: u64,
+}
+
+impl ReovimTimerHandle {
+    /// Create a null/invalid handle.
+    #[must_use]
+    pub const fn null() -> Self {
+        Self { id: 0 }
+    }
+
+    /// Create a handle from a timer ID.
+    #[must_use]
+    pub const fn new(id: u64) -> Self {
+        Self { id }
+    }
+
+    /// Check if this handle is valid.
+    #[must_use]
+    pub const fn is_valid(&self) -> bool {
+        self.id != 0
+    }
+}
+
+/// Timer callback function type.
+///
+/// Called when a timer fires. The `user_data` pointer is passed through
+/// from the scheduling call.
+///
+/// # Safety
+///
+/// - `user_data` must remain valid until the timer fires or is cancelled
+/// - Callbacks must not panic
+/// - Callbacks should return quickly
+pub type ReovimTimerCallback = Option<unsafe extern "C" fn(user_data: *mut libc::c_void)>;
+
+// ============================================================================
+// FFI functions
+// ============================================================================
+
+/// Schedule a one-shot timer.
+///
+/// The callback will be invoked once after `delay_ms` milliseconds.
+///
+/// # Arguments
+///
+/// - `delay_ms`: Delay in milliseconds before the callback fires
+/// - `callback`: Function to call when the timer fires
+/// - `user_data`: Opaque pointer passed to the callback
+///
+/// # Returns
+///
+/// A timer handle. Check `handle.id != 0` to verify success.
+/// Returns a null handle (id=0) if:
+/// - Timer wheel is not initialized
+/// - Maximum timer limit reached
+/// - Callback is null
+///
+/// # Safety
+///
+/// - `user_data` must remain valid until the timer fires or is cancelled
+/// - The callback must be a valid function pointer (or null)
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn reovim_schedule_delayed(
+    delay_ms: u64,
+    callback: ReovimTimerCallback,
+    user_data: *mut libc::c_void,
+) -> ReovimTimerHandle {
+    let Some(wheel) = get_timer_wheel() else {
+        tracing::warn!("Timer wheel not initialized, cannot schedule delayed timer");
+        return ReovimTimerHandle::null();
+    };
+
+    let Some(cb) = callback else {
+        tracing::warn!("Null callback passed to reovim_schedule_delayed");
+        return ReovimTimerHandle::null();
+    };
+
+    let delay = std::time::Duration::from_millis(delay_ms);
+
+    // Wrap the FFI callback in a Rust closure
+    // Safety: We trust the caller to keep user_data valid
+    let user_data_ptr = user_data as usize; // Convert to usize for Send
+    let handle = wheel.schedule_oneshot(delay, Priority::NORMAL, move || {
+        // Safety: caller guarantees user_data is valid
+        unsafe { cb(user_data_ptr as *mut libc::c_void) };
+    });
+
+    if handle.is_failed() {
+        tracing::warn!("Failed to schedule delayed timer (capacity exceeded?)");
+        return ReovimTimerHandle::null();
+    }
+
+    let id = handle.id().as_u64();
+    let _ = handle.detach(); // Don't cancel on Rust handle drop
+
+    ReovimTimerHandle::new(id)
+}
+
+/// Schedule a periodic timer.
+///
+/// The callback will be invoked repeatedly at `interval_ms` intervals.
+///
+/// # Arguments
+///
+/// - `interval_ms`: Interval in milliseconds between callback invocations
+/// - `callback`: Function to call when the timer fires
+/// - `user_data`: Opaque pointer passed to the callback
+///
+/// # Returns
+///
+/// A timer handle. Check `handle.id != 0` to verify success.
+/// Returns a null handle (id=0) if:
+/// - Timer wheel is not initialized
+/// - Maximum timer limit reached
+/// - Callback is null
+///
+/// # Safety
+///
+/// - `user_data` must remain valid for the lifetime of the timer
+/// - The callback must be a valid function pointer (or null)
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn reovim_schedule_periodic(
+    interval_ms: u64,
+    callback: ReovimTimerCallback,
+    user_data: *mut libc::c_void,
+) -> ReovimTimerHandle {
+    let Some(wheel) = get_timer_wheel() else {
+        tracing::warn!("Timer wheel not initialized, cannot schedule periodic timer");
+        return ReovimTimerHandle::null();
+    };
+
+    let Some(cb) = callback else {
+        tracing::warn!("Null callback passed to reovim_schedule_periodic");
+        return ReovimTimerHandle::null();
+    };
+
+    let interval = std::time::Duration::from_millis(interval_ms);
+
+    // Wrap the FFI callback in a Rust closure
+    // Safety: We trust the caller to keep user_data valid
+    let user_data_ptr = user_data as usize; // Convert to usize for Send
+    let handle = wheel.schedule_periodic(interval, Priority::NORMAL, move || {
+        // Safety: caller guarantees user_data is valid
+        unsafe { cb(user_data_ptr as *mut libc::c_void) };
+    });
+
+    if handle.is_failed() {
+        tracing::warn!("Failed to schedule periodic timer (capacity exceeded?)");
+        return ReovimTimerHandle::null();
+    }
+
+    let id = handle.id().as_u64();
+    let _ = handle.detach(); // Don't cancel on Rust handle drop
+
+    ReovimTimerHandle::new(id)
+}
+
+/// Cancel a scheduled timer.
+///
+/// After cancellation, the timer's callback will not be invoked.
+/// It is safe to call this on an already-cancelled or fired timer.
+///
+/// # Arguments
+///
+/// - `handle`: The timer handle returned from `reovim_schedule_delayed` or
+///   `reovim_schedule_periodic`
+///
+/// # Returns
+///
+/// `true` if the timer was found and cancelled, `false` if the timer was
+/// already cancelled, has fired, or the handle was invalid.
+#[unsafe(no_mangle)]
+pub extern "C" fn reovim_cancel_timer(handle: ReovimTimerHandle) -> bool {
+    if !handle.is_valid() {
+        return false;
+    }
+
+    let Some(wheel) = get_timer_wheel() else {
+        return false;
+    };
+
+    let timer_id = reovim_kernel::api::v1::TimerId::from_raw(handle.id);
+    wheel.cancel(timer_id)
+}
+
+/// Check if a timer is still pending.
+///
+/// # Arguments
+///
+/// - `handle`: The timer handle to check
+///
+/// # Returns
+///
+/// `true` if the timer is still scheduled and hasn't fired yet,
+/// `false` if the timer has fired, was cancelled, or the handle is invalid.
+#[unsafe(no_mangle)]
+pub extern "C" fn reovim_timer_is_pending(handle: ReovimTimerHandle) -> bool {
+    if !handle.is_valid() {
+        return false;
+    }
+
+    let Some(wheel) = get_timer_wheel() else {
+        return false;
+    };
+
+    let timer_id = reovim_kernel::api::v1::TimerId::from_raw(handle.id);
+    wheel.is_pending(timer_id)
+}
+
+/// Get the number of currently active timers.
+///
+/// # Returns
+///
+/// The number of pending timers, or 0 if the timer wheel is not initialized.
+#[unsafe(no_mangle)]
+pub extern "C" fn reovim_timer_count() -> usize {
+    get_timer_wheel().map_or(0, |w| w.pending_count())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timer_handle_null() {
+        let handle = ReovimTimerHandle::null();
+        assert_eq!(handle.id, 0);
+        assert!(!handle.is_valid());
+    }
+
+    #[test]
+    fn test_timer_handle_new() {
+        let handle = ReovimTimerHandle::new(42);
+        assert_eq!(handle.id, 42);
+        assert!(handle.is_valid());
+    }
+
+    #[test]
+    fn test_timer_handle_size() {
+        // Verify FFI-safe size
+        assert_eq!(std::mem::size_of::<ReovimTimerHandle>(), 8);
+        assert_eq!(std::mem::align_of::<ReovimTimerHandle>(), 8);
+    }
+
+    #[test]
+    fn test_schedule_without_init_returns_null() {
+        // Timer wheel not initialized, should return null handle
+        unsafe extern "C" fn dummy_callback(_: *mut libc::c_void) {}
+
+        let handle =
+            unsafe { reovim_schedule_delayed(100, Some(dummy_callback), std::ptr::null_mut()) };
+
+        // Note: This test may fail if run after other tests that initialize
+        // the global. In practice, the global is only set once.
+        // For isolated testing, we'd need a different approach.
+        assert!(!handle.is_valid() || TIMER_WHEEL.get().is_some());
+    }
+
+    #[test]
+    fn test_schedule_null_callback_returns_null() {
+        // Even if wheel is initialized, null callback should fail
+        let handle = unsafe { reovim_schedule_delayed(100, None, std::ptr::null_mut()) };
+
+        // Should return null (either wheel not init or null callback)
+        // The function checks callback before wheel, so this always fails
+        assert!(!handle.is_valid());
+    }
+
+    #[test]
+    fn test_cancel_null_handle() {
+        let handle = ReovimTimerHandle::null();
+        assert!(!reovim_cancel_timer(handle));
+    }
+
+    #[test]
+    fn test_is_pending_null_handle() {
+        let handle = ReovimTimerHandle::null();
+        assert!(!reovim_timer_is_pending(handle));
+    }
+}

--- a/lib/kernel/src/api/v1.rs
+++ b/lib/kernel/src/api/v1.rs
@@ -143,6 +143,7 @@ pub use crate::sched::{
     BoxedTask,
     // Configuration constants
     DEFAULT_BATCH_SIZE,
+    DEFAULT_MAX_TIMERS,
     DEFAULT_PRIORITY_QUEUE_CAPACITY,
     DEFAULT_WORK_QUEUE_CAPACITY,
     Executor,
@@ -157,6 +158,11 @@ pub use crate::sched::{
     Task,
     TaskId,
     TaskState,
+    // Timer types
+    TimerConfig,
+    TimerHandle,
+    TimerId,
+    TimerWheel,
     WORK_QUEUE_DEFAULT_CAPACITY,
     WORK_QUEUE_MAX_CAPACITY,
     WorkQueue,

--- a/lib/kernel/src/sched/mod.rs
+++ b/lib/kernel/src/sched/mod.rs
@@ -82,6 +82,7 @@ mod priority;
 mod runtime;
 mod state;
 mod task;
+mod timer;
 mod work_queue;
 
 // Re-export all public types
@@ -94,6 +95,7 @@ pub use {
     },
     state::RuntimeState,
     task::{BoxedTask, Priority, Task, TaskId, TaskState},
+    timer::{DEFAULT_MAX_TIMERS, TimerConfig, TimerHandle, TimerId, TimerWheel},
     work_queue::{
         DEFAULT_CAPACITY as WORK_QUEUE_DEFAULT_CAPACITY, MAX_CAPACITY as WORK_QUEUE_MAX_CAPACITY,
         WorkQueue,

--- a/lib/kernel/src/sched/runtime.rs
+++ b/lib/kernel/src/sched/runtime.rs
@@ -33,7 +33,7 @@
 //! assert_eq!(runtime.state(), RuntimeState::Stopping);
 //! ```
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use {
     super::{
@@ -41,6 +41,7 @@ use {
         priority::PriorityQueue,
         state::RuntimeState,
         task::{Priority, Task},
+        timer::{DEFAULT_MAX_TIMERS, TimerHandle, TimerId, TimerWheel},
         work_queue::WorkQueue,
     },
     crate::ipc::{DynEvent, EventBus, EventScope, Receiver, Sender, channel},
@@ -68,6 +69,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 16;
 ///     work_queue_capacity: 2048,
 ///     priority_queue_capacity: 512,
 ///     batch_size: 32,
+///     max_timers: 512,
 /// };
 ///
 /// let runtime = Runtime::with_config(config);
@@ -82,6 +84,9 @@ pub struct RuntimeConfig {
 
     /// Maximum tasks processed per tick.
     pub batch_size: usize,
+
+    /// Maximum concurrent timers.
+    pub max_timers: usize,
 }
 
 impl Default for RuntimeConfig {
@@ -90,6 +95,7 @@ impl Default for RuntimeConfig {
             work_queue_capacity: DEFAULT_WORK_QUEUE_CAPACITY,
             priority_queue_capacity: DEFAULT_PRIORITY_QUEUE_CAPACITY,
             batch_size: DEFAULT_BATCH_SIZE,
+            max_timers: DEFAULT_MAX_TIMERS,
         }
     }
 }
@@ -131,6 +137,12 @@ pub struct RuntimeStats {
 
     /// Total tasks that failed (error or panic).
     pub tasks_failed: u64,
+
+    /// Number of active (pending) timers.
+    pub active_timers: usize,
+
+    /// Number of timers dropped due to capacity limit.
+    pub timers_dropped: u64,
 }
 
 /// Runtime event loop coordinator.
@@ -166,6 +178,9 @@ pub struct Runtime {
     /// Work queue for deferred tasks.
     work_queue: Arc<WorkQueue>,
 
+    /// Timer wheel for delayed/periodic work.
+    timer_wheel: Arc<TimerWheel>,
+
     /// Task executor with panic handling.
     executor: Executor,
 
@@ -195,6 +210,7 @@ impl Runtime {
         let work_queue = Arc::new(WorkQueue::with_capacity(config.work_queue_capacity));
         let executor = Executor::new(Arc::clone(&work_queue)).with_batch_size(config.batch_size);
         let event_queue = PriorityQueue::with_capacity(config.priority_queue_capacity);
+        let timer_wheel = Arc::new(TimerWheel::with_max_timers(config.max_timers));
         let (command_tx, command_rx) = channel();
 
         Self {
@@ -202,6 +218,7 @@ impl Runtime {
             event_bus: Arc::new(EventBus::new()),
             event_queue,
             work_queue,
+            timer_wheel,
             executor,
             command_tx,
             command_rx,
@@ -255,9 +272,10 @@ impl Runtime {
     ///
     /// This method:
     /// 1. Processes runtime commands
-    /// 2. Dispatches events from the priority queue
-    /// 3. Executes tasks from the work queue
-    /// 4. Processes queued async events
+    /// 2. Processes expired timers (schedules their callbacks as tasks)
+    /// 3. Dispatches events from the priority queue
+    /// 4. Executes tasks from the work queue
+    /// 5. Processes queued async events
     ///
     /// Returns `true` if the runtime should continue, `false` if it should stop.
     pub fn tick(&mut self) -> bool {
@@ -275,6 +293,12 @@ impl Runtime {
 
         // Only process work when running
         if self.state.is_running() {
+            // Process timers FIRST - may schedule new work
+            let timer_tasks = self.timer_wheel.tick(std::time::Instant::now());
+            for task in timer_tasks {
+                self.work_queue.push(task);
+            }
+
             // Dispatch events from priority queue
             self.dispatch_events();
 
@@ -358,6 +382,85 @@ impl Runtime {
         self.work_queue.push(task)
     }
 
+    /// Schedule work to execute after a delay (one-shot timer).
+    ///
+    /// The callback executes once after the delay passes, on the next tick
+    /// after the deadline. Returns a handle that cancels the timer when dropped.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::api::v1::*;
+    /// use std::time::Duration;
+    ///
+    /// let mut runtime = Runtime::new();
+    /// runtime.boot();
+    ///
+    /// // Schedule work for 100ms from now
+    /// let handle = runtime.schedule_delayed(Duration::from_millis(100), || {
+    ///     println!("Delayed work executed!");
+    /// });
+    ///
+    /// // Timer will fire on the tick after 100ms passes
+    /// // Drop handle to cancel, or let it fire
+    /// ```
+    pub fn schedule_delayed<F>(&self, delay: Duration, work: F) -> TimerHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.timer_wheel
+            .schedule_oneshot(delay, Priority::NORMAL, work)
+    }
+
+    /// Schedule work to execute periodically.
+    ///
+    /// The callback executes repeatedly at the specified interval. Returns a
+    /// handle that cancels the timer when dropped.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::api::v1::*;
+    /// use std::time::Duration;
+    ///
+    /// let mut runtime = Runtime::new();
+    /// runtime.boot();
+    ///
+    /// // Schedule periodic work every 50ms
+    /// let handle = runtime.schedule_periodic(Duration::from_millis(50), || {
+    ///     println!("Periodic work!");
+    /// });
+    ///
+    /// // Timer fires every 50ms until handle is dropped
+    /// ```
+    pub fn schedule_periodic<F>(&self, interval: Duration, work: F) -> TimerHandle
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.timer_wheel
+            .schedule_periodic(interval, Priority::NORMAL, work)
+    }
+
+    /// Cancel a timer by ID.
+    ///
+    /// Returns `true` if the timer was found and cancelled, `false` if it
+    /// was already cancelled or has already fired.
+    ///
+    /// Note: Timers are automatically cancelled when their [`TimerHandle`] is
+    /// dropped, so explicit cancellation is rarely needed.
+    pub fn cancel_timer(&self, id: TimerId) -> bool {
+        self.timer_wheel.cancel(id)
+    }
+
+    /// Get a reference to the timer wheel.
+    ///
+    /// This allows external code to schedule timers directly with custom
+    /// configuration.
+    #[must_use]
+    pub const fn timer_wheel(&self) -> &Arc<TimerWheel> {
+        &self.timer_wheel
+    }
+
     /// Queue an event for priority-ordered processing.
     ///
     /// Returns `false` if the queue is full.
@@ -421,7 +524,10 @@ impl Runtime {
     /// Check if the runtime is idle (no pending work).
     #[must_use]
     pub fn is_idle(&self) -> bool {
-        self.event_queue.is_empty() && self.work_queue.is_empty() && self.event_bus.queue_is_empty()
+        self.event_queue.is_empty()
+            && self.work_queue.is_empty()
+            && self.event_bus.queue_is_empty()
+            && self.timer_wheel.pending_count() == 0
     }
 
     /// Get runtime statistics.
@@ -434,6 +540,8 @@ impl Runtime {
             work_dropped: self.work_queue.dropped_count(),
             tasks_executed: self.executor.executed_count(),
             tasks_failed: self.executor.failed_count(),
+            active_timers: self.timer_wheel.pending_count(),
+            timers_dropped: self.timer_wheel.dropped_count(),
         }
     }
 
@@ -494,6 +602,7 @@ mod tests {
             work_queue_capacity: 100,
             priority_queue_capacity: 50,
             batch_size: 8,
+            max_timers: 64,
         };
         let runtime = Runtime::with_config(config);
         assert_eq!(runtime.state(), RuntimeState::Booting);

--- a/lib/kernel/src/sched/timer.rs
+++ b/lib/kernel/src/sched/timer.rs
@@ -387,6 +387,14 @@ impl TimerWheel {
         })
     }
 
+    /// Check if a timer is still pending (scheduled but not yet fired).
+    ///
+    /// Returns `true` if the timer exists and hasn't been cancelled or fired.
+    pub fn is_pending(&self, id: TimerId) -> bool {
+        let timers = self.timers.lock();
+        timers.get(&id).is_some_and(|entry| !entry.is_cancelled())
+    }
+
     /// Process expired timers and return tasks to execute.
     ///
     /// This should be called during each tick with the current time.

--- a/lib/kernel/src/sched/timer.rs
+++ b/lib/kernel/src/sched/timer.rs
@@ -1,0 +1,957 @@
+//! Timer mechanism for delayed and periodic work scheduling.
+//!
+//! Linux equivalent: `kernel/time/timer.c`
+//!
+//! This module provides timer primitives for scheduling work to execute
+//! after a delay or at regular intervals. Timers integrate with the
+//! [`Runtime`](super::Runtime) tick cycle and execute callbacks via the
+//! work queue for panic safety.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                       TimerWheel                             │
+//! │  ┌──────────────────────────────────────────────────────┐   │
+//! │  │  HashMap<TimerId, TimerEntry>                        │   │
+//! │  │    - deadline: Instant                               │   │
+//! │  │    - work: TimerWork (OneShot or Periodic)           │   │
+//! │  └──────────────────────────────────────────────────────┘   │
+//! │                           │                                  │
+//! │                           │ tick(now)                        │
+//! │                           v                                  │
+//! │  ┌──────────────────────────────────────────────────────┐   │
+//! │  │  WorkQueue <- expired timers scheduled as Tasks      │   │
+//! │  └──────────────────────────────────────────────────────┘   │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use reovim_kernel::api::v1::*;
+//! use std::time::Duration;
+//! use std::sync::atomic::{AtomicUsize, Ordering};
+//! use std::sync::Arc;
+//!
+//! let mut runtime = Runtime::new();
+//! runtime.boot();
+//!
+//! // Schedule a one-shot timer
+//! let counter = Arc::new(AtomicUsize::new(0));
+//! let counter_clone = counter.clone();
+//! let _handle = runtime.schedule_delayed(Duration::from_millis(10), move || {
+//!     counter_clone.fetch_add(1, Ordering::SeqCst);
+//! });
+//!
+//! // Timer fires when tick advances past deadline
+//! ```
+//!
+//! # Panic Safety
+//!
+//! Timer callbacks are executed via the work queue, which uses the executor's
+//! `catch_unwind` for panic safety. A panicking callback is marked as failed
+//! and does not repeat (for periodic timers).
+
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use crate::arch::sync::Mutex;
+
+use super::task::{Priority, Task};
+
+/// Unique timer identifier.
+///
+/// Timer IDs are monotonically increasing and never reused within a session.
+/// This follows the same pattern as [`TaskId`](super::TaskId) and
+/// [`BufferId`](crate::mm::BufferId).
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::*;
+///
+/// let id1 = TimerId::new();
+/// let id2 = TimerId::new();
+/// assert_ne!(id1, id2);
+/// assert!(id2.as_u64() > id1.as_u64());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TimerId(u64);
+
+impl TimerId {
+    /// Create a new unique timer ID.
+    ///
+    /// IDs start at 1 and increment monotonically.
+    #[must_use]
+    pub fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        Self(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw numeric value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Create from raw value.
+    ///
+    /// Primarily for testing and deserialization.
+    #[inline]
+    #[must_use]
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl Default for TimerId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for TimerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Timer({})", self.0)
+    }
+}
+
+/// Timer configuration.
+///
+/// Specifies when a timer should fire and at what priority the callback
+/// should execute. This struct is provided for advanced use cases where
+/// you need more control than `Runtime::schedule_delayed()` provides.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::*;
+/// use std::time::Duration;
+///
+/// // One-shot timer after 100ms
+/// let config = TimerConfig {
+///     delay: Duration::from_millis(100),
+///     interval: None,
+///     priority: Priority::NORMAL,
+/// };
+///
+/// // Periodic timer every 50ms
+/// let periodic = TimerConfig {
+///     delay: Duration::from_millis(50),
+///     interval: Some(Duration::from_millis(50)),
+///     priority: Priority::LOW,
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct TimerConfig {
+    /// Initial delay before first execution.
+    pub delay: Duration,
+
+    /// Optional interval for periodic timers.
+    ///
+    /// If `Some`, the timer will reschedule after each execution.
+    /// If `None`, the timer is one-shot and removed after firing.
+    pub interval: Option<Duration>,
+
+    /// Priority for the scheduled task.
+    ///
+    /// Determines execution order relative to other work in the queue.
+    pub priority: Priority,
+}
+
+impl Default for TimerConfig {
+    fn default() -> Self {
+        Self {
+            delay: Duration::ZERO,
+            interval: None,
+            priority: Priority::NORMAL,
+        }
+    }
+}
+
+/// Type-erased one-shot timer callback.
+type BoxedOneShotCallback = Box<dyn FnOnce() + Send + 'static>;
+
+/// Type-erased periodic timer callback.
+///
+/// Uses `Arc` instead of `Box` because periodic callbacks need to be cloned
+/// for each invocation.
+type BoxedPeriodicCallback = Arc<dyn Fn() + Send + Sync + 'static>;
+
+/// Timer callback storage.
+///
+/// Distinguishes between one-shot (`FnOnce`) and periodic (`Fn`) callbacks.
+enum TimerWork {
+    /// One-shot timer: callback is consumed on execution.
+    OneShot(Option<BoxedOneShotCallback>),
+
+    /// Periodic timer: callback can be called multiple times.
+    Periodic(BoxedPeriodicCallback),
+}
+
+impl fmt::Debug for TimerWork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OneShot(_) => write!(f, "OneShot(...)"),
+            Self::Periodic(_) => write!(f, "Periodic(...)"),
+        }
+    }
+}
+
+/// Internal timer entry in the wheel.
+struct TimerEntry {
+    /// Unique identifier.
+    id: TimerId,
+
+    /// When the timer should fire.
+    deadline: Instant,
+
+    /// Interval for periodic rescheduling.
+    interval: Option<Duration>,
+
+    /// Priority for the work task.
+    priority: Priority,
+
+    /// The callback to execute.
+    work: TimerWork,
+
+    /// Whether this timer has been cancelled.
+    cancelled: AtomicBool,
+}
+
+impl TimerEntry {
+    /// Check if this timer has been cancelled.
+    #[inline]
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Mark this timer as cancelled.
+    #[inline]
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+impl fmt::Debug for TimerEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimerEntry")
+            .field("id", &self.id)
+            .field("deadline", &self.deadline)
+            .field("interval", &self.interval)
+            .field("priority", &self.priority)
+            .field("work", &self.work)
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+/// Default maximum number of concurrent timers.
+pub const DEFAULT_MAX_TIMERS: usize = 1024;
+
+/// Timer wheel for managing scheduled timers.
+///
+/// The timer wheel stores active timers indexed by ID and checks for
+/// expired timers during each tick. Expired timers have their callbacks
+/// scheduled as tasks on the work queue.
+///
+/// # Thread Safety
+///
+/// The wheel uses a `Mutex<HashMap>` internally, making it safe to
+/// schedule and cancel from multiple threads.
+pub struct TimerWheel {
+    /// Active timers indexed by ID.
+    timers: Mutex<HashMap<TimerId, TimerEntry>>,
+
+    /// Next timer ID (atomic for thread-safe allocation).
+    next_id: AtomicU64,
+
+    /// Maximum number of timers allowed.
+    max_timers: usize,
+
+    /// Count of timers dropped due to capacity limit.
+    dropped: AtomicU64,
+}
+
+impl TimerWheel {
+    /// Create a new timer wheel with default capacity.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_max_timers(DEFAULT_MAX_TIMERS)
+    }
+
+    /// Create a timer wheel with specified maximum timer count.
+    #[must_use]
+    pub fn with_max_timers(max_timers: usize) -> Self {
+        Self {
+            timers: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+            max_timers,
+            dropped: AtomicU64::new(0),
+        }
+    }
+
+    /// Schedule a one-shot timer.
+    ///
+    /// Returns a handle that cancels the timer when dropped.
+    pub fn schedule_oneshot<F>(
+        self: &Arc<Self>,
+        delay: Duration,
+        priority: Priority,
+        work: F,
+    ) -> TimerHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.schedule_internal(delay, None, priority, TimerWork::OneShot(Some(Box::new(work))))
+    }
+
+    /// Schedule a periodic timer.
+    ///
+    /// Returns a handle that cancels the timer when dropped.
+    pub fn schedule_periodic<F>(
+        self: &Arc<Self>,
+        interval: Duration,
+        priority: Priority,
+        work: F,
+    ) -> TimerHandle
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.schedule_internal(
+            interval,
+            Some(interval),
+            priority,
+            TimerWork::Periodic(Arc::new(work)),
+        )
+    }
+
+    /// Internal scheduling implementation.
+    fn schedule_internal(
+        self: &Arc<Self>,
+        delay: Duration,
+        interval: Option<Duration>,
+        priority: Priority,
+        work: TimerWork,
+    ) -> TimerHandle {
+        let id = TimerId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let deadline = Instant::now() + delay;
+
+        let mut timers = self.timers.lock();
+
+        // Check capacity limit
+        if timers.len() >= self.max_timers {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            // Timer limit exceeded - return a failed handle
+            // Caller can check handle.is_failed() to detect this
+            return TimerHandle::failed(id);
+        }
+
+        let entry = TimerEntry {
+            id,
+            deadline,
+            interval,
+            priority,
+            work,
+            cancelled: AtomicBool::new(false),
+        };
+
+        timers.insert(id, entry);
+        drop(timers);
+
+        TimerHandle::new(id, Arc::downgrade(self))
+    }
+
+    /// Cancel a timer by ID.
+    ///
+    /// Returns `true` if the timer was found and cancelled, `false` if
+    /// it was already cancelled or has fired.
+    pub fn cancel(&self, id: TimerId) -> bool {
+        let timers = self.timers.lock();
+        timers.get(&id).is_some_and(|entry| {
+            if entry.is_cancelled() {
+                false
+            } else {
+                entry.cancel();
+                true
+            }
+        })
+    }
+
+    /// Process expired timers and return tasks to execute.
+    ///
+    /// This should be called during each tick with the current time.
+    /// Returns a vector of tasks for expired timers.
+    pub fn tick(&self, now: Instant) -> Vec<Task> {
+        let mut tasks = Vec::new();
+        let mut to_remove = Vec::new();
+        let mut to_reschedule = Vec::new();
+
+        {
+            let mut timers = self.timers.lock();
+
+            for (id, entry) in timers.iter_mut() {
+                // Skip cancelled timers
+                if entry.is_cancelled() {
+                    to_remove.push(*id);
+                    continue;
+                }
+
+                // Check if timer has expired
+                if entry.deadline <= now {
+                    match &mut entry.work {
+                        TimerWork::OneShot(work_opt) => {
+                            // Take the FnOnce callback
+                            if let Some(work) = work_opt.take() {
+                                let task = Task::with_priority(entry.priority, work);
+                                tasks.push(task);
+                            }
+                            to_remove.push(*id);
+                        }
+                        TimerWork::Periodic(work) => {
+                            // Clone the Arc callback for execution
+                            let work_clone = Arc::clone(work);
+                            let task = Task::with_priority(entry.priority, move || work_clone());
+                            tasks.push(task);
+
+                            // Reschedule for next interval
+                            if let Some(interval) = entry.interval {
+                                to_reschedule.push((*id, now + interval));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Remove completed/cancelled timers
+            for id in to_remove {
+                timers.remove(&id);
+            }
+
+            // Update deadlines for periodic timers
+            for (id, new_deadline) in to_reschedule {
+                if let Some(entry) = timers.get_mut(&id) {
+                    entry.deadline = new_deadline;
+                }
+            }
+        }
+
+        tasks
+    }
+
+    /// Get the number of pending timers.
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.timers.lock().len()
+    }
+
+    /// Get the number of timers dropped due to capacity limits.
+    #[must_use]
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for TimerWheel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for TimerWheel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimerWheel")
+            .field("pending", &self.pending_count())
+            .field("max_timers", &self.max_timers)
+            .field("dropped", &self.dropped_count())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Handle to a scheduled timer with RAII cancellation.
+///
+/// When dropped, the handle automatically cancels the timer if it hasn't
+/// fired yet. This follows the RAII pattern for resource management.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::*;
+/// use std::time::Duration;
+///
+/// let mut runtime = Runtime::new();
+/// runtime.boot();
+///
+/// {
+///     // Timer is scheduled
+///     let handle = runtime.schedule_delayed(Duration::from_secs(10), || {
+///         println!("This won't print");
+///     });
+///     // handle dropped here - timer is cancelled
+/// }
+///
+/// // Timer was cancelled, won't fire
+/// ```
+///
+/// # Manual Cancellation
+///
+/// You can also explicitly cancel via [`Runtime::cancel_timer`](super::Runtime::cancel_timer):
+///
+/// ```
+/// use reovim_kernel::api::v1::*;
+/// use std::time::Duration;
+///
+/// let mut runtime = Runtime::new();
+/// runtime.boot();
+///
+/// let handle = runtime.schedule_delayed(Duration::from_secs(10), || {});
+/// let id = handle.id();
+///
+/// // Explicit cancellation
+/// std::mem::forget(handle); // Prevent drop cancellation
+/// let was_pending = runtime.cancel_timer(id);
+/// ```
+pub struct TimerHandle {
+    /// The timer's unique identifier.
+    id: TimerId,
+
+    /// Weak reference to the timer wheel for cancellation.
+    ///
+    /// If the wheel has been dropped (runtime shutdown), cancellation
+    /// is a no-op since all timers are already gone.
+    wheel: Option<Weak<TimerWheel>>,
+
+    /// Whether this handle represents a failed scheduling attempt.
+    ///
+    /// When `max_timers` is exceeded, we return a "failed" handle that
+    /// doesn't actually have a timer to cancel.
+    failed: bool,
+}
+
+impl TimerHandle {
+    /// Create a new timer handle.
+    pub(crate) const fn new(id: TimerId, wheel: Weak<TimerWheel>) -> Self {
+        Self {
+            id,
+            wheel: Some(wheel),
+            failed: false,
+        }
+    }
+
+    /// Create a failed handle (timer wasn't actually scheduled).
+    pub(crate) const fn failed(id: TimerId) -> Self {
+        Self {
+            id,
+            wheel: None,
+            failed: true,
+        }
+    }
+
+    /// Get the timer's unique identifier.
+    #[inline]
+    #[must_use]
+    pub const fn id(&self) -> TimerId {
+        self.id
+    }
+
+    /// Check if this handle represents a failed scheduling attempt.
+    ///
+    /// Returns `true` if the timer was not actually scheduled (e.g., due
+    /// to hitting the `max_timers` limit).
+    #[inline]
+    #[must_use]
+    pub const fn is_failed(&self) -> bool {
+        self.failed
+    }
+
+    /// Prevent automatic cancellation on drop.
+    ///
+    /// After calling this, dropping the handle will NOT cancel the timer.
+    /// Use this when you want the timer to fire regardless of handle lifetime.
+    ///
+    /// Returns the timer ID for manual cancellation if needed later.
+    #[must_use]
+    pub fn detach(mut self) -> TimerId {
+        let id = self.id;
+        self.wheel = None; // Prevent Drop from cancelling
+        id
+    }
+}
+
+impl Drop for TimerHandle {
+    fn drop(&mut self) {
+        // If we have a wheel reference and it's still alive, cancel the timer
+        if let Some(ref weak) = self.wheel
+            && let Some(wheel) = weak.upgrade()
+        {
+            wheel.cancel(self.id);
+        }
+    }
+}
+
+impl fmt::Debug for TimerHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimerHandle")
+            .field("id", &self.id)
+            .field("failed", &self.failed)
+            .field("wheel_alive", &self.wheel.as_ref().is_some_and(|w| w.strong_count() > 0))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timer_id_unique() {
+        let id1 = TimerId::new();
+        let id2 = TimerId::new();
+        let id3 = TimerId::new();
+
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert!(id2.as_u64() > id1.as_u64());
+        assert!(id3.as_u64() > id2.as_u64());
+    }
+
+    #[test]
+    fn test_timer_id_display() {
+        let id = TimerId::from_raw(42);
+        assert_eq!(format!("{id}"), "Timer(42)");
+    }
+
+    #[test]
+    fn test_timer_id_from_raw() {
+        let id = TimerId::from_raw(123);
+        assert_eq!(id.as_u64(), 123);
+    }
+
+    #[test]
+    fn test_timer_id_default() {
+        let id1 = TimerId::default();
+        let id2 = TimerId::default();
+        assert_ne!(id1, id2); // Each default creates a new unique ID
+    }
+
+    #[test]
+    fn test_timer_id_ordering() {
+        let id1 = TimerId::from_raw(10);
+        let id2 = TimerId::from_raw(20);
+        let id3 = TimerId::from_raw(10);
+
+        assert!(id1 < id2);
+        assert!(id2 > id1);
+        assert_eq!(id1, id3);
+    }
+
+    #[test]
+    fn test_timer_config_default() {
+        let config = TimerConfig::default();
+        assert_eq!(config.delay, Duration::ZERO);
+        assert!(config.interval.is_none());
+        assert_eq!(config.priority, Priority::NORMAL);
+    }
+
+    #[test]
+    fn test_timer_config_periodic() {
+        let config = TimerConfig {
+            delay: Duration::from_millis(100),
+            interval: Some(Duration::from_millis(50)),
+            priority: Priority::HIGH,
+        };
+
+        assert_eq!(config.delay, Duration::from_millis(100));
+        assert_eq!(config.interval, Some(Duration::from_millis(50)));
+        assert_eq!(config.priority, Priority::HIGH);
+    }
+
+    #[test]
+    fn test_timer_handle_debug() {
+        let handle = TimerHandle::failed(TimerId::from_raw(99));
+        let debug = format!("{handle:?}");
+        assert!(debug.contains("TimerHandle"));
+        assert!(debug.contains("99"));
+        assert!(debug.contains("failed: true"));
+    }
+
+    #[test]
+    fn test_timer_handle_failed() {
+        let handle = TimerHandle::failed(TimerId::from_raw(1));
+        assert!(handle.is_failed());
+        assert_eq!(handle.id().as_u64(), 1);
+    }
+
+    #[test]
+    fn test_timer_handle_detach() {
+        let handle = TimerHandle::failed(TimerId::from_raw(42));
+        let id = handle.detach();
+        assert_eq!(id.as_u64(), 42);
+        // Handle is consumed, no cancel on drop
+    }
+
+    #[test]
+    fn test_timer_entry_cancel() {
+        let entry = TimerEntry {
+            id: TimerId::from_raw(1),
+            deadline: Instant::now(),
+            interval: None,
+            priority: Priority::NORMAL,
+            work: TimerWork::OneShot(Some(Box::new(|| {}))),
+            cancelled: AtomicBool::new(false),
+        };
+
+        assert!(!entry.is_cancelled());
+        entry.cancel();
+        assert!(entry.is_cancelled());
+    }
+
+    #[test]
+    fn test_timer_entry_interval() {
+        let one_shot = TimerEntry {
+            id: TimerId::from_raw(1),
+            deadline: Instant::now(),
+            interval: None,
+            priority: Priority::NORMAL,
+            work: TimerWork::OneShot(Some(Box::new(|| {}))),
+            cancelled: AtomicBool::new(false),
+        };
+
+        let periodic = TimerEntry {
+            id: TimerId::from_raw(2),
+            deadline: Instant::now(),
+            interval: Some(Duration::from_millis(100)),
+            priority: Priority::NORMAL,
+            work: TimerWork::Periodic(Arc::new(|| {})),
+            cancelled: AtomicBool::new(false),
+        };
+
+        // One-shot timers have no interval
+        assert!(one_shot.interval.is_none());
+        // Periodic timers have an interval
+        assert!(periodic.interval.is_some());
+    }
+
+    #[test]
+    fn test_timer_work_debug() {
+        let one_shot = TimerWork::OneShot(Some(Box::new(|| {})));
+        let periodic = TimerWork::Periodic(Arc::new(|| {}));
+
+        assert_eq!(format!("{one_shot:?}"), "OneShot(...)");
+        assert_eq!(format!("{periodic:?}"), "Periodic(...)");
+    }
+
+    #[test]
+    fn test_timer_wheel_schedule_and_tick() {
+        use std::sync::atomic::AtomicUsize;
+
+        let wheel = Arc::new(TimerWheel::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        // Schedule a timer with zero delay (fires immediately on next tick)
+        let handle = wheel.schedule_oneshot(Duration::ZERO, Priority::NORMAL, move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert!(!handle.is_failed());
+        assert_eq!(wheel.pending_count(), 1);
+
+        // Tick should fire the timer and return a task
+        let mut tasks = wheel.tick(Instant::now() + Duration::from_millis(1));
+        assert_eq!(tasks.len(), 1);
+
+        // Execute the task
+        let _ = tasks[0].execute();
+
+        // Counter should have been incremented
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        // Timer should be removed after firing
+        assert_eq!(wheel.pending_count(), 0);
+    }
+
+    #[test]
+    fn test_timer_wheel_periodic_rescheduling() {
+        use std::sync::atomic::AtomicUsize;
+
+        let wheel = Arc::new(TimerWheel::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        // Schedule periodic timer with zero delay (fires immediately, repeats every 100ms)
+        let handle = wheel.schedule_periodic(Duration::ZERO, Priority::NORMAL, move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert!(!handle.is_failed());
+        let _ = handle.detach(); // Detach so it keeps running
+
+        // First tick - should fire and reschedule
+        let mut tasks = wheel.tick(Instant::now());
+        assert_eq!(tasks.len(), 1);
+        let _ = tasks[0].execute();
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        // Timer should still be pending (rescheduled with interval = 0)
+        assert_eq!(wheel.pending_count(), 1);
+
+        // Second tick - should fire again
+        let mut tasks = wheel.tick(Instant::now() + Duration::from_millis(1));
+        assert_eq!(tasks.len(), 1);
+        let _ = tasks[0].execute();
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+
+        // Still pending
+        assert_eq!(wheel.pending_count(), 1);
+    }
+
+    #[test]
+    fn test_timer_handle_drop_cancels() {
+        use std::sync::atomic::AtomicUsize;
+
+        let wheel = Arc::new(TimerWheel::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        {
+            // Create and drop handle in this scope
+            let _handle =
+                wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, move || {
+                    counter_clone.fetch_add(1, Ordering::SeqCst);
+                });
+            assert_eq!(wheel.pending_count(), 1);
+            // Handle drops here, should cancel timer
+        }
+
+        // Timer should be cancelled
+        // Tick should not produce any tasks
+        let tasks = wheel.tick(Instant::now() + Duration::from_secs(2));
+        assert!(tasks.is_empty());
+
+        // Counter should not have been incremented
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_timer_wheel_max_timers_enforced() {
+        let wheel = Arc::new(TimerWheel::with_max_timers(3)); // Very small limit
+
+        // Schedule 3 timers successfully
+        let h1 = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+        let h2 = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+        let h3 = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+
+        assert!(!h1.is_failed());
+        assert!(!h2.is_failed());
+        assert!(!h3.is_failed());
+        assert_eq!(wheel.pending_count(), 3);
+
+        // Fourth timer should fail
+        let h4 = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+        assert!(h4.is_failed());
+        assert_eq!(wheel.dropped_count(), 1);
+
+        // Still only 3 pending
+        assert_eq!(wheel.pending_count(), 3);
+    }
+
+    #[test]
+    fn test_timer_wheel_cancel() {
+        let wheel = Arc::new(TimerWheel::new());
+
+        let handle = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+
+        assert_eq!(wheel.pending_count(), 1);
+
+        // Cancel via the wheel directly
+        let cancelled = wheel.cancel(handle.id());
+        assert!(cancelled);
+
+        // Timer still exists but is marked cancelled
+        assert_eq!(wheel.pending_count(), 1);
+
+        // Tick should remove cancelled timer without producing a task
+        let tasks = wheel.tick(Instant::now() + Duration::from_secs(2));
+        assert!(tasks.is_empty());
+        assert_eq!(wheel.pending_count(), 0);
+    }
+
+    #[test]
+    fn test_timer_wheel_cancel_idempotent() {
+        let wheel = Arc::new(TimerWheel::new());
+
+        let handle = wheel.schedule_oneshot(Duration::from_secs(1), Priority::NORMAL, || {});
+
+        // First cancel succeeds
+        assert!(wheel.cancel(handle.id()));
+
+        // Second cancel returns false (already cancelled)
+        assert!(!wheel.cancel(handle.id()));
+    }
+
+    #[test]
+    fn test_timer_wheel_thread_safety() {
+        use std::{sync::atomic::AtomicUsize, thread};
+
+        let wheel = Arc::new(TimerWheel::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+
+        // Spawn multiple threads that schedule timers
+        for _ in 0..4 {
+            let wheel = Arc::clone(&wheel);
+            let counter = Arc::clone(&counter);
+
+            let handle = thread::spawn(move || {
+                for _ in 0..10 {
+                    let counter = Arc::clone(&counter);
+                    let _ = wheel.schedule_oneshot(Duration::ZERO, Priority::NORMAL, move || {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                    });
+                }
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Should have 40 pending timers (or close, some may have fired)
+        let pending = wheel.pending_count();
+        assert!(pending <= 40, "pending count should be <= 40, got {pending}");
+
+        // Tick to fire all timers
+        let mut tasks = wheel.tick(Instant::now() + Duration::from_secs(1));
+
+        // Execute all tasks
+        for task in &mut tasks {
+            let _ = task.execute();
+        }
+
+        // Counter should match tasks executed
+        assert_eq!(counter.load(Ordering::SeqCst), tasks.len());
+    }
+
+    #[test]
+    fn test_timer_wheel_empty_tick() {
+        let wheel = Arc::new(TimerWheel::new());
+
+        // Tick on empty wheel should be safe
+        let tasks = wheel.tick(Instant::now());
+        assert!(tasks.is_empty());
+        assert_eq!(wheel.pending_count(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Add timer mechanism to kernel scheduler enabling modules to schedule time-based operations. Pure mechanism - modules decide policy.

## Issue

Closes #343

## Changes

**Kernel layer:**
- Add `TimerId`, `TimerHandle`, `TimerConfig`, `TimerWheel` types
- Implement timer wheel with O(1) cancellation via atomic flags
- Integrate with `Runtime.tick()` cycle (timers checked before work queue)
- RAII `TimerHandle` auto-cancels on drop
- Thread-safe with configurable `max_timers` limit

**FFI layer:**
- Add `reovim_schedule_delayed()` for one-shot timers
- Add `reovim_schedule_periodic()` for repeating timers
- Add `reovim_cancel_timer()` to cancel scheduled timers
- Add `reovim_timer_is_pending()` to check timer status
- Add `reovim_timer_count()` to get active timer count

**API exports:**
- Export timer types via `api::v1`

## Test Plan

- [x] `./scripts/check.sh` passed
- [x] Unit tests added (21 tests in timer.rs)
- [x] Manual testing completed

## Checklist

- [x] Issue linked above
- [x] CHANGELOG.md updated
- [x] Documentation updated (if applicable)