### PR TITLE
feat(tui): TUI client improvements with debug mode (#356, #320, #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - CLI auto_discover() checks registry before port scanning
   - REPL: add `list` and `connect` commands for server switching
 
+- Server now emits `render/complete` notification (#320)
+  - Emitted after any visual state change (mode, cursor, buffer modified)
+  - Buffer-scoped when active buffer exists, session-wide otherwise
+  - TUI clients use this to know when to refresh display
+
 ### Added
 
 - Register selection prefix (`"a`) - specify register for yank/delete/paste (#333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- TUI Debug Mode with statusline and frame buffer capture (#358)
+  - `--debug` flag enables debug statusline with timestamp, server, mode, modules
+  - Frame buffer capture every 5 seconds to `~/.local/share/reovim/logs/tui/frame-buffer/`
+  - LLM-friendly capture format with metadata header and ANSI-styled screen content
+  - Wired TUI to use `FrameRenderer` double-buffer for accurate capture
+  - Session logging to `~/.local/share/reovim/logs/tui/{name}_{time}.log`
+  - Known issue: ghost statusline on resize due to double-buffer swap (deferred)
+
 - Register selection prefix (`"a`) - specify register for yank/delete/paste (#333)
   - `"ayy` yanks line into register 'a'
   - `"ap` pastes from register 'a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ## [Unreleased] - v0.9.1-dev
 
+### Fixed
+
+- Complete manager integration for server discovery (#356)
+  - Port separation: manager owns 12521, servers start at 12522
+  - Server auto-starts manager and registers on startup
+  - CLI auto_discover() checks registry before port scanning
+  - REPL: add `list` and `connect` commands for server switching
+
 ### Added
 
 - Register selection prefix (`"a`) - specify register for yank/delete/paste (#333)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,6 +550,38 @@ reovim cli log-tail --follow --level warn
 Output is color-coded when stdout is a TTY:
 - ERROR (red), WARN (yellow), INFO (green), DEBUG (cyan), TRACE (gray)
 
+### TUI Debug Mode
+
+Enable debug mode for TUI diagnostics:
+
+```bash
+# Enable debug statusline and frame capture
+reovim tui --debug
+
+# Custom log directory
+reovim tui --debug --debug-dir /tmp/reovim-debug
+
+# Custom session name
+reovim tui --debug --debug-name mysession
+```
+
+**Output files:**
+- `~/.local/share/reovim/logs/tui/{name}_{start_time}.log` - Session log
+- `~/.local/share/reovim/logs/tui/frame-buffer/{name}-{timestamp}.frame` - Frame captures (every 5 seconds)
+
+**Statusline format:**
+```
+[YY-MM-DD HH:MM:SS TZ] [server: ADDR] [mode: MODE] [modules: N]
+```
+
+The statusline is rendered at the bottom of the screen with inverse colors.
+
+**Session log events:**
+- Session start/end
+- Mode changes
+- Terminal resize
+- Frame captures
+
 ### Debugging Flaky Tests
 
 **Think Twice Before Assuming Race Conditions**: When tests pass/fail intermittently:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "reovim"
 version = "0.9.1-dev"
 dependencies = [
+ "chrono",
  "clap",
  "crossterm",
  "futures",

--- a/docs/user-guide/server-mode.md
+++ b/docs/user-guide/server-mode.md
@@ -193,6 +193,42 @@ reovim tui --tcp 127.0.0.1:12521
 reovim tui --socket /tmp/reovim.sock
 ```
 
+### TUI Debug Mode
+
+Enable debug mode for TUI diagnostics:
+
+```bash
+# Enable debug statusline and frame capture
+reovim tui --debug
+
+# Custom log directory
+reovim tui --debug --debug-dir /tmp/reovim-debug
+
+# Custom session name
+reovim tui --debug --debug-name mysession
+```
+
+**Debug Features:**
+
+1. **Statusline**: Shows current time, server address, mode, and module count at the bottom of the screen
+   ```
+   [26-01-18 12:34:56 KST] [server: 127.0.0.1:12521] [mode: NORMAL] [modules: 5]
+   ```
+
+2. **Frame Buffer Capture**: Captures rendered frames every 5 seconds
+   - Path: `~/.local/share/reovim/logs/tui/frame-buffer/{name}-{timestamp}.frame`
+
+3. **Session Log**: Records key events (mode changes, resize, etc.)
+   - Path: `~/.local/share/reovim/logs/tui/{name}_{start_time}.log`
+
+**TUI Debug Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--debug` | Enable debug mode (statusline + frame capture) |
+| `--debug-dir <DIR>` | Custom log directory (default: `~/.local/share/reovim/logs/tui/`) |
+| `--debug-name <NAME>` | Session name for filenames (default: `default`) |
+
 ## JSON-RPC Protocol
 
 ### Request Format

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -77,6 +77,9 @@ clap = { workspace = true }
 # Terminal handling for TUI client
 crossterm = { workspace = true }
 
+# Timestamps for TUI debug mode
+chrono = { workspace = true }
+
 # Editor module is a dev-dependency for the demo example
 # (avoids cyclic dependency since editor module depends on runner-new)
 [dev-dependencies]

--- a/runner/src/client/cli/repl.rs
+++ b/runner/src/client/cli/repl.rs
@@ -2,7 +2,9 @@
 //!
 //! Provides a command-line interface for interactive testing.
 
-use crate::client::common::{ConnectionConfig, RpcClient};
+use crate::client::common::{ConnectionConfig, RpcClient, discovery};
+use crate::manager::{ManagerClient, is_manager_alive};
+use crate::server::instance::InstanceRegistry;
 
 use super::{
     commands,
@@ -47,6 +49,45 @@ pub async fn run_repl(config: &ConnectionConfig) -> Result<(), Box<dyn std::erro
         match cmd {
             "help" | "?" => print_help(),
             "exit" | "quit" | "q" => break,
+
+            "list" | "servers" => {
+                print_server_list().await;
+            }
+
+            "connect" => {
+                if args.len() < 2 {
+                    eprintln!("Usage: connect <instance-name> | connect <host:port>");
+                    continue;
+                }
+                let target = args[1];
+                let new_config = if target.contains(':') {
+                    // host:port format
+                    match ConnectionConfig::parse_tcp(target) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            eprintln!("Invalid address: {e}");
+                            continue;
+                        }
+                    }
+                } else {
+                    // Instance name
+                    match ConnectionConfig::from_instance(target) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            eprintln!("Instance not found: {e}");
+                            continue;
+                        }
+                    }
+                };
+
+                match RpcClient::connect(&new_config).await {
+                    Ok(new_client) => {
+                        client = new_client;
+                        println!("Connected to {target}");
+                    }
+                    Err(e) => eprintln!("Connection failed: {e}"),
+                }
+            }
 
             "keys" | "k" => {
                 if args.len() < 2 {
@@ -187,10 +228,56 @@ pub async fn run_repl(config: &ConnectionConfig) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
+/// Print list of running servers.
+async fn print_server_list() {
+    use std::collections::HashSet;
+
+    let mut seen_addrs = HashSet::new();
+    let mut found_any = false;
+
+    // First, try to query the manager
+    if is_manager_alive().await {
+        if let Ok(mut client) = ManagerClient::connect().await {
+            if let Ok(instances) = client.list().await {
+                for instance in instances {
+                    let addr = instance.transport.display();
+                    seen_addrs.insert(addr.clone());
+                    println!("  {} ({}) pid: {}", addr, instance.name, instance.pid);
+                    found_any = true;
+                }
+            }
+        }
+    }
+
+    // Fall back to file registry
+    if !found_any {
+        let registry = InstanceRegistry::new();
+        if let Ok(instances) = registry.list() {
+            for instance in instances {
+                let addr = instance.transport.display();
+                seen_addrs.insert(addr.clone());
+                println!("  {} ({}) pid: {}", addr, instance.name, instance.pid);
+            }
+        }
+    }
+
+    // Scan ports for unregistered servers
+    for s in discovery::list_servers() {
+        let addr = format!("{}:{}", s.host, s.port);
+        if !seen_addrs.contains(&addr) {
+            let pid = s.pid.map_or_else(|| "?".into(), |p| p.to_string());
+            println!("  {addr} (unregistered) pid: {pid}");
+        }
+    }
+}
+
 /// Print help text.
 fn print_help() {
     println!(
         r"Commands:
+  list            List running servers
+  connect <dest>  Connect to server (instance name or host:port)
+
   keys <seq>      Inject key sequence (e.g., keys iHello<Esc>)
   mode            Get current mode
   cursor          Get cursor position

--- a/runner/src/client/cli/repl.rs
+++ b/runner/src/client/cli/repl.rs
@@ -2,9 +2,11 @@
 //!
 //! Provides a command-line interface for interactive testing.
 
-use crate::client::common::{ConnectionConfig, RpcClient, discovery};
-use crate::manager::{ManagerClient, is_manager_alive};
-use crate::server::instance::InstanceRegistry;
+use crate::{
+    client::common::{ConnectionConfig, RpcClient, discovery},
+    manager::{ManagerClient, is_manager_alive},
+    server::instance::InstanceRegistry,
+};
 
 use super::{
     commands,
@@ -236,16 +238,15 @@ async fn print_server_list() {
     let mut found_any = false;
 
     // First, try to query the manager
-    if is_manager_alive().await {
-        if let Ok(mut client) = ManagerClient::connect().await {
-            if let Ok(instances) = client.list().await {
-                for instance in instances {
-                    let addr = instance.transport.display();
-                    seen_addrs.insert(addr.clone());
-                    println!("  {} ({}) pid: {}", addr, instance.name, instance.pid);
-                    found_any = true;
-                }
-            }
+    if is_manager_alive().await
+        && let Ok(mut client) = ManagerClient::connect().await
+        && let Ok(instances) = client.list().await
+    {
+        for instance in instances {
+            let addr = instance.transport.display();
+            seen_addrs.insert(addr.clone());
+            println!("  {} ({}) pid: {}", addr, instance.name, instance.pid);
+            found_any = true;
         }
     }
 

--- a/runner/src/client/common/connection.rs
+++ b/runner/src/client/common/connection.rs
@@ -32,11 +32,13 @@ pub enum ConnectionConfig {
 
 impl ConnectionConfig {
     /// Create TCP config with default host and port.
+    ///
+    /// Uses port 12522 (port 12521 is reserved for manager daemon).
     #[must_use]
     pub fn tcp_default() -> Self {
         Self::Tcp {
             host: "127.0.0.1".to_string(),
-            port: 12521,
+            port: 12522,
         }
     }
 
@@ -83,12 +85,19 @@ impl ConnectionConfig {
 
     /// Auto-discover a running server.
     ///
-    /// Scans default ports and returns the first available server.
-    /// Falls back to default port if no server found.
+    /// Discovery order:
+    /// 1. Check instance registry for "default" instance
+    /// 2. Scan default ports (12522-12531)
+    /// 3. Fall back to default port
     #[must_use]
     pub fn auto_discover() -> Self {
-        use super::discovery;
+        // First, try to find "default" instance in registry
+        if let Ok(config) = Self::from_instance("default") {
+            return config;
+        }
 
+        // Fall back to port scanning
+        use super::discovery;
         let servers = discovery::list_servers();
         servers
             .first()

--- a/runner/src/client/common/connection.rs
+++ b/runner/src/client/common/connection.rs
@@ -91,13 +91,14 @@ impl ConnectionConfig {
     /// 3. Fall back to default port
     #[must_use]
     pub fn auto_discover() -> Self {
+        use super::discovery;
+
         // First, try to find "default" instance in registry
         if let Ok(config) = Self::from_instance("default") {
             return config;
         }
 
         // Fall back to port scanning
-        use super::discovery;
         let servers = discovery::list_servers();
         servers
             .first()

--- a/runner/src/client/common/discovery.rs
+++ b/runner/src/client/common/discovery.rs
@@ -5,7 +5,10 @@
 use std::{net::TcpStream, time::Duration};
 
 /// Default server port.
-pub const DEFAULT_PORT: u16 = 12521;
+///
+/// Port 12521 is reserved for the manager daemon.
+/// Server instances start at 12522.
+pub const DEFAULT_PORT: u16 = 12522;
 
 /// Number of ports to scan for fallback.
 pub const PORT_FALLBACK_COUNT: u16 = 10;

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -3,7 +3,11 @@
 //! Connects to server, handles input, and renders output.
 //! Uses concurrent notification handling with `tokio::select!`.
 
-use std::io;
+use std::{
+    fmt::Write as _,
+    io::{self, Write},
+    time::{Duration, Instant},
+};
 
 use {
     crossterm::event::{Event, EventStream, KeyCode, KeyModifiers},
@@ -20,9 +24,14 @@ use {
     tokio::{sync::mpsc, task::JoinHandle},
 };
 
+/// Interval for frame buffer capture (5 seconds).
+const FRAME_CAPTURE_INTERVAL: Duration = Duration::from_secs(5);
+
 use crate::client::common::{
     ConnectionConfig, ConnectionReader, RpcClient, RpcClientError, RpcWriter, ServerMessage,
 };
+
+use reovim_driver_display::{ColorMode, FrameRenderer, Style};
 
 use super::{
     input::InputHandler,
@@ -99,6 +108,8 @@ struct TuiState {
     buffer_modified: bool,
     /// Whether screen needs redraw.
     needs_redraw: bool,
+    /// Loaded modules list.
+    modules: Vec<String>,
 }
 
 /// TUI application.
@@ -109,8 +120,10 @@ pub struct TuiApp {
     message_rx: mpsc::Receiver<ServerMessage>,
     /// Handle to notification listener task.
     listener_handle: JoinHandle<()>,
-    /// Terminal renderer.
+    /// Terminal renderer (basic terminal ops).
     renderer: Renderer,
+    /// Frame renderer with double-buffering for content.
+    frame_renderer: FrameRenderer,
     /// Whether the app is running.
     running: bool,
     /// Last known terminal size.
@@ -123,6 +136,14 @@ pub struct TuiApp {
     log_panel: LogPanelState,
     /// Server log subscription ID.
     subscription_id: Option<u64>,
+    /// Connected server address for statusline.
+    server_address: String,
+    /// Debug configuration (None = debug disabled).
+    debug_config: Option<super::TuiDebugConfig>,
+    /// Debug session log file handle.
+    debug_log_file: Option<std::fs::File>,
+    /// Last frame capture time.
+    last_frame_capture: Instant,
 }
 
 impl TuiApp {
@@ -130,10 +151,25 @@ impl TuiApp {
     ///
     /// Fetches initial state before entering notification-driven mode.
     ///
+    /// # Arguments
+    ///
+    /// * `config` - Connection configuration for server
+    /// * `debug_config` - Optional debug configuration for statusline/frame capture
+    ///
     /// # Errors
     ///
     /// Returns error if connection or initial state fetch fails.
-    pub async fn connect(config: &ConnectionConfig) -> Result<Self, TuiError> {
+    pub async fn connect(
+        config: &ConnectionConfig,
+        debug_config: Option<super::TuiDebugConfig>,
+    ) -> Result<Self, TuiError> {
+        // Get server address for statusline display
+        let server_address = match config {
+            ConnectionConfig::Tcp { host, port } => format!("{host}:{port}"),
+            #[cfg(unix)]
+            ConnectionConfig::UnixSocket(path) => path.display().to_string(),
+        };
+
         // Connect and fetch initial state while we have blocking RpcClient
         let mut client = RpcClient::connect(config).await?;
 
@@ -157,6 +193,24 @@ impl TuiApp {
             .and_then(serde_json::Value::as_u64)
             .map_or(0, |v| v as usize);
 
+        // Get loaded modules
+        let modules = match client.call("module/list", json!({})).await {
+            Ok(result) => result
+                .get("modules")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|m| m.get("id").and_then(|id| id.as_str()))
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(e) => {
+                tracing::debug!("Failed to get module list: {e}");
+                Vec::new()
+            }
+        };
+
         // Subscribe to server logs (info level and above)
         let subscription_id = match client.call("debug/log_subscribe", json!({})).await {
             Ok(result) => result
@@ -179,11 +233,34 @@ impl TuiApp {
 
         let renderer = Renderer::new();
 
+        // Initialize debug features if enabled
+        let debug_log_file = debug_config.as_ref().and_then(|cfg| {
+            // Create directories
+            let frame_dir = cfg.log_dir.join("frame-buffer");
+            if let Err(e) = std::fs::create_dir_all(&frame_dir) {
+                tracing::warn!("Failed to create frame capture dir: {e}");
+            }
+
+            // Open session log file
+            let log_path = cfg.session_log_path();
+            match std::fs::File::create(&log_path) {
+                Ok(file) => {
+                    tracing::debug!("Debug session log: {}", log_path.display());
+                    Some(file)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create debug log file: {e}");
+                    None
+                }
+            }
+        });
+
         Ok(Self {
             rpc_writer,
             message_rx,
             listener_handle,
             renderer,
+            frame_renderer: FrameRenderer::default(), // Resized on run()
             running: false,
             last_size: (0, 0),
             state: TuiState {
@@ -192,10 +269,15 @@ impl TuiApp {
                 cursor_column,
                 buffer_modified: false,
                 needs_redraw: true,
+                modules,
             },
             log_buffer: TuiLogBuffer::new(DEFAULT_TUI_LOG_CAPACITY),
             log_panel: LogPanelState::new(),
             subscription_id,
+            server_address,
+            debug_config,
+            debug_log_file,
+            last_frame_capture: Instant::now(),
         })
     }
 
@@ -207,6 +289,13 @@ impl TuiApp {
     ///
     /// Returns error if fatal error occurs.
     pub async fn run(&mut self) -> Result<(), TuiError> {
+        // Log session start
+        self.debug_log(&format!(
+            "TUI session started - server: {}, mode: {}",
+            self.server_address,
+            self.state.mode_display.as_deref().unwrap_or("?")
+        ));
+
         // Install panic hook before entering raw mode to ensure terminal cleanup
         let original_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
@@ -224,6 +313,7 @@ impl TuiApp {
         // Get initial size and notify server
         let (width, height) = self.renderer.size()?;
         self.last_size = (width, height);
+        self.frame_renderer.resize(width, height);
         self.send_resize(width, height).await?;
 
         // Request initial screen content
@@ -231,6 +321,9 @@ impl TuiApp {
 
         // Run the main event loop
         let result = self.run_event_loop().await;
+
+        // Log session end
+        self.debug_log("TUI session ended");
 
         // Unsubscribe from log notifications
         if let Some(sub_id) = self.subscription_id {
@@ -252,6 +345,10 @@ impl TuiApp {
     /// Main event loop using `tokio::select!`.
     async fn run_event_loop(&mut self) -> Result<(), TuiError> {
         let mut terminal_events = EventStream::new();
+
+        // Create a 1-second interval for statusline updates (only ticks if debug mode)
+        let mut statusline_tick = tokio::time::interval(Duration::from_secs(1));
+        statusline_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         while self.running {
             tokio::select! {
@@ -284,6 +381,14 @@ impl TuiApp {
                             return Err(TuiError::Disconnected);
                         }
                     }
+                }
+
+                // Periodic statusline update (debug mode only)
+                // Update frame buffer and flush to keep capture in sync
+                _ = statusline_tick.tick(), if self.debug_config.is_some() => {
+                    self.write_statusline_to_buffer();
+                    self.maybe_capture_frame();
+                    self.frame_renderer.flush(&mut io::stdout())?;
                 }
             }
 
@@ -370,9 +475,11 @@ impl TuiApp {
     async fn handle_resize(&mut self, width: u16, height: u16) -> Result<(), TuiError> {
         if (width, height) != self.last_size {
             self.last_size = (width, height);
+            self.frame_renderer.resize(width, height);
             self.send_resize(width, height).await?;
             // Request refresh after resize
             self.state.needs_redraw = true;
+            self.debug_log(&format!("Terminal resized: {width}x{height}"));
         }
         Ok(())
     }
@@ -384,9 +491,11 @@ impl TuiApp {
                 if let Ok(payload) =
                     serde_json::from_value::<ModeChangedPayload>(notification.params)
                 {
+                    let new_mode = payload.mode.display.clone();
                     self.state.mode_display = Some(payload.mode.display);
                     self.state.needs_redraw = true;
                     tracing::debug!("Mode changed to: {:?}", self.state.mode_display);
+                    self.debug_log(&format!("Mode changed: {new_mode}"));
                 }
             }
             CURSOR_MOVED => {
@@ -488,15 +597,29 @@ impl TuiApp {
     }
 
     /// Refresh screen content from server.
+    ///
+    /// Uses double-buffered frame renderer:
+    /// 1. Clear back buffer
+    /// 2. Write server content to back buffer
+    /// 3. Write log panel to back buffer (if visible)
+    /// 4. Write statusline to back buffer (if debug mode)
+    /// 5. Flush (diff render to stdout)
     async fn refresh_screen(&mut self) -> Result<(), TuiError> {
-        // Send screen content request (fire-and-forget style, but we wait for immediate response)
-        // This is a transitional implementation - ideally we'd poll from cached state
+        let (width, height) = self.last_size;
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        // Clear back buffer
+        self.frame_renderer.buffer_mut().clear();
+
+        // Request screen content from server
         let _ = self
             .rpc_writer
-            .send_request("state/screen_content", json!({ "format": "raw_ansi" }))
+            .send_request("state/screen_content", json!({ "format": "plain_text" }))
             .await;
 
-        // Read response from message channel with short timeout
+        // Read response and write to frame buffer
         match tokio::time::timeout(
             std::time::Duration::from_millis(100),
             self.wait_for_screen_content(),
@@ -504,33 +627,52 @@ impl TuiApp {
         .await
         {
             Ok(Ok(content)) => {
-                self.renderer.render(&content)?;
+                // Write server content to frame buffer (line by line)
+                let default_style = Style::default();
+                for (y, line) in content.lines().enumerate().take(height as usize) {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let y_u16 = y as u16;
+                    self.frame_renderer
+                        .buffer_mut()
+                        .write_str(0, y_u16, line, &default_style);
+                }
             }
             Ok(Err(e)) => return Err(e),
             Err(_) => {
-                // Timeout - just position cursor
                 tracing::debug!("Screen content timeout, skipping render");
             }
         }
 
-        // Render log panel if visible
+        // Write log panel to frame buffer (if visible)
         if self.log_panel.visible {
-            let (width, height) = self.last_size;
-            let panel_height = self.log_panel.height.min(height / 2); // Max half screen
+            let panel_height = self.log_panel.height.min(height / 2);
             let entries = self.log_buffer.entries();
             let lines = render_panel(&entries, &self.log_panel, width, panel_height);
 
-            // Position cursor at start of panel area
             let panel_start = height.saturating_sub(panel_height);
-            self.renderer.set_cursor(0, panel_start)?;
-
-            // Render panel lines
-            for line in lines {
-                self.renderer.write_line(&line)?;
+            let default_style = Style::default();
+            for (i, line) in lines.iter().enumerate() {
+                #[allow(clippy::cast_possible_truncation)]
+                let y = panel_start + i as u16;
+                if y < height {
+                    self.frame_renderer
+                        .buffer_mut()
+                        .write_str(0, y, line, &default_style);
+                }
             }
         }
 
-        // Position cursor based on current state
+        // Write debug statusline to frame buffer (if enabled)
+        self.write_statusline_to_buffer();
+
+        // Capture frame BEFORE flush (back buffer has current content)
+        // After flush, buffers swap and back becomes stale
+        self.maybe_capture_frame();
+
+        // Flush frame buffer to stdout (diff rendering)
+        self.frame_renderer.flush(&mut io::stdout())?;
+
+        // Position cursor and show
         #[allow(clippy::cast_possible_truncation)]
         self.renderer
             .set_cursor(self.state.cursor_column as u16, self.state.cursor_line as u16)?;
@@ -538,6 +680,188 @@ impl TuiApp {
         self.renderer.flush()?;
 
         Ok(())
+    }
+
+    /// Write debug statusline to frame buffer.
+    ///
+    /// Uses inverse video style. Only writes if debug mode is enabled.
+    fn write_statusline_to_buffer(&mut self) {
+        if self.debug_config.is_none() {
+            return;
+        }
+
+        let (width, height) = self.last_size;
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let statusline_y = height.saturating_sub(1);
+
+        // Build statusline content
+        let now = chrono::Local::now();
+        let timestamp = now.format("%y-%m-%d %H:%M:%S %Z").to_string();
+        let server = &self.server_address;
+        let mode = self.state.mode_display.as_deref().unwrap_or("?");
+        let modules_count = self.state.modules.len();
+
+        let line =
+            format!(" [{timestamp}] [server: {server}] [mode: {mode}] [modules: {modules_count}]");
+
+        // Truncate or pad to width
+        let display_line: String = if line.chars().count() > width as usize {
+            line.chars().take(width as usize).collect()
+        } else {
+            format!("{:width$}", line, width = width as usize)
+        };
+
+        // Write to frame buffer with inverse style
+        let inverse_style = Style::default().reverse();
+        self.frame_renderer
+            .buffer_mut()
+            .write_str(0, statusline_y, &display_line, &inverse_style);
+    }
+
+    /// Capture frame buffer to file if interval has elapsed.
+    ///
+    /// Captures the complete TUI screen state including:
+    /// - Server content (main editor area)
+    /// - Log panel (if visible)
+    /// - Debug statusline
+    ///
+    /// Only captures if debug mode is enabled and sufficient time has passed.
+    fn maybe_capture_frame(&mut self) {
+        let Some(ref config) = self.debug_config else {
+            return;
+        };
+
+        // Check if capture interval has elapsed
+        if self.last_frame_capture.elapsed() < FRAME_CAPTURE_INTERVAL {
+            return;
+        }
+
+        self.last_frame_capture = Instant::now();
+
+        // Build the complete frame content from current TUI state
+        let frame_content = self.build_frame_content();
+
+        // Generate timestamp for filename
+        let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();
+        let path = config.frame_capture_path(&timestamp);
+
+        // Ensure directory exists
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::warn!("Failed to create frame capture dir: {e}");
+            return;
+        }
+
+        // Write frame content
+        if let Err(e) = std::fs::write(&path, &frame_content) {
+            tracing::warn!("Failed to write frame capture: {e}");
+        } else {
+            // Log to session log
+            self.debug_log(&format!("Frame captured: {}", path.display()));
+        }
+    }
+
+    /// Build frame content from the frame buffer in LLM-friendly format.
+    ///
+    /// Reads directly from `frame_renderer.buffer()` - the same source
+    /// that was flushed to stdout. This ensures capture = render.
+    ///
+    /// Format designed for easy parsing by language models:
+    /// - Clear section markers with `===`
+    /// - Key-value metadata
+    /// - Explicit line numbers in `[N]` format
+    /// - ANSI codes preserved for styled content (e.g., inverse statusline)
+    fn build_frame_content(&self) -> String {
+        let (width, height) = self.last_size;
+        if width == 0 || height == 0 {
+            return String::new();
+        }
+
+        let mut output = String::new();
+
+        // Metadata section (key: value format for easy parsing)
+        let now = chrono::Local::now();
+        let timestamp = now.format("%Y-%m-%d %H:%M:%S %z").to_string();
+        let mode = self.state.mode_display.as_deref().unwrap_or("UNKNOWN");
+        let cursor_line = self.state.cursor_line;
+        let cursor_col = self.state.cursor_column;
+        let modules_count = self.state.modules.len();
+
+        let _ = writeln!(output, "=== FRAME CAPTURE ===");
+        let _ = writeln!(output, "timestamp: {timestamp}");
+        let _ = writeln!(output, "screen_size: {width}x{height}");
+        let _ = writeln!(output, "server: {}", self.server_address);
+        let _ = writeln!(output, "mode: {mode}");
+        let _ = writeln!(output, "cursor: line={cursor_line}, col={cursor_col}");
+        let _ = writeln!(output, "modules: {modules_count}");
+        let _ = writeln!(output, "log_panel_visible: {}", self.log_panel.visible);
+
+        // Read screen content directly from frame buffer
+        let buffer = self.frame_renderer.buffer();
+        let buf_height = buffer.height();
+
+        let _ = writeln!(output, "\n=== SCREEN CONTENT ({width} cols x {buf_height} rows) ===");
+
+        // Read each row from frame buffer
+        for y in 0..buf_height {
+            let mut line = String::new();
+            let mut current_style: Option<Style> = None;
+
+            if let Some(row) = buffer.row(y) {
+                for cell in row {
+                    if cell.is_continuation {
+                        continue;
+                    }
+
+                    // Track style changes for ANSI output
+                    let cell_style = &cell.style;
+                    if current_style.as_ref() != Some(cell_style) {
+                        // Close previous style if any
+                        if current_style.is_some() {
+                            line.push_str("\x1b[0m");
+                        }
+                        // Open new style if not default
+                        let ansi = cell_style.to_ansi_start(ColorMode::TrueColor);
+                        if !ansi.is_empty() {
+                            line.push_str(&ansi);
+                        }
+                        current_style = Some(cell_style.clone());
+                    }
+
+                    line.push(cell.char);
+                }
+
+                // Close any open style
+                if current_style.is_some() {
+                    line.push_str("\x1b[0m");
+                }
+            }
+
+            // Use [N] format for easy regex matching
+            let _ = writeln!(output, "[{}] {}", y + 1, line);
+        }
+
+        let _ = writeln!(output, "=== END FRAME ===");
+
+        output
+    }
+
+    /// Write a message to the debug session log.
+    ///
+    /// Only writes if debug mode is enabled and log file is available.
+    fn debug_log(&mut self, msg: &str) {
+        if let Some(ref mut file) = self.debug_log_file {
+            let timestamp = chrono::Local::now().format("%H:%M:%S%.3f");
+            if let Err(e) = writeln!(file, "[{timestamp}] {msg}") {
+                tracing::warn!("Failed to write debug log: {e}");
+            }
+            // Flush immediately for debugging
+            let _ = file.flush();
+        }
     }
 
     /// Wait for screen content response from message channel.

--- a/runner/src/client/tui/mod.rs
+++ b/runner/src/client/tui/mod.rs
@@ -8,6 +8,57 @@ use clap::Args;
 
 use crate::client::common::ConnectionConfig;
 
+/// Debug configuration for TUI.
+///
+/// Created when `--debug` flag is passed. Controls debug output paths
+/// and enables debug features like statusline and frame capture.
+#[derive(Debug, Clone)]
+pub struct TuiDebugConfig {
+    /// Base directory for debug output.
+    pub log_dir: PathBuf,
+    /// Session name (used in filenames).
+    pub name: String,
+    /// Session start time in `YYYYMMDDHHmmss` format.
+    pub start_time: String,
+}
+
+impl TuiDebugConfig {
+    /// Create a new debug config with the given parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `log_dir` - Base directory for debug output
+    /// * `name` - Session name for filenames
+    #[must_use]
+    pub fn new(log_dir: PathBuf, name: String) -> Self {
+        let start_time = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();
+        Self {
+            log_dir,
+            name,
+            start_time,
+        }
+    }
+
+    /// Get the path for a frame capture file.
+    ///
+    /// Format: `{log_dir}/frame-buffer/{name}-{timestamp}.frame`
+    #[must_use]
+    pub fn frame_capture_path(&self, timestamp: &str) -> PathBuf {
+        self.log_dir
+            .join("frame-buffer")
+            .join(format!("{}-{}.frame", self.name, timestamp))
+    }
+
+    /// Get the path for the session log file.
+    ///
+    /// Format: `{log_dir}/{name}_{start_time}.log`
+    #[must_use]
+    pub fn session_log_path(&self) -> PathBuf {
+        self.log_dir
+            .join(format!("{}_{}.log", self.name, self.start_time))
+    }
+}
+
 pub mod app;
 pub mod input;
 pub mod log_buffer;
@@ -58,6 +109,25 @@ pub struct TuiArgs {
     #[cfg(unix)]
     #[arg(long, value_name = "PATH", hide = true)]
     pub socket: Option<PathBuf>,
+
+    /// Enable debug mode (statusline + frame capture).
+    ///
+    /// Shows a debug statusline at the bottom of the screen and
+    /// captures frame buffers periodically to files.
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Debug log directory.
+    ///
+    /// Default: ~/.local/share/reovim/logs/tui/
+    #[arg(long, value_name = "DIR")]
+    pub debug_dir: Option<PathBuf>,
+
+    /// Debug session name.
+    ///
+    /// Used in log filenames. Default: "default"
+    #[arg(long, value_name = "NAME")]
+    pub debug_name: Option<String>,
 }
 
 impl TuiArgs {
@@ -92,5 +162,32 @@ impl TuiArgs {
 
         // No flags: auto-discover
         ConnectionConfig::auto_discover()
+    }
+
+    /// Create debug configuration if debug mode is enabled.
+    ///
+    /// Returns `None` if `--debug` flag is not set.
+    #[must_use]
+    pub fn into_debug_config(&self) -> Option<TuiDebugConfig> {
+        if !self.debug {
+            return None;
+        }
+
+        // Resolve log directory
+        let log_dir = self.debug_dir.clone().unwrap_or_else(|| {
+            reovim_arch::dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("reovim")
+                .join("logs")
+                .join("tui")
+        });
+
+        // Resolve session name
+        let name = self
+            .debug_name
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+
+        Some(TuiDebugConfig::new(log_dir, name))
     }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -433,9 +433,46 @@ fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
     rt.block_on(async {
         // Handle list command without connection
         if matches!(action, CliAction::List) {
+            use runner::manager::{ManagerClient, is_manager_alive};
+            use runner::server::instance::InstanceRegistry;
+            use std::collections::HashSet;
+
+            let mut seen_addrs = HashSet::new();
+            let mut found_any = false;
+
+            // First, try to query the manager (preferred source)
+            if is_manager_alive().await {
+                if let Ok(mut client) = ManagerClient::connect().await {
+                    if let Ok(instances) = client.list().await {
+                        for instance in instances {
+                            let addr = instance.transport.display();
+                            seen_addrs.insert(addr.clone());
+                            println!("{} ({}) pid: {}", addr, instance.name, instance.pid);
+                            found_any = true;
+                        }
+                    }
+                }
+            }
+
+            // Fall back to file registry if manager unavailable
+            if !found_any {
+                let registry = InstanceRegistry::new();
+                if let Ok(instances) = registry.list() {
+                    for instance in instances {
+                        let addr = instance.transport.display();
+                        seen_addrs.insert(addr.clone());
+                        println!("{} ({}) pid: {}", addr, instance.name, instance.pid);
+                    }
+                }
+            }
+
+            // Also scan ports for any unregistered servers
             for s in discovery::list_servers() {
-                let pid = s.pid.map_or_else(|| "?".into(), |p| p.to_string());
-                println!("{}:{} (pid: {pid})", s.host, s.port);
+                let addr = format!("{}:{}", s.host, s.port);
+                if !seen_addrs.contains(&addr) {
+                    let pid = s.pid.map_or_else(|| "?".into(), |p| p.to_string());
+                    println!("{addr} (unregistered) pid: {pid}");
+                }
             }
             return;
         }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -433,24 +433,27 @@ fn run_cli(config: &ConnectionConfig, action: &CliAction, format: &str) {
     rt.block_on(async {
         // Handle list command without connection
         if matches!(action, CliAction::List) {
-            use runner::manager::{ManagerClient, is_manager_alive};
-            use runner::server::instance::InstanceRegistry;
-            use std::collections::HashSet;
+            use {
+                runner::{
+                    manager::{ManagerClient, is_manager_alive},
+                    server::instance::InstanceRegistry,
+                },
+                std::collections::HashSet,
+            };
 
             let mut seen_addrs = HashSet::new();
             let mut found_any = false;
 
             // First, try to query the manager (preferred source)
-            if is_manager_alive().await {
-                if let Ok(mut client) = ManagerClient::connect().await {
-                    if let Ok(instances) = client.list().await {
-                        for instance in instances {
-                            let addr = instance.transport.display();
-                            seen_addrs.insert(addr.clone());
-                            println!("{} ({}) pid: {}", addr, instance.name, instance.pid);
-                            found_any = true;
-                        }
-                    }
+            if is_manager_alive().await
+                && let Ok(mut client) = ManagerClient::connect().await
+                && let Ok(instances) = client.list().await
+            {
+                for instance in instances {
+                    let addr = instance.transport.display();
+                    seen_addrs.insert(addr.clone());
+                    println!("{} ({}) pid: {}", addr, instance.name, instance.pid);
+                    found_any = true;
                 }
             }
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -110,8 +110,9 @@ fn main() {
         }
 
         Some(Command::Tui(tui_args) | Command::Attach(tui_args)) => {
+            let debug_config = tui_args.into_debug_config();
             let config = tui_args.into_config();
-            run_tui(&config);
+            run_tui(&config, debug_config);
         }
 
         Some(Command::Cli(cli_args)) => {
@@ -224,7 +225,8 @@ fn run_integrated(files: &[PathBuf]) {
 
     rt.block_on(async {
         let config = ConnectionConfig::tcp(addr.ip().to_string(), addr.port());
-        match TuiApp::connect(&config).await {
+        // Integrated mode doesn't support debug flags (no CLI args available)
+        match TuiApp::connect(&config, None).await {
             Ok(mut app) => {
                 if let Err(e) = app.run().await {
                     eprintln!("TUI error: {e}");
@@ -375,14 +377,14 @@ fn run_manager(action: &ManagerAction) {
     });
 }
 
-fn run_tui(config: &ConnectionConfig) {
+fn run_tui(config: &ConnectionConfig, debug_config: Option<runner::client::tui::TuiDebugConfig>) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("Failed to create runtime");
 
     rt.block_on(async {
-        match TuiApp::connect(config).await {
+        match TuiApp::connect(config, debug_config).await {
             Ok(mut app) => {
                 if let Err(e) = app.run().await {
                     eprintln!("TUI error: {e}");

--- a/runner/src/server/mod.rs
+++ b/runner/src/server/mod.rs
@@ -542,6 +542,46 @@ impl Server {
             eprintln!("Listening on {}", listener.local_addr_string());
         }
 
+        // Build instance info for registration
+        let transport_info = Self::transport_info_from_listener(&listener);
+        let instance_info = instance::InstanceInfo::new(
+            self.config.instance_name.clone(),
+            std::process::id(),
+            transport_info,
+        );
+
+        // Register with manager if available (auto-starts if needed)
+        let manager_registered = self.register_with_manager(&instance_info).await;
+
+        // Also register in file-based registry as fallback
+        let registry = instance::InstanceRegistry::new();
+        if let Err(e) = registry.register(&instance_info) {
+            tracing::warn!(
+                instance = %self.config.instance_name,
+                error = %e,
+                "Failed to register instance in file registry"
+            );
+        } else {
+            tracing::debug!(
+                instance = %self.config.instance_name,
+                "Registered instance in file registry"
+            );
+        }
+
+        if manager_registered {
+            tracing::info!(
+                instance = %self.config.instance_name,
+                transport = %instance_info.transport,
+                "Registered instance with manager"
+            );
+        } else {
+            tracing::info!(
+                instance = %self.config.instance_name,
+                transport = %instance_info.transport,
+                "Registered instance (file registry only, manager unavailable)"
+            );
+        }
+
         // Accept loop
         while !self.shutdown.load(Ordering::Relaxed) {
             match listener.accept().await {
@@ -581,6 +621,23 @@ impl Server {
             }
         }
 
+        // Unregister from manager
+        self.unregister_from_manager().await;
+
+        // Unregister from file registry
+        if let Err(e) = registry.unregister(&self.config.instance_name) {
+            tracing::warn!(
+                instance = %self.config.instance_name,
+                error = %e,
+                "Failed to unregister instance from file registry"
+            );
+        } else {
+            tracing::debug!(
+                instance = %self.config.instance_name,
+                "Unregistered instance from file registry"
+            );
+        }
+
         tracing::info!("Server shutting down");
         Ok(())
     }
@@ -613,6 +670,67 @@ impl Server {
 
         tracing::info!("Stdio client disconnected");
         Ok(())
+    }
+
+    /// Create transport info from a listener.
+    ///
+    /// Extracts the address information from the listener to create
+    /// a `TransportInfo` for registry registration.
+    fn transport_info_from_listener(listener: &TransportListener) -> instance::TransportInfo {
+        match listener {
+            TransportListener::Tcp { local_addr, .. } => {
+                instance::TransportInfo::tcp(local_addr.ip().to_string(), local_addr.port())
+            }
+            #[cfg(unix)]
+            TransportListener::Unix { path, .. } => {
+                instance::TransportInfo::local(path.display().to_string())
+            }
+        }
+    }
+
+    /// Register this server instance with the manager daemon.
+    ///
+    /// Auto-starts the manager if not running. Returns true if registration
+    /// succeeded, false if manager is unavailable.
+    async fn register_with_manager(&self, info: &instance::InstanceInfo) -> bool {
+        use crate::manager::{ManagerClient, ensure_manager_running};
+
+        // Try to ensure manager is running (auto-starts if needed)
+        if let Err(e) = ensure_manager_running().await {
+            tracing::debug!(error = %e, "Manager not available, using file registry only");
+            return false;
+        }
+
+        // Connect and register
+        match ManagerClient::connect().await {
+            Ok(mut client) => match client.register(info.clone()).await {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to register with manager");
+                    false
+                }
+            },
+            Err(e) => {
+                tracing::debug!(error = %e, "Failed to connect to manager");
+                false
+            }
+        }
+    }
+
+    /// Unregister this server instance from the manager daemon.
+    ///
+    /// Called on shutdown. Silently ignores failures.
+    async fn unregister_from_manager(&self) {
+        use crate::manager::{ManagerClient, is_manager_alive};
+
+        // Only try if manager is running
+        if !is_manager_alive().await {
+            return;
+        }
+
+        if let Ok(mut client) = ManagerClient::connect().await {
+            let _ = client.unregister(&self.config.instance_name).await;
+        }
     }
 
     /// Request server shutdown.

--- a/runner/src/server/session/notify.rs
+++ b/runner/src/server/session/notify.rs
@@ -2,9 +2,23 @@
 //!
 //! Compares state snapshots and emits appropriate notifications
 //! to connected clients for any detected changes.
+//!
+//! # Notifications Emitted
+//!
+//! This module emits four notification types:
+//!
+//! | Notification | Trigger | Scope |
+//! |--------------|---------|-------|
+//! | `notify/mode_changed` | Mode changes | Session-wide |
+//! | `notify/cursor_moved` | Cursor position changes | Buffer-scoped |
+//! | `notify/buffer_modified` | Buffer modified flag changes | Buffer-scoped |
+//! | `notify/render_complete` | Any visual state change | Buffer-scoped (or session-wide) |
+//!
+//! The `render_complete` notification is always emitted last, after all
+//! specific change notifications, to signal clients that they can refresh.
 
 use reovim_protocol::v1::{
-    BufferModifiedPayload, CursorMovedPayload, ModeChangedPayload, ModeInfo,
+    BufferModifiedPayload, CursorMovedPayload, ModeChangedPayload, ModeInfo, RenderCompletePayload,
 };
 
 use {
@@ -19,15 +33,23 @@ use {
 /// - `notify/mode_changed` when mode changes (session-wide broadcast)
 /// - `notify/cursor_moved` when cursor position changes (buffer-scoped broadcast)
 /// - `notify/buffer_modified` when buffer modified flag changes (buffer-scoped broadcast)
+/// - `notify/render_complete` when any visual state changes (buffer-scoped or session-wide)
 ///
 /// # Buffer-Scoped Notifications
 ///
-/// Cursor and buffer-modified notifications are sent only to clients viewing
-/// the affected buffer. This is more efficient than session-wide broadcasts
-/// and prevents irrelevant notifications (e.g., a client viewing buffer A
-/// doesn't need cursor updates for buffer B).
+/// Cursor, buffer-modified, and render-complete notifications are sent only to
+/// clients viewing the affected buffer when an active buffer exists. This is more
+/// efficient than session-wide broadcasts and prevents irrelevant notifications
+/// (e.g., a client viewing buffer A doesn't need cursor updates for buffer B).
 ///
 /// Mode changes remain session-wide since mode is shared across all clients.
+/// When no active buffer exists, render-complete falls back to session-wide broadcast.
+///
+/// # Render Complete
+///
+/// The `render_complete` notification is emitted after all specific change
+/// notifications (mode, cursor, buffer) when any visual state has changed.
+/// Clients use this as a signal to refresh their display.
 ///
 /// # Arguments
 ///
@@ -38,7 +60,10 @@ use {
 /// # Panics
 ///
 /// This function will not panic as notification serialization is infallible.
+#[allow(clippy::useless_let_if_seq)] // We track changes across multiple independent conditions
 pub async fn emit_state_changes(session: &Session, before: &StateSnapshot, after: &StateSnapshot) {
+    let mut any_changes = false;
+
     // Mode changed - broadcast to ALL clients (mode is session-wide)
     if before.mode != after.mode {
         let mode_info = session
@@ -57,6 +82,7 @@ pub async fn emit_state_changes(session: &Session, before: &StateSnapshot, after
         let json = serde_json::to_string(&payload.into_notification())
             .expect("notification serialization cannot fail");
         NotificationBroadcaster::broadcast_to_session(session, &json).await;
+        any_changes = true;
     }
 
     // Cursor moved - broadcast only to clients viewing this buffer
@@ -73,6 +99,7 @@ pub async fn emit_state_changes(session: &Session, before: &StateSnapshot, after
         let json = serde_json::to_string(&payload.into_notification())
             .expect("notification serialization cannot fail");
         NotificationBroadcaster::broadcast_to_buffer(session, buffer_id, &json).await;
+        any_changes = true;
     }
 
     // Buffer modified flag changed - broadcast only to clients viewing this buffer
@@ -86,6 +113,31 @@ pub async fn emit_state_changes(session: &Session, before: &StateSnapshot, after
         let json = serde_json::to_string(&payload.into_notification())
             .expect("notification serialization cannot fail");
         NotificationBroadcaster::broadcast_to_buffer(session, buffer_id, &json).await;
+        any_changes = true;
+    }
+
+    // Emit render_complete if any visual state changed
+    if any_changes {
+        emit_render_complete(session, after.active_buffer).await;
+    }
+}
+
+/// Emit `render_complete` notification to signal clients to refresh display.
+///
+/// Uses buffer-scoped broadcast when an active buffer exists, otherwise
+/// falls back to session-wide broadcast.
+async fn emit_render_complete(
+    session: &Session,
+    active_buffer: Option<reovim_kernel::api::v1::BufferId>,
+) {
+    let payload = RenderCompletePayload::default();
+    let json = serde_json::to_string(&payload.into_notification())
+        .expect("RenderCompletePayload serialization cannot fail");
+
+    if let Some(buffer_id) = active_buffer {
+        NotificationBroadcaster::broadcast_to_buffer(session, buffer_id, &json).await;
+    } else {
+        NotificationBroadcaster::broadcast_to_session(session, &json).await;
     }
 }
 
@@ -175,6 +227,105 @@ mod tests {
         };
 
         // Should not panic with no clients
+        // Also emits render_complete (buffer-scoped)
+        emit_state_changes(&session, &before, &after).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_cursor_move() {
+        use reovim_kernel::api::v1::{BufferId, Position};
+
+        let session = test_session();
+        let buffer_id = BufferId::new();
+
+        let before = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 0, column: 0 }),
+            modified: None,
+        };
+        let after = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 1, column: 5 }),
+            modified: None,
+        };
+
+        // Should not panic with no clients
+        // Emits cursor_moved + render_complete (buffer-scoped)
+        emit_state_changes(&session, &before, &after).await;
+    }
+
+    #[tokio::test]
+    async fn test_emit_combined_changes() {
+        use reovim_kernel::api::v1::{BufferId, Position};
+
+        let session = test_session();
+        let buffer_id = BufferId::new();
+
+        let before = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 0, column: 0 }),
+            modified: Some(false),
+        };
+        let after = StateSnapshot {
+            mode: insert_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 1, column: 5 }),
+            modified: Some(true),
+        };
+
+        // Should not panic with no clients
+        // Emits mode_changed + cursor_moved + buffer_modified + render_complete
+        // render_complete is emitted exactly once despite multiple changes
+        emit_state_changes(&session, &before, &after).await;
+    }
+
+    #[tokio::test]
+    async fn test_render_complete_session_wide_when_no_buffer() {
+        let session = test_session();
+
+        let before = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: None,
+            cursor: None,
+            modified: None,
+        };
+        let after = StateSnapshot {
+            mode: insert_mode(),
+            active_buffer: None,
+            cursor: None,
+            modified: None,
+        };
+
+        // Should not panic with no clients
+        // render_complete is session-wide when no active buffer
+        emit_state_changes(&session, &before, &after).await;
+    }
+
+    #[tokio::test]
+    async fn test_render_complete_buffer_scoped_when_buffer_exists() {
+        use reovim_kernel::api::v1::{BufferId, Position};
+
+        let session = test_session();
+        let buffer_id = BufferId::new();
+
+        let before = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 0, column: 0 }),
+            modified: None,
+        };
+        let after = StateSnapshot {
+            mode: normal_mode(),
+            active_buffer: Some(buffer_id),
+            cursor: Some(Position { line: 0, column: 1 }),
+            modified: None,
+        };
+
+        // Should not panic with no clients
+        // render_complete is buffer-scoped when active buffer exists
         emit_state_changes(&session, &before, &after).await;
     }
 }

--- a/runner/src/server/transport/tcp.rs
+++ b/runner/src/server/transport/tcp.rs
@@ -7,7 +7,10 @@ use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
 
 /// Default TCP port for reovim server.
-pub const DEFAULT_PORT: u16 = 12521;
+///
+/// Port 12521 is reserved for the manager daemon.
+/// Server instances start at 12522.
+pub const DEFAULT_PORT: u16 = 12522;
 
 /// Number of ports to try when the default is busy.
 pub const PORT_FALLBACK_COUNT: u16 = 10;

--- a/runner/tests/client_integration.rs
+++ b/runner/tests/client_integration.rs
@@ -369,7 +369,7 @@ mod common {
         match config {
             ConnectionConfig::Tcp { host, port } => {
                 assert_eq!(host, "127.0.0.1");
-                assert_eq!(port, 12521);
+                assert_eq!(port, 12522);
             }
             #[cfg(unix)]
             _ => panic!("Expected TCP config"),


### PR DESCRIPTION
## Summary

This PR introduces TUI client improvements including server discovery, render synchronization, and debug mode for diagnostics.

### Commits

1. **fix(runner): complete manager integration for server discovery (#356)**
   - Port separation: manager owns 12521, servers start at 12522
   - Server auto-starts manager and registers on startup
   - CLI auto_discover() checks registry before port scanning
   - REPL: add `list` and `connect` commands for server switching

2. **fix(runner): server emits render/complete notification (#320)**
   - Emitted after any visual state change (mode, cursor, buffer modified)
   - Buffer-scoped when active buffer exists, session-wide otherwise
   - TUI clients use this to know when to refresh display

3. **feat(tui): add debug statusline and frame buffer capture (#358)**
   - `--debug` flag enables debug statusline with timestamp, server, mode, modules
   - Frame buffer capture every 5 seconds to `~/.local/share/reovim/logs/tui/`
   - LLM-friendly capture format with metadata header and ANSI-styled screen content
   - Wired TUI to use `FrameRenderer` double-buffer for render/capture parity

## Test plan

- [x] `./scripts/check.sh` passes (format, build, clippy, tests)
- [x] Manual testing of TUI debug mode with frame captures
- [x] Verified frame capture shows accurate statusline positioning
- [x] Server discovery with multiple instances
- [x] Render/complete notification triggers TUI refresh

## Known issues

- Ghost statusline on resize due to double-buffer swap timing (tracked in #362)

Closes #356, Closes #320, Closes #358