### PR TITLE
TUI enhancements (#362, #364, #365, #368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Fixed
 
+- TUI not receiving buffer-scoped notifications (#365)
+  - TUI now calls `editor/set_active_buffer` on connect to register for notifications
+  - Fixes input appearing unresponsive (cursor_moved, buffer_modified, render_complete were missed)
+
 - Complete manager integration for server discovery (#356)
   - Port separation: manager owns 12521, servers start at 12522
   - Server auto-starts manager and registers on startup
@@ -23,6 +27,11 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - Prevents ghost from ping-ponging between double buffers after resize
 
 ### Added
+
+- Unified debug flags in integrated mode (#364)
+  - `reovim --debug` now works (previously only `reovim tui --debug`)
+  - Added `--debug-dir` and `--debug-name` flags to main CLI
+  - More verbose help descriptions
 
 - TUI Debug Mode with statusline and frame buffer capture (#358)
   - `--debug` flag enables debug statusline with timestamp, server, mode, modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - Buffer-scoped when active buffer exists, session-wide otherwise
   - TUI clients use this to know when to refresh display
 
+- Ghost statusline on resize in TUI debug mode (#362)
+  - Clear both buffers in `FrameRenderer::resize()` to remove stale content
+  - Tick handler now triggers full refresh instead of independent flush/swap
+  - Prevents ghost from ping-ponging between double buffers after resize
+
 ### Added
 
 - TUI Debug Mode with statusline and frame buffer capture (#358)
@@ -25,7 +30,6 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - LLM-friendly capture format with metadata header and ANSI-styled screen content
   - Wired TUI to use `FrameRenderer` double-buffer for accurate capture
   - Session logging to `~/.local/share/reovim/logs/tui/{name}_{time}.log`
-  - Known issue: ghost statusline on resize due to double-buffer swap (deferred)
 
 - Register selection prefix (`"a`) - specify register for yank/delete/paste (#333)
   - `"ayy` yanks line into register 'a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- TUI local shortcuts, error display, and embedded CLI panel (#368)
+  - Error display: RPC errors shown in statusline (red, auto-clear after 5s)
+  - Prefix mode: `<C-b>` enters prefix mode (2s timeout, `^B-` indicator in debug mode)
+    - `<C-b>d` detaches from server without killing it
+    - `<C-b>;` toggles embedded CLI panel
+    - `<C-b><C-b>` sends literal Ctrl+B to server
+  - CLI panel: embedded command panel for quick commands
+    - Fire-and-forget commands: `keys`, `resize`, `open`, `kill`, `help`
+    - Command history navigation with Up/Down arrows
+    - Line editing: Left/Right, Home/End, Backspace, Delete
+
 - Unified debug flags in integrated mode (#364)
   - `reovim --debug` now works (previously only `reovim tui --debug`)
   - Added `--debug-dir` and `--debug-name` flags to main CLI

--- a/lib/drivers/display/src/frame/renderer.rs
+++ b/lib/drivers/display/src/frame/renderer.rs
@@ -43,9 +43,15 @@ impl FrameRenderer {
     }
 
     /// Resize both buffers to new dimensions.
+    ///
+    /// Clears both buffers after resize to prevent ghost artifacts from
+    /// stale content at old row positions (e.g., statuslines from before resize).
     pub fn resize(&mut self, width: u16, height: u16) {
         self.front.resize(width, height);
         self.back.resize(width, height);
+        // Clear both buffers to prevent ghost artifacts from stale content
+        self.front.clear();
+        self.back.clear();
         self.initialized = false; // Force full redraw after resize
     }
 

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -211,6 +211,23 @@ impl TuiApp {
             }
         };
 
+        // Register for buffer notifications by setting the active buffer.
+        // This is required to receive buffer-scoped notifications like cursor_moved,
+        // buffer_modified, and render_complete which trigger TUI updates.
+        if let Ok(buffer_list) = client.call("buffer/list", json!({})).await
+            && let Some(buffers) = buffer_list.get("buffers").and_then(|v| v.as_array())
+            && let Some(first_buffer) = buffers.first()
+            && let Some(buffer_id) = first_buffer.get("id").and_then(|v| v.as_u64())
+        {
+            match client
+                .call("editor/set_active_buffer", json!({ "buffer_id": buffer_id }))
+                .await
+            {
+                Ok(_) => tracing::debug!("Set active buffer to {buffer_id}"),
+                Err(e) => tracing::debug!("Failed to set active buffer: {e}"),
+            }
+        }
+
         // Subscribe to server logs (info level and above)
         let subscription_id = match client.call("debug/log_subscribe", json!({})).await {
             Ok(result) => result

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -34,15 +34,21 @@ use crate::client::common::{
 use reovim_driver_display::{ColorMode, FrameRenderer, Style};
 
 use super::{
+    cli_executor,
+    cli_panel::CliPanelState,
+    cli_render::render_panel as render_cli_panel,
     input::InputHandler,
     log_buffer::{DEFAULT_TUI_LOG_CAPACITY, TuiLogBuffer},
     log_panel::LogPanelState,
-    log_render::render_panel,
+    log_render::render_panel as render_log_panel,
     render::Renderer,
 };
 
 /// Channel buffer size for server messages.
 const MESSAGE_CHANNEL_SIZE: usize = 256;
+
+/// Timeout for prefix mode (2 seconds).
+const PREFIX_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// Extract HH:MM:SS from an ISO 8601 timestamp.
 ///
@@ -110,6 +116,12 @@ struct TuiState {
     needs_redraw: bool,
     /// Loaded modules list.
     modules: Vec<String>,
+    /// Last key sent to server (for debug).
+    last_key: Option<String>,
+    /// Last RPC error message (for statusline display).
+    last_error: Option<String>,
+    /// When the error occurred (for auto-clear after 5 seconds).
+    error_timestamp: Option<Instant>,
 }
 
 /// TUI application.
@@ -134,6 +146,8 @@ pub struct TuiApp {
     log_buffer: TuiLogBuffer,
     /// Log panel state.
     log_panel: LogPanelState,
+    /// CLI panel state.
+    cli_panel: CliPanelState,
     /// Server log subscription ID.
     subscription_id: Option<u64>,
     /// Connected server address for statusline.
@@ -144,6 +158,10 @@ pub struct TuiApp {
     debug_log_file: Option<std::fs::File>,
     /// Last frame capture time.
     last_frame_capture: Instant,
+    /// Whether we're in prefix mode waiting for next key (e.g., after `<C-b>`).
+    prefix_mode: bool,
+    /// When prefix mode was entered (for timeout).
+    prefix_entered: Option<Instant>,
 }
 
 impl TuiApp {
@@ -159,6 +177,7 @@ impl TuiApp {
     /// # Errors
     ///
     /// Returns error if connection or initial state fetch fails.
+    #[allow(clippy::too_many_lines)]
     pub async fn connect(
         config: &ConnectionConfig,
         debug_config: Option<super::TuiDebugConfig>,
@@ -217,7 +236,7 @@ impl TuiApp {
         if let Ok(buffer_list) = client.call("buffer/list", json!({})).await
             && let Some(buffers) = buffer_list.get("buffers").and_then(|v| v.as_array())
             && let Some(first_buffer) = buffers.first()
-            && let Some(buffer_id) = first_buffer.get("id").and_then(|v| v.as_u64())
+            && let Some(buffer_id) = first_buffer.get("id").and_then(serde_json::Value::as_u64)
         {
             match client
                 .call("editor/set_active_buffer", json!({ "buffer_id": buffer_id }))
@@ -287,14 +306,20 @@ impl TuiApp {
                 buffer_modified: false,
                 needs_redraw: true,
                 modules,
+                last_key: None,
+                last_error: None,
+                error_timestamp: None,
             },
             log_buffer: TuiLogBuffer::new(DEFAULT_TUI_LOG_CAPACITY),
             log_panel: LogPanelState::new(),
+            cli_panel: CliPanelState::new(),
             subscription_id,
             server_address,
             debug_config,
             debug_log_file,
             last_frame_capture: Instant::now(),
+            prefix_mode: false,
+            prefix_entered: None,
         })
     }
 
@@ -407,6 +432,15 @@ impl TuiApp {
                 }
             }
 
+            // Auto-clear error after 5 seconds
+            if let Some(ts) = self.state.error_timestamp
+                && ts.elapsed() > Duration::from_secs(5)
+            {
+                self.state.last_error = None;
+                self.state.error_timestamp = None;
+                self.state.needs_redraw = true;
+            }
+
             // Render if needed
             if self.state.needs_redraw {
                 self.render().await?;
@@ -418,7 +452,72 @@ impl TuiApp {
     }
 
     /// Handle a key event.
+    #[allow(clippy::too_many_lines)]
     async fn handle_key_event(&mut self, key: crossterm::event::KeyEvent) -> Result<(), TuiError> {
+        // Check prefix timeout first
+        if self.prefix_mode
+            && let Some(entered) = self.prefix_entered
+            && entered.elapsed() > PREFIX_TIMEOUT
+        {
+            self.prefix_mode = false;
+            self.prefix_entered = None;
+            self.state.needs_redraw = true;
+            // Timeout - continue to normal handling
+        }
+
+        // Handle prefix mode keys
+        if self.prefix_mode {
+            self.prefix_mode = false;
+            self.prefix_entered = None;
+            self.state.needs_redraw = true;
+
+            return match key.code {
+                KeyCode::Char('d') => {
+                    // Detach: quit TUI without killing server
+                    tracing::info!("Detaching from server (prefix mode)");
+                    self.debug_log("Detach via <C-b>d");
+                    self.running = false;
+                    Ok(())
+                }
+                // <C-b>; toggles CLI panel
+                KeyCode::Char(';') => {
+                    self.cli_panel.toggle();
+                    self.state.needs_redraw = true;
+                    Ok(())
+                }
+                // <C-b><C-b> sends literal <C-b>
+                KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.send_keys("<C-b>").await?;
+                    Ok(())
+                }
+                KeyCode::Char('\x02') => {
+                    self.send_keys("<C-b>").await?;
+                    Ok(())
+                }
+                KeyCode::Esc => {
+                    // Cancel prefix mode
+                    Ok(())
+                }
+                _ => {
+                    // Unknown prefix command - ignore
+                    tracing::debug!("Unknown prefix command: {:?}", key.code);
+                    Ok(())
+                }
+            };
+        }
+
+        // Check for prefix mode entry (Ctrl+B)
+        // Handle both 'b' with CONTROL modifier and raw control character '\x02'
+        let is_ctrl_b = matches!(key.code, KeyCode::Char('b'))
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+            || matches!(key.code, KeyCode::Char('\x02'));
+        if is_ctrl_b {
+            self.prefix_mode = true;
+            self.prefix_entered = Some(Instant::now());
+            self.state.needs_redraw = true;
+            return Ok(());
+        }
+
         // Check for quit (Ctrl+C or Ctrl+Q)
         if matches!(key.code, KeyCode::Char('c' | 'q'))
             && key.modifiers.contains(KeyModifiers::CONTROL)
@@ -432,6 +531,78 @@ impl TuiApp {
             self.log_panel.toggle();
             self.state.needs_redraw = true;
             return Ok(());
+        }
+
+        // Handle CLI panel keys when visible
+        if self.cli_panel.visible {
+            match key.code {
+                KeyCode::Esc => {
+                    self.cli_panel.hide();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Enter => {
+                    if let Some(cmd) = self.cli_panel.submit() {
+                        // Check for clear command specially
+                        if cmd.trim() == "clear" {
+                            self.cli_panel.history.clear();
+                            self.state.needs_redraw = true;
+                            return Ok(());
+                        }
+                        let result =
+                            cli_executor::execute_command(&mut self.rpc_writer, &cmd).await;
+                        self.cli_panel.add_result(cmd, result);
+                        self.state.needs_redraw = true;
+                    }
+                    return Ok(());
+                }
+                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.cli_panel.insert_char(c);
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Backspace => {
+                    self.cli_panel.backspace();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Delete => {
+                    self.cli_panel.delete();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Left => {
+                    self.cli_panel.move_cursor_left();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Right => {
+                    self.cli_panel.move_cursor_right();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Up => {
+                    self.cli_panel.history_prev();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Down => {
+                    self.cli_panel.history_next();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::Home => {
+                    self.cli_panel.move_cursor_home();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                KeyCode::End => {
+                    self.cli_panel.move_cursor_end();
+                    self.state.needs_redraw = true;
+                    return Ok(());
+                }
+                _ => {} // Other keys pass through
+            }
         }
 
         // Handle log panel keys when visible
@@ -479,8 +650,8 @@ impl TuiApp {
 
         // Convert key to notation and send to server
         if let Some(keys) = InputHandler::key_to_notation(&key) {
+            self.state.last_key = Some(keys.clone());
             self.send_keys(&keys).await?;
-            // Note: We no longer refresh here - notifications will trigger updates
         }
 
         Ok(())
@@ -587,11 +758,14 @@ impl TuiApp {
 
     /// Handle a server response.
     ///
-    /// In notification-driven mode, responses are mostly informational.
-    #[allow(clippy::unused_self)] // Method signature for future expansion
-    fn handle_response(&self, response: RpcResponse) {
+    /// Captures RPC errors for statusline display (auto-clears after 5 seconds).
+    fn handle_response(&mut self, response: RpcResponse) {
         if let Some(error) = response.error {
-            tracing::warn!("RPC error for id={}: {}", response.id, error.message);
+            let msg = format!("RPC {}: {}", response.id, error.message);
+            tracing::warn!("{}", msg);
+            self.state.last_error = Some(msg);
+            self.state.error_timestamp = Some(Instant::now());
+            self.state.needs_redraw = true;
         }
         // State updates come via notifications, not responses
     }
@@ -658,18 +832,44 @@ impl TuiApp {
             }
         }
 
-        // Write log panel to frame buffer (if visible)
-        if self.log_panel.visible {
-            let panel_height = self.log_panel.height.min(height / 2);
-            let entries = self.log_buffer.entries();
-            let lines = render_panel(&entries, &self.log_panel, width, panel_height);
+        // Calculate panel heights and positions
+        let statusline_height: u16 = u16::from(self.debug_config.is_some());
+        let available_height = height.saturating_sub(statusline_height);
 
-            let panel_start = height.saturating_sub(panel_height);
+        // Write CLI panel to frame buffer (if visible)
+        let cli_panel_height = if self.cli_panel.visible {
+            let panel_height = self.cli_panel.height.min(available_height / 2);
+            let lines = render_cli_panel(&self.cli_panel, width, panel_height);
+
+            let panel_start = available_height.saturating_sub(panel_height);
             let default_style = Style::default();
             for (i, line) in lines.iter().enumerate() {
                 #[allow(clippy::cast_possible_truncation)]
                 let y = panel_start + i as u16;
-                if y < height {
+                if y < available_height {
+                    self.frame_renderer
+                        .buffer_mut()
+                        .write_str(0, y, line, &default_style);
+                }
+            }
+            panel_height
+        } else {
+            0
+        };
+
+        // Write log panel to frame buffer (if visible)
+        if self.log_panel.visible {
+            let max_log_height = available_height.saturating_sub(cli_panel_height);
+            let panel_height = self.log_panel.height.min(max_log_height / 2);
+            let entries = self.log_buffer.entries();
+            let lines = render_log_panel(&entries, &self.log_panel, width, panel_height);
+
+            let panel_start = available_height.saturating_sub(cli_panel_height + panel_height);
+            let default_style = Style::default();
+            for (i, line) in lines.iter().enumerate() {
+                #[allow(clippy::cast_possible_truncation)]
+                let y = panel_start + i as u16;
+                if y < available_height.saturating_sub(cli_panel_height) {
                     self.frame_renderer
                         .buffer_mut()
                         .write_str(0, y, line, &default_style);
@@ -699,7 +899,8 @@ impl TuiApp {
 
     /// Write debug statusline to frame buffer.
     ///
-    /// Uses inverse video style. Only writes if debug mode is enabled.
+    /// Shows error in red if present, otherwise normal status with inverse video.
+    /// Only writes if debug mode is enabled.
     fn write_statusline_to_buffer(&mut self) {
         if self.debug_config.is_none() {
             return;
@@ -712,14 +913,32 @@ impl TuiApp {
 
         let statusline_y = height.saturating_sub(1);
 
-        // Build statusline content
-        let now = chrono::Local::now();
-        let timestamp = now.format("%y-%m-%d %H:%M:%S %Z").to_string();
-        let server = &self.server_address;
-        let mode = self.state.mode_display.as_deref().unwrap_or("?");
-        let modules_count = self.state.modules.len();
+        // If error exists, show in red; otherwise show normal status
+        let (line, style) = if let Some(ref err) = self.state.last_error {
+            // Error statusline: red background
+            let err_line = format!("ERR: {err}");
+            let style = Style::default()
+                .bg(reovim_driver_display::Color::Red)
+                .fg(reovim_driver_display::Color::White);
+            (err_line, style)
+        } else {
+            // Normal statusline: inverse video
+            let now = chrono::Local::now();
+            let timestamp = now.format("%y-%m-%d %H:%M:%S %Z").to_string();
+            let server = &self.server_address;
+            let mode = self.state.mode_display.as_deref().unwrap_or("?");
+            let modules_count = self.state.modules.len();
+            let last_key = self.state.last_key.as_deref().unwrap_or("-");
+            let cursor = format!("{}:{}", self.state.cursor_line, self.state.cursor_column);
+            let prefix_indicator = if self.prefix_mode { "^B-" } else { "" };
 
-        let line = format!("{timestamp}|{server}|{mode}| m: {modules_count}");
+            let line = format!(
+                "{prefix_indicator}{timestamp}|{server}|{mode}|k:{last_key}|c:{cursor}|m:{modules_count}"
+            );
+            let style = Style::default().reverse();
+            (line, style)
+        };
+
         // Truncate or pad to width
         let display_line: String = if line.chars().count() > width as usize {
             line.chars().take(width as usize).collect()
@@ -727,11 +946,10 @@ impl TuiApp {
             format!("{:width$}", line, width = width as usize)
         };
 
-        // Write to frame buffer with inverse style
-        let inverse_style = Style::default().reverse();
+        // Write to frame buffer
         self.frame_renderer
             .buffer_mut()
-            .write_str(0, statusline_y, &display_line, &inverse_style);
+            .write_str(0, statusline_y, &display_line, &style);
     }
 
     /// Capture frame buffer to file if interval has elapsed.

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -384,11 +384,9 @@ impl TuiApp {
                 }
 
                 // Periodic statusline update (debug mode only)
-                // Update frame buffer and flush to keep capture in sync
+                // Trigger a full refresh to update statusline and capture
                 _ = statusline_tick.tick(), if self.debug_config.is_some() => {
-                    self.write_statusline_to_buffer();
-                    self.maybe_capture_frame();
-                    self.frame_renderer.flush(&mut io::stdout())?;
+                    self.state.needs_redraw = true;
                 }
             }
 
@@ -704,9 +702,7 @@ impl TuiApp {
         let mode = self.state.mode_display.as_deref().unwrap_or("?");
         let modules_count = self.state.modules.len();
 
-        let line =
-            format!(" [{timestamp}] [server: {server}] [mode: {mode}] [modules: {modules_count}]");
-
+        let line = format!("{timestamp}|{server}|{mode}| m: {modules_count}");
         // Truncate or pad to width
         let display_line: String = if line.chars().count() > width as usize {
             line.chars().take(width as usize).collect()

--- a/runner/src/client/tui/cli_executor.rs
+++ b/runner/src/client/tui/cli_executor.rs
@@ -1,0 +1,139 @@
+//! CLI command execution for embedded REPL.
+//!
+//! Adapts CLI commands for use with `RpcWriter` (async, fire-and-forget).
+//! Query commands that need responses are not supported - users should
+//! use `reovim cli -i` for full interactive mode.
+
+use serde_json::json;
+
+use crate::client::common::RpcWriter;
+
+use super::cli_panel::CliResult;
+
+/// Execute a CLI command and return formatted result.
+///
+/// Commands are parsed from whitespace-separated input.
+/// Uses fire-and-forget RPC for commands that don't need responses.
+///
+/// # Arguments
+///
+/// * `writer` - RPC writer for sending requests
+/// * `input` - Raw command input string
+///
+/// # Returns
+///
+/// Result indicating success or error with message.
+pub async fn execute_command(writer: &mut RpcWriter, input: &str) -> CliResult {
+    let args: Vec<&str> = input.split_whitespace().collect();
+    let cmd = args.first().copied().unwrap_or("");
+
+    match cmd {
+        "help" | "?" => CliResult::Ok(HELP_TEXT.to_string()),
+
+        // Commands that modify state (fire-and-forget OK)
+        "keys" | "k" => {
+            if args.len() < 2 {
+                return CliResult::Err("Usage: keys <sequence>".to_string());
+            }
+            let keys = args[1..].join(" ");
+            match writer
+                .send_request("input/keys", json!({ "keys": keys }))
+                .await
+            {
+                Ok(id) => CliResult::Ok(format!("Sent keys (id={id})")),
+                Err(e) => CliResult::Err(format!("Error: {e}")),
+            }
+        }
+
+        "resize" => {
+            if args.len() < 3 {
+                return CliResult::Err("Usage: resize <width> <height>".to_string());
+            }
+            let width: u16 = match args[1].parse() {
+                Ok(w) => w,
+                Err(_) => return CliResult::Err("Invalid width".to_string()),
+            };
+            let height: u16 = match args[2].parse() {
+                Ok(h) => h,
+                Err(_) => return CliResult::Err("Invalid height".to_string()),
+            };
+            match writer
+                .send_request("editor/resize", json!({ "width": width, "height": height }))
+                .await
+            {
+                Ok(id) => CliResult::Ok(format!("Resized to {width}x{height} (id={id})")),
+                Err(e) => CliResult::Err(format!("Error: {e}")),
+            }
+        }
+
+        "open" | "e" => {
+            if args.len() < 2 {
+                return CliResult::Err("Usage: open <path>".to_string());
+            }
+            let path = args[1..].join(" ");
+            match writer
+                .send_request("buffer/open_file", json!({ "path": path }))
+                .await
+            {
+                Ok(id) => CliResult::Ok(format!("Opening '{path}' (id={id})")),
+                Err(e) => CliResult::Err(format!("Error: {e}")),
+            }
+        }
+
+        "kill" => match writer.send_request("server/kill", json!({})).await {
+            Ok(_) => CliResult::Ok("Kill signal sent".to_string()),
+            Err(e) => CliResult::Err(format!("Error: {e}")),
+        },
+
+        // Commands that need responses - not supported in embedded panel
+        "mode" | "cursor" | "screen" | "buffers" | "ls" | "buffer" | "modules" | "version"
+        | "uptime" | "registers" | "marks" | "content" | "selection" => CliResult::Err(format!(
+            "'{cmd}' requires response - use 'reovim cli -i' for interactive mode"
+        )),
+
+        // Panel control commands
+        "quit" | "exit" | "q" => CliResult::Ok("Use Esc or Ctrl+; to close panel".to_string()),
+
+        "clear" => CliResult::Ok("__CLEAR__".to_string()),
+
+        "" => CliResult::Ok(String::new()),
+
+        _ => CliResult::Err(format!("Unknown command: '{cmd}'. Type 'help' for commands.")),
+    }
+}
+
+const HELP_TEXT: &str = r"CLI Panel Commands:
+
+Write Commands (fire-and-forget):
+  keys <seq>       Inject key sequence (e.g., keys iHello<Esc>)
+  k <seq>          Alias for keys
+  resize <w> <h>   Resize editor
+  open <path>      Open file (alias: e)
+  kill             Kill server
+
+Panel Control:
+  help, ?          Show this help
+  clear            Clear history
+  quit, q          Close panel (or use Esc/<C-b>;)
+
+Query commands (mode, cursor, buffers, etc.) require 'reovim cli -i'
+
+Panel Keys:
+  Enter            Execute command
+  Up/Down          History navigation
+  Esc              Close panel
+  <C-b>;           Toggle panel
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_help_command() {
+        // Can't test async easily, just verify help text exists
+        assert!(!HELP_TEXT.is_empty());
+        assert!(HELP_TEXT.contains("keys"));
+        assert!(HELP_TEXT.contains("help"));
+    }
+}

--- a/runner/src/client/tui/cli_panel.rs
+++ b/runner/src/client/tui/cli_panel.rs
@@ -1,0 +1,347 @@
+//! CLI panel state for embedded REPL.
+//!
+//! Provides a tmux-like command panel for executing CLI commands
+//! without leaving the TUI.
+
+use std::collections::VecDeque;
+
+/// Maximum command history size.
+const MAX_HISTORY: usize = 50;
+
+/// Maximum input length.
+const MAX_INPUT_LENGTH: usize = 256;
+
+/// CLI panel state.
+#[derive(Debug)]
+pub struct CliPanelState {
+    /// Whether panel is visible.
+    pub visible: bool,
+    /// Current input line.
+    pub input: String,
+    /// Cursor position in input.
+    pub cursor_pos: usize,
+    /// Command history.
+    pub history: VecDeque<CliHistoryEntry>,
+    /// History navigation index (None = editing new command).
+    history_index: Option<usize>,
+    /// Saved input when navigating history.
+    saved_input: String,
+    /// Panel height in rows.
+    pub height: u16,
+    /// Scroll offset in history view.
+    pub scroll_offset: usize,
+}
+
+/// Entry in command history.
+#[derive(Debug, Clone)]
+pub struct CliHistoryEntry {
+    /// The command that was executed.
+    pub command: String,
+    /// Result (success or error).
+    pub result: CliResult,
+}
+
+/// Result of a CLI command.
+#[derive(Debug, Clone)]
+pub enum CliResult {
+    /// Success with formatted output.
+    Ok(String),
+    /// Error message.
+    Err(String),
+}
+
+impl Default for CliPanelState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CliPanelState {
+    /// Create a new CLI panel state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            visible: false,
+            input: String::new(),
+            cursor_pos: 0,
+            history: VecDeque::new(),
+            history_index: None,
+            saved_input: String::new(),
+            height: 10,
+            scroll_offset: 0,
+        }
+    }
+
+    /// Toggle panel visibility.
+    ///
+    /// Returns the new visibility state.
+    pub const fn toggle(&mut self) -> bool {
+        self.visible = !self.visible;
+        if self.visible {
+            // Reset scroll to bottom when showing
+            self.scroll_offset = 0;
+        }
+        self.visible
+    }
+
+    /// Show the panel.
+    pub const fn show(&mut self) {
+        self.visible = true;
+        self.scroll_offset = 0;
+    }
+
+    /// Hide the panel.
+    pub const fn hide(&mut self) {
+        self.visible = false;
+    }
+
+    // Input editing methods
+
+    /// Insert a character at cursor position.
+    pub fn insert_char(&mut self, c: char) {
+        if self.input.len() < MAX_INPUT_LENGTH {
+            self.input.insert(self.cursor_pos, c);
+            self.cursor_pos += 1;
+            self.history_index = None;
+        }
+    }
+
+    /// Delete character before cursor (backspace).
+    pub fn backspace(&mut self) {
+        if self.cursor_pos > 0 {
+            self.cursor_pos -= 1;
+            self.input.remove(self.cursor_pos);
+            self.history_index = None;
+        }
+    }
+
+    /// Delete character at cursor (delete key).
+    pub fn delete(&mut self) {
+        if self.cursor_pos < self.input.len() {
+            self.input.remove(self.cursor_pos);
+            self.history_index = None;
+        }
+    }
+
+    /// Move cursor left.
+    pub const fn move_cursor_left(&mut self) {
+        if self.cursor_pos > 0 {
+            self.cursor_pos -= 1;
+        }
+    }
+
+    /// Move cursor right.
+    pub const fn move_cursor_right(&mut self) {
+        if self.cursor_pos < self.input.len() {
+            self.cursor_pos += 1;
+        }
+    }
+
+    /// Move cursor to start of input.
+    pub const fn move_cursor_home(&mut self) {
+        self.cursor_pos = 0;
+    }
+
+    /// Move cursor to end of input.
+    pub const fn move_cursor_end(&mut self) {
+        self.cursor_pos = self.input.len();
+    }
+
+    // History navigation
+
+    /// Navigate to previous command in history.
+    pub fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+
+        match self.history_index {
+            None => {
+                // Save current input and go to most recent
+                self.saved_input = self.input.clone();
+                self.history_index = Some(self.history.len() - 1);
+            }
+            Some(idx) if idx > 0 => {
+                self.history_index = Some(idx - 1);
+            }
+            Some(_) => {
+                // Already at oldest - do nothing
+                return;
+            }
+        }
+
+        if let Some(idx) = self.history_index
+            && let Some(entry) = self.history.get(idx)
+        {
+            self.input = entry.command.clone();
+            self.cursor_pos = self.input.len();
+        }
+    }
+
+    /// Navigate to next command in history.
+    pub fn history_next(&mut self) {
+        let Some(idx) = self.history_index else {
+            return;
+        };
+
+        if idx + 1 >= self.history.len() {
+            // Return to saved input
+            self.history_index = None;
+            self.input = std::mem::take(&mut self.saved_input);
+            self.cursor_pos = self.input.len();
+        } else {
+            self.history_index = Some(idx + 1);
+            if let Some(entry) = self.history.get(idx + 1) {
+                self.input = entry.command.clone();
+                self.cursor_pos = self.input.len();
+            }
+        }
+    }
+
+    // Command submission
+
+    /// Submit current input and return command string.
+    ///
+    /// Returns `None` if input is empty/whitespace.
+    pub fn submit(&mut self) -> Option<String> {
+        let trimmed = self.input.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let cmd = std::mem::take(&mut self.input);
+        self.cursor_pos = 0;
+        self.history_index = None;
+        self.saved_input.clear();
+        Some(cmd)
+    }
+
+    /// Add a command result to history.
+    pub fn add_result(&mut self, command: String, result: CliResult) {
+        self.history.push_back(CliHistoryEntry { command, result });
+        if self.history.len() > MAX_HISTORY {
+            self.history.pop_front();
+        }
+        // Scroll to bottom to show new result
+        self.scroll_offset = 0;
+    }
+
+    /// Clear input buffer.
+    pub fn clear_input(&mut self) {
+        self.input.clear();
+        self.cursor_pos = 0;
+        self.history_index = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_panel_state() {
+        let state = CliPanelState::new();
+        assert!(!state.visible);
+        assert!(state.input.is_empty());
+        assert_eq!(state.cursor_pos, 0);
+        assert!(state.history.is_empty());
+    }
+
+    #[test]
+    fn test_toggle() {
+        let mut state = CliPanelState::new();
+        assert!(!state.visible);
+        assert!(state.toggle());
+        assert!(state.visible);
+        assert!(!state.toggle());
+        assert!(!state.visible);
+    }
+
+    #[test]
+    fn test_insert_char() {
+        let mut state = CliPanelState::new();
+        state.insert_char('h');
+        state.insert_char('i');
+        assert_eq!(state.input, "hi");
+        assert_eq!(state.cursor_pos, 2);
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut state = CliPanelState::new();
+        state.input = "hello".to_string();
+        state.cursor_pos = 5;
+        state.backspace();
+        assert_eq!(state.input, "hell");
+        assert_eq!(state.cursor_pos, 4);
+    }
+
+    #[test]
+    fn test_cursor_movement() {
+        let mut state = CliPanelState::new();
+        state.input = "hello".to_string();
+        state.cursor_pos = 3;
+
+        state.move_cursor_left();
+        assert_eq!(state.cursor_pos, 2);
+
+        state.move_cursor_right();
+        assert_eq!(state.cursor_pos, 3);
+
+        state.move_cursor_home();
+        assert_eq!(state.cursor_pos, 0);
+
+        state.move_cursor_end();
+        assert_eq!(state.cursor_pos, 5);
+    }
+
+    #[test]
+    fn test_submit() {
+        let mut state = CliPanelState::new();
+        state.input = "  ".to_string();
+        assert!(state.submit().is_none());
+
+        state.input = "keys hello".to_string();
+        state.cursor_pos = 10;
+        let cmd = state.submit();
+        assert_eq!(cmd, Some("keys hello".to_string()));
+        assert!(state.input.is_empty());
+        assert_eq!(state.cursor_pos, 0);
+    }
+
+    #[test]
+    fn test_history_navigation() {
+        let mut state = CliPanelState::new();
+        state.add_result("cmd1".to_string(), CliResult::Ok("ok".to_string()));
+        state.add_result("cmd2".to_string(), CliResult::Ok("ok".to_string()));
+
+        state.input = "current".to_string();
+        state.cursor_pos = 7;
+
+        // Navigate to previous (cmd2)
+        state.history_prev();
+        assert_eq!(state.input, "cmd2");
+
+        // Navigate to previous (cmd1)
+        state.history_prev();
+        assert_eq!(state.input, "cmd1");
+
+        // Navigate to next (cmd2)
+        state.history_next();
+        assert_eq!(state.input, "cmd2");
+
+        // Navigate to next (back to current)
+        state.history_next();
+        assert_eq!(state.input, "current");
+    }
+
+    #[test]
+    fn test_add_result_overflow() {
+        let mut state = CliPanelState::new();
+        for i in 0..60 {
+            state.add_result(format!("cmd{i}"), CliResult::Ok("ok".to_string()));
+        }
+        assert_eq!(state.history.len(), MAX_HISTORY);
+        // First command should be cmd10 (0-9 were removed)
+        assert_eq!(state.history.front().unwrap().command, "cmd10");
+    }
+}

--- a/runner/src/client/tui/cli_render.rs
+++ b/runner/src/client/tui/cli_render.rs
@@ -1,0 +1,217 @@
+//! CLI panel rendering.
+//!
+//! Renders the CLI panel with command history, results, and input line.
+
+use super::cli_panel::{CliPanelState, CliResult};
+
+/// Render the CLI panel header.
+#[must_use]
+pub fn render_header(width: u16) -> String {
+    let header = "-- CLI (<C-b>; to close) ";
+    let padding = (width as usize).saturating_sub(header.len());
+    let dashes = "-".repeat(padding);
+    format!("\x1b[7m{header}{dashes}\x1b[0m")
+}
+
+/// Render the CLI panel content.
+///
+/// Returns a vector of lines to display.
+///
+/// # Arguments
+///
+/// * `state` - Panel state including history and input
+/// * `width` - Terminal width
+/// * `height` - Panel height in rows
+#[must_use]
+pub fn render_panel(state: &CliPanelState, width: u16, height: u16) -> Vec<String> {
+    let mut lines = Vec::with_capacity(height as usize);
+
+    // Header
+    lines.push(render_header(width));
+
+    let content_height = (height as usize).saturating_sub(2); // -1 header, -1 input
+
+    // Build history lines
+    let mut history_lines: Vec<String> = Vec::new();
+    for entry in &state.history {
+        // Command line (green prompt)
+        history_lines.push(format!("\x1b[32m>\x1b[0m {}", entry.command));
+        // Result line(s)
+        match &entry.result {
+            CliResult::Ok(output) => {
+                if output == "__CLEAR__" {
+                    // Special clear marker - don't show
+                    continue;
+                }
+                for line in output.lines() {
+                    if !line.is_empty() {
+                        history_lines.push(format!("  {line}"));
+                    }
+                }
+            }
+            CliResult::Err(msg) => {
+                history_lines.push(format!("\x1b[31m  Error: {msg}\x1b[0m"));
+            }
+        }
+    }
+
+    // Apply scroll and take visible lines
+    // scroll_offset=0 means showing latest (bottom)
+    let total_lines = history_lines.len();
+    let start = total_lines.saturating_sub(content_height + state.scroll_offset);
+    let end = total_lines.saturating_sub(state.scroll_offset);
+
+    for line in history_lines
+        .iter()
+        .skip(start)
+        .take(end.saturating_sub(start))
+    {
+        lines.push(truncate_line(line, width));
+    }
+
+    // Pad to fill height
+    while lines.len() < height as usize - 1 {
+        lines.push(String::new());
+    }
+
+    // Input line with cursor
+    let input_line = render_input_line(state, width);
+    lines.push(input_line);
+
+    lines
+}
+
+/// Render the input line with cursor.
+fn render_input_line(state: &CliPanelState, width: u16) -> String {
+    let prompt = "> ";
+    let max_input_width = (width as usize).saturating_sub(prompt.len() + 1);
+
+    // Simple cursor rendering: show underscore at cursor position
+    if state.cursor_pos >= state.input.len() {
+        // Cursor at end
+        let input = if state.input.len() > max_input_width {
+            // Truncate from start to show cursor
+            let start = state.input.len().saturating_sub(max_input_width);
+            &state.input[start..]
+        } else {
+            &state.input
+        };
+        format!("{prompt}{input}\x1b[7m \x1b[0m")
+    } else {
+        // Cursor in middle - highlight character at cursor
+        let (before, rest) = state.input.split_at(state.cursor_pos);
+        let cursor_char = rest.chars().next().unwrap_or(' ');
+        let after = &rest[cursor_char.len_utf8()..];
+
+        // Truncate if needed
+        let display = format!("{before}\x1b[7m{cursor_char}\x1b[0m{after}");
+        if display.len() > max_input_width + 10 {
+            // Account for ANSI codes
+            format!("{prompt}...{}", &display[display.len().saturating_sub(max_input_width)..])
+        } else {
+            format!("{prompt}{display}")
+        }
+    }
+}
+
+/// Truncate line to fit width, accounting for ANSI codes.
+fn truncate_line(line: &str, width: u16) -> String {
+    // Simple approach: count visible characters
+    let mut visible_len = 0;
+    let mut result = String::new();
+    let mut in_escape = false;
+
+    for c in line.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+            result.push(c);
+        } else if in_escape {
+            result.push(c);
+            if c == 'm' {
+                in_escape = false;
+            }
+        } else {
+            if visible_len >= width as usize {
+                break;
+            }
+            result.push(c);
+            visible_len += 1;
+        }
+    }
+
+    // Close any open ANSI sequences
+    if result.contains("\x1b[") && !result.ends_with("\x1b[0m") {
+        result.push_str("\x1b[0m");
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_header() {
+        let header = render_header(40);
+        assert!(header.contains("CLI"));
+        assert!(header.contains("\x1b[7m")); // Inverse video
+        assert!(header.contains("\x1b[0m")); // Reset
+    }
+
+    #[test]
+    fn test_render_panel_empty() {
+        let state = CliPanelState::new();
+        let lines = render_panel(&state, 80, 10);
+        assert_eq!(lines.len(), 10);
+        // First line is header
+        assert!(lines[0].contains("CLI"));
+        // Last line is input
+        assert!(lines[9].starts_with("> "));
+    }
+
+    #[test]
+    fn test_render_panel_with_history() {
+        let mut state = CliPanelState::new();
+        state.add_result("keys hello".to_string(), CliResult::Ok("Sent".to_string()));
+
+        let lines = render_panel(&state, 80, 10);
+        // Should contain the command and result
+        let combined = lines.join("\n");
+        assert!(combined.contains("keys hello"));
+        assert!(combined.contains("Sent"));
+    }
+
+    #[test]
+    fn test_truncate_line() {
+        let line = "hello world";
+        let truncated = truncate_line(line, 5);
+        assert_eq!(truncated, "hello");
+
+        // With ANSI codes
+        let ansi_line = "\x1b[32mhello\x1b[0m world";
+        let truncated = truncate_line(ansi_line, 5);
+        assert!(truncated.contains("hello"));
+    }
+
+    #[test]
+    fn test_input_line_cursor_at_end() {
+        let mut state = CliPanelState::new();
+        state.input = "test".to_string();
+        state.cursor_pos = 4;
+
+        let line = render_input_line(&state, 80);
+        assert!(line.starts_with("> test"));
+        assert!(line.contains("\x1b[7m")); // Cursor highlight
+    }
+
+    #[test]
+    fn test_input_line_cursor_in_middle() {
+        let mut state = CliPanelState::new();
+        state.input = "hello".to_string();
+        state.cursor_pos = 2;
+
+        let line = render_input_line(&state, 80);
+        assert!(line.contains("he\x1b[7ml\x1b[0mlo")); // 'l' highlighted
+    }
+}

--- a/runner/src/client/tui/mod.rs
+++ b/runner/src/client/tui/mod.rs
@@ -60,6 +60,9 @@ impl TuiDebugConfig {
 }
 
 pub mod app;
+pub mod cli_executor;
+pub mod cli_panel;
+pub mod cli_render;
 pub mod input;
 pub mod log_buffer;
 pub mod log_panel;
@@ -68,6 +71,7 @@ pub mod render;
 
 pub use {
     app::TuiApp,
+    cli_panel::{CliHistoryEntry, CliPanelState, CliResult},
     input::InputHandler,
     log_buffer::{LevelColor, TuiLogBuffer, TuiLogEntry},
     log_panel::LogPanelState,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -39,8 +39,30 @@ struct Args {
     command: Option<Command>,
 
     /// Start server in detached/daemon mode without TUI.
+    ///
+    /// Server runs in background, no TUI is attached.
+    /// Use `reovim tui` or `reovim attach` to connect later.
     #[arg(short = 'd', long)]
     detach: bool,
+
+    /// Enable debug mode for TUI (statusline + frame capture).
+    ///
+    /// Shows a debug statusline at the bottom with timestamp, server address,
+    /// mode, and module count. Also captures frame buffers periodically.
+    #[arg(long)]
+    debug: bool,
+
+    /// Debug log directory (requires --debug).
+    ///
+    /// Default: ~/.local/share/reovim/logs/tui/
+    #[arg(long, value_name = "DIR")]
+    debug_dir: Option<PathBuf>,
+
+    /// Debug session name for log filenames (requires --debug).
+    ///
+    /// Default: "default"
+    #[arg(long, value_name = "NAME")]
+    debug_name: Option<String>,
 
     /// Files to open on startup.
     #[arg(value_name = "FILE")]
@@ -136,7 +158,8 @@ fn main() {
                 run_server(ServerConfig::tcp_with_fallback());
             } else {
                 // Integrated mode: start server + attach TUI
-                run_integrated(&args.files);
+                let debug_config = create_debug_config(args.debug, &args.debug_dir, &args.debug_name);
+                run_integrated(&args.files, debug_config);
             }
         }
     }
@@ -177,8 +200,31 @@ fn build_legacy_server_config(args: &Args) -> ServerConfig {
 /// └── TUI Client               └── Server process
 ///     └── TCP connect ←────────── READY 127.0.0.1:12521
 /// ```
+/// Create debug configuration from CLI flags.
+fn create_debug_config(
+    debug: bool,
+    debug_dir: &Option<PathBuf>,
+    debug_name: &Option<String>,
+) -> Option<runner::client::tui::TuiDebugConfig> {
+    if !debug {
+        return None;
+    }
+
+    let log_dir = debug_dir.clone().unwrap_or_else(|| {
+        reovim_arch::dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("reovim")
+            .join("logs")
+            .join("tui")
+    });
+
+    let name = debug_name.clone().unwrap_or_else(|| "default".to_string());
+
+    Some(runner::client::tui::TuiDebugConfig::new(log_dir, name))
+}
+
 #[allow(unused_variables)] // files will be used later
-fn run_integrated(files: &[PathBuf]) {
+fn run_integrated(files: &[PathBuf], debug_config: Option<runner::client::tui::TuiDebugConfig>) {
     use std::{
         io::BufReader,
         process::{Command, Stdio},
@@ -225,8 +271,7 @@ fn run_integrated(files: &[PathBuf]) {
 
     rt.block_on(async {
         let config = ConnectionConfig::tcp(addr.ip().to_string(), addr.port());
-        // Integrated mode doesn't support debug flags (no CLI args available)
-        match TuiApp::connect(&config, None).await {
+        match TuiApp::connect(&config, debug_config).await {
             Ok(mut app) => {
                 if let Err(e) = app.run().await {
                     eprintln!("TUI error: {e}");

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -34,6 +34,7 @@ use {
     Run as a headless server, connect with TUI, or use CLI commands for automation.\n\n\
     Without arguments, starts server and attaches TUI (tmux-like behavior)."
 )]
+#[allow(clippy::struct_excessive_bools)]
 struct Args {
     #[command(subcommand)]
     command: Option<Command>,
@@ -158,7 +159,8 @@ fn main() {
                 run_server(ServerConfig::tcp_with_fallback());
             } else {
                 // Integrated mode: start server + attach TUI
-                let debug_config = create_debug_config(args.debug, &args.debug_dir, &args.debug_name);
+                let debug_config =
+                    create_debug_config(args.debug, &args.debug_dir, &args.debug_name);
                 run_integrated(&args.files, debug_config);
             }
         }
@@ -201,6 +203,7 @@ fn build_legacy_server_config(args: &Args) -> ServerConfig {
 ///     └── TCP connect ←────────── READY 127.0.0.1:12521
 /// ```
 /// Create debug configuration from CLI flags.
+#[allow(clippy::ref_option)]
 fn create_debug_config(
     debug: bool,
     debug_dir: &Option<PathBuf>,


### PR DESCRIPTION
## Summary

TUI client improvements: ghost statusline fix, unified debug flags, buffer notifications, prefix mode, error display, and embedded CLI panel.

### Closes #365: Buffer notifications fix
- TUI now calls `editor/set_active_buffer` on connect to register for notifications
- Fixes input appearing unresponsive (cursor_moved, buffer_modified, render_complete were missed)

### Fixes #362: Ghost statusline on resize
- Clear both buffers in `FrameRenderer::resize()` to remove stale content
- Tick handler now triggers full refresh instead of independent flush/swap
- Prevents ghost from ping-ponging between double buffers after resize

### Resolves #364: Unified debug flags
- `reovim --debug` now works (previously only `reovim tui --debug`)
- Added `--debug-dir` and `--debug-name` flags to main CLI
- More verbose help descriptions

### Refs #368: Prefix mode, error display, and CLI panel
- Prefix mode: `<C-b>` enters prefix mode (2s timeout)
  - `<C-b>d` detaches from server without killing it
  - `<C-b>;` toggles embedded CLI panel
  - `<C-b><C-b>` sends literal Ctrl+B to server
- Error display: RPC errors shown in red statusline (auto-clear 5s)
- CLI panel: fire-and-forget commands (keys, resize, open, kill, help)
  - Command history with Up/Down navigation
  - Line editing with cursor movement
- Query commands deferred to #371 (requires response correlation)

## Test plan

- [x] `./scripts/check.sh` passes
- [x] Manual testing of prefix mode (`<C-b>d`, `<C-b>;`)
- [x] Manual testing of CLI panel commands
- [x] Error display verified with RPC errors