### PR TITLE
feat(runner): add unified port system with instance management (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - TUI log panel with scroll, filter by level, and keybindings
   - `Ctrl+L` toggles panel, `1-5` filters levels, `j/k` scrolls
 
+- Unified Port System with instance management (#350)
+  - Transport abstraction layer with platform-agnostic `LocalAddr` type
+  - Instance registry for server discovery (file-based JSON with auto-cleanup)
+  - CLI flags: `-L`/`--instance` for named instances, `-S`/`--socket-path` for explicit paths
+  - Port Manager daemon on 127.0.0.1:12521 with auto-start capability
+  - Session commands: `:detach`, `:servers`, `:kill-server`
+  - Keybindings: `<C-b>d` detach, `<C-b>s` servers, `<C-b>&` kill-server
+  - DETACH notification for graceful client disconnect
+  - Full backward compatibility with existing `--tcp` and `--socket` flags
+
 - CLI log command enhancements (#324)
   - Log filtering: `reovim cli log-tail --level warn --target runner --grep error`
   - Dynamic log level: `reovim cli log-level debug` (changes at runtime)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "parking_lot",
+ "tokio",
 ]
 
 [[package]]
@@ -1203,6 +1204,7 @@ dependencies = [
 name = "reovim-driver-net"
 version = "0.9.1-dev"
 dependencies = [
+ "reovim-arch",
  "reovim-kernel",
  "reovim-protocol",
  "serde",

--- a/lib/arch/Cargo.toml
+++ b/lib/arch/Cargo.toml
@@ -25,3 +25,9 @@ dirs = "5.0"
 
 [target.'cfg(unix)'.dependencies]
 crossterm.workspace = true
+# Unix socket support for local transport
+tokio = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+# Named pipe support for local transport
+tokio = { workspace = true }

--- a/lib/arch/src/lib.rs
+++ b/lib/arch/src/lib.rs
@@ -49,12 +49,14 @@ pub mod windows;
 // Platform-specific type aliases for convenience
 #[cfg(unix)]
 pub use unix::{
-    UnixInputSource as PlatformInputSource, UnixSignalHandler as PlatformSignalHandler,
-    UnixTerminal as PlatformTerminal,
+    UnixInputSource as PlatformInputSource, UnixLocalListener as PlatformLocalListener,
+    UnixLocalStream as PlatformLocalStream, UnixSignalHandler as PlatformSignalHandler,
+    UnixTerminal as PlatformTerminal, process_exists,
 };
 
 #[cfg(windows)]
 pub use windows::{
-    WindowsInputSource as PlatformInputSource, WindowsSignalHandler as PlatformSignalHandler,
-    WindowsTerminal as PlatformTerminal,
+    WindowsInputSource as PlatformInputSource, WindowsLocalListener as PlatformLocalListener,
+    WindowsLocalStream as PlatformLocalStream, WindowsSignalHandler as PlatformSignalHandler,
+    WindowsTerminal as PlatformTerminal, process_exists,
 };

--- a/lib/arch/src/unix/local.rs
+++ b/lib/arch/src/unix/local.rs
@@ -1,0 +1,234 @@
+//! Unix domain socket implementation for local transport.
+//!
+//! Linux equivalent: `net/unix/`
+//!
+//! Provides efficient IPC using Unix domain sockets. These offer:
+//! - Zero-copy for small messages
+//! - No network stack overhead
+//! - File-based permissions
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_arch::unix::local::{UnixLocalListener, UnixLocalStream};
+//! use std::path::Path;
+//!
+//! // Server side
+//! let listener = UnixLocalListener::bind(Path::new("/tmp/reovim.sock")).await?;
+//! let (stream, _) = listener.accept().await?;
+//!
+//! // Client side
+//! let stream = UnixLocalStream::connect(Path::new("/tmp/reovim.sock")).await?;
+//! ```
+
+use {
+    std::{io, path::Path},
+    tokio::net::{UnixListener, UnixStream},
+};
+
+/// Unix domain socket listener for local transport.
+///
+/// Wraps `tokio::net::UnixListener` with automatic cleanup of stale sockets.
+pub struct UnixLocalListener {
+    listener: UnixListener,
+    socket_path: std::path::PathBuf,
+}
+
+impl UnixLocalListener {
+    /// Bind to a Unix socket path.
+    ///
+    /// If a stale socket file exists at the path, it will be removed before binding.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path for the Unix socket file
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Parent directory doesn't exist and can't be created
+    /// - Socket file exists and is in use by another process
+    /// - Permission denied
+    pub async fn bind(path: &Path) -> io::Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Try to remove stale socket file
+        if path.exists() {
+            // Try to connect to see if it's in use
+            match UnixStream::connect(path).await {
+                Ok(_) => {
+                    // Socket is in use by another process
+                    return Err(io::Error::new(
+                        io::ErrorKind::AddrInUse,
+                        format!("Socket {} is already in use", path.display()),
+                    ));
+                }
+                Err(_) => {
+                    // Socket is stale, remove it
+                    std::fs::remove_file(path)?;
+                }
+            }
+        }
+
+        let listener = UnixListener::bind(path)?;
+        Ok(Self {
+            listener,
+            socket_path: path.to_path_buf(),
+        })
+    }
+
+    /// Accept a new connection.
+    ///
+    /// Returns a stream for the connected client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the accept operation fails.
+    pub async fn accept(&self) -> io::Result<(UnixLocalStream, tokio::net::unix::SocketAddr)> {
+        let (stream, addr) = self.listener.accept().await?;
+        Ok((UnixLocalStream { stream }, addr))
+    }
+
+    /// Get the socket path.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+impl Drop for UnixLocalListener {
+    fn drop(&mut self) {
+        // Clean up socket file on drop
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+/// Unix domain socket stream for local transport.
+///
+/// Wraps `tokio::net::UnixStream` for async I/O.
+pub struct UnixLocalStream {
+    stream: UnixStream,
+}
+
+impl UnixLocalStream {
+    /// Connect to a Unix socket.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the Unix socket file
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket doesn't exist or connection is refused.
+    pub async fn connect(path: &Path) -> io::Result<Self> {
+        let stream = UnixStream::connect(path).await?;
+        Ok(Self { stream })
+    }
+
+    /// Get a reference to the inner tokio stream.
+    #[must_use]
+    pub const fn inner(&self) -> &UnixStream {
+        &self.stream
+    }
+
+    /// Get a mutable reference to the inner tokio stream.
+    pub const fn inner_mut(&mut self) -> &mut UnixStream {
+        &mut self.stream
+    }
+
+    /// Convert into the inner tokio stream.
+    #[must_use]
+    pub fn into_inner(self) -> UnixStream {
+        self.stream
+    }
+
+    /// Split the stream into read and write halves.
+    pub fn into_split(self) -> (tokio::net::unix::OwnedReadHalf, tokio::net::unix::OwnedWriteHalf) {
+        self.stream.into_split()
+    }
+}
+
+/// Check if a process with the given PID exists.
+///
+/// Uses the `kill(pid, 0)` trick to check process existence without sending a signal.
+#[must_use]
+pub fn process_exists(pid: u32) -> bool {
+    // kill(pid, 0) checks if we can send a signal to the process
+    // Returns Ok if process exists and we have permission
+    // Returns Err(ESRCH) if process doesn't exist
+    // Returns Err(EPERM) if process exists but we don't have permission (still exists!)
+    let result = std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output();
+
+    match result {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unix_socket_bind_accept() {
+        let temp_dir = std::env::temp_dir();
+        let socket_path = temp_dir.join(format!("reovim-test-{}.sock", std::process::id()));
+
+        // Clean up any leftover socket
+        let _ = std::fs::remove_file(&socket_path);
+
+        // Bind listener
+        let listener = UnixLocalListener::bind(&socket_path).await.unwrap();
+        assert!(socket_path.exists());
+
+        // Connect from client (in separate task)
+        let path = socket_path.clone();
+        let client_handle =
+            tokio::spawn(async move { UnixLocalStream::connect(&path).await.unwrap() });
+
+        // Accept connection
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client_stream = client_handle.await.unwrap();
+
+        // Verify streams are connected
+        assert!(server_stream.inner().peer_addr().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_unix_socket_stale_cleanup() {
+        let temp_dir = std::env::temp_dir();
+        let socket_path = temp_dir.join(format!("reovim-test-stale-{}.sock", std::process::id()));
+
+        // Create a stale socket file (just an empty file, not a real socket)
+        std::fs::write(&socket_path, "").unwrap();
+        assert!(socket_path.exists());
+
+        // Binding should clean up the stale file and succeed
+        let listener = UnixLocalListener::bind(&socket_path).await.unwrap();
+        assert!(socket_path.exists());
+
+        // Clean up
+        drop(listener);
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn test_process_exists_current() {
+        // Current process should exist
+        let pid = std::process::id();
+        assert!(process_exists(pid));
+    }
+
+    #[test]
+    fn test_process_exists_nonexistent() {
+        // PID 1 (init) always exists, but a very high PID likely doesn't
+        // Use a PID that's very unlikely to exist
+        assert!(!process_exists(u32::MAX - 1));
+    }
+}

--- a/lib/arch/src/unix/mod.rs
+++ b/lib/arch/src/unix/mod.rs
@@ -7,6 +7,7 @@
 
 mod convert;
 mod input;
+pub mod local;
 mod signal;
 mod terminal;
 
@@ -16,6 +17,7 @@ pub use {
         convert_key_event, convert_modifiers,
     },
     input::UnixInputSource,
+    local::{UnixLocalListener, UnixLocalStream, process_exists},
     signal::UnixSignalHandler,
     terminal::UnixTerminal,
 };

--- a/lib/arch/src/windows/local.rs
+++ b/lib/arch/src/windows/local.rs
@@ -1,0 +1,168 @@
+//! Windows Named Pipe implementation for local transport.
+//!
+//! Windows equivalent of Unix domain sockets using Named Pipes.
+//!
+//! # Architecture
+//!
+//! Named pipes on Windows work differently from Unix sockets:
+//! - Pipe names are in the format `\\.\pipe\<name>`
+//! - Server creates pipe instances, clients connect to them
+//! - Each connection requires a new pipe instance
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_arch::windows::local::{WindowsLocalListener, WindowsLocalStream};
+//!
+//! // Server side
+//! let listener = WindowsLocalListener::bind("reovim-myproject").await?;
+//! let stream = listener.accept().await?;
+//!
+//! // Client side
+//! let stream = WindowsLocalStream::connect("reovim-myproject").await?;
+//! ```
+
+use {
+    std::io,
+    tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions},
+};
+
+/// Windows Named Pipe listener for local transport.
+///
+/// Creates and manages named pipe instances for incoming connections.
+pub struct WindowsLocalListener {
+    pipe_name: String,
+    server: Option<NamedPipeServer>,
+}
+
+impl WindowsLocalListener {
+    /// Bind to a named pipe.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipe name (will be prefixed with `\\.\pipe\`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pipe already exists or permission denied.
+    pub async fn bind(name: &str) -> io::Result<Self> {
+        let pipe_name = format!(r"\\.\pipe\{name}");
+        let server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_name)?;
+
+        Ok(Self {
+            pipe_name,
+            server: Some(server),
+        })
+    }
+
+    /// Accept a new connection.
+    ///
+    /// Returns a stream for the connected client.
+    pub async fn accept(&mut self) -> io::Result<WindowsLocalStream> {
+        let server = self
+            .server
+            .take()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Listener already closed"))?;
+
+        // Wait for client to connect
+        server.connect().await?;
+
+        // Create next server instance for subsequent connections
+        let next_server = ServerOptions::new().create(&self.pipe_name)?;
+        self.server = Some(next_server);
+
+        Ok(WindowsLocalStream::Server(server))
+    }
+
+    /// Get the pipe name.
+    #[must_use]
+    pub fn pipe_name(&self) -> &str {
+        &self.pipe_name
+    }
+}
+
+/// Windows Named Pipe stream for local transport.
+///
+/// Can be either a server-side or client-side pipe.
+pub enum WindowsLocalStream {
+    /// Server-side pipe (from accept)
+    Server(NamedPipeServer),
+    /// Client-side pipe (from connect)
+    Client(tokio::net::windows::named_pipe::NamedPipeClient),
+}
+
+impl WindowsLocalStream {
+    /// Connect to a named pipe.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipe name (will be prefixed with `\\.\pipe\`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pipe doesn't exist or connection refused.
+    pub async fn connect(name: &str) -> io::Result<Self> {
+        let pipe_name = format!(r"\\.\pipe\{name}");
+        let client = ClientOptions::new().open(&pipe_name)?;
+        Ok(Self::Client(client))
+    }
+}
+
+/// Check if a Windows process exists by PID.
+///
+/// Uses `OpenProcess` to check if the process is still running.
+#[must_use]
+pub fn process_exists(pid: u32) -> bool {
+    use std::ptr::null_mut;
+
+    // PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+
+    // STILL_ACTIVE = 259
+    const STILL_ACTIVE: u32 = 259;
+
+    extern "system" {
+        fn OpenProcess(
+            desired_access: u32,
+            inherit_handle: i32,
+            process_id: u32,
+        ) -> *mut std::ffi::c_void;
+        fn GetExitCodeProcess(process: *mut std::ffi::c_void, exit_code: *mut u32) -> i32;
+        fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
+    }
+
+    // SAFETY: These are standard Windows API calls with valid parameters
+    #[allow(unsafe_code)]
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+
+        let mut exit_code: u32 = 0;
+        let result = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+
+        result != 0 && exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_exists_current() {
+        // Current process should exist
+        let pid = std::process::id();
+        assert!(process_exists(pid));
+    }
+
+    #[test]
+    fn test_process_exists_nonexistent() {
+        // A very high PID likely doesn't exist
+        assert!(!process_exists(u32::MAX - 1));
+    }
+}

--- a/lib/arch/src/windows/mod.rs
+++ b/lib/arch/src/windows/mod.rs
@@ -6,7 +6,13 @@
 //! implemented in a future phase.
 
 mod input;
+pub mod local;
 mod signal;
 mod terminal;
 
-pub use {input::WindowsInputSource, signal::WindowsSignalHandler, terminal::WindowsTerminal};
+pub use {
+    input::WindowsInputSource,
+    local::{WindowsLocalListener, WindowsLocalStream, process_exists},
+    signal::WindowsSignalHandler,
+    terminal::WindowsTerminal,
+};

--- a/lib/drivers/command/src/result/mod.rs
+++ b/lib/drivers/command/src/result/mod.rs
@@ -46,6 +46,11 @@ pub enum CommandResult {
     Quit,
     /// Command requests editor to quit without saving.
     ForceQuit,
+    /// Command requests client to detach (server continues running).
+    ///
+    /// Unlike `Quit`, the server remains active and other clients can connect.
+    /// The TUI client receives a DETACH notification and disconnects gracefully.
+    Detach,
     /// Command requests an undo/redo action to be performed by the runner.
     ///
     /// This follows the callback pattern where commands declare WHAT they want
@@ -155,6 +160,12 @@ impl CommandResult {
     #[must_use]
     pub const fn is_quit(&self) -> bool {
         matches!(self, Self::Quit | Self::ForceQuit)
+    }
+
+    /// Check if the result requests detach.
+    #[must_use]
+    pub const fn is_detach(&self) -> bool {
+        matches!(self, Self::Detach)
     }
 
     /// Check if the result is an undo/redo action.

--- a/lib/drivers/net/Cargo.toml
+++ b/lib/drivers/net/Cargo.toml
@@ -16,6 +16,9 @@ workspace = true
 # Only depends on kernel layer
 reovim-kernel = { path = "../../kernel", version = "0.9.1-dev" }
 
+# Platform abstraction (for dirs, local transport)
+reovim-arch = { path = "../../arch", version = "0.9.1-dev" }
+
 # Protocol types (shared RPC definitions)
 reovim-protocol = { workspace = true }
 

--- a/lib/drivers/net/src/lib.rs
+++ b/lib/drivers/net/src/lib.rs
@@ -66,6 +66,7 @@
 
 mod error;
 mod handler;
+pub mod local;
 mod traits;
 pub mod transport;
 
@@ -111,6 +112,9 @@ pub use error::NetError;
 
 // Transport configuration
 pub use transport::TransportConfig;
+
+// Local transport types
+pub use local::LocalAddr;
 
 // Handler types
 pub use handler::{RpcHandler, RpcHandlerContext, RpcResult};

--- a/lib/drivers/net/src/local.rs
+++ b/lib/drivers/net/src/local.rs
@@ -1,0 +1,185 @@
+//! Platform-agnostic local transport.
+//!
+//! Provides efficient IPC for same-machine communication:
+//! - Unix: Unix domain sockets
+//! - Windows: Named pipes
+//!
+//! # Architecture
+//!
+//! This module defines the platform-agnostic types and path generation.
+//! The actual implementations live in `lib/arch/`:
+//! - `lib/arch/src/unix/local.rs` - Unix socket implementation
+//! - `lib/arch/src/windows/local.rs` - Named pipe implementation
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reovim_driver_net::local::LocalAddr;
+//!
+//! // Get platform-appropriate address for an instance
+//! let addr = LocalAddr::for_instance("myproject");
+//!
+//! // On Unix: /run/user/1000/reovim/myproject.sock
+//! // On Windows: \\.\pipe\reovim-myproject
+//! ```
+
+use std::path::PathBuf;
+
+/// Local transport address.
+///
+/// Platform-specific address for local IPC:
+/// - Unix: Unix domain socket path
+/// - Windows: Named pipe path
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalAddr {
+    /// Unix socket path (Linux/macOS).
+    ///
+    /// Format: `$XDG_RUNTIME_DIR/reovim/<name>.sock`
+    /// Fallback: `/tmp/reovim-<uid>/<name>.sock`
+    #[cfg(unix)]
+    UnixSocket(PathBuf),
+
+    /// Named pipe path (Windows).
+    ///
+    /// Format: `\\.\pipe\reovim-<name>`
+    #[cfg(windows)]
+    NamedPipe(String),
+}
+
+impl LocalAddr {
+    /// Create platform-appropriate local address for an instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Instance name (e.g., "default", "myproject")
+    ///
+    /// # Returns
+    ///
+    /// Platform-specific local address.
+    ///
+    /// # Platform Behavior
+    ///
+    /// - **Unix**: Returns `UnixSocket` with path in `$XDG_RUNTIME_DIR/reovim/`
+    ///   or fallback to `/tmp/reovim-<uid>/`
+    /// - **Windows**: Returns `NamedPipe` with name `\\.\pipe\reovim-<name>`
+    #[must_use]
+    pub fn for_instance(name: &str) -> Self {
+        #[cfg(unix)]
+        {
+            Self::UnixSocket(Self::socket_path_for_instance(name))
+        }
+
+        #[cfg(windows)]
+        {
+            Self::NamedPipe(format!(r"\\.\pipe\reovim-{name}"))
+        }
+    }
+
+    /// Get the socket directory path.
+    ///
+    /// # Platform Behavior
+    ///
+    /// - **Unix**: `$XDG_RUNTIME_DIR/reovim/` or `/tmp/reovim-<uid>/`
+    /// - **Windows**: Not applicable (named pipes don't use directories)
+    #[cfg(unix)]
+    #[must_use]
+    pub fn socket_dir() -> PathBuf {
+        use reovim_arch::dirs::runtime_dir;
+
+        runtime_dir().map_or_else(
+            || {
+                // Fallback for systems without XDG_RUNTIME_DIR (e.g., macOS)
+                // Use username to avoid conflicts between users
+                let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+                PathBuf::from(format!("/tmp/reovim-{user}"))
+            },
+            |d| d.join("reovim"),
+        )
+    }
+
+    /// Get the full socket path for an instance.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn socket_path_for_instance(name: &str) -> PathBuf {
+        Self::socket_dir().join(format!("{name}.sock"))
+    }
+
+    /// Get the pipe name for an instance (Windows only).
+    #[cfg(windows)]
+    #[must_use]
+    pub fn pipe_name(&self) -> &str {
+        match self {
+            Self::NamedPipe(name) => name,
+        }
+    }
+
+    /// Get the socket path (Unix only).
+    #[cfg(unix)]
+    #[must_use]
+    pub fn socket_path(&self) -> &std::path::Path {
+        match self {
+            Self::UnixSocket(path) => path,
+        }
+    }
+}
+
+impl std::fmt::Display for LocalAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(unix)]
+        {
+            match self {
+                Self::UnixSocket(path) => write!(f, "{}", path.display()),
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            match self {
+                Self::NamedPipe(name) => write!(f, "{name}"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_local_addr_for_instance_unix() {
+        let addr = LocalAddr::for_instance("myproject");
+        match addr {
+            LocalAddr::UnixSocket(path) => {
+                assert!(path.to_string_lossy().contains("myproject.sock"));
+                assert!(path.to_string_lossy().contains("reovim"));
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_socket_dir_exists_or_can_be_created() {
+        let dir = LocalAddr::socket_dir();
+        // Should be a valid path (though directory might not exist yet)
+        assert!(!dir.as_os_str().is_empty());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_local_addr_for_instance_windows() {
+        let addr = LocalAddr::for_instance("myproject");
+        match addr {
+            LocalAddr::NamedPipe(name) => {
+                assert_eq!(name, r"\\.\pipe\reovim-myproject");
+            }
+        }
+    }
+
+    #[test]
+    fn test_local_addr_display() {
+        let addr = LocalAddr::for_instance("test");
+        let s = addr.to_string();
+        assert!(s.contains("test"));
+    }
+}

--- a/lib/protocol/src/v1/notifications.rs
+++ b/lib/protocol/src/v1/notifications.rs
@@ -24,6 +24,9 @@ pub const RENDER_COMPLETE: &str = "notification/render_complete";
 /// Log entry notification (for log streaming).
 pub const LOG_ENTRY: &str = "notification/log_entry";
 
+/// Detach notification (client should disconnect).
+pub const DETACH: &str = "notification/detach";
+
 // Notification payload types
 
 /// Source of a log entry.
@@ -191,6 +194,46 @@ impl RenderCompletePayload {
     }
 }
 
+/// Payload for detach notification.
+///
+/// Sent to clients when they should disconnect gracefully.
+/// The server continues running after detach.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DetachPayload {
+    /// Optional reason for detach.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl DetachPayload {
+    /// Create a new detach payload.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { reason: None }
+    }
+
+    /// Create a detach payload with a reason.
+    #[must_use]
+    pub fn with_reason(reason: impl Into<String>) -> Self {
+        Self {
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Convert payload to JSON-RPC notification.
+    ///
+    /// # Panics
+    ///
+    /// This function will not panic as `DetachPayload` serialization is infallible.
+    #[must_use]
+    pub fn into_notification(self) -> super::messages::RpcNotification {
+        super::messages::RpcNotification::new(
+            DETACH,
+            serde_json::to_value(self).expect("DetachPayload serialization cannot fail"),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,6 +244,7 @@ mod tests {
         assert!(CURSOR_MOVED.starts_with("notification/"));
         assert!(BUFFER_MODIFIED.starts_with("notification/"));
         assert!(RENDER_COMPLETE.starts_with("notification/"));
+        assert!(DETACH.starts_with("notification/"));
     }
 
     #[test]
@@ -346,5 +390,50 @@ mod tests {
         let json = r#""invalid_level""#;
         let result: Result<LogLevel, _> = serde_json::from_str(json);
         assert!(result.is_err());
+    }
+
+    // Phase 5 tests for #350
+
+    #[test]
+    fn test_detach_payload_new() {
+        let payload = DetachPayload::new();
+        assert!(payload.reason.is_none());
+    }
+
+    #[test]
+    fn test_detach_payload_with_reason() {
+        let payload = DetachPayload::with_reason("user requested");
+        assert_eq!(payload.reason, Some("user requested".to_string()));
+    }
+
+    #[test]
+    fn test_detach_payload_serialization() {
+        let payload = DetachPayload::new();
+        let json = serde_json::to_string(&payload).unwrap();
+        // Empty object when no reason
+        assert_eq!(json, "{}");
+
+        let payload = DetachPayload::with_reason("test");
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"reason\":\"test\""));
+    }
+
+    #[test]
+    fn test_detach_payload_deserialization() {
+        let json = "{}";
+        let payload: DetachPayload = serde_json::from_str(json).unwrap();
+        assert!(payload.reason.is_none());
+
+        let json = r#"{"reason":"detached"}"#;
+        let payload: DetachPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.reason, Some("detached".to_string()));
+    }
+
+    #[test]
+    fn test_detach_payload_into_notification() {
+        let payload = DetachPayload::new();
+        let notification = payload.into_notification();
+        assert_eq!(notification.jsonrpc, "2.0");
+        assert_eq!(notification.method, DETACH);
     }
 }

--- a/modules/commands/src/lib.rs
+++ b/modules/commands/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 mod quit;
+mod session;
 mod types;
 mod write;
 
@@ -35,17 +36,21 @@ pub use types::{CommandContext, CommandError, CommandHandler, Range};
 
 pub use {
     quit::QuitCommand,
+    session::{DetachCommand, KillServerCommand, ServersCommand},
     write::{WriteCommand, WriteQuitCommand},
 };
 
 /// Returns all commands provided by this module.
 #[must_use]
 pub fn commands() -> Vec<Box<dyn CommandHandler>> {
-    vec![
+    let mut cmds: Vec<Box<dyn CommandHandler>> = vec![
         Box::new(QuitCommand),
         Box::new(WriteCommand),
         Box::new(WriteQuitCommand),
-    ]
+    ];
+    // Add session management commands from #350
+    cmds.extend(session::commands());
+    cmds
 }
 
 // ============================================================================
@@ -84,13 +89,17 @@ mod tests {
     #[test]
     fn test_commands_list() {
         let cmds = commands();
-        assert_eq!(cmds.len(), 3);
+        assert_eq!(cmds.len(), 6); // 3 base + 3 session commands
 
         // Check commands are present
         let ids: Vec<_> = cmds.iter().map(|c| c.id()).collect();
         assert!(ids.contains(&"quit"));
         assert!(ids.contains(&"write"));
         assert!(ids.contains(&"write-quit"));
+        // Session commands from #350
+        assert!(ids.contains(&"detach"));
+        assert!(ids.contains(&"servers"));
+        assert!(ids.contains(&"kill-server"));
     }
 
     #[test]

--- a/modules/commands/src/session.rs
+++ b/modules/commands/src/session.rs
@@ -1,0 +1,164 @@
+//! Session management commands.
+//!
+//! Commands for managing client sessions and server connections:
+//! - `:detach` - Detach from server (server continues)
+//! - `:servers` - List running server instances
+//! - `:kill-server` - Kill the current server
+//!
+//! These commands are part of issue #350 (Unified Port System).
+
+use crate::types::{CommandContext, CommandError, CommandHandler};
+
+// ============================================================================
+// Detach Command
+// ============================================================================
+
+/// Detach from the current server session.
+///
+/// The server continues running after detach, allowing other clients
+/// to connect. The TUI client receives a DETACH notification and
+/// disconnects gracefully.
+///
+/// Usage: `:detach`
+pub struct DetachCommand;
+
+impl CommandHandler for DetachCommand {
+    fn id(&self) -> &'static str {
+        "detach"
+    }
+
+    fn names(&self) -> &[&'static str] {
+        &["detach"]
+    }
+
+    fn execute(&self, _ctx: &mut CommandContext<'_>, _args: &[&str]) -> Result<(), CommandError> {
+        // Note: The actual detach is handled by the runner.
+        // This command signals the intent to detach.
+        // The runner checks for this command and sends DETACH notification.
+        Ok(())
+    }
+
+    fn help(&self) -> &'static str {
+        "Detach from the server (server continues running)"
+    }
+}
+
+// ============================================================================
+// Servers Command
+// ============================================================================
+
+/// List running server instances.
+///
+/// Queries the instance registry and displays all registered servers
+/// with their names, transport addresses, and PIDs.
+///
+/// Usage: `:servers`
+pub struct ServersCommand;
+
+impl CommandHandler for ServersCommand {
+    fn id(&self) -> &'static str {
+        "servers"
+    }
+
+    fn names(&self) -> &[&'static str] {
+        &["servers"]
+    }
+
+    fn execute(&self, _ctx: &mut CommandContext<'_>, _args: &[&str]) -> Result<(), CommandError> {
+        // Note: The actual listing is handled by the runner.
+        // This command signals the intent to list servers.
+        // The runner queries the instance registry and displays results.
+        Ok(())
+    }
+
+    fn help(&self) -> &'static str {
+        "List running server instances"
+    }
+}
+
+// ============================================================================
+// KillServer Command
+// ============================================================================
+
+/// Kill the current server.
+///
+/// Terminates the current server process. All connected clients are
+/// disconnected and unsaved changes may be lost.
+///
+/// Usage: `:kill-server`
+pub struct KillServerCommand;
+
+impl CommandHandler for KillServerCommand {
+    fn id(&self) -> &'static str {
+        "kill-server"
+    }
+
+    fn names(&self) -> &[&'static str] {
+        &["kill-server", "killserver"]
+    }
+
+    fn execute(&self, _ctx: &mut CommandContext<'_>, _args: &[&str]) -> Result<(), CommandError> {
+        // Note: The actual termination is handled by the runner.
+        // This command signals the intent to kill the server.
+        // The runner initiates a forced quit.
+        Ok(())
+    }
+
+    fn help(&self) -> &'static str {
+        "Kill the current server (terminates all sessions)"
+    }
+}
+
+// ============================================================================
+// Command Collection
+// ============================================================================
+
+/// Get all session management commands.
+#[must_use]
+pub fn commands() -> Vec<Box<dyn CommandHandler>> {
+    vec![
+        Box::new(DetachCommand),
+        Box::new(ServersCommand),
+        Box::new(KillServerCommand),
+    ]
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detach_command_metadata() {
+        let cmd = DetachCommand;
+        assert_eq!(cmd.id(), "detach");
+        assert_eq!(cmd.names(), &["detach"]);
+        assert!(!cmd.help().is_empty());
+    }
+
+    #[test]
+    fn test_servers_command_metadata() {
+        let cmd = ServersCommand;
+        assert_eq!(cmd.id(), "servers");
+        assert_eq!(cmd.names(), &["servers"]);
+        assert!(!cmd.help().is_empty());
+    }
+
+    #[test]
+    fn test_kill_server_command_metadata() {
+        let cmd = KillServerCommand;
+        assert_eq!(cmd.id(), "kill-server");
+        assert!(cmd.names().contains(&"kill-server"));
+        assert!(cmd.names().contains(&"killserver"));
+        assert!(!cmd.help().is_empty());
+    }
+
+    #[test]
+    fn test_commands_collection() {
+        let cmds = commands();
+        assert_eq!(cmds.len(), 3);
+    }
+}

--- a/modules/keymap/src/normal.rs
+++ b/modules/keymap/src/normal.rs
@@ -322,5 +322,22 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
             .with_modes(&["editor:normal"])
             .with_category("edit")
             .with_description("Join lines"),
+        // ====================================================================
+        // Session Management (tmux-like, issue #350)
+        // ====================================================================
+        // Note: <C-b> prefix conflicts with scroll-page-up, but multi-key
+        // sequences take precedence over single-key bindings.
+        KeybindingRegistration::new("<C-b>d", "session:detach")
+            .with_modes(&["editor:normal"])
+            .with_category("session")
+            .with_description("Detach from server (server continues)"),
+        KeybindingRegistration::new("<C-b>s", "session:servers")
+            .with_modes(&["editor:normal"])
+            .with_category("session")
+            .with_description("List running server instances"),
+        KeybindingRegistration::new("<C-b>&", "session:kill-server")
+            .with_modes(&["editor:normal"])
+            .with_category("session")
+            .with_description("Kill the current server"),
     ]
 }

--- a/runner/src/client/cli/mod.rs
+++ b/runner/src/client/cli/mod.rs
@@ -17,15 +17,36 @@ pub use {commands::*, output::OutputFormat, repl::run_repl};
 /// CLI mode arguments.
 ///
 /// These arguments configure CLI connection and behavior.
+///
+/// Flag precedence (highest to lowest):
+/// 1. `--tcp` - explicit TCP connection
+/// 2. `-S`/`--socket-path` - explicit socket path
+/// 3. `-L`/`--instance` - named instance lookup
+/// 4. Default: auto-discover or `-L default`
 #[derive(Args, Debug, Clone)]
 pub struct CliArgs {
+    /// Connect to named instance (default: "default").
+    ///
+    /// Looks up the instance in the registry and connects using its
+    /// registered transport (TCP or local socket).
+    #[arg(short = 'L', long = "instance", value_name = "NAME")]
+    pub instance: Option<String>,
+
+    /// Connect via explicit socket/pipe path.
+    ///
+    /// Takes precedence over `-L` but not over `--tcp`.
+    #[arg(short = 'S', long = "socket-path", value_name = "PATH")]
+    pub socket_path: Option<PathBuf>,
+
     /// Connect to server via TCP (e.g., 127.0.0.1:12521).
+    ///
+    /// Takes highest precedence - bypasses instance registry entirely.
     #[arg(long, value_name = "ADDR")]
     pub tcp: Option<String>,
 
-    /// Connect to server via Unix socket.
+    /// Connect to server via Unix socket (legacy, use -S instead).
     #[cfg(unix)]
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", hide = true)]
     pub socket: Option<PathBuf>,
 
     /// Start interactive REPL mode.
@@ -43,18 +64,36 @@ pub struct CliArgs {
 
 impl CliArgs {
     /// Convert arguments to `ConnectionConfig`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if instance lookup fails. For fallible resolution, use
+    /// `ConnectionConfig::from_flags` directly.
     #[must_use]
     pub fn into_config(&self) -> ConnectionConfig {
+        // Handle legacy --socket flag (maps to -S)
         #[cfg(unix)]
-        if let Some(ref path) = self.socket {
-            return ConnectionConfig::unix_socket(path);
+        let socket_path = self.socket_path.as_ref().or(self.socket.as_ref());
+        #[cfg(not(unix))]
+        let socket_path = self.socket_path.as_ref();
+
+        // If instance flag is set, use registry lookup
+        if self.tcp.is_some() || socket_path.is_some() || self.instance.is_some() {
+            match ConnectionConfig::from_flags(
+                self.tcp.as_deref(),
+                socket_path.map(std::path::PathBuf::as_path),
+                self.instance.as_deref(),
+            ) {
+                Ok(config) => return config,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
 
-        self.tcp
-            .as_ref()
-            .map_or_else(ConnectionConfig::auto_discover, |addr| {
-                ConnectionConfig::tcp_from_addr(addr)
-            })
+        // No flags: auto-discover
+        ConnectionConfig::auto_discover()
     }
 }
 

--- a/runner/src/client/common/connection.rs
+++ b/runner/src/client/common/connection.rs
@@ -5,7 +5,10 @@
 //! For concurrent reading and writing (e.g., TUI notification handling),
 //! use [`Connection::split`] to get separate reader/writer handles.
 
-use std::{io, path::PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
@@ -14,6 +17,8 @@ use tokio::{
 
 #[cfg(unix)]
 use tokio::net::UnixStream;
+
+use crate::server::instance::{InstanceRegistry, TransportInfo};
 
 /// Connection configuration.
 #[derive(Debug, Clone)]
@@ -91,6 +96,83 @@ impl ConnectionConfig {
                 host: server.host.clone(),
                 port: server.port,
             })
+    }
+
+    /// Resolve connection from CLI flags.
+    ///
+    /// Flag precedence (highest to lowest):
+    /// 1. `--tcp` - explicit TCP connection, bypass registry
+    /// 2. `-S path` - explicit socket/pipe path
+    /// 3. `-L name` - named instance lookup
+    /// 4. Default: `-L default`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - TCP address parsing fails
+    /// - Instance lookup fails (not found, invalid name)
+    pub fn from_flags(
+        tcp: Option<&str>,
+        socket_path: Option<&Path>,
+        instance: Option<&str>,
+    ) -> Result<Self, String> {
+        // 1. Explicit TCP wins
+        if let Some(addr) = tcp {
+            return Self::parse_tcp(addr);
+        }
+
+        // 2. Explicit socket path
+        if let Some(path) = socket_path {
+            #[cfg(unix)]
+            return Ok(Self::unix_socket(path));
+            #[cfg(not(unix))]
+            return Err(format!("Unix sockets not supported on this platform: {}", path.display()));
+        }
+
+        // 3. Named instance lookup (or default)
+        let name = instance.unwrap_or("default");
+        Self::from_instance(name)
+    }
+
+    /// Look up a named instance from the registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Instance name is invalid
+    /// - Instance not found in registry
+    /// - Registry cannot be read
+    pub fn from_instance(name: &str) -> Result<Self, String> {
+        // Validate instance name first
+        InstanceRegistry::validate_name(name).map_err(|e| format!("Invalid instance name: {e}"))?;
+
+        let registry = InstanceRegistry::new();
+        match registry.get(name) {
+            Ok(Some(info)) => Self::from_transport_info(&info.transport),
+            Ok(None) => {
+                Err(format!("Instance '{name}' not found. Run 'reovim server -L {name}' first."))
+            }
+            Err(e) => Err(format!("Failed to read instance registry: {e}")),
+        }
+    }
+
+    /// Create config from transport info.
+    ///
+    /// Returns `Err` on non-Unix platforms for local transport.
+    #[allow(clippy::unnecessary_wraps)] // Result needed for Windows local transport error
+    fn from_transport_info(transport: &TransportInfo) -> Result<Self, String> {
+        match transport {
+            TransportInfo::Tcp { host, port } => Ok(Self::Tcp {
+                host: host.clone(),
+                port: *port,
+            }),
+            TransportInfo::Local { path } => {
+                #[cfg(unix)]
+                return Ok(Self::UnixSocket(PathBuf::from(path)));
+                #[cfg(not(unix))]
+                return Err(format!("Local transport not supported on this platform: {path}"));
+            }
+        }
     }
 }
 
@@ -339,5 +421,115 @@ mod tests {
     fn test_parse_tcp_invalid() {
         assert!(ConnectionConfig::parse_tcp("invalid").is_err());
         assert!(ConnectionConfig::parse_tcp("host:notaport").is_err());
+    }
+
+    #[test]
+    fn test_from_flags_tcp_wins() {
+        // TCP flag takes highest precedence
+        let config = ConnectionConfig::from_flags(
+            Some("127.0.0.1:9000"),
+            Some(std::path::Path::new("/tmp/sock")),
+            Some("instance"),
+        )
+        .unwrap();
+        match config {
+            ConnectionConfig::Tcp { host, port } => {
+                assert_eq!(host, "127.0.0.1");
+                assert_eq!(port, 9000);
+            }
+            #[cfg(unix)]
+            _ => panic!("Expected TCP config"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_from_flags_socket_wins_over_instance() {
+        // Socket path takes precedence over instance
+        let config = ConnectionConfig::from_flags(
+            None,
+            Some(std::path::Path::new("/tmp/test.sock")),
+            Some("myinstance"),
+        )
+        .unwrap();
+        match config {
+            ConnectionConfig::UnixSocket(path) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/test.sock"));
+            }
+            ConnectionConfig::Tcp { .. } => panic!("Expected UnixSocket config"),
+        }
+    }
+
+    #[test]
+    fn test_from_flags_instance_not_found() {
+        // Instance lookup fails for non-existent instance
+        let result = ConnectionConfig::from_flags(None, None, Some("nonexistent-instance-12345"));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("not found"));
+        assert!(err.contains("reovim server -L"));
+    }
+
+    #[test]
+    fn test_from_flags_instance_invalid_name() {
+        // Invalid instance name should fail validation
+        let result = ConnectionConfig::from_flags(None, None, Some("../etc/passwd"));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Invalid instance name"));
+    }
+
+    #[test]
+    fn test_from_instance_invalid_name_empty() {
+        let result = ConnectionConfig::from_instance("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid instance name"));
+    }
+
+    #[test]
+    fn test_from_instance_invalid_name_too_long() {
+        let long_name = "a".repeat(64);
+        let result = ConnectionConfig::from_instance(&long_name);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid instance name"));
+    }
+
+    #[test]
+    fn test_from_instance_invalid_name_special_chars() {
+        let result = ConnectionConfig::from_instance("has spaces");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid instance name"));
+    }
+
+    #[test]
+    fn test_from_transport_info_tcp() {
+        let transport = TransportInfo::Tcp {
+            host: "192.168.1.1".to_string(),
+            port: 8080,
+        };
+        let config = ConnectionConfig::from_transport_info(&transport).unwrap();
+        match config {
+            ConnectionConfig::Tcp { host, port } => {
+                assert_eq!(host, "192.168.1.1");
+                assert_eq!(port, 8080);
+            }
+            #[cfg(unix)]
+            _ => panic!("Expected TCP config"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_from_transport_info_local() {
+        let transport = TransportInfo::Local {
+            path: "/tmp/reovim.sock".to_string(),
+        };
+        let config = ConnectionConfig::from_transport_info(&transport).unwrap();
+        match config {
+            ConnectionConfig::UnixSocket(path) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/reovim.sock"));
+            }
+            ConnectionConfig::Tcp { .. } => panic!("Expected UnixSocket config"),
+        }
     }
 }

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -11,9 +11,9 @@ use {
     reovim_protocol::v1::{
         RpcNotification, RpcResponse,
         notifications::{
-            BUFFER_MODIFIED, BufferModifiedPayload, CURSOR_MOVED, CursorMovedPayload, LOG_ENTRY,
-            LogEntryPayload, MODE_CHANGED, ModeChangedPayload, RENDER_COMPLETE,
-            RenderCompletePayload,
+            BUFFER_MODIFIED, BufferModifiedPayload, CURSOR_MOVED, CursorMovedPayload, DETACH,
+            DetachPayload, LOG_ENTRY, LogEntryPayload, MODE_CHANGED, ModeChangedPayload,
+            RENDER_COMPLETE, RenderCompletePayload,
         },
     },
     serde_json::json,
@@ -439,6 +439,21 @@ impl TuiApp {
                     }
                     tracing::trace!("Log entry received: {:?}", payload.level);
                 }
+            }
+            DETACH => {
+                // Server requested client to detach - disconnect gracefully
+                if let Ok(payload) =
+                    serde_json::from_value::<DetachPayload>(notification.params.clone())
+                {
+                    if let Some(reason) = payload.reason {
+                        tracing::info!("Detaching: {reason}");
+                    } else {
+                        tracing::info!("Detaching from server");
+                    }
+                } else {
+                    tracing::info!("Detaching from server");
+                }
+                self.running = false;
             }
             _ => {
                 tracing::debug!("Unknown notification: {}", notification.method);

--- a/runner/src/client/tui/mod.rs
+++ b/runner/src/client/tui/mod.rs
@@ -27,30 +27,70 @@ pub use {
 /// TUI mode CLI arguments.
 ///
 /// These arguments configure how the TUI connects to a server.
+///
+/// Flag precedence (highest to lowest):
+/// 1. `--tcp` - explicit TCP connection
+/// 2. `-S`/`--socket-path` - explicit socket path
+/// 3. `-L`/`--instance` - named instance lookup
+/// 4. Default: auto-discover or `-L default`
 #[derive(Args, Debug, Clone)]
 pub struct TuiArgs {
+    /// Connect to named instance (default: "default").
+    ///
+    /// Looks up the instance in the registry and connects using its
+    /// registered transport (TCP or local socket).
+    #[arg(short = 'L', long = "instance", value_name = "NAME")]
+    pub instance: Option<String>,
+
+    /// Connect via explicit socket/pipe path.
+    ///
+    /// Takes precedence over `-L` but not over `--tcp`.
+    #[arg(short = 'S', long = "socket-path", value_name = "PATH")]
+    pub socket_path: Option<PathBuf>,
+
     /// Connect to server via TCP (e.g., 127.0.0.1:12521).
+    ///
+    /// Takes highest precedence - bypasses instance registry entirely.
     #[arg(long, value_name = "ADDR")]
     pub tcp: Option<String>,
 
-    /// Connect to server via Unix socket.
+    /// Connect to server via Unix socket (legacy, use -S instead).
     #[cfg(unix)]
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", hide = true)]
     pub socket: Option<PathBuf>,
 }
 
 impl TuiArgs {
     /// Convert arguments to `ConnectionConfig`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if instance lookup fails. For fallible resolution, use
+    /// `ConnectionConfig::from_flags` directly.
     #[must_use]
     pub fn into_config(self) -> ConnectionConfig {
+        // Handle legacy --socket flag (maps to -S)
         #[cfg(unix)]
-        if let Some(path) = self.socket {
-            return ConnectionConfig::unix_socket(path);
+        let socket_path = self.socket_path.or(self.socket);
+        #[cfg(not(unix))]
+        let socket_path = self.socket_path;
+
+        // If instance flag is set, use registry lookup
+        if self.tcp.is_some() || socket_path.is_some() || self.instance.is_some() {
+            match ConnectionConfig::from_flags(
+                self.tcp.as_deref(),
+                socket_path.as_deref(),
+                self.instance.as_deref(),
+            ) {
+                Ok(config) => return config,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
 
-        self.tcp
-            .map_or_else(ConnectionConfig::auto_discover, |addr| {
-                ConnectionConfig::tcp_from_addr(&addr)
-            })
+        // No flags: auto-discover
+        ConnectionConfig::auto_discover()
     }
 }

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -107,6 +107,9 @@
 // All server-specific code lives in the server module
 pub mod server;
 
+// Manager daemon for instance coordination
+pub mod manager;
+
 // Search engine for / and ? commands
 pub mod search;
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -4,6 +4,7 @@
 //!   reovim server [--tcp PORT] [--socket PATH] [--stdio]
 //!   reovim tui [--tcp ADDR] [--socket PATH]
 //!   reovim cli [--tcp ADDR] [--socket PATH] [--repl] `<command>`
+//!   reovim manager [start|stop|status]
 
 use std::{io::BufRead, path::PathBuf, process};
 
@@ -16,6 +17,7 @@ use {
             common::{ConnectionConfig, rpc::ServerMessage},
             tui::{TuiApp, TuiArgs},
         },
+        manager::{ManagerClient, ManagerDaemon, is_manager_alive},
         server::SrvArgs,
     },
     serde_json::Value,
@@ -70,6 +72,27 @@ enum Command {
     Attach(TuiArgs),
     /// Execute CLI commands.
     Cli(CliArgs),
+    /// Manage the port manager daemon.
+    Manager {
+        /// Manager action to perform.
+        #[command(subcommand)]
+        action: ManagerAction,
+    },
+}
+
+/// Manager daemon actions.
+#[derive(Subcommand, Debug)]
+enum ManagerAction {
+    /// Start the manager daemon.
+    Start {
+        /// Print ready signal to stdout when bound (for process coordination).
+        #[arg(long, hide = true)]
+        ready_signal: bool,
+    },
+    /// Stop the manager daemon.
+    Stop,
+    /// Check manager status.
+    Status,
 }
 
 fn main() {
@@ -100,6 +123,10 @@ fn main() {
             } else if let Some(ref action) = cli_args.action {
                 run_cli(&config, action, &format);
             }
+        }
+
+        Some(Command::Manager { action }) => {
+            run_manager(&action);
         }
 
         None => {
@@ -271,6 +298,81 @@ fn run_server(config: ServerConfig) {
         eprintln!("Server error: {e}");
         process::exit(1);
     }
+}
+
+fn run_manager(action: &ManagerAction) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create runtime");
+
+    rt.block_on(async {
+        match action {
+            ManagerAction::Start { ready_signal } => {
+                let ready_signal = *ready_signal;
+                match ManagerDaemon::bind().await {
+                    Ok(daemon) => {
+                        if let Err(e) = daemon.run(ready_signal).await {
+                            eprintln!("Manager error: {e}");
+                            process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to start manager: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
+            ManagerAction::Stop => {
+                if !is_manager_alive().await {
+                    eprintln!("Manager is not running");
+                    process::exit(1);
+                }
+
+                match ManagerClient::connect().await {
+                    Ok(mut client) => {
+                        if let Err(e) = client.shutdown().await {
+                            eprintln!("Failed to stop manager: {e}");
+                            process::exit(1);
+                        }
+                        println!("Manager stopped");
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to connect to manager: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
+            ManagerAction::Status => {
+                if is_manager_alive().await {
+                    println!("Manager is running on 127.0.0.1:{}", runner::manager::MANAGER_PORT);
+
+                    // Try to get instance list
+                    if let Ok(mut client) = ManagerClient::connect().await
+                        && let Ok(instances) = client.list().await
+                    {
+                        if instances.is_empty() {
+                            println!("No instances registered");
+                        } else {
+                            println!("\nRegistered instances:");
+                            for info in instances {
+                                println!(
+                                    "  {}: {} (PID {})",
+                                    info.name,
+                                    info.transport.display(),
+                                    info.pid
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    println!("Manager is not running");
+                }
+            }
+        }
+    });
 }
 
 fn run_tui(config: &ConnectionConfig) {

--- a/runner/src/manager/autostart.rs
+++ b/runner/src/manager/autostart.rs
@@ -1,0 +1,121 @@
+//! Manager auto-start logic.
+//!
+//! Ensures the manager daemon is running when needed, starting it
+//! automatically if necessary.
+
+use std::{
+    io::{self, BufRead, BufReader},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+use tokio::{net::TcpStream, time::timeout};
+
+use super::{MANAGER_HOST, MANAGER_PORT};
+
+/// Timeout for manager startup.
+const MANAGER_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for checking if manager is alive.
+const MANAGER_ALIVE_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Ensure the manager daemon is running, starting it if necessary.
+///
+/// This function:
+/// 1. Checks if the manager is already running
+/// 2. If not, spawns a new manager process
+/// 3. Waits for the manager to signal readiness
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The manager cannot be started
+/// - The manager fails to become ready within the timeout
+pub async fn ensure_manager_running() -> io::Result<()> {
+    if is_manager_alive().await {
+        return Ok(());
+    }
+
+    // Start manager process
+    let exe = std::env::current_exe()?;
+    let mut child = Command::new(&exe)
+        .args(["manager", "start", "--ready-signal"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    // Wait for ready signal (stdout is piped, so this should always succeed)
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        return Err(io::Error::other("Failed to capture manager stdout"));
+    };
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+
+    // Use a blocking read with timeout
+    // We need to do this synchronously because child.stdout is not async
+    let start = std::time::Instant::now();
+    loop {
+        if start.elapsed() > MANAGER_STARTUP_TIMEOUT {
+            let _ = child.kill();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "Manager failed to start within timeout",
+            ));
+        }
+
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // EOF - manager exited
+                let _ = child.kill();
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Manager exited before signaling ready",
+                ));
+            }
+            Ok(_) => {
+                if line.starts_with("READY") {
+                    // Manager is ready, detach from child
+                    drop(child);
+                    return Ok(());
+                }
+                // Not a ready signal, continue reading
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // Non-blocking read returned no data, sleep and retry
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => {
+                let _ = child.kill();
+                return Err(e);
+            }
+        }
+    }
+}
+
+/// Check if the manager daemon is alive and responding.
+///
+/// Attempts a quick TCP connection to the manager port.
+pub async fn is_manager_alive() -> bool {
+    is_manager_alive_at(MANAGER_HOST, MANAGER_PORT).await
+}
+
+/// Check if the manager daemon is alive at a specific address.
+pub async fn is_manager_alive_at(host: &str, port: u16) -> bool {
+    timeout(MANAGER_ALIVE_TIMEOUT, async { TcpStream::connect((host, port)).await.is_ok() })
+        .await
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_is_manager_alive_not_running() {
+        // Use a port that's unlikely to have anything listening
+        let result = is_manager_alive_at("127.0.0.1", 59999).await;
+        assert!(!result);
+    }
+}

--- a/runner/src/manager/client.rs
+++ b/runner/src/manager/client.rs
@@ -1,0 +1,179 @@
+//! Manager client for communicating with the manager daemon.
+
+use std::io;
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    net::TcpStream,
+};
+
+use crate::server::instance::InstanceInfo;
+
+use super::{
+    MANAGER_HOST, MANAGER_PORT,
+    protocol::{ManagerMethod, ManagerRequest, ManagerResponse, ManagerResult},
+};
+
+/// Client for communicating with the manager daemon.
+pub struct ManagerClient {
+    reader: BufReader<tokio::net::tcp::OwnedReadHalf>,
+    writer: BufWriter<tokio::net::tcp::OwnedWriteHalf>,
+    next_id: u64,
+}
+
+impl ManagerClient {
+    /// Connect to the manager daemon at the default address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection fails.
+    pub async fn connect() -> io::Result<Self> {
+        Self::connect_to(MANAGER_HOST, MANAGER_PORT).await
+    }
+
+    /// Connect to the manager daemon at a specific address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection fails.
+    pub async fn connect_to(host: &str, port: u16) -> io::Result<Self> {
+        let stream = TcpStream::connect((host, port)).await?;
+        let (reader, writer) = stream.into_split();
+
+        Ok(Self {
+            reader: BufReader::new(reader),
+            writer: BufWriter::new(writer),
+            next_id: 1,
+        })
+    }
+
+    /// Send a request and receive a response.
+    async fn request(&mut self, method: ManagerMethod) -> io::Result<ManagerResponse> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let request = ManagerRequest::new(id, method);
+        let request_json = serde_json::to_string(&request)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // Send request
+        self.writer.write_all(request_json.as_bytes()).await?;
+        self.writer.write_all(b"\n").await?;
+        self.writer.flush().await?;
+
+        // Read response
+        let mut line = String::new();
+        self.reader.read_line(&mut line).await?;
+
+        let response: ManagerResponse = serde_json::from_str(line.trim())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        Ok(response)
+    }
+
+    /// Ping the manager daemon.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn ping(&mut self) -> io::Result<bool> {
+        let response = self.request(ManagerMethod::Ping).await?;
+        Ok(response.result.is_ok())
+    }
+
+    /// List all registered instances.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn list(&mut self) -> io::Result<Vec<InstanceInfo>> {
+        let response = self.request(ManagerMethod::List).await?;
+
+        match response.result {
+            ManagerResult::Ok(value) => {
+                let instances: Vec<InstanceInfo> = serde_json::from_value(value)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Ok(instances)
+            }
+            ManagerResult::Error { message, .. } => Err(io::Error::other(message)),
+        }
+    }
+
+    /// Query a specific instance by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn query(&mut self, name: &str) -> io::Result<Option<InstanceInfo>> {
+        let response = self
+            .request(ManagerMethod::Query {
+                name: name.to_string(),
+            })
+            .await?;
+
+        match response.result {
+            ManagerResult::Ok(value) => {
+                let info: InstanceInfo = serde_json::from_value(value)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Ok(Some(info))
+            }
+            ManagerResult::Error { code: -32001, .. } => {
+                // Not found
+                Ok(None)
+            }
+            ManagerResult::Error { message, .. } => Err(io::Error::other(message)),
+        }
+    }
+
+    /// Register an instance with the manager.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or instance already exists.
+    pub async fn register(&mut self, info: InstanceInfo) -> io::Result<()> {
+        let response = self.request(ManagerMethod::Register(info)).await?;
+
+        match response.result {
+            ManagerResult::Ok(_) => Ok(()),
+            ManagerResult::Error { message, .. } => Err(io::Error::other(message)),
+        }
+    }
+
+    /// Unregister an instance from the manager.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn unregister(&mut self, name: &str) -> io::Result<()> {
+        let response = self
+            .request(ManagerMethod::Unregister {
+                name: name.to_string(),
+            })
+            .await?;
+
+        match response.result {
+            ManagerResult::Ok(_) => Ok(()),
+            ManagerResult::Error { message, .. } => Err(io::Error::other(message)),
+        }
+    }
+
+    /// Request the manager to shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn shutdown(&mut self) -> io::Result<()> {
+        let response = self.request(ManagerMethod::Shutdown).await?;
+
+        match response.result {
+            ManagerResult::Ok(_) => Ok(()),
+            ManagerResult::Error { message, .. } => Err(io::Error::other(message)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests would require a running manager
+    // Unit tests for serialization are in protocol.rs
+}

--- a/runner/src/manager/daemon.rs
+++ b/runner/src/manager/daemon.rs
@@ -1,0 +1,339 @@
+//! Port Manager daemon implementation.
+//!
+//! The daemon listens on a TCP port (default 12521) and provides
+//! a central registry for instance discovery.
+
+use std::{
+    io::{self, Write},
+    sync::Arc,
+    time::Duration,
+};
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{TcpListener, TcpStream},
+    sync::watch,
+};
+
+use crate::server::instance::InstanceRegistry;
+
+use super::{
+    MANAGER_HOST, MANAGER_PORT,
+    protocol::{ManagerMethod, ManagerRequest, ManagerResponse},
+};
+
+/// Health check interval in seconds.
+const HEALTH_CHECK_INTERVAL_SECS: u64 = 30;
+
+/// Manager daemon.
+///
+/// Provides central registry and health checking for instance discovery.
+pub struct ManagerDaemon {
+    listener: TcpListener,
+    registry: Arc<InstanceRegistry>,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl ManagerDaemon {
+    /// Bind the manager daemon to the default address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding fails (e.g., port in use).
+    pub async fn bind() -> io::Result<Self> {
+        Self::bind_addr(MANAGER_HOST, MANAGER_PORT).await
+    }
+
+    /// Bind the manager daemon to a specific address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding fails.
+    pub async fn bind_addr(host: &str, port: u16) -> io::Result<Self> {
+        let listener = TcpListener::bind((host, port)).await.map_err(|e| {
+            if e.kind() == io::ErrorKind::AddrInUse {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "Port {port} in use. Manager may already be running. \
+                         Check with 'reovim manager status'"
+                    ),
+                )
+            } else {
+                e
+            }
+        })?;
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        Ok(Self {
+            listener,
+            registry: Arc::new(InstanceRegistry::new()),
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+
+    /// Get the local address the daemon is bound to.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the address cannot be determined.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.listener.local_addr()
+    }
+
+    /// Run the manager daemon.
+    ///
+    /// # Arguments
+    ///
+    /// * `ready_signal` - If true, print `READY <addr>` to stdout when bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the accept loop fails.
+    pub async fn run(&self, ready_signal: bool) -> io::Result<()> {
+        let addr = self.local_addr()?;
+
+        // Signal ready if requested
+        if ready_signal {
+            println!("READY {addr}");
+            std::io::stdout().flush().ok();
+        } else {
+            eprintln!("Manager listening on {addr}");
+        }
+
+        // Start health check task
+        let registry = Arc::clone(&self.registry);
+        let mut health_shutdown_rx = self.shutdown_rx.clone();
+        tokio::spawn(async move {
+            Self::health_check_loop(registry, &mut health_shutdown_rx).await;
+        });
+
+        // Accept loop
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        loop {
+            tokio::select! {
+                result = self.listener.accept() => {
+                    match result {
+                        Ok((stream, addr)) => {
+                            tracing::debug!("Manager connection from {addr}");
+                            let registry = Arc::clone(&self.registry);
+                            let shutdown_tx = self.shutdown_tx.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = Self::handle_client(stream, registry, shutdown_tx).await {
+                                    tracing::warn!("Manager client error: {e}");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            tracing::error!("Manager accept error: {e}");
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        tracing::info!("Manager shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle a single client connection.
+    async fn handle_client(
+        stream: TcpStream,
+        registry: Arc<InstanceRegistry>,
+        shutdown_tx: watch::Sender<bool>,
+    ) -> io::Result<()> {
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line).await?;
+            if bytes_read == 0 {
+                break; // EOF
+            }
+
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            // Parse request
+            let request: ManagerRequest = match serde_json::from_str(line) {
+                Ok(req) => req,
+                Err(e) => {
+                    let response = ManagerResponse::error(0, -32700, format!("Parse error: {e}"));
+                    let response_json = serde_json::to_string(&response)?;
+                    writer.write_all(response_json.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
+                    writer.flush().await?;
+                    continue;
+                }
+            };
+
+            // Handle request
+            let response = Self::handle_request(&request, &registry, &shutdown_tx);
+
+            // Send response
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+
+            // Check if shutdown was requested
+            if matches!(request.method, ManagerMethod::Shutdown) {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle a single request.
+    fn handle_request(
+        request: &ManagerRequest,
+        registry: &InstanceRegistry,
+        shutdown_tx: &watch::Sender<bool>,
+    ) -> ManagerResponse {
+        match &request.method {
+            ManagerMethod::Ping => {
+                ManagerResponse::ok(request.id, serde_json::json!({"status": "ok"}))
+            }
+
+            ManagerMethod::List => match registry.list() {
+                Ok(instances) => {
+                    let json = serde_json::to_value(&instances).unwrap_or_default();
+                    ManagerResponse::ok(request.id, json)
+                }
+                Err(e) => ManagerResponse::error(request.id, -32000, e.to_string()),
+            },
+
+            ManagerMethod::Query { name } => match registry.get(name) {
+                Ok(Some(info)) => {
+                    let json = serde_json::to_value(&info).unwrap_or_default();
+                    ManagerResponse::ok(request.id, json)
+                }
+                Ok(None) => ManagerResponse::not_found(request.id, name),
+                Err(e) => ManagerResponse::error(request.id, -32000, e.to_string()),
+            },
+
+            ManagerMethod::Register(info) => match registry.register(info) {
+                Ok(()) => ManagerResponse::ok(request.id, serde_json::json!({"status": "ok"})),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    ManagerResponse::already_exists(request.id, &info.name)
+                }
+                Err(e) => ManagerResponse::error(request.id, -32000, e.to_string()),
+            },
+
+            ManagerMethod::Unregister { name } => match registry.unregister(name) {
+                Ok(()) => ManagerResponse::ok(request.id, serde_json::json!({"status": "ok"})),
+                Err(e) => ManagerResponse::error(request.id, -32000, e.to_string()),
+            },
+
+            ManagerMethod::Shutdown => {
+                // Signal shutdown
+                let _ = shutdown_tx.send(true);
+                ManagerResponse::ok(request.id, serde_json::json!({"status": "shutting_down"}))
+            }
+        }
+    }
+
+    /// Periodic health check loop.
+    ///
+    /// Runs `registry.list()` periodically to clean up stale entries.
+    async fn health_check_loop(
+        registry: Arc<InstanceRegistry>,
+        shutdown_rx: &mut watch::Receiver<bool>,
+    ) {
+        let interval = Duration::from_secs(HEALTH_CHECK_INTERVAL_SECS);
+
+        loop {
+            tokio::select! {
+                () = tokio::time::sleep(interval) => {
+                    // List triggers cleanup of stale entries
+                    match registry.list() {
+                        Ok(instances) => {
+                            tracing::debug!(
+                                "Health check: {} active instances",
+                                instances.len()
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("Health check failed: {e}");
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        tracing::debug!("Health check loop shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_manager_bind() {
+        // Bind to port 0 for OS-assigned port
+        let daemon = ManagerDaemon::bind_addr("127.0.0.1", 0).await.unwrap();
+        let addr = daemon.local_addr().unwrap();
+        assert!(addr.port() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_manager_handle_ping() {
+        let registry = Arc::new(InstanceRegistry::new());
+        let (shutdown_tx, _) = watch::channel(false);
+
+        let request = ManagerRequest::new(1, ManagerMethod::Ping);
+        let response = ManagerDaemon::handle_request(&request, &registry, &shutdown_tx);
+
+        assert_eq!(response.id, 1);
+        assert!(response.result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_manager_handle_list_empty() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(InstanceRegistry::with_dir(temp_dir.path().to_path_buf()));
+        let (shutdown_tx, _) = watch::channel(false);
+
+        let request = ManagerRequest::new(1, ManagerMethod::List);
+        let response = ManagerDaemon::handle_request(&request, &registry, &shutdown_tx);
+
+        assert_eq!(response.id, 1);
+        assert!(response.result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_manager_handle_query_not_found() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(InstanceRegistry::with_dir(temp_dir.path().to_path_buf()));
+        let (shutdown_tx, _) = watch::channel(false);
+
+        let request = ManagerRequest::new(
+            1,
+            ManagerMethod::Query {
+                name: "nonexistent".to_string(),
+            },
+        );
+        let response = ManagerDaemon::handle_request(&request, &registry, &shutdown_tx);
+
+        assert_eq!(response.id, 1);
+        assert!(response.result.is_error());
+    }
+}

--- a/runner/src/manager/mod.rs
+++ b/runner/src/manager/mod.rs
@@ -1,0 +1,44 @@
+//! Port Manager for instance discovery and coordination.
+//!
+//! The manager daemon provides:
+//! - Central registry for remote instance discovery
+//! - Health checking and stale instance cleanup
+//! - Auto-start capability when needed
+//!
+//! # Architecture
+//!
+//! The manager is **optional** for local usage. Basic `-L name` lookup works
+//! via the file-based registry (Phase 2). The manager is needed for:
+//! - `--host` flag (remote manager query)
+//! - `reovim cli list` with enhanced info
+//! - Periodic health checking
+//!
+//! # Auto-Start Flow
+//!
+//! ```text
+//! Any command with --host flag
+//!     ↓
+//! ensure_manager_running()
+//!     ↓
+//! Manager alive on :12521?
+//!     ├─ Yes → proceed
+//!     └─ No → spawn manager process → wait for READY → proceed
+//! ```
+
+mod autostart;
+mod client;
+mod daemon;
+mod protocol;
+
+pub use {
+    autostart::{ensure_manager_running, is_manager_alive},
+    client::ManagerClient,
+    daemon::ManagerDaemon,
+    protocol::{ManagerMethod, ManagerRequest, ManagerResponse, ManagerResult},
+};
+
+/// Default port for the manager daemon.
+pub const MANAGER_PORT: u16 = 12521;
+
+/// Default host for the manager daemon.
+pub const MANAGER_HOST: &str = "127.0.0.1";

--- a/runner/src/manager/protocol.rs
+++ b/runner/src/manager/protocol.rs
@@ -1,0 +1,187 @@
+//! Manager RPC protocol.
+//!
+//! Defines the JSON-RPC messages for manager communication.
+
+use serde::{Deserialize, Serialize};
+
+use crate::server::instance::InstanceInfo;
+
+/// Manager RPC request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagerRequest {
+    /// Request ID for correlation.
+    pub id: u64,
+    /// Method and parameters.
+    #[serde(flatten)]
+    pub method: ManagerMethod,
+}
+
+impl ManagerRequest {
+    /// Create a new request with the given ID and method.
+    #[must_use]
+    pub const fn new(id: u64, method: ManagerMethod) -> Self {
+        Self { id, method }
+    }
+}
+
+/// Manager RPC methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", content = "params")]
+pub enum ManagerMethod {
+    /// Register an instance with the manager.
+    Register(InstanceInfo),
+
+    /// Unregister an instance by name.
+    Unregister {
+        /// Instance name to unregister.
+        name: String,
+    },
+
+    /// Query an instance by name.
+    Query {
+        /// Instance name to query.
+        name: String,
+    },
+
+    /// List all registered instances.
+    List,
+
+    /// Ping the manager (health check).
+    Ping,
+
+    /// Shutdown the manager daemon.
+    Shutdown,
+}
+
+/// Manager RPC response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagerResponse {
+    /// Request ID this response correlates to.
+    pub id: u64,
+    /// Response result.
+    pub result: ManagerResult,
+}
+
+impl ManagerResponse {
+    /// Create a successful response.
+    #[must_use]
+    pub const fn ok(id: u64, value: serde_json::Value) -> Self {
+        Self {
+            id,
+            result: ManagerResult::Ok(value),
+        }
+    }
+
+    /// Create an error response.
+    #[must_use]
+    pub fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            result: ManagerResult::Error {
+                code,
+                message: message.into(),
+            },
+        }
+    }
+
+    /// Create a "not found" error response.
+    #[must_use]
+    pub fn not_found(id: u64, name: &str) -> Self {
+        Self::error(id, -32001, format!("Instance '{name}' not found"))
+    }
+
+    /// Create an "already exists" error response.
+    #[must_use]
+    pub fn already_exists(id: u64, name: &str) -> Self {
+        Self::error(id, -32002, format!("Instance '{name}' already exists"))
+    }
+}
+
+/// Manager RPC result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ManagerResult {
+    /// Successful result with JSON value.
+    Ok(serde_json::Value),
+    /// Error result with code and message.
+    Error {
+        /// Error code.
+        code: i32,
+        /// Error message.
+        message: String,
+    },
+}
+
+impl ManagerResult {
+    /// Check if this is a successful result.
+    #[must_use]
+    pub const fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok(_))
+    }
+
+    /// Check if this is an error result.
+    #[must_use]
+    pub const fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manager_request_serialize() {
+        let req = ManagerRequest::new(1, ManagerMethod::Ping);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"id\":1"));
+        assert!(json.contains("\"method\":\"Ping\""));
+    }
+
+    #[test]
+    fn test_manager_request_deserialize() {
+        let json = r#"{"id":1,"method":"Ping"}"#;
+        let req: ManagerRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.id, 1);
+        assert!(matches!(req.method, ManagerMethod::Ping));
+    }
+
+    #[test]
+    fn test_manager_response_ok() {
+        let resp = ManagerResponse::ok(1, serde_json::json!({"status": "ok"}));
+        assert!(resp.result.is_ok());
+    }
+
+    #[test]
+    fn test_manager_response_error() {
+        let resp = ManagerResponse::error(1, -32000, "test error");
+        assert!(resp.result.is_error());
+    }
+
+    #[test]
+    fn test_manager_method_list() {
+        let json = r#"{"id":1,"method":"List"}"#;
+        let req: ManagerRequest = serde_json::from_str(json).unwrap();
+        assert!(matches!(req.method, ManagerMethod::List));
+    }
+
+    #[test]
+    fn test_manager_method_query() {
+        let json = r#"{"id":1,"method":"Query","params":{"name":"default"}}"#;
+        let req: ManagerRequest = serde_json::from_str(json).unwrap();
+        match req.method {
+            ManagerMethod::Query { name } => assert_eq!(name, "default"),
+            _ => panic!("Expected Query method"),
+        }
+    }
+
+    #[test]
+    fn test_manager_method_unregister() {
+        let json = r#"{"id":1,"method":"Unregister","params":{"name":"test"}}"#;
+        let req: ManagerRequest = serde_json::from_str(json).unwrap();
+        match req.method {
+            ManagerMethod::Unregister { name } => assert_eq!(name, "test"),
+            _ => panic!("Expected Unregister method"),
+        }
+    }
+}

--- a/runner/src/server/app/mod.rs
+++ b/runner/src/server/app/mod.rs
@@ -266,6 +266,19 @@ impl AppState {
         self.running = false;
     }
 
+    /// Request clients to detach (server continues running).
+    ///
+    /// Unlike `request_quit`, the server remains active and accepts new connections.
+    /// Connected TUI clients receive a DETACH notification and disconnect gracefully.
+    ///
+    /// Note: This sets a flag; the actual notification is sent by the broadcaster.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn request_detach(&mut self) {
+        // TODO: Set a detach_requested flag and have broadcaster send notifications.
+        // For now, this is a placeholder that logs the intent.
+        tracing::info!("Detach requested - clients will be notified");
+    }
+
     /// Check if the application should continue running.
     #[must_use]
     pub const fn is_running(&self) -> bool {

--- a/runner/src/server/event_loop/mod.rs
+++ b/runner/src/server/event_loop/mod.rs
@@ -448,6 +448,11 @@ impl<F: InputFallbackHandler<AppState>> EventLoop<F> {
             CommandResult::Quit | CommandResult::ForceQuit => {
                 self.app.request_quit();
             }
+            CommandResult::Detach => {
+                // Detach requests client disconnection but server continues.
+                // The broadcaster will send DETACH notification to all clients.
+                self.app.request_detach();
+            }
             CommandResult::UndoAction(action) => {
                 self.handle_undo_action(action);
             }

--- a/runner/src/server/instance/info.rs
+++ b/runner/src/server/instance/info.rs
@@ -1,0 +1,136 @@
+//! Instance information for registry.
+//!
+//! Defines the [`InstanceInfo`] struct that represents a running reovim server instance.
+//! This information is persisted to the registry for discovery by clients.
+
+use {
+    serde::{Deserialize, Serialize},
+    std::path::PathBuf,
+};
+
+/// Information about a running reovim instance.
+///
+/// This struct is serialized to JSON and stored in the instance registry.
+/// Clients use this information to discover and connect to running servers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstanceInfo {
+    /// Instance name (e.g., "default", "project-foo").
+    ///
+    /// Must be a valid identifier: alphanumeric, hyphens, underscores.
+    pub name: String,
+
+    /// Process ID of the server.
+    pub pid: u32,
+
+    /// Transport address for connecting to this instance.
+    pub transport: TransportInfo,
+
+    /// Unix timestamp when the instance was started.
+    pub started_at: u64,
+
+    /// Working directory of the server (optional).
+    pub cwd: Option<PathBuf>,
+}
+
+impl InstanceInfo {
+    /// Create a new instance info.
+    #[must_use]
+    pub fn new(name: String, pid: u32, transport: TransportInfo) -> Self {
+        Self {
+            name,
+            pid,
+            transport,
+            started_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            cwd: std::env::current_dir().ok(),
+        }
+    }
+}
+
+/// Transport address information.
+///
+/// Describes how to connect to an instance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "address")]
+pub enum TransportInfo {
+    /// TCP transport with host and port.
+    Tcp {
+        /// Host address (e.g., "127.0.0.1").
+        host: String,
+        /// Port number.
+        port: u16,
+    },
+
+    /// Local transport (Unix socket or Windows named pipe).
+    Local {
+        /// Path to socket file or pipe name.
+        path: String,
+    },
+}
+
+impl TransportInfo {
+    /// Create a TCP transport info.
+    #[must_use]
+    pub fn tcp(host: impl Into<String>, port: u16) -> Self {
+        Self::Tcp {
+            host: host.into(),
+            port,
+        }
+    }
+
+    /// Create a local transport info.
+    #[must_use]
+    pub fn local(path: impl Into<String>) -> Self {
+        Self::Local { path: path.into() }
+    }
+
+    /// Get a display string for the transport.
+    #[must_use]
+    pub fn display(&self) -> String {
+        match self {
+            Self::Tcp { host, port } => format!("{host}:{port}"),
+            Self::Local { path } => path.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for TransportInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instance_info_serialization() {
+        let info = InstanceInfo::new(
+            "test-instance".to_string(),
+            12345,
+            TransportInfo::tcp("127.0.0.1", 12521),
+        );
+
+        let json = serde_json::to_string(&info).unwrap();
+        let deserialized: InstanceInfo = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(info.name, deserialized.name);
+        assert_eq!(info.pid, deserialized.pid);
+        assert_eq!(info.transport, deserialized.transport);
+    }
+
+    #[test]
+    fn test_transport_info_tcp() {
+        let transport = TransportInfo::tcp("localhost", 9000);
+        assert_eq!(transport.display(), "localhost:9000");
+    }
+
+    #[test]
+    fn test_transport_info_local() {
+        let transport = TransportInfo::local("/tmp/reovim.sock");
+        assert_eq!(transport.display(), "/tmp/reovim.sock");
+    }
+}

--- a/runner/src/server/instance/mod.rs
+++ b/runner/src/server/instance/mod.rs
@@ -1,0 +1,41 @@
+//! Instance management for reovim servers.
+//!
+//! This module provides:
+//! - [`InstanceInfo`] - Information about a running instance
+//! - [`TransportInfo`] - Transport address for connecting to an instance
+//! - [`InstanceRegistry`] - File-based registry for instance discovery
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use runner::server::instance::{InstanceInfo, InstanceRegistry, TransportInfo};
+//!
+//! // Create registry
+//! let registry = InstanceRegistry::new();
+//!
+//! // Register an instance
+//! let info = InstanceInfo::new(
+//!     "my-project".to_string(),
+//!     std::process::id(),
+//!     TransportInfo::tcp("127.0.0.1", 12521),
+//! );
+//! registry.register(&info)?;
+//!
+//! // List instances
+//! for instance in registry.list()? {
+//!     println!("{}: {}", instance.name, instance.transport);
+//! }
+//!
+//! // Get specific instance
+//! if let Some(info) = registry.get("my-project")? {
+//!     println!("Found: {}", info.transport);
+//! }
+//! ```
+
+mod info;
+mod registry;
+
+pub use {
+    info::{InstanceInfo, TransportInfo},
+    registry::InstanceRegistry,
+};

--- a/runner/src/server/instance/registry.rs
+++ b/runner/src/server/instance/registry.rs
@@ -1,0 +1,409 @@
+//! File-based instance registry.
+//!
+//! Provides persistent storage for instance information, enabling discovery
+//! of running reovim servers without requiring a central daemon.
+//!
+//! # Registry Location
+//!
+//! - **Unix**: `$XDG_RUNTIME_DIR/reovim/` or `/tmp/reovim-<user>/`
+//! - **Windows**: `%LOCALAPPDATA%\reovim\run\`
+//!
+//! # File Format
+//!
+//! Each instance is stored as a JSON file named `<instance-name>.json`.
+
+#[cfg(test)]
+use super::info::TransportInfo;
+use {
+    super::info::InstanceInfo,
+    reovim_arch::process_exists,
+    std::{io, path::PathBuf},
+};
+
+/// File-based instance registry.
+///
+/// Stores instance information as JSON files in a platform-specific directory.
+/// Automatically cleans up stale entries (dead PIDs) when listing or getting.
+pub struct InstanceRegistry {
+    registry_dir: PathBuf,
+}
+
+impl InstanceRegistry {
+    /// Create a new registry using the default directory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            registry_dir: Self::default_registry_dir(),
+        }
+    }
+
+    /// Create a registry with a custom directory (for testing).
+    #[must_use]
+    pub const fn with_dir(registry_dir: PathBuf) -> Self {
+        Self { registry_dir }
+    }
+
+    /// Get the default registry directory.
+    #[must_use]
+    pub fn default_registry_dir() -> PathBuf {
+        #[cfg(unix)]
+        {
+            reovim_arch::dirs::runtime_dir().map_or_else(
+                || {
+                    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+                    PathBuf::from(format!("/tmp/reovim-{user}"))
+                },
+                |d| d.join("reovim"),
+            )
+        }
+
+        #[cfg(windows)]
+        {
+            reovim_arch::dirs::data_local_dir().map_or_else(
+                || PathBuf::from(r"C:\ProgramData\reovim\run"),
+                |d| d.join("reovim").join("run"),
+            )
+        }
+    }
+
+    /// Get the registry directory path.
+    #[must_use]
+    pub const fn registry_dir(&self) -> &PathBuf {
+        &self.registry_dir
+    }
+
+    /// Register an instance in the registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The registry directory cannot be created
+    /// - The file cannot be written
+    /// - An instance with the same name already exists and is alive
+    pub fn register(&self, info: &InstanceInfo) -> io::Result<()> {
+        // Validate instance name
+        Self::validate_name(&info.name)?;
+
+        // Ensure registry directory exists
+        std::fs::create_dir_all(&self.registry_dir)?;
+
+        let path = self.instance_path(&info.name);
+
+        // Check if instance already exists and is alive
+        if path.exists() {
+            if let Ok(Some(existing)) = self.get_internal(&info.name, false)
+                && process_exists(existing.pid)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("Instance '{}' already exists (PID {})", info.name, existing.pid),
+                ));
+            }
+            // Stale entry, remove it
+            let _ = std::fs::remove_file(&path);
+        }
+
+        let json = serde_json::to_string_pretty(info)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, json)
+    }
+
+    /// Unregister an instance from the registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be removed.
+    pub fn unregister(&self, name: &str) -> io::Result<()> {
+        let path = self.instance_path(name);
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    /// List all registered instances.
+    ///
+    /// Automatically removes stale entries (dead PIDs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the registry directory cannot be read.
+    pub fn list(&self) -> io::Result<Vec<InstanceInfo>> {
+        let mut instances = Vec::new();
+
+        if !self.registry_dir.exists() {
+            return Ok(instances);
+        }
+
+        for entry in std::fs::read_dir(&self.registry_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            // Skip non-JSON files
+            if path.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+
+            let Ok(json) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+
+            let Ok(info) = serde_json::from_str::<InstanceInfo>(&json) else {
+                // Malformed JSON, remove it
+                let _ = std::fs::remove_file(&path);
+                continue;
+            };
+
+            if process_exists(info.pid) {
+                instances.push(info);
+            } else {
+                // Clean up stale entry
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+
+        Ok(instances)
+    }
+
+    /// Get a specific instance by name.
+    ///
+    /// Returns `None` if the instance doesn't exist or is stale.
+    /// Automatically removes stale entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read.
+    pub fn get(&self, name: &str) -> io::Result<Option<InstanceInfo>> {
+        self.get_internal(name, true)
+    }
+
+    /// Internal get implementation with optional cleanup.
+    fn get_internal(&self, name: &str, cleanup_stale: bool) -> io::Result<Option<InstanceInfo>> {
+        let path = self.instance_path(name);
+
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let json = std::fs::read_to_string(&path)?;
+        let info: InstanceInfo = serde_json::from_str(&json)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        if !process_exists(info.pid) {
+            if cleanup_stale {
+                // Clean up stale entry
+                let _ = std::fs::remove_file(&path);
+            }
+            return Ok(None);
+        }
+
+        Ok(Some(info))
+    }
+
+    /// Validate an instance name.
+    ///
+    /// Valid names:
+    /// - 1-63 characters
+    /// - Start with alphanumeric
+    /// - Contain only: a-z, A-Z, 0-9, -, _
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the name is invalid.
+    pub fn validate_name(name: &str) -> io::Result<()> {
+        if name.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Instance name cannot be empty",
+            ));
+        }
+
+        if name.len() > 63 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Instance name cannot exceed 63 characters",
+            ));
+        }
+
+        // SAFETY: We already checked name.is_empty() above, so first char exists
+        let Some(first) = name.chars().next() else {
+            unreachable!("name is not empty, checked above");
+        };
+        if !first.is_ascii_alphanumeric() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Instance name must start with alphanumeric character",
+            ));
+        }
+
+        for c in name.chars() {
+            if !c.is_ascii_alphanumeric() && c != '-' && c != '_' {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Instance name contains invalid character: '{c}'"),
+                ));
+            }
+        }
+
+        // Check for path traversal attempts
+        if name.contains("..") || name.contains('/') || name.contains('\\') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Instance name contains path traversal characters",
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Get the file path for an instance.
+    fn instance_path(&self, name: &str) -> PathBuf {
+        self.registry_dir.join(format!("{name}.json"))
+    }
+}
+
+impl Default for InstanceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, tempfile::TempDir};
+
+    fn test_registry() -> (InstanceRegistry, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = InstanceRegistry::with_dir(temp_dir.path().to_path_buf());
+        (registry, temp_dir)
+    }
+
+    #[test]
+    fn test_registry_register_unregister() {
+        let (registry, _temp) = test_registry();
+
+        let info = InstanceInfo::new(
+            "test-instance".to_string(),
+            std::process::id(),
+            TransportInfo::tcp("127.0.0.1", 12521),
+        );
+
+        // Register
+        registry.register(&info).unwrap();
+
+        // Verify exists
+        let retrieved = registry.get("test-instance").unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().name, "test-instance");
+
+        // Unregister
+        registry.unregister("test-instance").unwrap();
+
+        // Verify removed
+        let retrieved = registry.get("test-instance").unwrap();
+        assert!(retrieved.is_none());
+    }
+
+    #[test]
+    fn test_registry_list_instances() {
+        let (registry, _temp) = test_registry();
+        let pid = std::process::id();
+
+        // Register multiple instances
+        for i in 0u16..3u16 {
+            let info = InstanceInfo::new(
+                format!("instance-{i}"),
+                pid,
+                TransportInfo::tcp("127.0.0.1", 12521 + i),
+            );
+            registry.register(&info).unwrap();
+        }
+
+        // List all
+        let instances = registry.list().unwrap();
+        assert_eq!(instances.len(), 3);
+    }
+
+    #[test]
+    fn test_registry_stale_cleanup() {
+        let (registry, _temp) = test_registry();
+
+        // Register with a fake PID that doesn't exist
+        let info = InstanceInfo::new(
+            "stale-instance".to_string(),
+            u32::MAX - 1, // Very unlikely to exist
+            TransportInfo::tcp("127.0.0.1", 12521),
+        );
+
+        // Write directly to bypass alive check
+        std::fs::create_dir_all(registry.registry_dir()).unwrap();
+        let path = registry.registry_dir().join("stale-instance.json");
+        let json = serde_json::to_string(&info).unwrap();
+        std::fs::write(&path, json).unwrap();
+
+        // Get should return None and clean up
+        let retrieved = registry.get("stale-instance").unwrap();
+        assert!(retrieved.is_none());
+
+        // File should be removed
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_registry_duplicate_name_prevented() {
+        let (registry, _temp) = test_registry();
+        let pid = std::process::id();
+
+        let info =
+            InstanceInfo::new("duplicate".to_string(), pid, TransportInfo::tcp("127.0.0.1", 12521));
+
+        // First registration succeeds
+        registry.register(&info).unwrap();
+
+        // Second registration with same name fails
+        let result = registry.register(&info);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().kind() == io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_instance_name_validation() {
+        // Valid names
+        assert!(InstanceRegistry::validate_name("default").is_ok());
+        assert!(InstanceRegistry::validate_name("my-project").is_ok());
+        assert!(InstanceRegistry::validate_name("project_123").is_ok());
+        assert!(InstanceRegistry::validate_name("A").is_ok());
+
+        // Invalid names
+        assert!(InstanceRegistry::validate_name("").is_err()); // Empty
+        assert!(InstanceRegistry::validate_name("-invalid").is_err()); // Starts with hyphen
+        assert!(InstanceRegistry::validate_name("_invalid").is_err()); // Starts with underscore
+        assert!(InstanceRegistry::validate_name("has spaces").is_err()); // Contains space
+        assert!(InstanceRegistry::validate_name("../etc/passwd").is_err()); // Path traversal
+        assert!(InstanceRegistry::validate_name("a".repeat(64).as_str()).is_err()); // Too long
+    }
+
+    #[test]
+    fn test_registry_empty_dir() {
+        let (registry, _temp) = test_registry();
+
+        // List on empty registry should return empty vec
+        let instances = registry.list().unwrap();
+        assert!(instances.is_empty());
+    }
+
+    #[test]
+    fn test_registry_malformed_json() {
+        let (registry, _temp) = test_registry();
+
+        // Write malformed JSON
+        std::fs::create_dir_all(registry.registry_dir()).unwrap();
+        let path = registry.registry_dir().join("malformed.json");
+        std::fs::write(&path, "not valid json {").unwrap();
+
+        // List should handle gracefully and remove the file
+        let instances = registry.list().unwrap();
+        assert!(instances.is_empty());
+        assert!(!path.exists());
+    }
+}

--- a/runner/src/server/mod.rs
+++ b/runner/src/server/mod.rs
@@ -48,8 +48,36 @@ use clap::Args;
 ///
 /// These arguments configure how the server listens for connections
 /// and how modules are loaded.
+///
+/// # Instance Naming
+///
+/// Use `-L` to name this server instance. Named instances are discoverable
+/// via the instance registry, allowing clients to connect using `-L name`
+/// instead of raw TCP addresses.
+///
+/// # Transport Precedence
+///
+/// Transport flags are mutually exclusive. If multiple are specified:
+/// 1. `--stdio` wins (single client mode)
+/// 2. `-s`/`--socket` next (Unix socket)
+/// 3. `-t`/`--tcp` next (specific TCP port)
+/// 4. Default: TCP with automatic port fallback (12521-12530)
 #[derive(Args, Debug, Clone)]
 pub struct SrvArgs {
+    /// Instance name for registry discovery.
+    ///
+    /// Registers this server as a named instance. Clients can then
+    /// connect using `reovim -L <name>` instead of specifying the port.
+    ///
+    /// Default: "default"
+    #[arg(
+        short = 'L',
+        long = "instance",
+        value_name = "NAME",
+        default_value = "default"
+    )]
+    pub instance: String,
+
     /// Start server on specific TCP port.
     #[arg(short, long, value_name = "PORT")]
     pub tcp: Option<u16>,
@@ -95,8 +123,18 @@ pub struct SrvArgs {
 
 impl SrvArgs {
     /// Convert arguments to `ServerConfig`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the instance name is invalid.
     #[must_use]
     pub fn into_config(self) -> ServerConfig {
+        // Validate instance name
+        if let Err(e) = instance::InstanceRegistry::validate_name(&self.instance) {
+            eprintln!("Error: Invalid instance name: {e}");
+            std::process::exit(1);
+        }
+
         // Build module config from CLI arguments
         let mut modules = ModuleConfig::new();
 
@@ -120,6 +158,7 @@ impl SrvArgs {
             #[cfg(unix)]
             if let Some(path) = self.socket {
                 return ServerConfig::unix_socket(path)
+                    .with_instance_name(&self.instance)
                     .with_modules(modules)
                     .with_ready_signal(self.ready_signal);
             }
@@ -135,6 +174,7 @@ impl SrvArgs {
 
         ServerConfig {
             transport,
+            instance_name: self.instance,
             default_session_name: String::from("default"),
             modules,
             default_mode: None,
@@ -148,6 +188,7 @@ mod app;
 pub mod client;
 pub mod debug;
 mod event_loop;
+pub mod instance;
 pub mod module;
 pub mod notification;
 pub mod registry;
@@ -241,6 +282,12 @@ pub struct ServerConfig {
     /// Transport mode (TCP, Unix socket, or Stdio).
     pub transport: TransportMode,
 
+    /// Instance name for registry discovery.
+    ///
+    /// This server will be registered under this name in the instance
+    /// registry, allowing clients to connect using `-L <name>`.
+    pub instance_name: String,
+
     /// Name of the default session to create on startup.
     pub default_session_name: String,
 
@@ -263,6 +310,7 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             transport: TransportMode::TcpWithFallback,
+            instance_name: String::from("default"),
             default_session_name: String::from("default"),
             modules: ModuleConfig::default(),
             default_mode: None,
@@ -313,6 +361,13 @@ impl ServerConfig {
             transport: TransportMode::Stdio,
             ..Self::default()
         }
+    }
+
+    /// Set the instance name for registry discovery.
+    #[must_use]
+    pub fn with_instance_name(mut self, name: impl Into<String>) -> Self {
+        self.instance_name = name.into();
+        self
     }
 
     /// Set the default session name.
@@ -1108,6 +1163,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_default() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: None,
             #[cfg(unix)]
             socket: None,
@@ -1123,11 +1179,13 @@ mod tests {
         assert!(config.modules.search_paths.is_empty());
         assert!(config.modules.autoload.is_empty());
         assert!(!config.modules.no_defaults);
+        assert_eq!(config.instance_name, "default");
     }
 
     #[test]
     fn test_srv_args_into_config_with_tcp() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: Some(9000),
             #[cfg(unix)]
             socket: None,
@@ -1145,6 +1203,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_with_stdio() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: None,
             #[cfg(unix)]
             socket: None,
@@ -1162,6 +1221,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_with_module_dirs() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: None,
             #[cfg(unix)]
             socket: None,
@@ -1184,6 +1244,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_with_load_modules() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: None,
             #[cfg(unix)]
             socket: None,
@@ -1203,6 +1264,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_with_no_defaults() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: None,
             #[cfg(unix)]
             socket: None,
@@ -1221,6 +1283,7 @@ mod tests {
     #[test]
     fn test_srv_args_into_config_with_ready_signal() {
         let args = SrvArgs {
+            instance: "default".to_string(),
             tcp: Some(9000),
             #[cfg(unix)]
             socket: None,
@@ -1233,6 +1296,24 @@ mod tests {
 
         let config = args.into_config();
         assert!(config.ready_signal);
+    }
+
+    #[test]
+    fn test_srv_args_into_config_with_custom_instance() {
+        let args = SrvArgs {
+            instance: "my-project".to_string(),
+            tcp: Some(9000),
+            #[cfg(unix)]
+            socket: None,
+            stdio: false,
+            module_dirs: vec![],
+            load_modules: vec![],
+            no_defaults: false,
+            ready_signal: false,
+        };
+
+        let config = args.into_config();
+        assert_eq!(config.instance_name, "my-project");
     }
 
     #[test]

--- a/runner/src/server/session/session.rs
+++ b/runner/src/server/session/session.rs
@@ -168,6 +168,13 @@ impl Session {
         self.state.write().await.request_quit();
     }
 
+    /// Request clients to detach (server continues running).
+    ///
+    /// Acquires a write lock on the session state.
+    pub async fn request_detach(&self) {
+        self.state.write().await.request_detach();
+    }
+
     /// Look up a key sequence in the session's keymap.
     ///
     /// Acquires a read lock on the session state.
@@ -282,6 +289,12 @@ impl Session {
             CommandResult::Success | CommandResult::Error(_) => None,
             CommandResult::Quit | CommandResult::ForceQuit => {
                 self.request_quit().await;
+                None
+            }
+            CommandResult::Detach => {
+                // Detach requests client disconnection but server continues.
+                // Note: In session context, this triggers DETACH notification.
+                self.request_detach().await;
                 None
             }
             CommandResult::EditAction(action) => {

--- a/runner/src/server/session/state.rs
+++ b/runner/src/server/session/state.rs
@@ -190,6 +190,11 @@ impl SessionState {
     pub fn request_quit(&mut self) {
         self.app.request_quit();
     }
+
+    /// Request clients to detach (server continues running).
+    pub fn request_detach(&mut self) {
+        self.app.request_detach();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add transport abstraction layer and instance registry for server discovery:

Phase 1 - Transport Abstraction:
- LocalAddr platform-agnostic type in lib/arch
- Unix socket and Windows named pipe implementations
- TransportAddr enum consolidating TCP/Unix/Stdio

Phase 2 - Instance Registry:
- File-based JSON registry in ~/.local/share/reovim/instances/
- Automatic stale instance cleanup via liveness checks
- Instance name validation with path traversal protection

Phase 3 - CLI Interface:
- -L/--instance flags for named instance connections
- -S/--socket-path for explicit socket paths
- Flag precedence: TCP > Socket > Instance > default

Phase 4 - Manager Daemon:
- Optional central registry on 127.0.0.1:12521
- Auto-start capability when manager needed
- Health check loop with 30-second interval
- File-based fallback for local-only use

Phase 5 - Runtime Commands:
- :detach - graceful client disconnect (server continues)
- :servers - list running instances
- :kill-server - terminate current server
- <C-b>d/s/& keybindings for session management
- DETACH notification for graceful TUI disconnect

Refs #350