### PR TITLE
feat(cli): enhance log commands with filtering, streaming, and dynamic level (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Fixed
 
+- **Process separation for integrated mode** ([#331](https://github.com/ds1sqe/reovim/issues/331))
+  - Server now spawns as separate OS process instead of tokio task
+  - Fixes garbled terminal output when server logs conflict with TUI rendering
+  - Added `--ready-signal` flag for process coordination
+  - Server prints "READY <addr>" to stdout when bound
+
 ### Removed
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - `reovim_timer_count()` - Get active timer count
   - Added timer types to `include/reovim.h`
 
+- TUI log panel for real-time log streaming (#332)
+  - `debug/log_subscribe` and `debug/log_unsubscribe` RPC methods
+  - Real-time `LOG_ENTRY` notifications with level filtering
+  - Channel-based async bridge (sync tracing -> async notifications)
+  - TUI log panel with scroll, filter by level, and keybindings
+  - `Ctrl+L` toggles panel, `1-5` filters levels, `j/k` scrolls
+
+- CLI log command enhancements (#324)
+  - Log filtering: `reovim cli log-tail --level warn --target runner --grep error`
+  - Dynamic log level: `reovim cli log-level debug` (changes at runtime)
+  - Log streaming: `reovim cli log-tail --follow` (like `tail -f`)
+  - Color-coded output: ERROR (red), WARN (yellow), INFO (green), DEBUG (cyan), TRACE (gray)
+  - Uses `tracing_subscriber::reload` layer for runtime log level changes
+
 ### Changed
 
 - E2E tests: Enable 9 more tests after upstream changes (#308)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,13 +523,32 @@ Query and control logging on a running server via CLI:
 # Get current log level
 reovim cli log-level
 
-# Set log level (trace, debug, info, warn, error)
+# Set log level dynamically (trace, debug, info, warn, error, off)
 reovim cli log-level debug
 
 # Get recent log entries (default: 50)
 reovim cli log-tail
-reovim cli log-tail 100
+reovim cli log-tail --count 100
+
+# Filter by level (shows entries >= specified level)
+reovim cli log-tail --level warn
+
+# Filter by target module
+reovim cli log-tail --target runner::server
+
+# Search for text in messages (case-insensitive)
+reovim cli log-tail --grep "connection"
+
+# Combine filters
+reovim cli log-tail --level info --target runner --grep error
+
+# Follow mode - stream logs in real-time (Ctrl+C to stop)
+reovim cli log-tail --follow
+reovim cli log-tail --follow --level warn
 ```
+
+Output is color-coded when stdout is a TTY:
+- ERROR (red), WARN (yellow), INFO (green), DEBUG (cyan), TRACE (gray)
 
 ### Debugging Flaky Tests
 

--- a/docs/architecture/runner/client/cli.md
+++ b/docs/architecture/runner/client/cli.md
@@ -46,6 +46,25 @@ reovim cli list
 reovim cli kill
 ```
 
+### Debug Commands
+
+```bash
+# Log level control
+reovim cli log-level              # Get current level
+reovim cli log-level debug        # Set level dynamically
+
+# Log viewing with filters
+reovim cli log-tail --count 100   # Last 100 entries
+reovim cli log-tail --level warn  # Filter by level
+reovim cli log-tail --target mod  # Filter by module
+reovim cli log-tail --grep "err"  # Search messages
+
+# Real-time log streaming
+reovim cli log-tail --follow      # Stream like tail -f
+```
+
+Output is color-coded: ERROR (red), WARN (yellow), INFO (green), DEBUG (cyan), TRACE (gray)
+
 ### Interactive REPL
 
 ```bash

--- a/docs/user-guide/server-mode.md
+++ b/docs/user-guide/server-mode.md
@@ -136,6 +136,27 @@ reovim cli kill
 reovim cli -i
 ```
 
+### Debug Commands
+
+```bash
+# Get/set log level dynamically
+reovim cli log-level                      # Get current level
+reovim cli log-level debug                # Set to debug
+
+# View recent log entries
+reovim cli log-tail                       # Last 50 entries
+reovim cli log-tail --count 100           # Last 100 entries
+
+# Filter logs
+reovim cli log-tail --level warn          # WARN and above
+reovim cli log-tail --target runner       # Filter by module
+reovim cli log-tail --grep "error"        # Search messages
+
+# Stream logs in real-time (like tail -f)
+reovim cli log-tail --follow
+reovim cli log-tail --follow --level warn # Stream with filter
+```
+
 ### Connection Options
 
 ```bash
@@ -208,6 +229,10 @@ reovim tui --socket /tmp/reovim.sock
 | `cursor` | - | Get cursor position |
 | `mode` | - | Get current mode |
 | `kill` | - | Terminate server |
+| `debug/log_level` | `{ level?: string }` | Get/set log level |
+| `debug/log_tail` | `{ count?, level?, target?, grep? }` | Get filtered log entries |
+| `debug/log_subscribe` | `{ level?: string }` | Subscribe to log stream |
+| `debug/log_unsubscribe` | `{ subscription_id: number }` | Unsubscribe from log stream |
 
 ### Screen Formats
 

--- a/lib/protocol/src/v1/debug.rs
+++ b/lib/protocol/src/v1/debug.rs
@@ -231,6 +231,35 @@ pub struct LogTailResult {
     pub overflow_count: u64,
 }
 
+/// Parameters for `debug/log_subscribe` method.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LogSubscribeParams {
+    /// Minimum log level to receive (default: info).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<String>,
+}
+
+/// Result for `debug/log_subscribe` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogSubscribeResult {
+    /// Unique subscription ID for unsubscribing.
+    pub subscription_id: u64,
+}
+
+/// Parameters for `debug/log_unsubscribe` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogUnsubscribeParams {
+    /// Subscription ID to cancel.
+    pub subscription_id: u64,
+}
+
+/// Result for `debug/log_unsubscribe` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogUnsubscribeResult {
+    /// Whether the subscription was found and removed.
+    pub success: bool,
+}
+
 // ============================================================================
 // Phase 5: Visual Debug Types
 // ============================================================================
@@ -462,5 +491,51 @@ mod tests {
         };
         let json = serde_json::to_string(&params).unwrap();
         assert!(json.contains("\"level\":\"debug\""));
+    }
+
+    // Phase 1 tests for #332 - subscription types
+
+    #[test]
+    fn test_log_subscribe_params_serialization() {
+        // Default (no level filter)
+        let params = LogSubscribeParams::default();
+        let json = serde_json::to_string(&params).unwrap();
+        assert_eq!(json, "{}");
+
+        // With level filter
+        let params = LogSubscribeParams {
+            level: Some("warn".to_string()),
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        assert!(json.contains("\"level\":\"warn\""));
+    }
+
+    #[test]
+    fn test_log_subscribe_result_serialization() {
+        let result = LogSubscribeResult {
+            subscription_id: 42,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"subscription_id\":42"));
+    }
+
+    #[test]
+    fn test_log_unsubscribe_params_serialization() {
+        let params = LogUnsubscribeParams {
+            subscription_id: 123,
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        assert!(json.contains("\"subscription_id\":123"));
+    }
+
+    #[test]
+    fn test_log_unsubscribe_result_serialization() {
+        let result = LogUnsubscribeResult { success: true };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"success\":true"));
+
+        let result = LogUnsubscribeResult { success: false };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"success\":false"));
     }
 }

--- a/lib/protocol/src/v1/debug.rs
+++ b/lib/protocol/src/v1/debug.rs
@@ -195,6 +195,18 @@ pub struct LogTailParams {
     /// Number of log entries to return (default: 50).
     #[serde(default = "default_log_count")]
     pub count: usize,
+
+    /// Filter by minimum log level (trace, debug, info, warn, error).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<String>,
+
+    /// Filter by target module (substring match).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+
+    /// Filter by message content (substring match, case-insensitive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grep: Option<String>,
 }
 
 const fn default_log_count() -> usize {
@@ -205,6 +217,9 @@ impl Default for LogTailParams {
     fn default() -> Self {
         Self {
             count: default_log_count(),
+            level: None,
+            target: None,
+            grep: None,
         }
     }
 }
@@ -463,6 +478,56 @@ mod tests {
     fn test_log_tail_params_default() {
         let params = LogTailParams::default();
         assert_eq!(params.count, 50);
+        assert!(params.level.is_none());
+        assert!(params.target.is_none());
+        assert!(params.grep.is_none());
+    }
+
+    #[test]
+    fn test_log_tail_params_with_filters() {
+        let params = LogTailParams {
+            count: 100,
+            level: Some("warn".to_string()),
+            target: Some("runner::server".to_string()),
+            grep: Some("error".to_string()),
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        assert!(json.contains("\"count\":100"));
+        assert!(json.contains("\"level\":\"warn\""));
+        assert!(json.contains("\"target\":\"runner::server\""));
+        assert!(json.contains("\"grep\":\"error\""));
+    }
+
+    #[test]
+    fn test_log_tail_params_partial_filters() {
+        // Only level filter
+        let params = LogTailParams {
+            count: 50,
+            level: Some("info".to_string()),
+            target: None,
+            grep: None,
+        };
+        let json = serde_json::to_string(&params).unwrap();
+        assert!(json.contains("\"level\":\"info\""));
+        assert!(!json.contains("\"target\""));
+        assert!(!json.contains("\"grep\""));
+    }
+
+    #[test]
+    fn test_log_tail_params_deserialization() {
+        // With all filters
+        let json = r#"{"count": 25, "level": "debug", "target": "mymod", "grep": "test"}"#;
+        let params: LogTailParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.count, 25);
+        assert_eq!(params.level.as_deref(), Some("debug"));
+        assert_eq!(params.target.as_deref(), Some("mymod"));
+        assert_eq!(params.grep.as_deref(), Some("test"));
+
+        // With default count
+        let json = r#"{"level": "warn"}"#;
+        let params: LogTailParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.count, 50);
+        assert_eq!(params.level.as_deref(), Some("warn"));
     }
 
     #[test]

--- a/lib/protocol/src/v1/methods.rs
+++ b/lib/protocol/src/v1/methods.rs
@@ -129,6 +129,12 @@ pub const DEBUG_LOG_LEVEL: &str = "debug/log_level";
 /// Get recent log entries.
 pub const DEBUG_LOG_TAIL: &str = "debug/log_tail";
 
+/// Subscribe to log streaming.
+pub const DEBUG_LOG_SUBSCRIBE: &str = "debug/log_subscribe";
+
+/// Unsubscribe from log streaming.
+pub const DEBUG_LOG_UNSUBSCRIBE: &str = "debug/log_unsubscribe";
+
 /// Get full debug snapshot for AI/tooling.
 pub const DEBUG_VISUAL_SNAPSHOT: &str = "debug/visual_snapshot";
 

--- a/lib/protocol/src/v1/notifications.rs
+++ b/lib/protocol/src/v1/notifications.rs
@@ -21,7 +21,84 @@ pub const BUFFER_MODIFIED: &str = "notification/buffer_modified";
 /// Render complete notification.
 pub const RENDER_COMPLETE: &str = "notification/render_complete";
 
+/// Log entry notification (for log streaming).
+pub const LOG_ENTRY: &str = "notification/log_entry";
+
 // Notification payload types
+
+/// Source of a log entry.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogSource {
+    /// Log from the server.
+    #[default]
+    Server,
+    /// Log from the client.
+    Client,
+}
+
+/// Log level for filtering and display.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Trace level (most verbose).
+    Trace = 0,
+    /// Debug level.
+    Debug = 1,
+    /// Info level.
+    #[default]
+    Info = 2,
+    /// Warning level.
+    Warn = 3,
+    /// Error level (least verbose).
+    Error = 4,
+}
+
+impl LogLevel {
+    /// Parse a log level from a string.
+    #[must_use]
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "trace" => Self::Trace,
+            "debug" => Self::Debug,
+            "warn" | "warning" => Self::Warn,
+            "error" => Self::Error,
+            // "info" and anything else defaults to Info
+            _ => Self::Info,
+        }
+    }
+}
+
+/// Payload for log entry notification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntryPayload {
+    /// Timestamp in ISO 8601 format.
+    pub timestamp: String,
+    /// Log level.
+    pub level: LogLevel,
+    /// Target module.
+    pub target: String,
+    /// Log message.
+    pub message: String,
+    /// Source of the log entry.
+    #[serde(default)]
+    pub source: LogSource,
+}
+
+impl LogEntryPayload {
+    /// Convert payload to JSON-RPC notification.
+    ///
+    /// # Panics
+    ///
+    /// This function will not panic as `LogEntryPayload` serialization is infallible.
+    #[must_use]
+    pub fn into_notification(self) -> super::messages::RpcNotification {
+        super::messages::RpcNotification::new(
+            LOG_ENTRY,
+            serde_json::to_value(self).expect("LogEntryPayload serialization cannot fail"),
+        )
+    }
+}
 
 /// Payload for mode changed notification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,5 +257,94 @@ mod tests {
         let notification = payload.into_notification();
         assert_eq!(notification.jsonrpc, "2.0");
         assert_eq!(notification.method, RENDER_COMPLETE);
+    }
+
+    // Phase 1 tests for #332
+
+    #[test]
+    fn test_log_entry_payload_serialization() {
+        let payload = LogEntryPayload {
+            timestamp: "2026-01-17T12:00:00Z".to_string(),
+            level: LogLevel::Info,
+            target: "runner::server".to_string(),
+            message: "Test message".to_string(),
+            source: LogSource::Server,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"timestamp\":\"2026-01-17T12:00:00Z\""));
+        assert!(json.contains("\"level\":\"info\""));
+        assert!(json.contains("\"target\":\"runner::server\""));
+        assert!(json.contains("\"message\":\"Test message\""));
+        assert!(json.contains("\"source\":\"server\""));
+    }
+
+    #[test]
+    fn test_log_source_serialization() {
+        assert_eq!(serde_json::to_string(&LogSource::Server).unwrap(), "\"server\"");
+        assert_eq!(serde_json::to_string(&LogSource::Client).unwrap(), "\"client\"");
+    }
+
+    #[test]
+    fn test_log_level_ordering() {
+        assert!(LogLevel::Trace < LogLevel::Debug);
+        assert!(LogLevel::Debug < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Warn);
+        assert!(LogLevel::Warn < LogLevel::Error);
+    }
+
+    #[test]
+    fn test_log_entry_into_notification() {
+        let payload = LogEntryPayload {
+            timestamp: "2026-01-17T12:00:00Z".to_string(),
+            level: LogLevel::Warn,
+            target: "test".to_string(),
+            message: "warning".to_string(),
+            source: LogSource::Client,
+        };
+        let notification = payload.into_notification();
+        assert_eq!(notification.jsonrpc, "2.0");
+        assert_eq!(notification.method, LOG_ENTRY);
+    }
+
+    #[test]
+    fn test_log_entry_payload_missing_field_deserialization() {
+        // Missing 'source' field should use default (Server)
+        let json = r#"{"timestamp":"2026-01-17T12:00:00Z","level":"info","target":"test","message":"msg"}"#;
+        let payload: LogEntryPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.source, LogSource::Server);
+    }
+
+    #[test]
+    fn test_log_level_from_str_lossy() {
+        assert_eq!(LogLevel::from_str_lossy("trace"), LogLevel::Trace);
+        assert_eq!(LogLevel::from_str_lossy("DEBUG"), LogLevel::Debug);
+        assert_eq!(LogLevel::from_str_lossy("Info"), LogLevel::Info);
+        assert_eq!(LogLevel::from_str_lossy("WARN"), LogLevel::Warn);
+        assert_eq!(LogLevel::from_str_lossy("warning"), LogLevel::Warn);
+        assert_eq!(LogLevel::from_str_lossy("error"), LogLevel::Error);
+        assert_eq!(LogLevel::from_str_lossy("invalid"), LogLevel::Info); // fallback
+    }
+
+    #[test]
+    fn test_log_entry_with_empty_strings() {
+        let payload = LogEntryPayload {
+            timestamp: String::new(),
+            level: LogLevel::Debug,
+            target: String::new(),
+            message: String::new(),
+            source: LogSource::Server,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"timestamp\":\"\""));
+        assert!(json.contains("\"target\":\"\""));
+        assert!(json.contains("\"message\":\"\""));
+    }
+
+    #[test]
+    fn test_log_level_invalid_deserialization() {
+        // Invalid level should fail deserialization
+        let json = r#""invalid_level""#;
+        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
     }
 }

--- a/runner/src/client/cli/commands.rs
+++ b/runner/src/client/cli/commands.rs
@@ -286,14 +286,55 @@ pub async fn cmd_log_level(
     client.call("debug/log_level", params).await
 }
 
-/// Get recent log entries.
+/// Get recent log entries with optional filtering.
 ///
 /// # Errors
 ///
 /// Returns error if RPC call fails.
-pub async fn cmd_log_tail(client: &mut RpcClient, count: usize) -> Result<Value, RpcClientError> {
+pub async fn cmd_log_tail(
+    client: &mut RpcClient,
+    count: usize,
+    level: Option<&str>,
+    target: Option<&str>,
+    grep: Option<&str>,
+) -> Result<Value, RpcClientError> {
+    let mut params = json!({ "count": count });
+    if let Some(l) = level {
+        params["level"] = json!(l);
+    }
+    if let Some(t) = target {
+        params["target"] = json!(t);
+    }
+    if let Some(g) = grep {
+        params["grep"] = json!(g);
+    }
+    client.call("debug/log_tail", params).await
+}
+
+/// Subscribe to log streaming.
+///
+/// # Errors
+///
+/// Returns error if RPC call fails.
+pub async fn cmd_log_subscribe(
+    client: &mut RpcClient,
+    level: Option<&str>,
+) -> Result<Value, RpcClientError> {
+    let params = level.map_or_else(|| json!({}), |l| json!({ "level": l }));
+    client.call("debug/log_subscribe", params).await
+}
+
+/// Unsubscribe from log streaming.
+///
+/// # Errors
+///
+/// Returns error if RPC call fails.
+pub async fn cmd_log_unsubscribe(
+    client: &mut RpcClient,
+    subscription_id: u64,
+) -> Result<Value, RpcClientError> {
     client
-        .call("debug/log_tail", json!({ "count": count }))
+        .call("debug/log_unsubscribe", json!({ "subscription_id": subscription_id }))
         .await
 }
 

--- a/runner/src/client/cli/mod.rs
+++ b/runner/src/client/cli/mod.rs
@@ -160,6 +160,22 @@ pub enum CliAction {
         /// Number of entries to return (default: 50).
         #[arg(short, long, default_value = "50")]
         count: usize,
+
+        /// Filter by minimum log level (trace, debug, info, warn, error).
+        #[arg(short = 'l', long)]
+        level: Option<String>,
+
+        /// Filter by target module (substring match).
+        #[arg(short = 't', long)]
+        target: Option<String>,
+
+        /// Filter by message content (case-insensitive).
+        #[arg(short = 'g', long)]
+        grep: Option<String>,
+
+        /// Follow mode: stream new entries as they arrive (like tail -f).
+        #[arg(short = 'f', long)]
+        follow: bool,
     },
     /// Get full debug snapshot (JSON).
     Snapshot,

--- a/runner/src/client/cli/output.rs
+++ b/runner/src/client/cli/output.rs
@@ -70,10 +70,63 @@ fn format_plain_for_command(value: &Value, command: &str) -> String {
                 return format_buffer_list_typed(&result.buffers);
             }
         }
+        "log-tail" => {
+            return format_log_entries(value);
+        }
         _ => {}
     }
     // Fallback to generic formatting
     format_plain(value)
+}
+
+/// Format log entries for plain text output with color-coded levels.
+fn format_log_entries(value: &Value) -> String {
+    let Some(entries) = value.get("entries").and_then(Value::as_array) else {
+        return format_plain(value);
+    };
+
+    if entries.is_empty() {
+        return "No log entries".to_string();
+    }
+
+    let overflow = value
+        .get("overflow_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    // Check if stdout is a tty for color support
+    let use_color = std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+    let mut output = String::new();
+
+    for entry in entries {
+        let timestamp = entry.get("timestamp").and_then(Value::as_str).unwrap_or("");
+        let level = entry.get("level").and_then(Value::as_str).unwrap_or("INFO");
+        let target = entry.get("target").and_then(Value::as_str).unwrap_or("");
+        let message = entry.get("message").and_then(Value::as_str).unwrap_or("");
+
+        // Color-coded level
+        let level_str = if use_color {
+            match level.to_uppercase().as_str() {
+                "ERROR" => format!("\x1b[31m{level:5}\x1b[0m"), // red
+                "WARN" => format!("\x1b[33m{level:5}\x1b[0m"),  // yellow
+                "INFO" => format!("\x1b[32m{level:5}\x1b[0m"),  // green
+                "DEBUG" => format!("\x1b[36m{level:5}\x1b[0m"), // cyan
+                "TRACE" => format!("\x1b[90m{level:5}\x1b[0m"), // gray
+                _ => format!("{level:5}"),
+            }
+        } else {
+            format!("{level:5}")
+        };
+
+        let _ = writeln!(output, "{timestamp} {level_str} {target}: {message}");
+    }
+
+    if overflow > 0 {
+        let _ = writeln!(output, "\n({overflow} older entries dropped due to buffer overflow)");
+    }
+
+    output
 }
 
 /// Format buffer list from typed data.
@@ -329,5 +382,55 @@ mod tests {
         // JSON format should not do typed formatting
         assert!(output.contains("\"content\""));
         assert!(output.contains("\"test\""));
+    }
+
+    #[test]
+    fn test_format_log_entries() {
+        let value = json!({
+            "entries": [
+                {
+                    "timestamp": "2025-01-17T12:00:00Z",
+                    "level": "INFO",
+                    "target": "test::module",
+                    "message": "Test message"
+                },
+                {
+                    "timestamp": "2025-01-17T12:00:01Z",
+                    "level": "ERROR",
+                    "target": "test::module",
+                    "message": "Error occurred"
+                }
+            ],
+            "overflow_count": 0
+        });
+        let output = format_output_for_command(&value, OutputFormat::Plain, "log-tail");
+        assert!(output.contains("Test message"));
+        assert!(output.contains("Error occurred"));
+        assert!(output.contains("test::module"));
+    }
+
+    #[test]
+    fn test_format_log_entries_empty() {
+        let value = json!({
+            "entries": [],
+            "overflow_count": 0
+        });
+        let output = format_output_for_command(&value, OutputFormat::Plain, "log-tail");
+        assert_eq!(output, "No log entries");
+    }
+
+    #[test]
+    fn test_format_log_entries_with_overflow() {
+        let value = json!({
+            "entries": [{
+                "timestamp": "2025-01-17T12:00:00Z",
+                "level": "INFO",
+                "target": "test",
+                "message": "msg"
+            }],
+            "overflow_count": 100
+        });
+        let output = format_output_for_command(&value, OutputFormat::Plain, "log-tail");
+        assert!(output.contains("100 older entries dropped"));
     }
 }

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -11,8 +11,9 @@ use {
     reovim_protocol::v1::{
         RpcNotification, RpcResponse,
         notifications::{
-            BUFFER_MODIFIED, BufferModifiedPayload, CURSOR_MOVED, CursorMovedPayload, MODE_CHANGED,
-            ModeChangedPayload, RENDER_COMPLETE, RenderCompletePayload,
+            BUFFER_MODIFIED, BufferModifiedPayload, CURSOR_MOVED, CursorMovedPayload, LOG_ENTRY,
+            LogEntryPayload, MODE_CHANGED, ModeChangedPayload, RENDER_COMPLETE,
+            RenderCompletePayload,
         },
     },
     serde_json::json,
@@ -23,10 +24,32 @@ use crate::client::common::{
     ConnectionConfig, ConnectionReader, RpcClient, RpcClientError, RpcWriter, ServerMessage,
 };
 
-use super::{input::InputHandler, render::Renderer};
+use super::{
+    input::InputHandler,
+    log_buffer::{DEFAULT_TUI_LOG_CAPACITY, TuiLogBuffer},
+    log_panel::LogPanelState,
+    log_render::render_panel,
+    render::Renderer,
+};
 
 /// Channel buffer size for server messages.
 const MESSAGE_CHANNEL_SIZE: usize = 256;
+
+/// Extract HH:MM:SS from an ISO 8601 timestamp.
+///
+/// Falls back to "??:??:??" if the timestamp cannot be parsed.
+fn extract_hms(timestamp: &str) -> String {
+    // ISO 8601 format: 2026-01-17T12:34:56Z or 2026-01-17T12:34:56.123Z
+    // We want the HH:MM:SS part
+    if let Some(t_pos) = timestamp.find('T') {
+        let time_part = &timestamp[t_pos + 1..];
+        // Take first 8 characters (HH:MM:SS)
+        if time_part.len() >= 8 {
+            return time_part[..8].to_string();
+        }
+    }
+    "??:??:??".to_string()
+}
 
 /// TUI application error.
 #[derive(Debug)]
@@ -94,6 +117,12 @@ pub struct TuiApp {
     last_size: (u16, u16),
     /// Current state from server.
     state: TuiState,
+    /// Log buffer for storing log entries.
+    log_buffer: TuiLogBuffer,
+    /// Log panel state.
+    log_panel: LogPanelState,
+    /// Server log subscription ID.
+    subscription_id: Option<u64>,
 }
 
 impl TuiApp {
@@ -128,6 +157,17 @@ impl TuiApp {
             .and_then(serde_json::Value::as_u64)
             .map_or(0, |v| v as usize);
 
+        // Subscribe to server logs (info level and above)
+        let subscription_id = match client.call("debug/log_subscribe", json!({})).await {
+            Ok(result) => result
+                .get("subscription_id")
+                .and_then(serde_json::Value::as_u64),
+            Err(e) => {
+                tracing::debug!("Failed to subscribe to server logs: {e}");
+                None
+            }
+        };
+
         // Split client for concurrent operation
         let (reader, rpc_writer) = client.into_split();
 
@@ -153,6 +193,9 @@ impl TuiApp {
                 buffer_modified: false,
                 needs_redraw: true,
             },
+            log_buffer: TuiLogBuffer::new(DEFAULT_TUI_LOG_CAPACITY),
+            log_panel: LogPanelState::new(),
+            subscription_id,
         })
     }
 
@@ -188,6 +231,14 @@ impl TuiApp {
 
         // Run the main event loop
         let result = self.run_event_loop().await;
+
+        // Unsubscribe from log notifications
+        if let Some(sub_id) = self.subscription_id {
+            let _ = self
+                .rpc_writer
+                .send_request("debug/log_unsubscribe", json!({ "subscription_id": sub_id }))
+                .await;
+        }
 
         // Cleanup
         self.renderer.cleanup()?;
@@ -256,6 +307,56 @@ impl TuiApp {
             return Ok(());
         }
 
+        // Check for log panel toggle (Ctrl+L)
+        if matches!(key.code, KeyCode::Char('l')) && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.log_panel.toggle();
+            self.state.needs_redraw = true;
+            return Ok(());
+        }
+
+        // Handle log panel keys when visible
+        if self.log_panel.visible {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.log_panel.scroll_down(1);
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.log_panel.scroll_up(1);
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char('G') => {
+                    self.log_panel.scroll_to_bottom();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char('g') => {
+                    let total = self.log_buffer.len();
+                    self.log_panel.scroll_to_top(total);
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char('q') | KeyCode::Esc => {
+                    self.log_panel.hide();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char('c') => {
+                    self.log_buffer.clear();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Char(c @ '1'..='5') => {
+                    self.log_panel.set_level_filter_from_key(c);
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                _ => {} // Fall through to normal key handling
+            }
+        }
+
         // Convert key to notation and send to server
         if let Some(keys) = InputHandler::key_to_notation(&key) {
             self.send_keys(&keys).await?;
@@ -319,6 +420,26 @@ impl TuiApp {
                     tracing::debug!("Render complete notification received");
                 }
             }
+            LOG_ENTRY => {
+                if let Ok(payload) = serde_json::from_value::<LogEntryPayload>(notification.params)
+                {
+                    // Convert to TuiLogEntry and add to buffer
+                    let entry = super::log_buffer::TuiLogEntry::new(
+                        extract_hms(&payload.timestamp),
+                        payload.level,
+                        payload.target,
+                        payload.message,
+                        payload.source,
+                    );
+                    self.log_buffer.push(entry);
+                    self.log_panel.on_new_entries();
+                    // Only redraw if log panel is visible
+                    if self.log_panel.visible {
+                        self.state.needs_redraw = true;
+                    }
+                    tracing::trace!("Log entry received: {:?}", payload.level);
+                }
+            }
             _ => {
                 tracing::debug!("Unknown notification: {}", notification.method);
             }
@@ -374,6 +495,23 @@ impl TuiApp {
             Err(_) => {
                 // Timeout - just position cursor
                 tracing::debug!("Screen content timeout, skipping render");
+            }
+        }
+
+        // Render log panel if visible
+        if self.log_panel.visible {
+            let (width, height) = self.last_size;
+            let panel_height = self.log_panel.height.min(height / 2); // Max half screen
+            let entries = self.log_buffer.entries();
+            let lines = render_panel(&entries, &self.log_panel, width, panel_height);
+
+            // Position cursor at start of panel area
+            let panel_start = height.saturating_sub(panel_height);
+            self.renderer.set_cursor(0, panel_start)?;
+
+            // Render panel lines
+            for line in lines {
+                self.renderer.write_line(&line)?;
             }
         }
 

--- a/runner/src/client/tui/log_buffer.rs
+++ b/runner/src/client/tui/log_buffer.rs
@@ -1,0 +1,367 @@
+//! TUI-side log buffer for storing and displaying log entries.
+//!
+//! Provides a ring buffer for log entries from both server and client.
+
+use reovim_protocol::v1::{LogLevel, LogSource};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Default TUI log buffer capacity.
+pub const DEFAULT_TUI_LOG_CAPACITY: usize = 2000;
+
+// ============================================================================
+// TUI Log Entry
+// ============================================================================
+
+/// A log entry for display in the TUI.
+#[derive(Debug, Clone)]
+pub struct TuiLogEntry {
+    /// Timestamp in HH:MM:SS format for display.
+    pub timestamp: String,
+    /// Log level.
+    pub level: LogLevel,
+    /// Target module.
+    pub target: String,
+    /// Log message.
+    pub message: String,
+    /// Source of the log entry.
+    pub source: LogSource,
+}
+
+impl TuiLogEntry {
+    /// Create a new TUI log entry.
+    #[must_use]
+    pub const fn new(
+        timestamp: String,
+        level: LogLevel,
+        target: String,
+        message: String,
+        source: LogSource,
+    ) -> Self {
+        Self {
+            timestamp,
+            level,
+            target,
+            message,
+            source,
+        }
+    }
+
+    /// Create a client-side log entry with the current time.
+    #[must_use]
+    pub fn client_log(level: LogLevel, message: &str) -> Self {
+        Self {
+            timestamp: current_time_hms(),
+            level,
+            target: "tui".to_string(),
+            message: message.to_string(),
+            source: LogSource::Client,
+        }
+    }
+
+    /// Get the color style for this log level.
+    #[must_use]
+    pub const fn level_color(&self) -> LevelColor {
+        match self.level {
+            LogLevel::Error => LevelColor::Red,
+            LogLevel::Warn => LevelColor::Yellow,
+            LogLevel::Info => LevelColor::Default,
+            LogLevel::Debug | LogLevel::Trace => LevelColor::Dim,
+        }
+    }
+
+    /// Get the source prefix for display.
+    #[must_use]
+    pub const fn source_prefix(&self) -> &'static str {
+        match self.source {
+            LogSource::Server => "[S]",
+            LogSource::Client => "[C]",
+        }
+    }
+}
+
+/// Color for log level display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LevelColor {
+    /// Red for errors.
+    Red,
+    /// Yellow for warnings.
+    Yellow,
+    /// Default terminal color.
+    Default,
+    /// Dim/gray for debug/trace.
+    Dim,
+}
+
+impl LevelColor {
+    /// Get the ANSI color code.
+    #[must_use]
+    pub const fn ansi_code(&self) -> &'static str {
+        match self {
+            Self::Red => "\x1b[31m",
+            Self::Yellow => "\x1b[33m",
+            Self::Default => "\x1b[0m",
+            Self::Dim => "\x1b[90m",
+        }
+    }
+
+    /// Get the ANSI reset code.
+    #[must_use]
+    pub const fn reset_code() -> &'static str {
+        "\x1b[0m"
+    }
+}
+
+// ============================================================================
+// TUI Log Buffer
+// ============================================================================
+
+/// Ring buffer for TUI log entries.
+#[derive(Debug)]
+pub struct TuiLogBuffer {
+    /// Buffer storage.
+    entries: Vec<TuiLogEntry>,
+    /// Maximum capacity.
+    capacity: usize,
+    /// Write position (wraps around).
+    write_pos: usize,
+    /// Total entries written.
+    total_written: u64,
+}
+
+impl TuiLogBuffer {
+    /// Create a new TUI log buffer with the specified capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+            capacity,
+            write_pos: 0,
+            total_written: 0,
+        }
+    }
+
+    /// Push a new entry into the buffer.
+    pub fn push(&mut self, entry: TuiLogEntry) {
+        if self.entries.len() < self.capacity {
+            self.entries.push(entry);
+        } else {
+            self.entries[self.write_pos] = entry;
+        }
+        self.write_pos = (self.write_pos + 1) % self.capacity;
+        self.total_written += 1;
+    }
+
+    /// Get all entries in order (oldest to newest).
+    #[must_use]
+    pub fn entries(&self) -> Vec<&TuiLogEntry> {
+        let len = self.entries.len();
+        if len < self.capacity || self.total_written <= self.capacity as u64 {
+            // Buffer not full yet, entries are in order
+            self.entries.iter().collect()
+        } else {
+            // Buffer wrapped, need to reorder
+            let mut result = Vec::with_capacity(len);
+            for i in 0..len {
+                let idx = (self.write_pos + i) % len;
+                result.push(&self.entries[idx]);
+            }
+            result
+        }
+    }
+
+    /// Get the last N entries (newest first).
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn tail(&self, n: usize) -> Vec<&TuiLogEntry> {
+        let len = self.entries.len();
+        let count = n.min(len);
+
+        if count == 0 {
+            return Vec::new();
+        }
+
+        let mut result = Vec::with_capacity(count);
+
+        // Read backwards from write position
+        for i in 0..count {
+            let idx = if self.write_pos > i {
+                self.write_pos - 1 - i
+            } else if len > 0 {
+                len - 1 - (i - self.write_pos)
+            } else {
+                break;
+            };
+            result.push(&self.entries[idx]);
+        }
+
+        result
+    }
+
+    /// Get the number of entries in the buffer.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // Vec::len is not const stable
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if the buffer is empty.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // Vec::is_empty is not const stable
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Clear all entries.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.write_pos = 0;
+        // Keep total_written for statistics
+    }
+
+    /// Get the buffer capacity.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Get total entries written (for overflow calculation).
+    #[must_use]
+    pub const fn total_written(&self) -> u64 {
+        self.total_written
+    }
+}
+
+impl Default for TuiLogBuffer {
+    fn default() -> Self {
+        Self::new(DEFAULT_TUI_LOG_CAPACITY)
+    }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Get the current time in HH:MM:SS format.
+fn current_time_hms() -> String {
+    use std::time::SystemTime;
+
+    let now = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+
+    let secs = now.as_secs();
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    format!("{hours:02}:{minutes:02}:{seconds:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_capacity_enforcement() {
+        let mut buffer = TuiLogBuffer::new(3);
+
+        for i in 0..5 {
+            buffer.push(TuiLogEntry::client_log(LogLevel::Info, &format!("msg{i}")));
+        }
+
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.total_written(), 5);
+    }
+
+    #[test]
+    fn test_ring_buffer_overflow() {
+        let mut buffer = TuiLogBuffer::new(3);
+
+        for i in 0..5 {
+            buffer.push(TuiLogEntry::client_log(LogLevel::Info, &format!("msg{i}")));
+        }
+
+        // Should have the last 3 messages
+        let tail = buffer.tail(10);
+        assert_eq!(tail.len(), 3);
+        assert_eq!(tail[0].message, "msg4"); // newest
+        assert_eq!(tail[1].message, "msg3");
+        assert_eq!(tail[2].message, "msg2"); // oldest
+    }
+
+    #[test]
+    fn test_tail_returns_newest() {
+        let mut buffer = TuiLogBuffer::new(10);
+
+        for i in 0..5 {
+            buffer.push(TuiLogEntry::client_log(LogLevel::Info, &format!("msg{i}")));
+        }
+
+        let tail = buffer.tail(3);
+        assert_eq!(tail.len(), 3);
+        assert_eq!(tail[0].message, "msg4"); // newest first
+        assert_eq!(tail[1].message, "msg3");
+        assert_eq!(tail[2].message, "msg2");
+    }
+
+    #[test]
+    fn test_clear_empties_buffer() {
+        let mut buffer = TuiLogBuffer::new(10);
+
+        buffer.push(TuiLogEntry::client_log(LogLevel::Info, "test"));
+        buffer.push(TuiLogEntry::client_log(LogLevel::Warn, "test2"));
+
+        assert_eq!(buffer.len(), 2);
+
+        buffer.clear();
+
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.len(), 0);
+    }
+
+    #[test]
+    fn test_log_level_ordering() {
+        // LogLevel ordering is defined in protocol, just verify it's consistent
+        assert!(LogLevel::Trace < LogLevel::Debug);
+        assert!(LogLevel::Debug < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Warn);
+        assert!(LogLevel::Warn < LogLevel::Error);
+    }
+
+    #[test]
+    fn test_log_source_prefix() {
+        let server_entry = TuiLogEntry::new(
+            "12:00:00".to_string(),
+            LogLevel::Info,
+            "test".to_string(),
+            "msg".to_string(),
+            LogSource::Server,
+        );
+        assert_eq!(server_entry.source_prefix(), "[S]");
+
+        let client_entry = TuiLogEntry::client_log(LogLevel::Info, "msg");
+        assert_eq!(client_entry.source_prefix(), "[C]");
+    }
+
+    #[test]
+    fn test_level_color() {
+        let error = TuiLogEntry::client_log(LogLevel::Error, "err");
+        assert_eq!(error.level_color(), LevelColor::Red);
+
+        let warn = TuiLogEntry::client_log(LogLevel::Warn, "warn");
+        assert_eq!(warn.level_color(), LevelColor::Yellow);
+
+        let info = TuiLogEntry::client_log(LogLevel::Info, "info");
+        assert_eq!(info.level_color(), LevelColor::Default);
+
+        let debug = TuiLogEntry::client_log(LogLevel::Debug, "debug");
+        assert_eq!(debug.level_color(), LevelColor::Dim);
+
+        let trace = TuiLogEntry::client_log(LogLevel::Trace, "trace");
+        assert_eq!(trace.level_color(), LevelColor::Dim);
+    }
+}

--- a/runner/src/client/tui/log_panel.rs
+++ b/runner/src/client/tui/log_panel.rs
@@ -1,0 +1,261 @@
+//! Log panel state for the TUI.
+//!
+//! Tracks visibility, scroll position, and level filtering for the log panel.
+
+use reovim_protocol::v1::LogLevel;
+
+/// Default panel height in rows.
+pub const DEFAULT_PANEL_HEIGHT: u16 = 10;
+
+/// Log panel state.
+#[derive(Debug)]
+pub struct LogPanelState {
+    /// Whether the panel is visible.
+    pub visible: bool,
+    /// Scroll offset from the bottom (0 = newest entries visible).
+    pub scroll_offset: usize,
+    /// Panel height in rows.
+    pub height: u16,
+    /// Level filter (None = show all).
+    pub level_filter: Option<LogLevel>,
+    /// Auto-scroll to newest entries when new logs arrive.
+    pub auto_scroll: bool,
+}
+
+impl LogPanelState {
+    /// Create a new log panel state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            visible: false,
+            scroll_offset: 0,
+            height: DEFAULT_PANEL_HEIGHT,
+            level_filter: None,
+            auto_scroll: true,
+        }
+    }
+
+    /// Toggle panel visibility.
+    ///
+    /// Returns the new visibility state.
+    pub const fn toggle(&mut self) -> bool {
+        self.visible = !self.visible;
+        if self.visible {
+            // Reset scroll to bottom when showing
+            self.scroll_offset = 0;
+            self.auto_scroll = true;
+        }
+        self.visible
+    }
+
+    /// Show the panel.
+    pub const fn show(&mut self) {
+        if !self.visible {
+            self.visible = true;
+            self.scroll_offset = 0;
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Hide the panel.
+    pub const fn hide(&mut self) {
+        self.visible = false;
+    }
+
+    /// Scroll up (toward older entries).
+    pub const fn scroll_up(&mut self, n: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_add(n);
+        self.auto_scroll = false;
+    }
+
+    /// Scroll down (toward newer entries).
+    pub const fn scroll_down(&mut self, n: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(n);
+        if self.scroll_offset == 0 {
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Scroll to the bottom (newest entries).
+    pub const fn scroll_to_bottom(&mut self) {
+        self.scroll_offset = 0;
+        self.auto_scroll = true;
+    }
+
+    /// Scroll to the top (oldest entries).
+    pub const fn scroll_to_top(&mut self, total_entries: usize) {
+        let visible = self.height as usize;
+        self.scroll_offset = total_entries.saturating_sub(visible);
+        self.auto_scroll = false;
+    }
+
+    /// Set the level filter.
+    pub const fn set_level_filter(&mut self, level: Option<LogLevel>) {
+        self.level_filter = level;
+        // Reset scroll when changing filter
+        self.scroll_offset = 0;
+        self.auto_scroll = true;
+    }
+
+    /// Set the level filter from a number key (1-5).
+    ///
+    /// - 1 = Error only
+    /// - 2 = Warn and above
+    /// - 3 = Info and above
+    /// - 4 = Debug and above
+    /// - 5 = Trace (all)
+    pub const fn set_level_filter_from_key(&mut self, key: char) {
+        let level = match key {
+            '1' => Some(LogLevel::Error),
+            '2' => Some(LogLevel::Warn),
+            '3' => Some(LogLevel::Info),
+            '4' => Some(LogLevel::Debug),
+            '5' => None, // All levels (including trace)
+            _ => return,
+        };
+        self.set_level_filter(level);
+    }
+
+    /// Check if an entry passes the level filter.
+    #[must_use]
+    pub fn passes_filter(&self, level: LogLevel) -> bool {
+        self.level_filter.is_none_or(|min_level| level >= min_level)
+    }
+
+    /// Set panel height.
+    pub fn set_height(&mut self, height: u16) {
+        self.height = height.max(3); // Minimum 3 rows (header + 1 entry + status)
+    }
+
+    /// Called when new entries are added.
+    ///
+    /// If `auto_scroll` is enabled, keeps scroll at bottom.
+    pub const fn on_new_entries(&mut self) {
+        if self.auto_scroll {
+            self.scroll_offset = 0;
+        }
+    }
+}
+
+impl Default for LogPanelState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toggle_visibility() {
+        let mut state = LogPanelState::new();
+        assert!(!state.visible);
+
+        let visible = state.toggle();
+        assert!(visible);
+        assert!(state.visible);
+
+        let visible = state.toggle();
+        assert!(!visible);
+        assert!(!state.visible);
+    }
+
+    #[test]
+    fn test_scroll_bounds() {
+        let mut state = LogPanelState::new();
+        state.visible = true;
+
+        // Scroll up
+        state.scroll_up(5);
+        assert_eq!(state.scroll_offset, 5);
+        assert!(!state.auto_scroll);
+
+        // Scroll down
+        state.scroll_down(3);
+        assert_eq!(state.scroll_offset, 2);
+
+        // Scroll past bottom
+        state.scroll_down(10);
+        assert_eq!(state.scroll_offset, 0);
+        assert!(state.auto_scroll);
+    }
+
+    #[test]
+    fn test_auto_scroll_behavior() {
+        let mut state = LogPanelState::new();
+        state.visible = true;
+
+        // Initially auto_scroll is on
+        assert!(state.auto_scroll);
+
+        // Scrolling up disables auto_scroll
+        state.scroll_up(1);
+        assert!(!state.auto_scroll);
+
+        // Scrolling to bottom re-enables it
+        state.scroll_to_bottom();
+        assert!(state.auto_scroll);
+    }
+
+    #[test]
+    fn test_level_filter() {
+        let mut state = LogPanelState::new();
+
+        // No filter - all pass
+        assert!(state.passes_filter(LogLevel::Trace));
+        assert!(state.passes_filter(LogLevel::Error));
+
+        // Set warn filter
+        state.set_level_filter(Some(LogLevel::Warn));
+        assert!(!state.passes_filter(LogLevel::Info));
+        assert!(state.passes_filter(LogLevel::Warn));
+        assert!(state.passes_filter(LogLevel::Error));
+    }
+
+    #[test]
+    fn test_scroll_when_buffer_empty() {
+        let mut state = LogPanelState::new();
+        state.visible = true;
+
+        // Should not panic
+        state.scroll_up(10);
+        assert_eq!(state.scroll_offset, 10);
+
+        state.scroll_down(100);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_scroll_when_buffer_smaller_than_panel() {
+        let mut state = LogPanelState::new();
+        state.height = 10;
+        state.visible = true;
+
+        // Scroll to top with 5 entries (less than panel height)
+        state.scroll_to_top(5);
+        assert_eq!(state.scroll_offset, 0); // Can't scroll past visible
+
+        // Scroll to top with 15 entries
+        state.scroll_to_top(15);
+        assert_eq!(state.scroll_offset, 5); // 15 - 10 = 5
+    }
+
+    #[test]
+    fn test_level_filter_from_key() {
+        let mut state = LogPanelState::new();
+
+        state.set_level_filter_from_key('1');
+        assert_eq!(state.level_filter, Some(LogLevel::Error));
+
+        state.set_level_filter_from_key('3');
+        assert_eq!(state.level_filter, Some(LogLevel::Info));
+
+        state.set_level_filter_from_key('5');
+        assert_eq!(state.level_filter, None);
+
+        // Invalid key should not change filter
+        state.set_level_filter_from_key('9');
+        assert_eq!(state.level_filter, None);
+    }
+}

--- a/runner/src/client/tui/log_render.rs
+++ b/runner/src/client/tui/log_render.rs
@@ -1,0 +1,314 @@
+//! Log panel rendering utilities.
+//!
+//! Provides functions to format and render log entries for the TUI panel.
+
+use reovim_protocol::v1::LogLevel;
+
+use super::{
+    log_buffer::{LevelColor, TuiLogEntry},
+    log_panel::LogPanelState,
+};
+
+/// Maximum message length before truncation.
+const MAX_MESSAGE_LENGTH: usize = 256;
+
+/// Format a single log entry for display.
+///
+/// Format: `[HH:MM:SS] [LEVEL] [S/C] message`
+#[must_use]
+pub fn format_entry(entry: &TuiLogEntry, width: u16) -> String {
+    let color = entry.level_color();
+    let reset = LevelColor::reset_code();
+
+    // Format level (5 chars, right-aligned)
+    let level_str = match entry.level {
+        LogLevel::Error => "ERROR",
+        LogLevel::Warn => " WARN",
+        LogLevel::Info => " INFO",
+        LogLevel::Debug => "DEBUG",
+        LogLevel::Trace => "TRACE",
+    };
+
+    // Source prefix
+    let source = entry.source_prefix();
+
+    // Calculate available width for message
+    // Format: [HH:MM:SS] [LEVEL] [S] message
+    // Width:  10 + 1 + 5 + 1 + 3 + 1 = 21 chars fixed overhead
+    let overhead = 21_usize;
+    let available = (width as usize).saturating_sub(overhead);
+
+    // Truncate and sanitize message
+    let message = sanitize_message(&entry.message, available.min(MAX_MESSAGE_LENGTH));
+
+    format!(
+        "{}[{}] {} {} {}{}",
+        color.ansi_code(),
+        entry.timestamp,
+        level_str,
+        source,
+        message,
+        reset
+    )
+}
+
+/// Sanitize a message for display.
+///
+/// - Replaces newlines with spaces
+/// - Escapes embedded ANSI codes
+/// - Truncates to max length with ellipsis
+#[must_use]
+fn sanitize_message(message: &str, max_length: usize) -> String {
+    if max_length == 0 {
+        return String::new();
+    }
+
+    // Replace newlines and tabs with spaces
+    let mut result: String = message
+        .chars()
+        .map(|c| match c {
+            '\n' | '\r' | '\t' => ' ',
+            // Escape escape character to prevent ANSI injection
+            '\x1b' => '^',
+            c => c,
+        })
+        .collect();
+
+    // Truncate if needed
+    if result.len() > max_length {
+        result.truncate(max_length.saturating_sub(3));
+        result.push_str("...");
+    }
+
+    result
+}
+
+/// Generate the log panel header line.
+#[must_use]
+pub fn render_header(width: u16, level_filter: Option<LogLevel>) -> String {
+    let filter_str = match level_filter {
+        Some(LogLevel::Error) => " [ERROR+]",
+        Some(LogLevel::Warn) => " [WARN+]",
+        Some(LogLevel::Info) => " [INFO+]",
+        Some(LogLevel::Debug) => " [DEBUG+]",
+        _ => "",
+    };
+
+    let header = format!("-- Messages{filter_str} (q to close) ");
+    let padding = (width as usize).saturating_sub(header.len());
+    let dashes = "-".repeat(padding);
+
+    format!("\x1b[7m{header}{dashes}\x1b[0m") // Reverse video for header
+}
+
+/// Render the complete log panel.
+///
+/// Returns a vector of lines to display.
+#[must_use]
+pub fn render_panel(
+    entries: &[&TuiLogEntry],
+    state: &LogPanelState,
+    width: u16,
+    height: u16,
+) -> Vec<String> {
+    let mut lines = Vec::with_capacity(height as usize);
+
+    // Header
+    lines.push(render_header(width, state.level_filter));
+
+    // Filter entries by level
+    let filtered: Vec<_> = entries
+        .iter()
+        .filter(|e| state.passes_filter(e.level))
+        .collect();
+
+    // Calculate visible range
+    let visible_height = (height as usize).saturating_sub(1); // -1 for header
+    let total = filtered.len();
+
+    // Apply scroll offset (scroll_offset = 0 means showing newest)
+    let start = if total <= visible_height {
+        0
+    } else {
+        total
+            .saturating_sub(visible_height)
+            .saturating_sub(state.scroll_offset)
+    };
+    let end = (start + visible_height).min(total);
+
+    // Add entries
+    for entry in filtered.iter().skip(start).take(end - start) {
+        lines.push(format_entry(entry, width));
+    }
+
+    // Pad with empty lines if needed
+    while lines.len() < height as usize {
+        lines.push(String::new());
+    }
+
+    lines
+}
+
+/// Get the ANSI color code for a log level.
+#[must_use]
+pub const fn level_color_code(level: LogLevel) -> &'static str {
+    match level {
+        LogLevel::Error => "\x1b[31m",                   // Red
+        LogLevel::Warn => "\x1b[33m",                    // Yellow
+        LogLevel::Info => "\x1b[0m",                     // Default
+        LogLevel::Debug | LogLevel::Trace => "\x1b[90m", // Dim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reovim_protocol::v1::LogSource;
+
+    use super::*;
+
+    fn test_entry(level: LogLevel, message: &str) -> TuiLogEntry {
+        TuiLogEntry::new(
+            "12:34:56".to_string(),
+            level,
+            "test".to_string(),
+            message.to_string(),
+            LogSource::Server,
+        )
+    }
+
+    #[test]
+    fn test_color_code_for_each_level() {
+        assert_eq!(level_color_code(LogLevel::Error), "\x1b[31m");
+        assert_eq!(level_color_code(LogLevel::Warn), "\x1b[33m");
+        assert_eq!(level_color_code(LogLevel::Info), "\x1b[0m");
+        assert_eq!(level_color_code(LogLevel::Debug), "\x1b[90m");
+        assert_eq!(level_color_code(LogLevel::Trace), "\x1b[90m");
+    }
+
+    #[test]
+    fn test_entry_formatting_with_timestamp() {
+        let entry = test_entry(LogLevel::Info, "test message");
+        let formatted = format_entry(&entry, 80);
+        assert!(formatted.contains("[12:34:56]"));
+        assert!(formatted.contains("INFO"));
+        assert!(formatted.contains("[S]"));
+        assert!(formatted.contains("test message"));
+    }
+
+    #[test]
+    fn test_scroll_offset_application() {
+        let entries: Vec<TuiLogEntry> = (0..20)
+            .map(|i| test_entry(LogLevel::Info, &format!("msg{i}")))
+            .collect();
+        let entry_refs: Vec<_> = entries.iter().collect();
+
+        let mut state = LogPanelState::new();
+        state.visible = true;
+        state.height = 5; // 1 header + 4 entries
+
+        // No scroll - should show newest (msg16-19)
+        let lines = render_panel(&entry_refs, &state, 80, 5);
+        assert_eq!(lines.len(), 5);
+        assert!(lines[4].contains("msg19")); // Bottom line has newest
+
+        // Scroll up 5 - should show older messages
+        state.scroll_up(5);
+        let lines = render_panel(&entry_refs, &state, 80, 5);
+        assert!(lines[4].contains("msg14")); // Now showing older
+    }
+
+    #[test]
+    fn test_panel_height_limiting() {
+        let entries: Vec<TuiLogEntry> = (0..5)
+            .map(|i| test_entry(LogLevel::Info, &format!("msg{i}")))
+            .collect();
+        let entry_refs: Vec<_> = entries.iter().collect();
+
+        let state = LogPanelState::new();
+
+        // With height 3: 1 header + 2 entries max
+        let lines = render_panel(&entry_refs, &state, 80, 3);
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn test_source_prefix_formatting() {
+        let server_entry = TuiLogEntry::new(
+            "12:00:00".to_string(),
+            LogLevel::Info,
+            "test".to_string(),
+            "msg".to_string(),
+            LogSource::Server,
+        );
+        let client_entry = TuiLogEntry::new(
+            "12:00:00".to_string(),
+            LogLevel::Info,
+            "test".to_string(),
+            "msg".to_string(),
+            LogSource::Client,
+        );
+
+        let server_fmt = format_entry(&server_entry, 80);
+        let client_fmt = format_entry(&client_entry, 80);
+
+        assert!(server_fmt.contains("[S]"));
+        assert!(client_fmt.contains("[C]"));
+    }
+
+    #[test]
+    fn test_long_message_truncation() {
+        let long_msg = "a".repeat(500);
+        let entry = test_entry(LogLevel::Info, &long_msg);
+        let formatted = format_entry(&entry, 80);
+
+        // Should be truncated with ellipsis
+        assert!(formatted.len() < 500);
+        assert!(formatted.contains("..."));
+    }
+
+    #[test]
+    fn test_embedded_ansi_codes_escaped() {
+        let entry = test_entry(LogLevel::Info, "test \x1b[31mred\x1b[0m text");
+        let formatted = format_entry(&entry, 80);
+
+        // Escape characters should be replaced with ^
+        assert!(!formatted.contains("\x1b[31m")); // Original codes should not appear twice
+        assert!(formatted.contains("^[31m")); // Escaped
+    }
+
+    #[test]
+    fn test_newlines_in_message() {
+        let entry = test_entry(LogLevel::Info, "line1\nline2\nline3");
+        let formatted = format_entry(&entry, 80);
+
+        // Newlines should be replaced with spaces
+        assert!(!formatted.contains('\n'));
+        assert!(formatted.contains("line1 line2 line3"));
+    }
+
+    #[test]
+    fn test_empty_buffer_renders_blank() {
+        let entries: Vec<&TuiLogEntry> = vec![];
+        let state = LogPanelState::new();
+
+        let lines = render_panel(&entries, &state, 80, 5);
+        assert_eq!(lines.len(), 5);
+        assert!(lines[0].contains("Messages")); // Header still present
+        // Rest should be empty
+        assert!(lines[1].is_empty() || lines[1].trim().is_empty());
+    }
+
+    #[test]
+    fn test_single_entry_in_large_panel() {
+        let entry = test_entry(LogLevel::Info, "single message");
+        let entries: Vec<&TuiLogEntry> = vec![&entry];
+
+        let state = LogPanelState::new();
+
+        let lines = render_panel(&entries, &state, 80, 10);
+        assert_eq!(lines.len(), 10);
+        assert!(lines[0].contains("Messages")); // Header
+        assert!(lines[1].contains("single message")); // Entry
+        // Rest should be empty padding
+    }
+}

--- a/runner/src/client/tui/mod.rs
+++ b/runner/src/client/tui/mod.rs
@@ -10,9 +10,19 @@ use crate::client::common::ConnectionConfig;
 
 pub mod app;
 pub mod input;
+pub mod log_buffer;
+pub mod log_panel;
+pub mod log_render;
 pub mod render;
 
-pub use {app::TuiApp, input::InputHandler, render::Renderer};
+pub use {
+    app::TuiApp,
+    input::InputHandler,
+    log_buffer::{LevelColor, TuiLogBuffer, TuiLogEntry},
+    log_panel::LogPanelState,
+    log_render::{format_entry, render_panel},
+    render::Renderer,
+};
 
 /// TUI mode CLI arguments.
 ///

--- a/runner/src/client/tui/render.rs
+++ b/runner/src/client/tui/render.rs
@@ -134,6 +134,15 @@ impl Renderer {
     pub fn flush(&mut self) -> io::Result<()> {
         self.stdout.flush()
     }
+
+    /// Write a line of content (with newline).
+    ///
+    /// # Errors
+    ///
+    /// Returns error if write fails.
+    pub fn write_line(&mut self, content: &str) -> io::Result<()> {
+        writeln!(self.stdout, "{content}")
+    }
 }
 
 impl Default for Renderer {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -12,12 +12,13 @@ use {
     runner::{
         Server, ServerConfig,
         client::{
-            cli::{self, CliAction, CliArgs},
-            common::ConnectionConfig,
+            cli::{self, CliAction, CliArgs, OutputFormat},
+            common::{ConnectionConfig, rpc::ServerMessage},
             tui::{TuiApp, TuiArgs},
         },
         server::SrvArgs,
     },
+    serde_json::Value,
 };
 
 /// Main CLI arguments.
@@ -306,6 +307,7 @@ fn run_repl(config: &ConnectionConfig) {
     }
 }
 
+#[allow(clippy::too_many_lines)] // CLI dispatch function with many action variants
 fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
     use {
         cli::{
@@ -387,7 +389,33 @@ fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
             CliAction::LogLevel { level } => {
                 cmd::cmd_log_level(&mut client, level.as_deref()).await
             }
-            CliAction::LogTail { count } => cmd::cmd_log_tail(&mut client, *count).await,
+            CliAction::LogTail {
+                count,
+                level,
+                target,
+                grep,
+                follow,
+            } => {
+                if *follow {
+                    run_log_follow(
+                        &mut client,
+                        level.as_deref(),
+                        target.as_deref(),
+                        grep.as_deref(),
+                        output_fmt,
+                    )
+                    .await
+                } else {
+                    cmd::cmd_log_tail(
+                        &mut client,
+                        *count,
+                        level.as_deref(),
+                        target.as_deref(),
+                        grep.as_deref(),
+                    )
+                    .await
+                }
+            }
             CliAction::Snapshot => cmd::cmd_snapshot(&mut client).await,
         };
 
@@ -400,6 +428,7 @@ fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
                     CliAction::Screen => "screen",
                     CliAction::Content { .. } => "content",
                     CliAction::Buffers => "buffers",
+                    CliAction::LogTail { .. } => "log-tail",
                     _ => "",
                 };
                 let out = format_output_for_command(&v, output_fmt, command);
@@ -411,6 +440,123 @@ fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
             }
         }
     });
+}
+
+/// Run log follow mode: subscribe to log notifications and stream until Ctrl+C.
+async fn run_log_follow(
+    client: &mut runner::client::common::rpc::RpcClient,
+    level: Option<&str>,
+    target: Option<&str>,
+    grep: Option<&str>,
+    format: OutputFormat,
+) -> Result<Value, runner::client::common::rpc::RpcClientError> {
+    // Subscribe with level filter
+    let result: Value = cli::cmd_log_subscribe(client, level).await?;
+    let sub_id = result
+        .get("subscription_id")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            runner::client::common::rpc::RpcClientError::UnexpectedResponse(
+                "missing subscription_id".to_string(),
+            )
+        })?;
+
+    eprintln!("Following logs (Ctrl+C to stop)...");
+
+    // Read notifications until interrupted
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    loop {
+        tokio::select! {
+            _ = &mut ctrl_c => {
+                // Unsubscribe on Ctrl+C
+                let _ = cli::cmd_log_unsubscribe(client, sub_id).await;
+                eprintln!("\nStopped.");
+                break;
+            }
+            msg = client.read_message() => {
+                match msg {
+                    Ok(ServerMessage::Notification(notification)) => {
+                        // Only process LOG_ENTRY notifications
+                        if notification.method == "LOG_ENTRY" {
+                            // Apply client-side filters (target, grep)
+                            if should_display_log(&notification.params, target, grep) {
+                                print_log_entry(&notification.params, format);
+                            }
+                        }
+                        // Ignore other notification types
+                    }
+                    Ok(ServerMessage::Response(_)) => {
+                        // Ignore responses (shouldn't happen during streaming)
+                    }
+                    Err(e) => {
+                        eprintln!("Stream error: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(serde_json::json!({"status": "stopped"}))
+}
+
+/// Check if log entry passes client-side filters.
+fn should_display_log(params: &Value, target: Option<&str>, grep: Option<&str>) -> bool {
+    if let Some(target_filter) = target
+        && let Some(entry_target) = params.get("target").and_then(Value::as_str)
+        && !entry_target.contains(target_filter)
+    {
+        return false;
+    }
+
+    if let Some(grep_filter) = grep
+        && let Some(message) = params.get("message").and_then(Value::as_str)
+        && !message.to_lowercase().contains(&grep_filter.to_lowercase())
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Print a log entry to stdout with color-coded level.
+fn print_log_entry(params: &Value, format: OutputFormat) {
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string(params).unwrap_or_default());
+        }
+        OutputFormat::Plain => {
+            let timestamp = params
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let level = params
+                .get("level")
+                .and_then(|v| v.as_str())
+                .unwrap_or("INFO");
+            let target = params.get("target").and_then(|v| v.as_str()).unwrap_or("");
+            let message = params.get("message").and_then(|v| v.as_str()).unwrap_or("");
+
+            // Color-coded level if stdout is a tty
+            let use_color = std::io::IsTerminal::is_terminal(&std::io::stdout());
+            let level_str = if use_color {
+                match level.to_uppercase().as_str() {
+                    "ERROR" => format!("\x1b[31m{level:5}\x1b[0m"), // red
+                    "WARN" => format!("\x1b[33m{level:5}\x1b[0m"),  // yellow
+                    "INFO" => format!("\x1b[32m{level:5}\x1b[0m"),  // green
+                    "DEBUG" => format!("\x1b[36m{level:5}\x1b[0m"), // cyan
+                    "TRACE" => format!("\x1b[90m{level:5}\x1b[0m"), // gray
+                    _ => format!("{level:5}"),
+                }
+            } else {
+                format!("{level:5}")
+            };
+
+            println!("{timestamp} {level_str} {target}: {message}");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -5,7 +5,7 @@
 //!   reovim tui [--tcp ADDR] [--socket PATH]
 //!   reovim cli [--tcp ADDR] [--socket PATH] [--repl] `<command>`
 
-use std::{path::PathBuf, process};
+use std::{io::BufRead, path::PathBuf, process};
 
 use {
     clap::{Parser, Subcommand},
@@ -136,54 +136,127 @@ fn build_legacy_server_config(args: &Args) -> ServerConfig {
     }
 }
 
-/// Run integrated mode: spawn server in background, attach TUI.
+/// Run integrated mode: spawn server as separate process, attach TUI.
 ///
 /// This is the default behavior when `reovim` is invoked without arguments.
 /// Similar to tmux, the server continues running after TUI exits.
-#[allow(unused_variables)] // files will be used in Phase 4
+///
+/// # Process Architecture
+///
+/// ```text
+/// reovim (parent)              reovim server (child)
+/// └── TUI Client               └── Server process
+///     └── TCP connect ←────────── READY 127.0.0.1:12521
+/// ```
+#[allow(unused_variables)] // files will be used later
 fn run_integrated(files: &[PathBuf]) {
-    use {runner::client::common::ConnectionConfig, std::net::SocketAddr, tokio::sync::oneshot};
+    use std::{
+        io::BufReader,
+        process::{Command, Stdio},
+        time::Duration,
+    };
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    use runner::client::common::ConnectionConfig;
+
+    // 1. Get current executable path
+    let exe = std::env::current_exe().expect("Failed to get current executable path");
+
+    // 2. Spawn server as child process
+    let mut child = Command::new(&exe)
+        .args(["server", "--tcp", "0", "--ready-signal"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null()) // Suppress server logs
+        .spawn()
+        .expect("Failed to spawn server process");
+
+    // 3. Read ready signal from child stdout
+    let stdout = child.stdout.take().expect("Failed to get child stdout");
+    let mut reader = BufReader::new(stdout);
+
+    let addr = match read_ready_signal(&mut reader, Duration::from_secs(5)) {
+        Ok(addr) => addr,
+        Err(e) => {
+            eprintln!("{e}");
+            // Try to kill the child if it's still running
+            let _ = child.kill();
+            process::exit(1);
+        }
+    };
+
+    // 4. Detach from child process - let it continue running independently
+    // On Unix, the child becomes an orphan and gets adopted by init
+    // We don't wait() on it, so it won't become a zombie
+    drop(child);
+
+    // 5. Connect TUI to the server
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("Failed to create runtime");
 
     rt.block_on(async {
-        // 1. Create oneshot channel for server ready signal
-        let (tx, rx) = oneshot::channel::<SocketAddr>();
-
-        // 2. Spawn server task in background
-        let server = Server::new(ServerConfig::tcp_with_fallback());
-        tokio::spawn(async move {
-            if let Err(e) = server.run_with_ready_signal(tx).await {
-                eprintln!("Server error: {e}");
-            }
-        });
-
-        // 3. Wait for server to be ready and get bound address
-        let Ok(addr) = rx.await else {
-            eprintln!("Server failed to start");
-            process::exit(1);
-        };
-
-        // 4. Connect TUI to the server
         let config = ConnectionConfig::tcp(addr.ip().to_string(), addr.port());
         match TuiApp::connect(&config).await {
             Ok(mut app) => {
-                // 5. Run TUI (blocks until user exits)
                 if let Err(e) = app.run().await {
                     eprintln!("TUI error: {e}");
                     process::exit(1);
                 }
-                // 6. TUI exited - server continues in background (graceful detach)
+                // TUI exited - server continues in background (graceful detach)
             }
             Err(e) => {
-                eprintln!("Connection failed: {e}");
+                eprintln!("Failed to connect to server at {addr}: {e}");
                 process::exit(1);
             }
         }
     });
+}
+
+/// Parse ready signal from server stdout.
+///
+/// Reads lines until finding `READY <ip>:<port>` format.
+/// Returns error if timeout or invalid format.
+fn read_ready_signal<R: BufRead>(
+    reader: &mut R,
+    timeout: std::time::Duration,
+) -> Result<std::net::SocketAddr, String> {
+    use std::time::Instant;
+
+    let start = Instant::now();
+    let mut line = String::new();
+
+    loop {
+        // Check timeout
+        if start.elapsed() > timeout {
+            return Err("Server failed to start within 5 seconds".to_string());
+        }
+
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // EOF - server exited
+                return Err("Server exited unexpectedly before ready signal".to_string());
+            }
+            Ok(_) => {
+                // Try to parse ready signal
+                if let Some(addr) = parse_ready_signal(&line) {
+                    return Ok(addr);
+                }
+                // Not a ready signal, continue reading
+            }
+            Err(e) => {
+                return Err(format!("Failed to read server output: {e}"));
+            }
+        }
+    }
+}
+
+/// Parse a ready signal line into a socket address.
+///
+/// Expected format: `READY <ip>:<port>\n`
+fn parse_ready_signal(line: &str) -> Option<std::net::SocketAddr> {
+    line.strip_prefix("READY ")
+        .and_then(|addr| addr.trim().parse().ok())
 }
 
 fn run_server(config: ServerConfig) {
@@ -422,5 +495,82 @@ mod tests {
         // --help should cause parse to fail with specific error
         let result = Args::try_parse_from(["reovim", "--help"]);
         assert!(result.is_err());
+    }
+
+    // Tests for parse_ready_signal
+
+    #[test]
+    fn test_parse_ready_signal_valid_localhost() {
+        let addr = parse_ready_signal("READY 127.0.0.1:12521\n");
+        assert!(addr.is_some());
+        let addr = addr.unwrap();
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+        assert_eq!(addr.port(), 12521);
+    }
+
+    #[test]
+    fn test_parse_ready_signal_valid_any() {
+        let addr = parse_ready_signal("READY 0.0.0.0:9000\n");
+        assert!(addr.is_some());
+        let addr = addr.unwrap();
+        assert_eq!(addr.ip().to_string(), "0.0.0.0");
+        assert_eq!(addr.port(), 9000);
+    }
+
+    #[test]
+    fn test_parse_ready_signal_invalid_prefix() {
+        let addr = parse_ready_signal("INVALID\n");
+        assert!(addr.is_none());
+    }
+
+    #[test]
+    fn test_parse_ready_signal_invalid_address() {
+        let addr = parse_ready_signal("READY not_an_addr\n");
+        assert!(addr.is_none());
+    }
+
+    #[test]
+    fn test_parse_ready_signal_no_newline() {
+        // Should still work without trailing newline
+        let addr = parse_ready_signal("READY 127.0.0.1:8080");
+        assert!(addr.is_some());
+        assert_eq!(addr.unwrap().port(), 8080);
+    }
+
+    // Tests for read_ready_signal
+
+    #[test]
+    fn test_read_ready_signal_immediate() {
+        use std::{io::Cursor, time::Duration};
+
+        let data = "READY 127.0.0.1:12521\n";
+        let mut reader = Cursor::new(data);
+        let result = read_ready_signal(&mut reader, Duration::from_secs(1));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().port(), 12521);
+    }
+
+    #[test]
+    fn test_read_ready_signal_with_prefix_lines() {
+        use std::{io::Cursor, time::Duration};
+
+        // Server might output some lines before READY
+        let data = "Loading modules...\nInitializing...\nREADY 127.0.0.1:9999\n";
+        let mut reader = Cursor::new(data);
+        let result = read_ready_signal(&mut reader, Duration::from_secs(1));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().port(), 9999);
+    }
+
+    #[test]
+    fn test_read_ready_signal_eof() {
+        use std::{io::Cursor, time::Duration};
+
+        // EOF before ready signal
+        let data = "";
+        let mut reader = Cursor::new(data);
+        let result = read_ready_signal(&mut reader, Duration::from_secs(1));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exited unexpectedly"));
     }
 }

--- a/runner/src/server/debug/handlers/log.rs
+++ b/runner/src/server/debug/handlers/log.rs
@@ -10,7 +10,7 @@ use reovim_protocol::v1::{
 
 use crate::server::rpc::{HandlerFuture, RpcContext};
 
-use super::super::infrastructure::{current_log_level, log_buffer, log_subscribers};
+use super::super::infrastructure::{get_current_level, log_buffer, log_subscribers, set_log_level};
 
 /// Handle `debug/log_level` request.
 ///
@@ -20,36 +20,70 @@ pub fn debug_log_level(_ctx: RpcContext, params: serde_json::Value) -> HandlerFu
     Box::pin(async move {
         let params: LogLevelParams = serde_json::from_value(params).unwrap_or_default();
 
-        // For now, we only support getting the level (setting requires tracing reload)
-        let level = current_log_level();
-
-        let result = if params.level.is_some() {
-            // Setting level is not yet implemented
-            LogLevelResult {
-                level: level.clone(),
-                previous: Some(level),
-            }
-        } else {
-            LogLevelResult {
-                level,
-                previous: None,
-            }
-        };
-
-        serde_json::to_value(result).map_err(|e| RpcError::internal_error(e.to_string()))
+        params.level.map_or_else(
+            || {
+                // Just return current level
+                let level = get_current_level();
+                let result = LogLevelResult {
+                    level,
+                    previous: None,
+                };
+                serde_json::to_value(result).map_err(|e| RpcError::internal_error(e.to_string()))
+            },
+            |new_level| {
+                // Set the new log level
+                match set_log_level(&new_level) {
+                    Ok(previous) => {
+                        let result = LogLevelResult {
+                            level: new_level,
+                            previous: Some(previous),
+                        };
+                        serde_json::to_value(result)
+                            .map_err(|e| RpcError::internal_error(e.to_string()))
+                    }
+                    Err(e) => Err(RpcError::invalid_params(e.to_string())),
+                }
+            },
+        )
     })
 }
 
 /// Handle `debug/log_tail` request.
 ///
-/// Get the last N log entries.
+/// Get the last N log entries with optional filtering.
 #[must_use]
 pub fn debug_log_tail(_ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
     Box::pin(async move {
         let params: LogTailParams = serde_json::from_value(params).unwrap_or_default();
 
         let buffer = log_buffer();
-        let entries = buffer.tail(params.count);
+
+        // Get more entries than requested if filtering (to account for filtered out)
+        // Cap at 5000 to prevent memory spikes with aggressive filtering
+        let has_filters =
+            params.level.is_some() || params.target.is_some() || params.grep.is_some();
+        let fetch_count = if has_filters {
+            (params.count * 10).min(5000)
+        } else {
+            params.count
+        };
+        let mut entries = buffer.tail(fetch_count);
+
+        // Apply filters
+        if let Some(ref level_filter) = params.level {
+            let min_level = LogLevel::from_str_lossy(level_filter);
+            entries.retain(|e| LogLevel::from_str_lossy(&e.level) >= min_level);
+        }
+        if let Some(ref target_filter) = params.target {
+            entries.retain(|e| e.target.contains(target_filter));
+        }
+        if let Some(ref grep) = params.grep {
+            let grep_lower = grep.to_lowercase();
+            entries.retain(|e| e.message.to_lowercase().contains(&grep_lower));
+        }
+
+        // Limit to requested count after filtering
+        entries.truncate(params.count);
 
         let entries: Vec<LogEntryResult> = entries
             .into_iter()
@@ -132,6 +166,84 @@ mod tests {
         let value = result.unwrap();
         assert!(value.get("entries").is_some());
         assert!(value.get("overflow_count").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_with_level_filter() {
+        let ctx = test_ctx();
+
+        let result = debug_log_tail(ctx, serde_json::json!({ "count": 50, "level": "warn" })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("entries").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_with_target_filter() {
+        let ctx = test_ctx();
+
+        let result =
+            debug_log_tail(ctx, serde_json::json!({ "count": 50, "target": "runner" })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("entries").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_with_grep_filter() {
+        let ctx = test_ctx();
+
+        let result = debug_log_tail(ctx, serde_json::json!({ "count": 50, "grep": "error" })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("entries").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_with_combined_filters() {
+        let ctx = test_ctx();
+
+        let result = debug_log_tail(
+            ctx,
+            serde_json::json!({
+                "count": 50,
+                "level": "info",
+                "target": "runner",
+                "grep": "test"
+            }),
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("entries").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_boundary_count_zero() {
+        let ctx = test_ctx();
+
+        let result = debug_log_tail(ctx, serde_json::json!({ "count": 0 })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        let entries = value.get("entries").unwrap().as_array().unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_tail_boundary_count_one() {
+        let ctx = test_ctx();
+
+        let result = debug_log_tail(ctx, serde_json::json!({ "count": 1 })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        let entries = value.get("entries").unwrap().as_array().unwrap();
+        assert!(entries.len() <= 1);
     }
 
     #[tokio::test]

--- a/runner/src/server/debug/handlers/log.rs
+++ b/runner/src/server/debug/handlers/log.rs
@@ -3,12 +3,14 @@
 //! These handlers provide log access for debugging.
 
 use reovim_protocol::v1::{
-    LogEntryResult, LogLevelParams, LogLevelResult, LogTailParams, LogTailResult, RpcError,
+    LogEntryResult, LogLevel, LogLevelParams, LogLevelResult, LogSubscribeParams,
+    LogSubscribeResult, LogTailParams, LogTailResult, LogUnsubscribeParams, LogUnsubscribeResult,
+    RpcError,
 };
 
 use crate::server::rpc::{HandlerFuture, RpcContext};
 
-use super::super::infrastructure::{current_log_level, log_buffer};
+use super::super::infrastructure::{current_log_level, log_buffer, log_subscribers};
 
 /// Handle `debug/log_level` request.
 ///
@@ -68,6 +70,43 @@ pub fn debug_log_tail(_ctx: RpcContext, params: serde_json::Value) -> HandlerFut
     })
 }
 
+/// Handle `debug/log_subscribe` request.
+///
+/// Subscribe to real-time log streaming.
+#[must_use]
+#[allow(clippy::needless_pass_by_value)] // Handler signature is fixed by HandlerFn type
+pub fn debug_log_subscribe(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
+    let client = ctx.client;
+    Box::pin(async move {
+        let params: LogSubscribeParams = serde_json::from_value(params).unwrap_or_default();
+
+        let level_filter = params.level.map(|s| LogLevel::from_str_lossy(&s));
+
+        let subscription_id = log_subscribers().subscribe(&client, level_filter);
+
+        let result = LogSubscribeResult { subscription_id };
+
+        serde_json::to_value(result).map_err(|e| RpcError::internal_error(e.to_string()))
+    })
+}
+
+/// Handle `debug/log_unsubscribe` request.
+///
+/// Unsubscribe from log streaming.
+#[must_use]
+pub fn debug_log_unsubscribe(_ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
+    Box::pin(async move {
+        let params: LogUnsubscribeParams =
+            serde_json::from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+        let success = log_subscribers().unsubscribe(params.subscription_id);
+
+        let result = LogUnsubscribeResult { success };
+
+        serde_json::to_value(result).map_err(|e| RpcError::internal_error(e.to_string()))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, crate::server::rpc::handlers::test_utils::test_ctx};
@@ -93,5 +132,62 @@ mod tests {
         let value = result.unwrap();
         assert!(value.get("entries").is_some());
         assert!(value.get("overflow_count").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_subscribe() {
+        let ctx = test_ctx();
+
+        let result = debug_log_subscribe(ctx, serde_json::json!({})).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("subscription_id").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_subscribe_with_level() {
+        let ctx = test_ctx();
+
+        let result = debug_log_subscribe(ctx, serde_json::json!({ "level": "warn" })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        let sub_id = value.get("subscription_id").unwrap().as_u64().unwrap();
+        assert!(sub_id > 0);
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_unsubscribe_valid() {
+        let ctx = test_ctx();
+
+        // First subscribe
+        let result = debug_log_subscribe(ctx.clone(), serde_json::json!({})).await;
+        let sub_id = result
+            .unwrap()
+            .get("subscription_id")
+            .unwrap()
+            .as_u64()
+            .unwrap();
+
+        // Then unsubscribe
+        let result =
+            debug_log_unsubscribe(ctx, serde_json::json!({ "subscription_id": sub_id })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(value.get("success").unwrap().as_bool().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_debug_log_unsubscribe_invalid() {
+        let ctx = test_ctx();
+
+        let result =
+            debug_log_unsubscribe(ctx, serde_json::json!({ "subscription_id": 99999 })).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(!value.get("success").unwrap().as_bool().unwrap());
     }
 }

--- a/runner/src/server/debug/handlers/mod.rs
+++ b/runner/src/server/debug/handlers/mod.rs
@@ -16,7 +16,7 @@ pub mod snapshot;
 pub use {
     info::{debug_uptime, debug_version},
     inspect::{debug_kernel_state, debug_marks, debug_mode_stack, debug_registers},
-    log::{debug_log_level, debug_log_tail},
+    log::{debug_log_level, debug_log_subscribe, debug_log_tail, debug_log_unsubscribe},
     metrics::{debug_handlers, debug_metrics},
     snapshot::debug_visual_snapshot,
 };

--- a/runner/src/server/debug/infrastructure/log_bridge.rs
+++ b/runner/src/server/debug/infrastructure/log_bridge.rs
@@ -1,0 +1,161 @@
+//! Async bridge for log notifications.
+//!
+//! Bridges the synchronous tracing layer to async notification broadcasting.
+//! Uses a bounded channel to avoid blocking the tracing callback.
+
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+
+use tokio::sync::mpsc;
+
+use super::{
+    log_buffer::LogEntry,
+    log_subscriber::{entry_to_payload, log_subscribers},
+};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Channel capacity for log entries.
+///
+/// Chosen to handle burst logging without dropping too many entries,
+/// while keeping memory bounded.
+const LOG_CHANNEL_CAPACITY: usize = 1000;
+
+// ============================================================================
+// Global Channel
+// ============================================================================
+
+/// Global log entry sender.
+static LOG_SENDER: OnceLock<mpsc::Sender<LogEntry>> = OnceLock::new();
+
+/// Counter for dropped entries (when channel is full).
+static DROPPED_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Initialize the log bridge channel.
+///
+/// Returns the receiver end for the drain task, or `None` if already initialized.
+/// Should only be called once during server startup.
+#[must_use]
+pub fn init_log_bridge() -> Option<mpsc::Receiver<LogEntry>> {
+    let (tx, rx) = mpsc::channel(LOG_CHANNEL_CAPACITY);
+
+    match LOG_SENDER.set(tx) {
+        Ok(()) => Some(rx),
+        Err(_) => {
+            // Already initialized - this is OK for tests or multiple init calls
+            None
+        }
+    }
+}
+
+/// Try to send a log entry to the bridge.
+///
+/// This is called from the synchronous tracing layer.
+/// Uses `try_send` to avoid blocking - if the channel is full,
+/// the entry is dropped and the counter is incremented.
+pub fn try_send_log(entry: LogEntry) {
+    if let Some(sender) = LOG_SENDER.get()
+        && sender.try_send(entry).is_err()
+    {
+        DROPPED_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    // If sender not initialized, silently drop (startup race)
+}
+
+/// Get the number of dropped log entries.
+#[must_use]
+pub fn dropped_count() -> u64 {
+    DROPPED_COUNT.load(Ordering::Relaxed)
+}
+
+/// Reset the dropped counter (for testing).
+#[cfg(test)]
+pub fn reset_dropped_count() {
+    DROPPED_COUNT.store(0, Ordering::Relaxed);
+}
+
+// ============================================================================
+// Drain Task
+// ============================================================================
+
+/// Spawn the log drain task.
+///
+/// This task reads from the log bridge channel and broadcasts
+/// notifications to subscribed clients.
+///
+/// # Returns
+///
+/// The `JoinHandle` for the drain task (can be used for shutdown).
+#[must_use]
+pub fn spawn_drain_task(mut rx: mpsc::Receiver<LogEntry>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(entry) = rx.recv().await {
+            broadcast_log_entry(&entry).await;
+        }
+        tracing::debug!("Log drain task shutting down");
+    })
+}
+
+/// Broadcast a log entry to all matching subscribers.
+async fn broadcast_log_entry(entry: &LogEntry) {
+    use reovim_protocol::v1::LogLevel;
+
+    let level = LogLevel::from_str_lossy(&entry.level);
+    let subscribers = log_subscribers().matching_subscriptions(level);
+
+    if subscribers.is_empty() {
+        return;
+    }
+
+    // Convert entry to notification payload
+    let payload = entry_to_payload(entry);
+    let notification = payload.into_notification();
+
+    // Serialize once for all clients
+    let json = match serde_json::to_string(&notification) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::warn!("Failed to serialize log notification: {e}");
+            return;
+        }
+    };
+
+    // Send to each subscriber
+    for sub in subscribers {
+        // Try to upgrade weak reference to strong and send
+        if let Some(client) = sub.client.upgrade()
+            && let Err(e) = client.send_line(&json).await
+        {
+            tracing::trace!("Failed to send log to client {:?}: {e}", sub.client_id);
+            // Client may have disconnected - the weak ref will fail next time
+        }
+        // If upgrade fails, client is gone - subscription cleanup happens elsewhere
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: Most tests for the bridge are integration tests
+    // because the global state makes unit testing difficult.
+    // These tests verify the atomic counter behavior.
+
+    #[test]
+    fn test_dropped_count_initial() {
+        // Counter should start at 0 (or whatever previous tests left it at)
+        let _ = dropped_count();
+    }
+
+    #[test]
+    fn test_try_send_without_init() {
+        // Should not panic when sender is not initialized
+        let entry = LogEntry::new("INFO", "test", "message");
+        try_send_log(entry);
+        // Entry is silently dropped
+    }
+}

--- a/runner/src/server/debug/infrastructure/log_buffer_layer.rs
+++ b/runner/src/server/debug/infrastructure/log_buffer_layer.rs
@@ -2,6 +2,7 @@
 //!
 //! This layer captures tracing events and pushes them to the global
 //! `LogRingBuffer` for later retrieval via `debug/log_tail`.
+//! Also sends entries to the log bridge for real-time notification streaming.
 
 use {
     tracing::{
@@ -11,7 +12,10 @@ use {
     tracing_subscriber::layer::{Context, Layer},
 };
 
-use super::log_buffer::{LogEntry, log_buffer};
+use super::{
+    log_bridge::try_send_log,
+    log_buffer::{LogEntry, log_buffer},
+};
 
 // ============================================================================
 // Message Visitor
@@ -81,9 +85,14 @@ where
         let mut visitor = MessageVisitor::new();
         event.record(&mut visitor);
 
-        // Push to the global log buffer
+        // Create the log entry
         let entry = LogEntry::new(&level, &target, &visitor.message);
-        log_buffer().push(entry);
+
+        // Push to the global log buffer (for debug/log_tail)
+        log_buffer().push(entry.clone());
+
+        // Send to bridge for real-time notifications (non-blocking)
+        try_send_log(entry);
     }
 }
 

--- a/runner/src/server/debug/infrastructure/log_level.rs
+++ b/runner/src/server/debug/infrastructure/log_level.rs
@@ -1,0 +1,185 @@
+//! Dynamic log level control.
+//!
+//! Provides runtime log level changes using `tracing_subscriber` reload layer.
+//!
+//! # Type Note
+//!
+//! The reload layer type depends on the subscriber composition.
+//! With our current setup (`registry().with(reload_layer).with(LogBufferLayer)...`),
+//! the handle type is `reload::Handle<LevelFilter, tracing_subscriber::Registry>`.
+//! This is because the reload layer is applied directly to the Registry before
+//! other layers. If the layer composition order changes, the type would need
+//! to be updated.
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::{filter::LevelFilter, reload};
+
+/// Error type for log level operations.
+#[derive(Debug, Clone)]
+pub enum LogLevelError {
+    /// Invalid log level string.
+    InvalidLevel(String),
+    /// Reload handle not initialized.
+    NotInitialized,
+    /// Failed to apply new level.
+    ReloadFailed(String),
+}
+
+impl std::fmt::Display for LogLevelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLevel(s) => write!(f, "invalid log level: {s}"),
+            Self::NotInitialized => write!(f, "log level control not initialized"),
+            Self::ReloadFailed(s) => write!(f, "failed to reload log level: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for LogLevelError {}
+
+/// Global reload handle for log level filter.
+///
+/// The type parameter is `Registry` because the reload layer is applied
+/// directly to `tracing_subscriber::registry()` before other layers.
+static LEVEL_HANDLE: OnceLock<reload::Handle<LevelFilter, tracing_subscriber::Registry>> =
+    OnceLock::new();
+
+/// Initialize the level reload handle.
+///
+/// Should be called once during server initialization, after creating
+/// the reload layer but before `try_init()`.
+pub fn init_level_handle(handle: reload::Handle<LevelFilter, tracing_subscriber::Registry>) {
+    let _ = LEVEL_HANDLE.set(handle);
+}
+
+/// Get current log level from the reload layer.
+///
+/// Falls back to `STATIC_MAX_LEVEL` if the reload handle is not initialized.
+#[must_use]
+pub fn get_current_level() -> String {
+    LEVEL_HANDLE.get().map_or_else(
+        || {
+            tracing::level_filters::STATIC_MAX_LEVEL
+                .to_string()
+                .to_lowercase()
+        },
+        |handle| {
+            handle.clone_current().map_or_else(
+                || {
+                    tracing::level_filters::STATIC_MAX_LEVEL
+                        .to_string()
+                        .to_lowercase()
+                },
+                |filter| format!("{filter:?}").to_lowercase(),
+            )
+        },
+    )
+}
+
+/// Set log level dynamically.
+///
+/// # Arguments
+///
+/// * `level` - Log level string (trace, debug, info, warn, error, off)
+///
+/// # Returns
+///
+/// The previous log level string on success.
+///
+/// # Errors
+///
+/// Returns error if the level string is invalid, the reload handle is not
+/// initialized, or the reload operation fails.
+pub fn set_log_level(level: &str) -> Result<String, LogLevelError> {
+    let filter = match level.to_lowercase().as_str() {
+        "trace" => LevelFilter::TRACE,
+        "debug" => LevelFilter::DEBUG,
+        "info" => LevelFilter::INFO,
+        "warn" | "warning" => LevelFilter::WARN,
+        "error" => LevelFilter::ERROR,
+        "off" => LevelFilter::OFF,
+        _ => return Err(LogLevelError::InvalidLevel(level.to_string())),
+    };
+
+    let handle = LEVEL_HANDLE.get().ok_or(LogLevelError::NotInitialized)?;
+    let previous = handle
+        .clone_current()
+        .map_or_else(|| "unknown".to_string(), |f| format!("{f:?}").to_lowercase());
+
+    handle
+        .reload(filter)
+        .map_err(|e| LogLevelError::ReloadFailed(e.to_string()))?;
+
+    Ok(previous)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_level_error_display() {
+        let err = LogLevelError::InvalidLevel("bad".to_string());
+        assert!(err.to_string().contains("invalid log level"));
+
+        let err = LogLevelError::NotInitialized;
+        assert!(err.to_string().contains("not initialized"));
+
+        let err = LogLevelError::ReloadFailed("error".to_string());
+        assert!(err.to_string().contains("failed to reload"));
+    }
+
+    #[test]
+    fn test_get_current_level_fallback() {
+        // When handle is not initialized, should return STATIC_MAX_LEVEL
+        // This test relies on the fact that in test context, the handle
+        // may not be initialized (depends on test execution order)
+        let level = get_current_level();
+        assert!(!level.is_empty());
+    }
+
+    #[test]
+    fn test_set_log_level_not_initialized() {
+        // In test context without proper initialization, should return NotInitialized
+        // Note: This test may pass or fail depending on whether other tests
+        // have initialized the handle. The global state makes this tricky.
+        // The key behavior we're testing is that invalid levels return error.
+        let result = set_log_level("invalid_level");
+        assert!(result.is_err());
+        match result {
+            Err(LogLevelError::InvalidLevel(_) | LogLevelError::NotInitialized) => {}
+            _ => panic!("Expected InvalidLevel or NotInitialized error"),
+        }
+    }
+
+    #[test]
+    fn test_level_parsing() {
+        // Test that level parsing works for valid levels
+        // We can't test the actual reload without proper initialization,
+        // but we can verify the parsing logic by checking error types
+        let levels = ["trace", "debug", "info", "warn", "warning", "error", "off"];
+        for level in levels {
+            let result = set_log_level(level);
+            // Should either succeed or fail with NotInitialized, not InvalidLevel
+            match result {
+                Ok(_) | Err(LogLevelError::NotInitialized | LogLevelError::ReloadFailed(_)) => {}
+                Err(LogLevelError::InvalidLevel(l)) => {
+                    panic!("Valid level '{level}' was rejected as invalid: {l}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_level_rejected() {
+        let result = set_log_level("foobar");
+        assert!(matches!(result, Err(LogLevelError::InvalidLevel(_))));
+
+        let result = set_log_level("");
+        assert!(matches!(result, Err(LogLevelError::InvalidLevel(_))));
+
+        let result = set_log_level("DEBUG"); // uppercase should still work
+        assert!(!matches!(result, Err(LogLevelError::InvalidLevel(_))));
+    }
+}

--- a/runner/src/server/debug/infrastructure/log_subscriber.rs
+++ b/runner/src/server/debug/infrastructure/log_subscriber.rs
@@ -1,0 +1,426 @@
+//! Log subscription system for real-time log streaming.
+//!
+//! Provides infrastructure for clients to subscribe to log events
+//! and receive them as notifications.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock, Weak,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use {
+    reovim_arch::sync::ArcSwap,
+    reovim_protocol::v1::{LogEntryPayload, LogLevel, LogSource},
+};
+
+use crate::{server::client::Client, session::ClientId};
+
+use super::log_buffer::LogEntry;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Unique subscription identifier.
+pub type SubscriptionId = u64;
+
+/// A single log subscription.
+#[derive(Clone)]
+pub struct LogSubscription {
+    /// The subscription ID.
+    pub id: SubscriptionId,
+    /// The client that created this subscription.
+    pub client_id: ClientId,
+    /// Weak reference to the client for sending notifications.
+    /// When the client disconnects, this becomes invalid.
+    pub client: Weak<Client>,
+    /// Minimum log level to receive (None = all levels).
+    pub level_filter: Option<LogLevel>,
+}
+
+impl std::fmt::Debug for LogSubscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogSubscription")
+            .field("id", &self.id)
+            .field("client_id", &self.client_id)
+            .field("level_filter", &self.level_filter)
+            .field("client_alive", &self.client.upgrade().is_some())
+            .finish()
+    }
+}
+
+/// Thread-safe registry of log subscriptions.
+#[derive(Debug)]
+pub struct LogSubscribers {
+    /// Subscriptions indexed by ID.
+    subscriptions: ArcSwap<HashMap<SubscriptionId, LogSubscription>>,
+    /// Next subscription ID.
+    next_id: AtomicU64,
+}
+
+impl LogSubscribers {
+    /// Create a new empty subscriber registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            subscriptions: ArcSwap::from_pointee(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    /// Subscribe to log events.
+    ///
+    /// Returns a unique subscription ID for unsubscribing.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - Arc to the client (stored as Weak to allow cleanup)
+    /// * `level_filter` - Minimum log level to receive (None = all levels)
+    pub fn subscribe(
+        &self,
+        client: &Arc<Client>,
+        level_filter: Option<LogLevel>,
+    ) -> SubscriptionId {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let subscription = LogSubscription {
+            id,
+            client_id: client.id(),
+            client: Arc::downgrade(client),
+            level_filter,
+        };
+
+        self.subscriptions.rcu(|current| {
+            let mut new = (**current).clone();
+            new.insert(id, subscription.clone());
+            new
+        });
+
+        id
+    }
+
+    /// Unsubscribe from log events.
+    ///
+    /// Returns true if the subscription was found and removed.
+    pub fn unsubscribe(&self, subscription_id: SubscriptionId) -> bool {
+        let mut found = false;
+        self.subscriptions.rcu(|current| {
+            let mut new = (**current).clone();
+            found = new.remove(&subscription_id).is_some();
+            new
+        });
+        found
+    }
+
+    /// Remove all subscriptions for a client.
+    ///
+    /// Called when a client disconnects.
+    pub fn remove_client(&self, client_id: ClientId) {
+        self.subscriptions.rcu(|current| {
+            let new: HashMap<_, _> = current
+                .iter()
+                .filter(|(_, sub)| sub.client_id != client_id)
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
+            new
+        });
+    }
+
+    /// Get all subscriptions that should receive a log entry.
+    ///
+    /// Filters by level if the subscription has a level filter.
+    pub fn matching_subscriptions(&self, level: LogLevel) -> Vec<LogSubscription> {
+        self.subscriptions
+            .load()
+            .values()
+            .filter(|sub| sub.level_filter.is_none_or(|min_level| level >= min_level))
+            .cloned()
+            .collect()
+    }
+
+    /// Get all current subscriptions (for testing/debugging).
+    pub fn all_subscriptions(&self) -> Vec<LogSubscription> {
+        self.subscriptions.load().values().cloned().collect()
+    }
+
+    /// Check if subscriber list is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.subscriptions.load().is_empty()
+    }
+
+    /// Get subscription count.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.subscriptions.load().len()
+    }
+}
+
+impl Default for LogSubscribers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Global Subscriber Registry
+// ============================================================================
+
+/// Global log subscribers registry.
+static LOG_SUBSCRIBERS: OnceLock<LogSubscribers> = OnceLock::new();
+
+/// Get or initialize the global log subscribers registry.
+pub fn log_subscribers() -> &'static LogSubscribers {
+    LOG_SUBSCRIBERS.get_or_init(LogSubscribers::new)
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Convert a `LogEntry` to a `LogEntryPayload` notification.
+#[must_use]
+pub fn entry_to_payload(entry: &LogEntry) -> LogEntryPayload {
+    LogEntryPayload {
+        timestamp: entry.timestamp_iso(),
+        level: LogLevel::from_str_lossy(&entry.level),
+        target: entry.target.clone(),
+        message: entry.message.clone(),
+        source: LogSource::Server,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{server::transport::TransportWriter, session::SessionId};
+
+    use super::*;
+
+    /// Create a test client with the given ID.
+    fn test_client(id: u64) -> Arc<Client> {
+        Client::new(ClientId::new(id), SessionId::new("test"), TransportWriter::from_stdio())
+    }
+
+    #[test]
+    fn test_subscribe_returns_unique_id() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        let id1 = subscribers.subscribe(&client, None);
+        let id2 = subscribers.subscribe(&client, None);
+
+        assert_ne!(id1, id2);
+        assert_eq!(subscribers.len(), 2);
+    }
+
+    #[test]
+    fn test_unsubscribe_valid_id() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        let id = subscribers.subscribe(&client, None);
+        assert_eq!(subscribers.len(), 1);
+
+        let result = subscribers.unsubscribe(id);
+        assert!(result);
+        assert_eq!(subscribers.len(), 0);
+    }
+
+    #[test]
+    fn test_unsubscribe_invalid_id() {
+        let subscribers = LogSubscribers::new();
+
+        let result = subscribers.unsubscribe(999);
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_level_filtering() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        // Subscribe with warn filter
+        subscribers.subscribe(&client, Some(LogLevel::Warn));
+
+        // Should match warn and error
+        let matches = subscribers.matching_subscriptions(LogLevel::Error);
+        assert_eq!(matches.len(), 1);
+
+        let matches = subscribers.matching_subscriptions(LogLevel::Warn);
+        assert_eq!(matches.len(), 1);
+
+        // Should NOT match info and below
+        let matches = subscribers.matching_subscriptions(LogLevel::Info);
+        assert_eq!(matches.len(), 0);
+
+        let matches = subscribers.matching_subscriptions(LogLevel::Debug);
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_subscriptions_same_client() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        let id1 = subscribers.subscribe(&client, Some(LogLevel::Error));
+        let id2 = subscribers.subscribe(&client, Some(LogLevel::Debug));
+
+        assert_eq!(subscribers.len(), 2);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_broadcast_to_multiple_subscribers() {
+        let subscribers = LogSubscribers::new();
+        let client1 = test_client(1);
+        let client2 = test_client(2);
+        let client3 = test_client(3);
+
+        subscribers.subscribe(&client1, None);
+        subscribers.subscribe(&client2, None);
+        subscribers.subscribe(&client3, Some(LogLevel::Warn));
+
+        // Info should match 2 subscribers (client 1, 2 with no filter)
+        let matches = subscribers.matching_subscriptions(LogLevel::Info);
+        assert_eq!(matches.len(), 2);
+
+        // Error should match all 3
+        let matches = subscribers.matching_subscriptions(LogLevel::Error);
+        assert_eq!(matches.len(), 3);
+    }
+
+    #[test]
+    fn test_remove_client() {
+        let subscribers = LogSubscribers::new();
+        let client1 = test_client(1);
+        let client2 = test_client(2);
+
+        subscribers.subscribe(&client1, None);
+        subscribers.subscribe(&client1, Some(LogLevel::Warn));
+        subscribers.subscribe(&client2, None);
+
+        assert_eq!(subscribers.len(), 3);
+
+        subscribers.remove_client(client1.id());
+
+        assert_eq!(subscribers.len(), 1);
+        let remaining = subscribers.all_subscriptions();
+        assert_eq!(remaining[0].client_id, client2.id());
+    }
+
+    #[test]
+    fn test_broadcast_empty_subscribers() {
+        let subscribers = LogSubscribers::new();
+
+        let matches = subscribers.matching_subscriptions(LogLevel::Info);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_concurrent_subscribe_safety() {
+        use std::thread;
+
+        let subscribers = LogSubscribers::new();
+        let subscribers = std::sync::Arc::new(subscribers);
+
+        // Pre-create clients (can't create in threads due to lifetime)
+        let clients: Vec<_> = (0..10).map(test_client).collect();
+
+        let mut handles = vec![];
+
+        for client in clients {
+            let subs = subscribers.clone();
+            handles.push(thread::spawn(move || {
+                subs.subscribe(&client, None);
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(subscribers.len(), 10);
+    }
+
+    #[test]
+    fn test_concurrent_subscribe_unsubscribe() {
+        use std::thread;
+
+        let subscribers = LogSubscribers::new();
+        let subscribers = std::sync::Arc::new(subscribers);
+
+        // Pre-create clients
+        let clients: Vec<_> = (0..5).map(test_client).collect();
+
+        // Subscribe from multiple threads
+        let mut handles = vec![];
+        for client in clients {
+            let subs = subscribers.clone();
+            handles.push(thread::spawn(move || subs.subscribe(&client, None)));
+        }
+
+        let ids: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Unsubscribe from multiple threads
+        let mut handles = vec![];
+        for id in ids {
+            let subs = subscribers.clone();
+            handles.push(thread::spawn(move || subs.unsubscribe(id)));
+        }
+
+        for handle in handles {
+            assert!(handle.join().unwrap());
+        }
+
+        assert!(subscribers.is_empty());
+    }
+
+    #[test]
+    fn test_subscription_cleanup_on_disconnect() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        subscribers.subscribe(&client, None);
+        subscribers.subscribe(&client, Some(LogLevel::Warn));
+        assert_eq!(subscribers.len(), 2);
+
+        // Simulate disconnect
+        subscribers.remove_client(client.id());
+        assert!(subscribers.is_empty());
+    }
+
+    #[test]
+    fn test_entry_to_payload() {
+        let entry = LogEntry::new("INFO", "test::module", "test message");
+        let payload = entry_to_payload(&entry);
+
+        assert_eq!(payload.level, LogLevel::Info);
+        assert_eq!(payload.target, "test::module");
+        assert_eq!(payload.message, "test message");
+        assert_eq!(payload.source, LogSource::Server);
+    }
+
+    #[test]
+    fn test_weak_client_expires_when_dropped() {
+        let subscribers = LogSubscribers::new();
+        let client = test_client(1);
+
+        let id = subscribers.subscribe(&client, None);
+
+        // Client is still alive
+        let subs = subscribers.all_subscriptions();
+        assert!(subs[0].client.upgrade().is_some());
+
+        // Drop the client
+        drop(client);
+
+        // Weak reference should now be expired
+        let subs = subscribers.all_subscriptions();
+        assert!(subs[0].client.upgrade().is_none());
+
+        // Unsubscribe still works
+        assert!(subscribers.unsubscribe(id));
+    }
+}

--- a/runner/src/server/debug/infrastructure/mod.rs
+++ b/runner/src/server/debug/infrastructure/mod.rs
@@ -5,15 +5,23 @@
 //! - Handler metrics (Phase 3)
 //! - Log buffer (Phase 4)
 //! - Log buffer tracing layer (Phase 4 enhancement)
+//! - Log subscription for real-time streaming (#332)
+//! - Log bridge for async notification broadcasting (#332)
 
+pub mod log_bridge;
 pub mod log_buffer;
 pub mod log_buffer_layer;
+pub mod log_subscriber;
 pub mod metrics;
 pub mod uptime;
 
 pub use {
+    log_bridge::{dropped_count, init_log_bridge, spawn_drain_task, try_send_log},
     log_buffer::{LogEntry, LogRingBuffer, current_log_level, log_buffer},
     log_buffer_layer::LogBufferLayer,
+    log_subscriber::{
+        LogSubscribers, LogSubscription, SubscriptionId, entry_to_payload, log_subscribers,
+    },
     metrics::{
         HandlerMetricsSnapshot, RequestTimer, increment_total_requests, snapshot_handler_metrics,
         total_requests,

--- a/runner/src/server/debug/infrastructure/mod.rs
+++ b/runner/src/server/debug/infrastructure/mod.rs
@@ -7,10 +7,12 @@
 //! - Log buffer tracing layer (Phase 4 enhancement)
 //! - Log subscription for real-time streaming (#332)
 //! - Log bridge for async notification broadcasting (#332)
+//! - Dynamic log level control (#324)
 
 pub mod log_bridge;
 pub mod log_buffer;
 pub mod log_buffer_layer;
+pub mod log_level;
 pub mod log_subscriber;
 pub mod metrics;
 pub mod uptime;
@@ -19,6 +21,7 @@ pub use {
     log_bridge::{dropped_count, init_log_bridge, spawn_drain_task, try_send_log},
     log_buffer::{LogEntry, LogRingBuffer, current_log_level, log_buffer},
     log_buffer_layer::LogBufferLayer,
+    log_level::{LogLevelError, get_current_level, init_level_handle, set_log_level},
     log_subscriber::{
         LogSubscribers, LogSubscription, SubscriptionId, entry_to_payload, log_subscribers,
     },

--- a/runner/src/server/debug/mod.rs
+++ b/runner/src/server/debug/mod.rs
@@ -51,7 +51,9 @@ use {
         DEBUG_LOG_UNSUBSCRIBE, DEBUG_MARKS, DEBUG_METRICS, DEBUG_MODE_STACK, DEBUG_REGISTERS,
         DEBUG_UPTIME, DEBUG_VERSION, DEBUG_VISUAL_SNAPSHOT,
     },
-    tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
+    tracing_subscriber::{
+        filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt,
+    },
 };
 
 /// Register all debug handlers with the dispatcher.
@@ -92,6 +94,7 @@ pub fn register_handlers(dispatcher: &mut RpcDispatcher) {
 /// - Handler metrics collection
 /// - Log ring buffer
 /// - Log bridge for real-time notifications (#332)
+/// - Dynamic log level control via reload layer (#324)
 ///
 /// # Arguments
 ///
@@ -103,18 +106,29 @@ pub fn init(quiet: bool) {
     // Returns None if already initialized (safe for multiple calls).
     let log_rx = infrastructure::init_log_bridge();
 
+    // Create reloadable level filter for dynamic log level changes (#324).
+    // The type is reload::Handle<LevelFilter, Registry> because the reload layer
+    // is applied directly to the Registry before other layers.
+    let (level_filter, reload_handle) = reload::Layer::new(LevelFilter::INFO);
+
+    // Store reload handle for runtime changes via debug/log_level
+    infrastructure::init_level_handle(reload_handle);
+
     // Initialize tracing subscriber with LogBufferLayer.
     // This captures log events to the ring buffer for debug/log_tail,
     // and sends them to the bridge for real-time notifications.
     // Uses try_init() to avoid panic if subscriber already set.
+    // Both quiet and non-quiet modes use the same reload layer.
     if quiet {
         // Quiet mode: only capture to buffer, no stderr output
         let _ = tracing_subscriber::registry()
+            .with(level_filter)
             .with(infrastructure::LogBufferLayer)
             .try_init();
     } else {
         // Normal mode: capture to buffer AND write to stderr
         let _ = tracing_subscriber::registry()
+            .with(level_filter)
             .with(infrastructure::LogBufferLayer)
             .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
             .try_init();

--- a/runner/src/server/debug/mod.rs
+++ b/runner/src/server/debug/mod.rs
@@ -89,14 +89,27 @@ pub fn register_handlers(dispatcher: &mut RpcDispatcher) {
 /// - Tracing subscriber with `LogBufferLayer` for log capture
 /// - Handler metrics collection
 /// - Log ring buffer
-pub fn init() {
+///
+/// # Arguments
+///
+/// * `quiet` - If true, suppress stderr logging (for integrated mode).
+///   Logs are still captured to the ring buffer for `debug/log_tail`.
+pub fn init(quiet: bool) {
     // Initialize tracing subscriber with LogBufferLayer.
     // This captures log events to the ring buffer for debug/log_tail.
     // Uses try_init() to avoid panic if subscriber already set.
-    let _ = tracing_subscriber::registry()
-        .with(infrastructure::LogBufferLayer)
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .try_init();
+    if quiet {
+        // Quiet mode: only capture to buffer, no stderr output
+        let _ = tracing_subscriber::registry()
+            .with(infrastructure::LogBufferLayer)
+            .try_init();
+    } else {
+        // Normal mode: capture to buffer AND write to stderr
+        let _ = tracing_subscriber::registry()
+            .with(infrastructure::LogBufferLayer)
+            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .try_init();
+    }
 
     infrastructure::init_server_start();
 }
@@ -135,7 +148,13 @@ mod tests {
     #[test]
     fn test_init() {
         // Should not panic when called multiple times
-        init();
-        init();
+        init(false);
+        init(false);
+    }
+
+    #[test]
+    fn test_init_quiet() {
+        // Quiet mode should also not panic
+        init(true);
     }
 }

--- a/runner/src/server/debug/mod.rs
+++ b/runner/src/server/debug/mod.rs
@@ -47,9 +47,9 @@ pub mod infrastructure;
 use {
     crate::server::rpc::RpcDispatcher,
     reovim_protocol::v1::{
-        DEBUG_HANDLERS, DEBUG_KERNEL_STATE, DEBUG_LOG_LEVEL, DEBUG_LOG_TAIL, DEBUG_MARKS,
-        DEBUG_METRICS, DEBUG_MODE_STACK, DEBUG_REGISTERS, DEBUG_UPTIME, DEBUG_VERSION,
-        DEBUG_VISUAL_SNAPSHOT,
+        DEBUG_HANDLERS, DEBUG_KERNEL_STATE, DEBUG_LOG_LEVEL, DEBUG_LOG_SUBSCRIBE, DEBUG_LOG_TAIL,
+        DEBUG_LOG_UNSUBSCRIBE, DEBUG_MARKS, DEBUG_METRICS, DEBUG_MODE_STACK, DEBUG_REGISTERS,
+        DEBUG_UPTIME, DEBUG_VERSION, DEBUG_VISUAL_SNAPSHOT,
     },
     tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
 };
@@ -76,6 +76,8 @@ pub fn register_handlers(dispatcher: &mut RpcDispatcher) {
     // Phase 4: Log Access
     dispatcher.register(DEBUG_LOG_LEVEL, handlers::debug_log_level);
     dispatcher.register(DEBUG_LOG_TAIL, handlers::debug_log_tail);
+    dispatcher.register(DEBUG_LOG_SUBSCRIBE, handlers::debug_log_subscribe);
+    dispatcher.register(DEBUG_LOG_UNSUBSCRIBE, handlers::debug_log_unsubscribe);
 
     // Phase 5: Visual Debug
     dispatcher.register(DEBUG_VISUAL_SNAPSHOT, handlers::debug_visual_snapshot);
@@ -89,14 +91,21 @@ pub fn register_handlers(dispatcher: &mut RpcDispatcher) {
 /// - Tracing subscriber with `LogBufferLayer` for log capture
 /// - Handler metrics collection
 /// - Log ring buffer
+/// - Log bridge for real-time notifications (#332)
 ///
 /// # Arguments
 ///
 /// * `quiet` - If true, suppress stderr logging (for integrated mode).
 ///   Logs are still captured to the ring buffer for `debug/log_tail`.
 pub fn init(quiet: bool) {
+    // Initialize log bridge first (before tracing subscriber)
+    // This creates the channel that LogBufferLayer will send to.
+    // Returns None if already initialized (safe for multiple calls).
+    let log_rx = infrastructure::init_log_bridge();
+
     // Initialize tracing subscriber with LogBufferLayer.
-    // This captures log events to the ring buffer for debug/log_tail.
+    // This captures log events to the ring buffer for debug/log_tail,
+    // and sends them to the bridge for real-time notifications.
     // Uses try_init() to avoid panic if subscriber already set.
     if quiet {
         // Quiet mode: only capture to buffer, no stderr output
@@ -112,6 +121,19 @@ pub fn init(quiet: bool) {
     }
 
     infrastructure::init_server_start();
+
+    // Spawn the drain task to process log entries and send notifications.
+    // Only spawn if this is the first initialization (we got the receiver).
+    // The task will run until the channel is closed (server shutdown).
+    if let Some(rx) = log_rx {
+        // Only spawn if we're in a tokio runtime context.
+        // This check handles test scenarios where init() is called outside a runtime.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let _drain_handle = infrastructure::spawn_drain_task(rx);
+            // Note: We don't store the handle - the task will exit when the channel closes.
+            // For graceful shutdown, we'd store this and await it.
+        }
+    }
 }
 
 #[cfg(test)]
@@ -140,6 +162,8 @@ mod tests {
         // Phase 4 handlers should be registered
         assert!(dispatcher.has_method(DEBUG_LOG_LEVEL));
         assert!(dispatcher.has_method(DEBUG_LOG_TAIL));
+        assert!(dispatcher.has_method(DEBUG_LOG_SUBSCRIBE));
+        assert!(dispatcher.has_method(DEBUG_LOG_UNSUBSCRIBE));
 
         // Phase 5 handlers should be registered
         assert!(dispatcher.has_method(DEBUG_VISUAL_SNAPSHOT));

--- a/runner/src/server/mod.rs
+++ b/runner/src/server/mod.rs
@@ -83,6 +83,14 @@ pub struct SrvArgs {
     /// Useful for testing or minimal startup.
     #[arg(long = "no-defaults")]
     pub no_defaults: bool,
+
+    /// Print ready signal to stdout when server is bound.
+    ///
+    /// When set, server prints `READY <ip>:<port>` to stdout after binding.
+    /// Used by integrated mode for process coordination.
+    /// Format: `READY 127.0.0.1:12521\n`
+    #[arg(long, hide = true)]
+    pub ready_signal: bool,
 }
 
 impl SrvArgs {
@@ -111,7 +119,9 @@ impl SrvArgs {
         let transport = {
             #[cfg(unix)]
             if let Some(path) = self.socket {
-                return ServerConfig::unix_socket(path).with_modules(modules);
+                return ServerConfig::unix_socket(path)
+                    .with_modules(modules)
+                    .with_ready_signal(self.ready_signal);
             }
 
             if self.stdio {
@@ -128,6 +138,7 @@ impl SrvArgs {
             default_session_name: String::from("default"),
             modules,
             default_mode: None,
+            ready_signal: self.ready_signal,
         }
     }
 }
@@ -158,7 +169,6 @@ pub use {
 };
 
 use std::{
-    net::SocketAddr,
     path::PathBuf,
     sync::{
         Arc,
@@ -239,6 +249,12 @@ pub struct ServerConfig {
     ///
     /// If None, falls back to "editor:normal".
     pub default_mode: Option<ModeId>,
+
+    /// Print ready signal to stdout when server is bound.
+    ///
+    /// When true, server prints `READY <ip>:<port>\n` to stdout after binding.
+    /// Used by integrated mode for process coordination.
+    pub ready_signal: bool,
 }
 
 impl Default for ServerConfig {
@@ -248,6 +264,7 @@ impl Default for ServerConfig {
             default_session_name: String::from("default"),
             modules: ModuleConfig::default(),
             default_mode: None,
+            ready_signal: false,
         }
     }
 }
@@ -337,6 +354,15 @@ impl ServerConfig {
         self
     }
 
+    /// Enable ready signal output.
+    ///
+    /// When enabled, server prints `READY <ip>:<port>\n` to stdout after binding.
+    #[must_use]
+    pub const fn with_ready_signal(mut self, enable: bool) -> Self {
+        self.ready_signal = enable;
+        self
+    }
+
     /// Get the effective default mode.
     ///
     /// Returns the configured default mode, or falls back to "editor:normal".
@@ -410,7 +436,8 @@ impl Server {
     /// Returns an error if binding fails.
     pub async fn run(&self) -> std::io::Result<()> {
         // Initialize debug infrastructure (uptime tracking, etc.)
-        debug::init();
+        // Quiet mode when ready_signal is set (no stderr output)
+        debug::init(self.config.ready_signal);
 
         // Load modules from configuration
         self.load_modules();
@@ -437,74 +464,6 @@ impl Server {
         }
     }
 
-    /// Run the server and signal when ready.
-    ///
-    /// Similar to [`run`], but sends the bound address through the provided
-    /// channel before entering the accept loop. Used by integrated mode to
-    /// coordinate server startup with TUI attachment.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if binding fails.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let (tx, rx) = tokio::sync::oneshot::channel();
-    /// tokio::spawn(async move {
-    ///     server.run_with_ready_signal(tx).await
-    /// });
-    /// let addr = rx.await?; // Server is now listening
-    /// ```
-    pub async fn run_with_ready_signal(
-        &self,
-        ready_tx: tokio::sync::oneshot::Sender<SocketAddr>,
-    ) -> std::io::Result<()> {
-        // Initialize debug infrastructure (uptime tracking, etc.)
-        debug::init();
-
-        // Load modules from configuration
-        self.load_modules();
-
-        // Create default session
-        let default_session_id = SessionId::new(self.config.default_session_name.as_str());
-        self.ensure_default_session(&default_session_id);
-
-        match &self.config.transport {
-            TransportMode::TcpWithFallback => {
-                let listener = TransportListener::bind_tcp_with_fallback().await?;
-                let addr = listener.local_addr();
-                // Signal ready with bound address
-                if ready_tx.send(addr).is_err() {
-                    tracing::warn!("Ready signal receiver dropped before server sent address");
-                }
-                self.run_listener(listener, &default_session_id).await
-            }
-            TransportMode::Tcp { port } => {
-                let listener = TransportListener::bind_tcp(*port).await?;
-                let addr = listener.local_addr();
-                // Signal ready with bound address
-                if ready_tx.send(addr).is_err() {
-                    tracing::warn!("Ready signal receiver dropped before server sent address");
-                }
-                self.run_listener(listener, &default_session_id).await
-            }
-            #[cfg(unix)]
-            TransportMode::UnixSocket { path } => {
-                let listener = TransportListener::bind_unix(path)?;
-                // Unix sockets don't have a SocketAddr, use a placeholder
-                // The caller should use discovery for Unix sockets
-                drop(ready_tx); // Can't send meaningful address for Unix socket
-                self.run_listener(listener, &default_session_id).await
-            }
-            TransportMode::Stdio => {
-                // Stdio doesn't have an address to report
-                drop(ready_tx);
-                self.run_stdio(&default_session_id).await
-            }
-        }
-    }
-
     /// Run the server with a listener transport (TCP or Unix socket).
     ///
     /// Accepts connections in a loop and spawns a task for each client.
@@ -513,8 +472,18 @@ impl Server {
         listener: TransportListener,
         default_session_id: &SessionId,
     ) -> std::io::Result<()> {
-        // Print listening address to stderr (like tmux)
-        eprintln!("Listening on {}", listener.local_addr_string());
+        // Print ready signal or listening message
+        if self.config.ready_signal {
+            // Ready signal for process coordination (stdout)
+            // Format: READY <ip>:<port>\n
+            use std::io::Write;
+            let addr = listener.local_addr();
+            println!("READY {addr}");
+            std::io::stdout().flush().ok();
+        } else {
+            // Normal mode: print to stderr (like tmux)
+            eprintln!("Listening on {}", listener.local_addr_string());
+        }
 
         // Accept loop
         while !self.shutdown.load(Ordering::Relaxed) {
@@ -1128,6 +1097,7 @@ mod tests {
             module_dirs: vec![],
             load_modules: vec![],
             no_defaults: false,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1147,6 +1117,7 @@ mod tests {
             module_dirs: vec![],
             load_modules: vec![],
             no_defaults: false,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1163,6 +1134,7 @@ mod tests {
             module_dirs: vec![],
             load_modules: vec![],
             no_defaults: false,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1182,6 +1154,7 @@ mod tests {
             ],
             load_modules: vec![],
             no_defaults: false,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1200,6 +1173,7 @@ mod tests {
             module_dirs: vec![],
             load_modules: vec!["editor".into(), "keymap".into()],
             no_defaults: false,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1218,6 +1192,7 @@ mod tests {
             module_dirs: vec![],
             load_modules: vec!["my-module".into()],
             no_defaults: true,
+            ready_signal: false,
         };
 
         let config = args.into_config();
@@ -1225,42 +1200,29 @@ mod tests {
         assert_eq!(config.modules.autoload, vec!["my-module"]);
     }
 
-    #[tokio::test]
-    async fn test_run_with_ready_signal_sends_address() {
-        use std::time::Duration;
+    #[test]
+    fn test_srv_args_into_config_with_ready_signal() {
+        let args = SrvArgs {
+            tcp: Some(9000),
+            #[cfg(unix)]
+            socket: None,
+            stdio: false,
+            module_dirs: vec![],
+            load_modules: vec![],
+            no_defaults: false,
+            ready_signal: true,
+        };
 
-        // Use port 0 to let OS assign a free port
-        let server = Server::new(ServerConfig::tcp(0));
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        // Spawn server, wait for ready signal
-        let handle = tokio::spawn(async move { server.run_with_ready_signal(tx).await });
-
-        // Verify we receive a valid address within timeout
-        let addr = tokio::time::timeout(Duration::from_secs(5), rx)
-            .await
-            .expect("timeout waiting for ready signal")
-            .expect("ready signal channel closed");
-
-        assert!(addr.port() > 0);
-
-        // Cleanup
-        handle.abort();
+        let config = args.into_config();
+        assert!(config.ready_signal);
     }
 
-    #[tokio::test]
-    async fn test_run_with_ready_signal_continues_on_dropped_receiver() {
-        use std::time::Duration;
+    #[test]
+    fn test_server_config_with_ready_signal_builder() {
+        let config = ServerConfig::tcp(9000).with_ready_signal(true);
+        assert!(config.ready_signal);
 
-        let server = Server::new(ServerConfig::tcp(0));
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        drop(rx); // Drop receiver before server sends
-
-        // Server should not panic, just log warning and continue
-        let handle = tokio::spawn(async move { server.run_with_ready_signal(tx).await });
-
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        assert!(!handle.is_finished(), "Server should still be running");
-        handle.abort();
+        let config = ServerConfig::tcp(9000).with_ready_signal(false);
+        assert!(!config.ready_signal);
     }
 }

--- a/runner/src/server/rpc/mod.rs
+++ b/runner/src/server/rpc/mod.rs
@@ -142,7 +142,7 @@ mod tests {
         // Server handlers
         assert!(dispatcher.has_method(SERVER_KILL));
 
-        // 16 implemented + 9 stubs + 11 debug (2 info + 4 inspect + 2 metrics + 2 log + 1 snapshot) = 37 total
-        assert_eq!(dispatcher.method_count(), 37);
+        // 16 implemented + 9 stubs + 13 debug (2 info + 4 inspect + 2 metrics + 4 log + 1 snapshot) = 39 total
+        assert_eq!(dispatcher.method_count(), 39);
     }
 }


### PR DESCRIPTION
## Summary

This PR combines three related features for the debug/logging infrastructure:

### #331 - Process Separation for Integrated Mode
- Server spawns as separate OS process instead of tokio task
- Fixes garbled terminal output when server logs conflict with TUI rendering
- Added `--ready-signal` flag for process coordination
- Server prints "READY <addr>" to stdout when bound

### #332 - TUI Log Panel with Real-time Streaming
- `debug/log_subscribe` and `debug/log_unsubscribe` RPC methods
- Real-time `LOG_ENTRY` notifications with level filtering
- Channel-based async bridge (sync tracing -> async notifications)
- TUI log panel with scroll, filter by level, and keybindings
- `Ctrl+L` toggles panel, `1-5` filters levels, `j/k` scrolls

### #324 - CLI Log Command Enhancements
- **Log filtering**: `--level`, `--target`, `--grep` flags for `log-tail` command
- **Dynamic log level**: Runtime changes via `tracing_subscriber` reload layer
- **Log streaming**: `--follow` mode with Ctrl+C graceful shutdown
- **Color output**: TTY-aware color-coded log levels (ERROR red, WARN yellow, INFO green, DEBUG cyan, TRACE gray)

## Commits

1. `c811728` - fix(cli): spawn server as separate process in integrated mode (#331)
2. `0ad50e5` - feat(debug): add TUI log panel with real-time streaming (#332)
3. `f351414` - feat(cli): enhance log commands with filtering, streaming, and dynamic level (#324)

## Usage Examples

### TUI Log Panel (#332)
```
Ctrl+L    Toggle log panel
1-5       Filter by level (1=ERROR, 5=TRACE)
j/k       Scroll logs
```

### CLI Log Commands (#324)
```bash
# Filter by level (show WARN and above)
reovim cli log-tail --level warn

# Filter by target module
reovim cli log-tail --target runner::server

# Grep for specific text
reovim cli log-tail --grep "connection"

# Combined filters
reovim cli log-tail --level info --target runner --grep error

# Follow mode (like tail -f)
reovim cli log-tail --follow

# Change log level at runtime
reovim cli log-level debug
```

## Files Changed

### #331 - Process Separation
- `runner/src/main.rs` - spawn server as child process

### #332 - TUI Log Panel
- `lib/protocol/src/v1/notifications.rs` - LOG_ENTRY notification
- `runner/src/server/debug/infrastructure/log_bridge.rs` - async bridge
- `runner/src/server/debug/infrastructure/log_subscriber.rs` - subscription registry
- `runner/src/client/tui/log_panel.rs` - TUI panel component
- `runner/src/client/tui/log_buffer.rs` - client-side log buffer
- `runner/src/client/tui/log_render.rs` - log rendering

### #324 - CLI Enhancements
- `lib/protocol/src/v1/debug.rs` - filter fields in LogTailParams
- `runner/src/server/debug/infrastructure/log_level.rs` - dynamic level control
- `runner/src/server/debug/handlers/log.rs` - filtering logic
- `runner/src/client/cli/mod.rs` - CLI flags
- `runner/src/client/cli/output.rs` - color-coded output
- `runner/src/main.rs` - streaming loop

### Documentation
- `CLAUDE.md` - RPC Debug Commands section
- `docs/user-guide/server-mode.md` - debug commands
- `docs/architecture/runner/client/cli.md` - CLI debug commands

## Test plan

- [x] Unit tests for TUI log panel components
- [x] Unit tests for filtering logic (level, target, grep, combined)
- [x] Unit tests for dynamic log level (valid/invalid levels, error types)
- [x] Unit tests for color-coded output formatting
- [x] `./scripts/check.sh` passes (format, build, clippy, all tests)
- [x] Manual testing of CLI and TUI features

Closes #324, #331, #332