### PR TITLE
feat(testing): Phase-7 - test infrastructure and operator fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- Per-test server log capture for integration tests (#428)
+  - `TestServerHarness::spawn_with_log(test_name)` captures server stderr to per-test log files
+  - Logs saved to `tmp/test-logs/{test_name}_{timestamp}.log`
+  - Background tokio task streams logs during test execution
+  - `REOVIM_LOG=debug` by default for full tracing visibility
+  - `IntegrationTest::log_path()` and `StepTest::log_path()` expose log location
+  - `TestResult` assertions include log path hint on failure
+  - `StepTrace::print_trace()` shows log path for debugging
+  - Replaces manual file-based debug logging with proper `tracing::debug!()` calls
+  - Added `tracing` dependency to vim module for resolver instrumentation
+  - Operator resolvers (delete, yank, change) now emit debug traces for count flow
+
 - UniqueProvider service abstraction Phase 6b - runner cleanup (#417)
   - Deleted 924 lines of redundant code from runner
   - Removed `runner/src/search.rs` (unused, module version exists)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,43 @@ cargo run -- tui --tcp 127.0.0.1:12521    # Connect to specific server
 - If no issue exists, create one with `gh issue create` before proceeding
 - Reference the issue in commit messages: `type(scope): description (#ISSUE_NUMBER)`
 
+**Deferral Protocol (MANDATORY):**
+
+When deferring work (skipping a test, leaving a TODO, postponing a feature), you MUST:
+
+1. **Create a draft proposal** - Write `tmp/deferral-draft-{topic}.md` with:
+   ```markdown
+   # Deferral Proposal: {topic}
+
+   ## What
+   [Description of deferred work]
+
+   ## Why
+   [Reason for deferring]
+
+   ## Draft Issue
+   - Title: `fix: {description}`
+   - Body: [Acceptance criteria, context]
+
+   ## Code Reference
+   [File and line where `#[ignore]` or `// TODO` will be added]
+   ```
+2. **Continue working** - Don't block on approval
+3. **Mention at finish** - At end of work session, remind user: "Review deferral draft at `tmp/deferral-draft-*.md`"
+4. **After user approval** - Create issue with `gh issue create`, update code with issue reference
+
+**Never create tracking issues without user approval.** The draft file gives user control over what gets tracked and how.
+
+Example workflow:
+```
+[During work] Claude encounters failing test
+[During work] Claude creates tmp/deferral-draft-dG-motion.md
+[During work] Claude continues with other tasks
+[At finish]  Claude: "Review deferral draft at tmp/deferral-draft-dG-motion.md"
+[User]       Reviews and approves
+[Claude]     Creates issue #429, updates #[ignore = "... (#429)"]
+```
+
 **Self-Contained Issues Policy:**
 - **Every GitHub issue MUST be completely self-contained**
 - A developer reading ONLY the issue must have ALL information needed to implement it
@@ -658,7 +695,7 @@ The statusline is rendered at the bottom of the screen with inverse colors.
 
 ### Integration Test Infrastructure
 
-Phase 7 integration tests use a fluent builder API in `runner/tests/common/`:
+Phase 7 integration tests use a fluent builder API in `runner/src/testing/`:
 
 ```rust
 // Single-client test example
@@ -669,6 +706,18 @@ let result = IntegrationTest::new()
     .run()
     .await;
 result.assert_buffer_eq("world");
+
+// Step-by-step test with per-key assertions (Issue #428)
+let trace = StepTest::new()
+    .await
+    .with_buffer("hello world")
+    .step("d")
+        .expect_mode_contains("DELETE")
+    .step("w")
+        .expect_buffer("world")
+    .run()
+    .await;
+trace.assert_ok();
 
 // Multi-client test example
 MultiClientTest::with_clients(2)
@@ -684,7 +733,17 @@ MultiClientTest::with_clients(2)
 **Key components:**
 - `TestServerHarness` - Spawns server on OS-assigned port, auto-cleanup via Drop
 - `IntegrationTest` - Fluent builder for single-client tests, temp file cleanup
+- `StepTest` - Per-keystroke state tracking with inline assertions
 - `MultiClientTest` - Multi-client concurrent testing
-- `TestResult` - Assertions: `assert_buffer_eq!`, `assert_cursor!`, `assert_mode!`
+- `TestResult` - Assertions: `assert_buffer_eq!`, `assert_cursor!`, `assert_register!`, `assert_mode!`
 
-**Note:** Integration tests are `#[ignore]` pending module loading. Run with `cargo test --ignored`.
+**Per-test log capture (Issue #428):**
+- Logs are saved to `{module}/tmp/test-logs/{test_name}_{timestamp}.log`
+- Example: `modules/vim/tmp/test-logs/test_dw_delete_word_20260124_140503.log`
+- Failed assertions include log path hint: `Server log: tmp/test-logs/...`
+- Access via `result.log_path()` or `trace.log_path()`
+
+**Module loading troubleshooting:**
+- If tests behave unexpectedly, check logs for `WARN module not found`
+- This indicates `.so` files are outdated - run `./scripts/build-module.sh <module> --install`
+- Verify FFI symbols with the install script output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,7 @@ dependencies = [
  "reovim-module-motions",
  "reovim-module-textobjects",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/modules/vim/Cargo.toml
+++ b/modules/vim/Cargo.toml
@@ -25,6 +25,7 @@ reovim-module-motions = { path = "../motions" }
 # Note: operators module merged into vim (Epic #385)
 reovim-module-textobjects = { path = "../textobjects" }
 reovim-driver-clipboard = { path = "../../lib/drivers/clipboard" }
+tracing = { workspace = true }
 
 [dev-dependencies]
 # Integration test harness from runner

--- a/modules/vim/src/modes.rs
+++ b/modules/vim/src/modes.rs
@@ -55,7 +55,7 @@ pub enum VimMode {
     Replace = 5,
     /// Command line mode - ex commands.
     CommandLine = 6,
-    /// Window mode - window management (<C-w> prefix).
+    /// Window mode - window management (`<C-w>` prefix).
     Window = 8,
     /// Delete operator mode - waiting for motion to delete.
     Delete = 9,

--- a/modules/vim/src/operators/commands.rs
+++ b/modules/vim/src/operators/commands.rs
@@ -74,7 +74,37 @@ impl Command for YankCommand {
 
 impl CommandHandler for YankCommand {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
-        execute_operator(&YankOperator, runtime, args)
+        use reovim_driver_session::api::BufferApi;
+
+        // In Vim, after yank the cursor should be restored to the start of the yanked range.
+        // Get the range start BEFORE executing the yank, so we can restore cursor after.
+        let (start_line, start_col) = args.range_start().unwrap_or((0, 0));
+        let restore_pos = Position::new(start_line, start_col);
+
+        let cur_pos = args.buffer_id().and_then(|id| runtime.buffer_position(id));
+        tracing::debug!(
+            range_start = ?restore_pos,
+            current_pos = ?cur_pos,
+            "yank command: before execute"
+        );
+
+        let result = execute_operator(&YankOperator, runtime, args);
+
+        // Restore cursor to start of yanked range (Vim behavior)
+        if matches!(result, CommandResult::Success)
+            && let Some(buffer_id) = args.buffer_id()
+        {
+            runtime.set_buffer_position(buffer_id, restore_pos);
+
+            let cur_pos = runtime.buffer_position(buffer_id);
+            tracing::debug!(
+                restored_to = ?restore_pos,
+                current_pos = ?cur_pos,
+                "yank command: cursor restored"
+            );
+        }
+
+        result
     }
 }
 

--- a/modules/vim/src/resolvers/change.rs
+++ b/modules/vim/src/resolvers/change.rs
@@ -29,8 +29,8 @@ use {
 use {
     super::operator_common::{
         KeymapAction, OperatorState, OperatorType, apply_keymap_policy, build_cancelled,
-        build_operator_execute, is_count_digit, is_escape, is_line_operator_key,
-        is_linewise_motion,
+        build_operator_execute, is_count_digit, is_escape, is_inclusive_motion,
+        is_line_operator_key, is_linewise_motion, is_word_forward_motion,
     },
     crate::{modes::VimMode, session_state::PendingMotion},
 };
@@ -169,16 +169,27 @@ impl ModeKeyResolver for VimChangeResolver {
         state.push_key(*key);
         let keys = state.keys();
 
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                let effective_count = state.effective_count();
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -207,6 +218,8 @@ impl ModeKeyResolver for VimChangeResolver {
         session: &mut dyn SessionApiDyn,
         extensions: &mut ExtensionMap,
     ) -> ResolveResult {
+        tracing::debug!(key = ?key, "change resolver: resolve_with_session");
+
         if is_escape(key) {
             self.clear_state();
             return ResolveResult::ModeTransition(build_cancelled());
@@ -219,6 +232,13 @@ impl ModeKeyResolver for VimChangeResolver {
             if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    register = ?state.register,
+                    "change resolver: initialized from VimSessionState"
+                );
+            } else {
+                tracing::warn!("change resolver: VimSessionState not found in extensions");
             }
             state.initialized = true;
         }
@@ -267,12 +287,33 @@ impl ModeKeyResolver for VimChangeResolver {
         state.push_key(*key);
         let keys = state.keys();
 
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                // For 2cw: operator_count=2, motion_count=None → effective=2
+                // For c2w: operator_count=None, motion_count=2 → effective=2
+                // For 2c3w: operator_count=2, motion_count=3 → effective=6
+                let effective_count = state.effective_count();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    motion_count = ?state.motion_count,
+                    effective_count,
+                    cmd = %cmd,
+                    "change resolver: executing motion"
+                );
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
 
                 if let Some(buffer) = session.active_buffer()
@@ -281,14 +322,18 @@ impl ModeKeyResolver for VimChangeResolver {
                     state.set_start_position(start_pos);
                 }
 
+                // Inclusive motions need end position adjustment ($ returns ON last char)
+                let inclusive = !linewise && is_inclusive_motion(&cmd);
+                let word_forward = !linewise && is_word_forward_motion(&cmd);
                 if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
-                    vim.pending_motion = Some(PendingMotion::new(linewise));
+                    vim.pending_motion =
+                        Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
 
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -323,10 +368,35 @@ impl ModeKeyResolver for VimChangeResolver {
         let buffer_id = session.active_buffer()?;
         let end_pos = session.buffer_position(buffer_id)?;
 
-        let (range_start, range_end) = if start_pos <= end_pos {
-            (start_pos, end_pos)
-        } else {
-            (end_pos, start_pos)
+        // Normalize range and adjust for motion type
+        //
+        // Special case: `cw` and `cW` in Vim behave like `ce` and `cE` respectively.
+        // They change to the END of the current word, not to the start of the next word.
+        // This is documented Vim behavior (`:help cw`).
+        let (range_start, range_end) = {
+            // First normalize direction (start <= end)
+            let (start, end) = if start_pos <= end_pos {
+                (start_pos, end_pos)
+            } else {
+                (end_pos, start_pos)
+            };
+
+            // For inclusive characterwise motions, make end exclusive
+            // ($ returns cursor ON last char, but Range.end is exclusive)
+            if !motion.linewise && motion.inclusive {
+                (start, Position::new(end.line, end.column + 1))
+            } else if motion.word_forward {
+                // For change operator, `cw` should behave like `ce` - change to
+                // end of word, not including trailing whitespace. This means we
+                // need to subtract 1 from exclusive word-forward motions.
+                // The motion puts cursor at start of next word (col 6 for "hello world"),
+                // but we only want to change "hello" (cols 0-4), so end should be col 5.
+                //
+                // This is documented Vim behavior (`:help cw`).
+                (start, Position::new(end.line, end.column.saturating_sub(1)))
+            } else {
+                (start, end)
+            }
         };
 
         let count = state.operator_count;
@@ -440,6 +510,7 @@ mod tests {
     use reovim_kernel::api::v1::ModuleId;
 
     const TEST_MODULE: ModuleId = ModuleId::new("test");
+    const EDITOR_MODULE: ModuleId = ModuleId::new("editor");
 
     struct MockKeymap {
         response: reovim_driver_input::KeyLookupState,
@@ -452,6 +523,15 @@ mod tests {
                     TEST_MODULE,
                     cmd,
                 )),
+            }
+        }
+
+        /// Create a keymap that returns ExactWithLonger (simulating 'c' with 'cc' as longer match)
+        fn exact_with_longer_editor(cmd: &'static str) -> Self {
+            Self {
+                response: reovim_driver_input::KeyLookupState::ExactWithLonger {
+                    exact: CommandId::new(EDITOR_MODULE, cmd),
+                },
             }
         }
     }
@@ -485,6 +565,161 @@ mod tests {
             assert_eq!(cmd.name(), "word-forward");
         } else {
             panic!("expected Execute, got {:?}", result);
+        }
+    }
+
+    // =========================================================================
+    // Test operator_count with effective_count (Epic #415)
+    // =========================================================================
+
+    #[test]
+    fn test_operator_count_with_context() {
+        // This test verifies: when operator_count=2, effective_count should be 2
+        // Simulates the flow after entering change mode with a count
+        let resolver = VimChangeResolver::with_context(Some(2), None);
+        let mut mstate = test_state();
+        let keymap = MockKeymap::exact_only("word-forward");
+        let input = resolve_input(&keymap);
+
+        // Resolver processes 'w' with pre-set operator_count=2
+        let result = resolver.resolve_with_keymap(&key('w'), &mut mstate, &input);
+
+        // Verify: should execute motion with count=2
+        if let ResolveResult::Execute(cmd, ctx) = result {
+            assert_eq!(cmd.name(), "word-forward");
+            assert_eq!(ctx.count, Some(2), "effective_count should be 2 for 2cw");
+        } else {
+            panic!("expected Execute, got {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_operator_count_multiplied_with_motion_count() {
+        // This test verifies: 2c3w should have effective_count=6
+        let resolver = VimChangeResolver::with_context(Some(2), None);
+        let mut mstate = test_state();
+        let keymap = MockKeymap::exact_only("word-forward");
+        let input = resolve_input(&keymap);
+
+        // Process '3' (motion count)
+        let result = resolver.resolve_with_keymap(&key('3'), &mut mstate, &input);
+        assert!(matches!(result, ResolveResult::Pending));
+
+        // Process 'w' (motion)
+        let result = resolver.resolve_with_keymap(&key('w'), &mut mstate, &input);
+
+        // Verify: should execute motion with count=6 (2*3)
+        if let ResolveResult::Execute(cmd, ctx) = result {
+            assert_eq!(cmd.name(), "word-forward");
+            assert_eq!(ctx.count, Some(6), "effective_count should be 6 for 2c3w");
+        } else {
+            panic!("expected Execute, got {:?}", result);
+        }
+    }
+
+    // =========================================================================
+    // Test VimSessionState flow (the actual 2cw flow)
+    // =========================================================================
+
+    #[test]
+    fn test_full_2cw_flow() {
+        // This test simulates the FULL flow of typing "2cw":
+        // 1. Normal resolver processes '2' -> stores pending_count=2
+        // 2. Normal resolver processes 'c' -> mode transition to CHANGE
+        // 3. Change resolver processes 'w' -> should read pending_count=2
+
+        use {crate::resolvers::VimNormalResolver, reovim_driver_session::ExtensionMap};
+
+        // Shared extensions map (like in the runner)
+        let mut extensions = ExtensionMap::new();
+
+        // Step 1: Normal resolver processes '2'
+        {
+            let normal_resolver = VimNormalResolver::new();
+            let mut state = reovim_driver_input::ModeState::new(VimMode::NORMAL_ID);
+            let keymap = MockKeymap::exact_only("word-forward"); // Doesn't matter for count digit
+            let input = resolve_input(&keymap);
+
+            let result = normal_resolver.resolve_with_extensions(
+                &key('2'),
+                &mut state,
+                &input,
+                &mut extensions,
+            );
+            assert!(
+                matches!(result, ResolveResult::Pending),
+                "Expected Pending after '2', got {:?}",
+                result
+            );
+        }
+
+        // Verify pending_count is set after step 1
+        {
+            let vim = extensions
+                .get::<crate::VimSessionState>()
+                .expect("VimSessionState should exist");
+            assert_eq!(vim.pending_count, Some(2), "After '2', pending_count should be Some(2)");
+        }
+
+        // Step 2: Normal resolver processes 'c'
+        // Note: Real keymap returns ExactWithLonger because 'cc' exists as longer match
+        // Also uses 'editor' module, not 'test' module
+        {
+            let normal_resolver = VimNormalResolver::new();
+            let mut state = reovim_driver_input::ModeState::new(VimMode::NORMAL_ID);
+            let keymap = MockKeymap::exact_with_longer_editor("enter-change-operator");
+            let input = resolve_input(&keymap);
+
+            let result = normal_resolver.resolve_with_extensions(
+                &key('c'),
+                &mut state,
+                &input,
+                &mut extensions,
+            );
+            assert!(
+                matches!(result, ResolveResult::ModeTransition(ModeTransition::Push { .. })),
+                "Expected ModeTransition::Push after 'c', got {:?}",
+                result
+            );
+        }
+
+        // Verify pending_count is STILL set after step 2 (not consumed by normal resolver)
+        {
+            let vim = extensions
+                .get::<crate::VimSessionState>()
+                .expect("VimSessionState should exist");
+            assert_eq!(
+                vim.pending_count,
+                Some(2),
+                "After 'c', pending_count should STILL be Some(2)"
+            );
+        }
+
+        // Step 3: Verify pending_count is still available for change resolver
+        // Note: We can't fully test resolve_with_session without a complex mock,
+        // but we verify the state is correct. The test_operator_count_with_context
+        // test verifies that the resolver works correctly when operator_count is set.
+        {
+            // Verify pending_count is still Some(2) after mode transition
+            let vim = extensions
+                .get::<crate::VimSessionState>()
+                .expect("VimSessionState");
+            assert_eq!(
+                vim.pending_count,
+                Some(2),
+                "After mode transition to CHANGE, pending_count should still be Some(2)"
+            );
+
+            // The change resolver's resolve_with_session will:
+            // 1. Check state.initialized (false for new resolver)
+            // 2. Call extensions.get_mut::<VimSessionState>() - should find it
+            // 3. Take pending_count - should get Some(2)
+            // 4. Store in state.operator_count
+            // 5. Calculate effective_count = operator_count * motion_count = 2 * 1 = 2
+
+            // The test_operator_count_with_context test verifies this logic works
+            // when operator_count is pre-set. This test verifies the normal resolver
+            // correctly preserves pending_count through the mode transition.
         }
     }
 }

--- a/modules/vim/src/resolvers/delete.rs
+++ b/modules/vim/src/resolvers/delete.rs
@@ -31,8 +31,8 @@ use {
 use {
     super::operator_common::{
         KeymapAction, OperatorState, OperatorType, apply_keymap_policy, build_cancelled,
-        build_operator_execute, is_count_digit, is_escape, is_line_operator_key,
-        is_linewise_motion,
+        build_operator_execute, is_count_digit, is_escape, is_inclusive_motion,
+        is_line_operator_key, is_linewise_motion, is_word_forward_motion,
     },
     crate::{modes::VimMode, session_state::PendingMotion},
 };
@@ -182,17 +182,28 @@ impl ModeKeyResolver for VimDeleteResolver {
         let keys = state.keys();
 
         // Query keymap for motion/text-object
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                let effective_count = state.effective_count();
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
-                // Build context with motion count
+                // Build context with effective count (operator_count * motion_count)
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -229,6 +240,8 @@ impl ModeKeyResolver for VimDeleteResolver {
         session: &mut dyn SessionApiDyn,
         extensions: &mut ExtensionMap,
     ) -> ResolveResult {
+        tracing::debug!(key = ?key, "delete resolver: resolve_with_session");
+
         // Escape cancels the operator
         if is_escape(key) {
             self.clear_state();
@@ -242,6 +255,11 @@ impl ModeKeyResolver for VimDeleteResolver {
             if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    register = ?state.register,
+                    "delete resolver: initialized from VimSessionState"
+                );
             }
             state.initialized = true;
         }
@@ -295,12 +313,34 @@ impl ModeKeyResolver for VimDeleteResolver {
         let keys = state.keys();
 
         // Query keymap for motion/text-object
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                // For 2dw: operator_count=2, motion_count=None → effective=2
+                // For d2w: operator_count=None, motion_count=2 → effective=2
+                // For 2d3w: operator_count=2, motion_count=3 → effective=6
+                let effective_count = state.effective_count();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    motion_count = ?state.motion_count,
+                    effective_count,
+                    cmd = %cmd,
+                    linewise,
+                    "delete resolver: executing motion"
+                );
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
 
                 // Store start position before motion
@@ -311,15 +351,19 @@ impl ModeKeyResolver for VimDeleteResolver {
                 }
 
                 // Store motion info in VimSessionState for on_command_complete
+                // Inclusive motions need end position adjustment ($ returns ON last char)
+                let inclusive = !linewise && is_inclusive_motion(&cmd);
+                let word_forward = !linewise && is_word_forward_motion(&cmd);
                 if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
-                    vim.pending_motion = Some(PendingMotion::new(linewise));
+                    vim.pending_motion =
+                        Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
 
                 drop(state);
 
-                // Build context with motion count
+                // Build context with effective count (operator_count * motion_count)
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -360,11 +404,22 @@ impl ModeKeyResolver for VimDeleteResolver {
         let buffer_id = session.active_buffer()?;
         let end_pos = session.buffer_position(buffer_id)?;
 
-        // Normalize range (start <= end for characterwise)
-        let (range_start, range_end) = if start_pos <= end_pos {
-            (start_pos, end_pos)
-        } else {
-            (end_pos, start_pos)
+        // Normalize range and adjust for motion type
+        let (range_start, range_end) = {
+            // First normalize direction (start <= end)
+            let (start, end) = if start_pos <= end_pos {
+                (start_pos, end_pos)
+            } else {
+                (end_pos, start_pos)
+            };
+
+            // For inclusive characterwise motions, make end exclusive
+            // ($ returns cursor ON last char, but Range.end is exclusive)
+            if !motion.linewise && motion.inclusive {
+                (start, Position::new(end.line, end.column + 1))
+            } else {
+                (start, end)
+            }
         };
 
         let count = state.operator_count;

--- a/modules/vim/src/resolvers/operator_common.rs
+++ b/modules/vim/src/resolvers/operator_common.rs
@@ -132,11 +132,11 @@ pub fn is_line_operator_key(key: &KeyEvent, operator: OperatorType) -> bool {
 /// are linewise vs characterwise based on the command name.
 ///
 /// # Linewise Motions
-/// - j, k (line up/down)
-/// - gg, G (document start/end)
-/// - H, M, L (screen positions)
-/// - {, } (paragraph motions)
-/// - +, - (line motions)
+/// - j, k (line up/down) - `cursor-down`, `cursor-up`
+/// - gg, G (document start/end) - `document-start`, `document-end`
+/// - H, M, L (screen positions) - `screen-top`, `screen-middle`, `screen-bottom`
+/// - {, } (paragraph motions) - `paragraph-forward`, `paragraph-backward`
+/// - +, - (line motions) - `next-line`, `prev-line`
 /// - whole-line (for dd, yy, cc)
 ///
 /// # Characterwise Motions (default)
@@ -149,18 +149,78 @@ pub fn is_linewise_motion(cmd: &CommandId) -> bool {
     let name = cmd.name();
     matches!(
         name,
-        "move-down"
-            | "move-up"
+        // j, k - cursor up/down (editor module)
+        "cursor-down"
+            | "cursor-up"
+            // gg, G - document start/end (motions module)
             | "document-start"
             | "document-end"
+            // H, M, L - screen positions
             | "screen-top"
             | "screen-middle"
             | "screen-bottom"
+            // {, } - paragraph motions
             | "paragraph-forward"
             | "paragraph-backward"
+            // +, - - next/prev line
             | "next-line"
             | "prev-line"
+            // Special: whole-line for dd, yy, cc
             | "whole-line"
+    )
+}
+
+/// Determine if a motion is inclusive (cursor lands ON last char).
+///
+/// This is vim policy knowledge - classifies motions by their end position semantics.
+///
+/// # Inclusive Motions
+/// - $: line-end (cursor on last char)
+/// - e, E: word-end (cursor on last char of word)
+/// - f, F: find-char (cursor on found char)
+/// - t, T: till-char (cursor before/after found char)
+/// - G: document-end (cursor on last line)
+/// - %: match-bracket (cursor on matching bracket)
+///
+/// # Exclusive Motions (default)
+/// - w, W, b, B: word motions (cursor at start of next/prev word)
+/// - h, l: character motions (cursor moves by 1)
+/// - 0, ^: line-start motions (cursor at start)
+///
+/// For characterwise inclusive motions, the Range.end (which is exclusive)
+/// needs to be adjusted by +1 to include the character under the cursor.
+#[must_use]
+pub fn is_inclusive_motion(cmd: &CommandId) -> bool {
+    let name = cmd.name();
+    matches!(
+        name,
+        "line-end"           // $
+            | "word-end"     // e
+            | "word-end-big" // E
+            | "find-char"    // f
+            | "find-char-back" // F
+            | "till-char"    // t
+            | "till-char-back" // T
+            | "match-bracket" // %
+    )
+}
+
+/// Determine if a motion is word-forward (w, W).
+///
+/// This is used for the `cw` special case in Vim: `cw` behaves like `ce`
+/// (change to end of word, not to start of next word).
+/// See `:help cw` for Vim documentation.
+///
+/// Word-forward motions move cursor to the START of the next word,
+/// but when used with the change operator, they should only change
+/// to the END of the current word (excluding trailing whitespace).
+#[must_use]
+pub fn is_word_forward_motion(cmd: &CommandId) -> bool {
+    let name = cmd.name();
+    matches!(
+        name,
+        "word-forward"      // w
+            | "word-forward-big" // W
     )
 }
 
@@ -423,10 +483,25 @@ mod tests {
         use reovim_kernel::api::v1::ModuleId;
 
         let editor = ModuleId::new("editor");
+        let motions = ModuleId::new("motions");
 
-        assert!(is_linewise_motion(&CommandId::new(editor.clone(), "move-down")));
-        assert!(is_linewise_motion(&CommandId::new(editor.clone(), "whole-line")));
+        // j, k are linewise
+        assert!(is_linewise_motion(&CommandId::new(editor.clone(), "cursor-down")));
+        assert!(is_linewise_motion(&CommandId::new(editor.clone(), "cursor-up")));
+
+        // gg, G are linewise
+        assert!(is_linewise_motion(&CommandId::new(motions.clone(), "document-start")));
+        assert!(is_linewise_motion(&CommandId::new(motions.clone(), "document-end")));
+
+        // whole-line for dd, yy, cc
+        assert!(is_linewise_motion(&CommandId::new(motions.clone(), "whole-line")));
+
+        // h, l are NOT linewise
         assert!(!is_linewise_motion(&CommandId::new(editor.clone(), "cursor-left")));
+        assert!(!is_linewise_motion(&CommandId::new(editor.clone(), "cursor-right")));
+
+        // word motions are NOT linewise
+        assert!(!is_linewise_motion(&CommandId::new(motions, "word-forward")));
     }
 
     #[test]

--- a/modules/vim/src/resolvers/yank.rs
+++ b/modules/vim/src/resolvers/yank.rs
@@ -28,8 +28,8 @@ use {
 use {
     super::operator_common::{
         KeymapAction, OperatorState, OperatorType, apply_keymap_policy, build_cancelled,
-        build_operator_execute, is_count_digit, is_escape, is_line_operator_key,
-        is_linewise_motion,
+        build_operator_execute, is_count_digit, is_escape, is_inclusive_motion,
+        is_line_operator_key, is_linewise_motion, is_word_forward_motion,
     },
     crate::{modes::VimMode, session_state::PendingMotion},
 };
@@ -167,16 +167,27 @@ impl ModeKeyResolver for VimYankResolver {
         state.push_key(*key);
         let keys = state.keys();
 
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                let effective_count = state.effective_count();
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -205,6 +216,8 @@ impl ModeKeyResolver for VimYankResolver {
         session: &mut dyn SessionApiDyn,
         extensions: &mut ExtensionMap,
     ) -> ResolveResult {
+        tracing::debug!(key = ?key, "yank resolver: resolve_with_session");
+
         if is_escape(key) {
             self.clear_state();
             return ResolveResult::ModeTransition(build_cancelled());
@@ -217,6 +230,11 @@ impl ModeKeyResolver for VimYankResolver {
             if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    register = ?state.register,
+                    "yank resolver: initialized from VimSessionState"
+                );
             }
             state.initialized = true;
         }
@@ -265,12 +283,34 @@ impl ModeKeyResolver for VimYankResolver {
         state.push_key(*key);
         let keys = state.keys();
 
-        let lookup_state = input.keymap.query(input.mode, &keys);
+        // First try the current mode, then fall back to parent mode for motions
+        let lookup_state = {
+            let state = input.keymap.query(input.mode, &keys);
+            if matches!(state, reovim_driver_input::KeyLookupState::NotFound) {
+                // Motion bindings are in normal mode, not operator modes
+                input.keymap.query(&self.parent_mode_id, &keys)
+            } else {
+                state
+            }
+        };
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                let motion_count = state.take_motion_count();
+                // Calculate effective count BEFORE taking motion_count
+                // For 2yw: operator_count=2, motion_count=None → effective=2
+                // For y2w: operator_count=None, motion_count=2 → effective=2
+                // For 2y3w: operator_count=2, motion_count=3 → effective=6
+                let effective_count = state.effective_count();
+                tracing::debug!(
+                    operator_count = ?state.operator_count,
+                    motion_count = ?state.motion_count,
+                    effective_count,
+                    cmd = %cmd,
+                    linewise,
+                    "yank resolver: executing motion"
+                );
+                let _motion_count = state.take_motion_count();
                 state.clear_keys();
 
                 if let Some(buffer) = session.active_buffer()
@@ -279,14 +319,18 @@ impl ModeKeyResolver for VimYankResolver {
                     state.set_start_position(start_pos);
                 }
 
+                // Inclusive motions need end position adjustment ($ returns ON last char)
+                let inclusive = !linewise && is_inclusive_motion(&cmd);
+                let word_forward = !linewise && is_word_forward_motion(&cmd);
                 if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
-                    vim.pending_motion = Some(PendingMotion::new(linewise));
+                    vim.pending_motion =
+                        Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
 
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: motion_count,
+                    count: Some(effective_count),
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -321,10 +365,22 @@ impl ModeKeyResolver for VimYankResolver {
         let buffer_id = session.active_buffer()?;
         let end_pos = session.buffer_position(buffer_id)?;
 
-        let (range_start, range_end) = if start_pos <= end_pos {
-            (start_pos, end_pos)
-        } else {
-            (end_pos, start_pos)
+        // Normalize range and adjust for motion type
+        let (range_start, range_end) = {
+            // First normalize direction (start <= end)
+            let (start, end) = if start_pos <= end_pos {
+                (start_pos, end_pos)
+            } else {
+                (end_pos, start_pos)
+            };
+
+            // For inclusive characterwise motions, make end exclusive
+            // ($ returns cursor ON last char, but Range.end is exclusive)
+            if !motion.linewise && motion.inclusive {
+                (start, Position::new(end.line, end.column + 1))
+            } else {
+                (start, end)
+            }
         };
 
         let count = state.operator_count;

--- a/modules/vim/src/session_state.rs
+++ b/modules/vim/src/session_state.rs
@@ -141,29 +141,85 @@ impl VimSessionState {
 ///
 /// This replaces `CommandResult::Motion` - motion type classification
 /// is resolver policy knowledge, not command mechanism.
+///
+/// # Motion Semantics
+///
+/// - **Linewise**: The motion affects entire lines (j, k, gg, G)
+/// - **Inclusive**: The cursor lands ON the last character of the range ($, e, f, t)
+/// - **Exclusive**: The cursor lands at the START of the next unit (w, b, h, l)
+/// - **Word Forward**: The motion is word-forward (w, W) - needs special handling for `c`
+///
+/// For operators, exclusive motions work directly with `Range.end` (which is exclusive),
+/// but inclusive motions need +1 adjustment to include the character under the cursor.
 #[derive(Debug, Clone, Copy)]
 pub struct PendingMotion {
     /// Whether the motion is linewise (j, k, gg, G) or characterwise (w, b, h, l, $).
     pub linewise: bool,
+    /// Whether the motion is inclusive (cursor lands ON last char).
+    ///
+    /// Inclusive motions: $, e, E, f, F, t, T, G, gg, %
+    /// Exclusive motions: w, W, b, B, h, l, 0, ^
+    ///
+    /// For characterwise inclusive motions, the end position must be
+    /// adjusted by +1 to convert to exclusive range semantics.
+    pub inclusive: bool,
+    /// Whether this is a word-forward motion (w, W).
+    ///
+    /// This is used by the change operator for the `cw` special case:
+    /// `cw` behaves like `ce` (change to end of word, not to start of next word).
+    /// See `:help cw` in Vim for documentation of this behavior.
+    pub word_forward: bool,
 }
 
 impl PendingMotion {
-    /// Create a new pending motion.
+    /// Create a new pending motion with explicit flags.
     #[must_use]
-    pub const fn new(linewise: bool) -> Self {
-        Self { linewise }
+    pub const fn new(linewise: bool, inclusive: bool, word_forward: bool) -> Self {
+        Self {
+            linewise,
+            inclusive,
+            word_forward,
+        }
     }
 
-    /// Create a characterwise pending motion (w, b, h, l, $, etc.).
+    /// Create a characterwise exclusive pending motion (w, b, h, l, etc.).
     #[must_use]
     pub const fn characterwise() -> Self {
-        Self { linewise: false }
+        Self {
+            linewise: false,
+            inclusive: false,
+            word_forward: false,
+        }
+    }
+
+    /// Create a characterwise inclusive pending motion ($, e, f, t, etc.).
+    #[must_use]
+    pub const fn characterwise_inclusive() -> Self {
+        Self {
+            linewise: false,
+            inclusive: true,
+            word_forward: false,
+        }
     }
 
     /// Create a linewise pending motion (j, k, gg, G, etc.).
     #[must_use]
     pub const fn linewise() -> Self {
-        Self { linewise: true }
+        Self {
+            linewise: true,
+            inclusive: false,
+            word_forward: false,
+        }
+    }
+
+    /// Create a word-forward motion (w, W) for special cw handling.
+    #[must_use]
+    pub const fn word_forward() -> Self {
+        Self {
+            linewise: false,
+            inclusive: false,
+            word_forward: true,
+        }
     }
 }
 

--- a/modules/vim/tests/cursor_movement.rs
+++ b/modules/vim/tests/cursor_movement.rs
@@ -1,6 +1,6 @@
 //! Cursor movement tests (hjkl, 0$, gg/G, w/b/e).
 //!
-//! **Status**: All 22 tests IGNORED - cursor always at (0,0) (#425).
+//! **Status**: All 22 tests pass. Fixed #425 (cursor fallback to session buffer).
 //! Count prefix support (3j, 5G) implemented in RPC input handler.
 //! $ motion (end-of-line) fully covered with edge cases (#340).
 //! Design: $ ignores count prefix (2$ = $, simplified behavior).
@@ -12,7 +12,6 @@ use runner::testing::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_j_moves_down() {
     let result = IntegrationTest::new()
         .await
@@ -24,7 +23,6 @@ async fn test_j_moves_down() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_k_moves_up() {
     let result = IntegrationTest::new()
         .await
@@ -36,7 +34,6 @@ async fn test_k_moves_up() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_l_moves_right() {
     let result = IntegrationTest::new()
         .await
@@ -48,7 +45,6 @@ async fn test_l_moves_right() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_h_moves_left() {
     let result = IntegrationTest::new()
         .await
@@ -60,7 +56,6 @@ async fn test_h_moves_left() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_3j_count_movement() {
     let result = IntegrationTest::new()
         .await
@@ -76,7 +71,6 @@ async fn test_3j_count_movement() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_moves_to_eol() {
     let result = IntegrationTest::new()
         .await
@@ -88,7 +82,6 @@ async fn test_dollar_moves_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_0_moves_to_bol() {
     let result = IntegrationTest::new()
         .await
@@ -100,7 +93,6 @@ async fn test_0_moves_to_bol() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_caret_moves_to_first_nonblank() {
     let result = IntegrationTest::new()
         .await
@@ -112,7 +104,6 @@ async fn test_caret_moves_to_first_nonblank() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_from_middle_of_line() {
     // From middle of line, $ goes to last char
     let result = IntegrationTest::new()
@@ -127,7 +118,6 @@ async fn test_dollar_from_middle_of_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_on_empty_line() {
     // Edge case: empty line stays at col 0
     let result = IntegrationTest::new()
@@ -141,7 +131,6 @@ async fn test_dollar_on_empty_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_on_single_char_line() {
     // Edge case: single character
     let result = IntegrationTest::new()
@@ -155,7 +144,6 @@ async fn test_dollar_on_single_char_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_ignores_count() {
     // Design decision: $ ignores count prefix (simplified, not Vim-compatible)
     // 2$ behaves same as $ - goes to end of current line
@@ -170,7 +158,6 @@ async fn test_dollar_ignores_count() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_then_j_navigation() {
     // Combine $ with other motions
     let result = IntegrationTest::new()
@@ -188,7 +175,6 @@ async fn test_dollar_then_j_navigation() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_gg_moves_to_first_line() {
     let result = IntegrationTest::new()
         .await
@@ -200,7 +186,6 @@ async fn test_gg_moves_to_first_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_g_moves_to_last_line() {
     let result = IntegrationTest::new()
         .await
@@ -212,7 +197,6 @@ async fn test_g_moves_to_last_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_5g_moves_to_line_5() {
     let result = IntegrationTest::new()
         .await
@@ -228,7 +212,6 @@ async fn test_5g_moves_to_line_5() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_w_moves_to_next_word() {
     let result = IntegrationTest::new()
         .await
@@ -240,7 +223,6 @@ async fn test_w_moves_to_next_word() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_b_moves_to_prev_word() {
     let result = IntegrationTest::new()
         .await
@@ -252,7 +234,6 @@ async fn test_b_moves_to_prev_word() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_e_moves_to_end_of_word() {
     let result = IntegrationTest::new()
         .await
@@ -268,7 +249,6 @@ async fn test_e_moves_to_end_of_word() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_j_at_last_line() {
     let result = IntegrationTest::new()
         .await
@@ -280,7 +260,6 @@ async fn test_j_at_last_line() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_h_at_bol() {
     let result = IntegrationTest::new()
         .await
@@ -292,7 +271,6 @@ async fn test_h_at_bol() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_l_at_eol() {
     let result = IntegrationTest::new()
         .await

--- a/modules/vim/tests/operators.rs
+++ b/modules/vim/tests/operators.rs
@@ -1,12 +1,17 @@
 //! Operator integration tests (delete, yank, paste, change).
 //!
-//! **Status**: 24 tests enabled, 10 tests require operator-pending mode.
+//! **Status**: 54 tests enabled, 1 ignored (dG motion needs investigation).
 //!
-//! Operator-pending mode (d+motion, y+motion, c+motion) is not yet implemented.
-//! Tests using direct bindings (dd, yy, cc, x, 5dd, 3x, etc.) work.
-//! Count prefix edge cases fully covered (#337).
+//! Tests operator-pending mode (d+motion, y+motion, c+motion) with:
+//! - Direct bindings: dd, yy, cc, x, 5dd, 3x
+//! - Motion composition: dw, d$, dj, dk, de, dgg, yw, yj, y$, cw, c$, cj
+//! - Count prefixes: 2dj, 3dw, 2cw, d2j, y2j
+//! - Step-by-step tracing via StepTest (Issue #428)
+//! - Register assertions: assert_register()
 //!
-//! Run `cargo test --ignored` to run the remaining ignored tests.
+//! Note: dG (delete to document end) has a motion handling issue - tracked in #429.
+//!
+//! Run `cargo test --ignored` to run the remaining ignored test.
 
 use runner::testing::IntegrationTest;
 
@@ -125,7 +130,6 @@ async fn test_dw_delete_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_d_dollar_delete_to_eol() {
     let result = IntegrationTest::new()
         .await
@@ -137,7 +141,6 @@ async fn test_d_dollar_delete_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_dj_delete_two_lines() {
     let result = IntegrationTest::new()
         .await
@@ -186,7 +189,6 @@ async fn test_yy_p_multiline() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_yj_yank_two_lines() {
     let result = IntegrationTest::new()
         .await
@@ -235,15 +237,17 @@ async fn test_dd_p_paste_after() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_dd_upper_p_paste_before() {
+    // jddP: move to line 1, delete it (yanking "line 2\n"), paste before current line
+    // After dd: buffer is "line 1\nline 3", cursor on line 1 ("line 3")
+    // P pastes "line 2\n" before line 1, restoring original order
     let result = IntegrationTest::new()
         .await
         .with_buffer("line 1\nline 2\nline 3")
         .send_keys("jddP")
         .run()
         .await;
-    result.assert_buffer_eq("line 2\nline 1\nline 3");
+    result.assert_buffer_eq("line 1\nline 2\nline 3");
 }
 
 #[tokio::test]
@@ -284,7 +288,6 @@ async fn test_paste_preserves_register() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_cw_change_word() {
     let result = IntegrationTest::new()
         .await
@@ -297,7 +300,6 @@ async fn test_cw_change_word() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_c_dollar_change_to_eol() {
     let result = IntegrationTest::new()
         .await
@@ -320,7 +322,6 @@ async fn test_cc_change_line() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_2cw_change_count() {
     let result = IntegrationTest::new()
         .await
@@ -328,7 +329,10 @@ async fn test_2cw_change_count() {
         .send_keys("2cwXXX<Esc>")
         .run()
         .await;
-    result.assert_buffer_eq("XXXthree");
+    // Note: In Vim, `cw` changes to END of word (like `ce`), not start of next word.
+    // So `2cw` changes "one two" (not "one two "), leaving space before "three".
+    // This is documented Vim behavior (`:help cw`).
+    result.assert_buffer_eq("XXX three");
 }
 
 // ============================================================================
@@ -476,4 +480,323 @@ async fn debug_cc_single_char() {
     eprintln!("  Mode: {}", after_x.edit_mode);
 
     after_x.assert_buffer_eq("line 1\nX\nline 3");
+}
+
+// ============================================================================
+// OPERATOR + MOTION COMBINATIONS (Issue #415)
+// ============================================================================
+
+/// dk - delete current line and line above (linewise motion upward)
+#[tokio::test]
+async fn test_dk_delete_prev_line() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("jdk")
+        .run()
+        .await;
+    result.assert_buffer_eq("line 3");
+}
+
+/// y$ - yank to end of line (characterwise, inclusive)
+#[tokio::test]
+async fn test_y_dollar_yank_to_eol() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("hello world")
+        .send_keys("lly$P")
+        .run()
+        .await;
+    // At col 2 ('l'), y$ yanks "llo world", P pastes before cursor
+    result.assert_buffer_contains("llo world");
+}
+
+/// cj - change two lines (current + next), enter insert mode
+#[tokio::test]
+async fn test_cj_change_two_lines() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("cjX<Esc>")
+        .run()
+        .await;
+    result.assert_buffer_eq("X\nline 3");
+    result.assert_normal_mode();
+}
+
+/// de - delete to end of word (characterwise, inclusive)
+#[tokio::test]
+async fn test_de_delete_to_word_end() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("hello world")
+        .send_keys("de")
+        .run()
+        .await;
+    // de deletes "hello" (to end of word, inclusive)
+    result.assert_buffer_eq(" world");
+}
+
+/// dG - delete from current line to end of document
+/// Issue #429: G motion with delete operator not working correctly
+#[tokio::test]
+#[ignore = "G motion with delete operator needs investigation - Issue #429"]
+async fn test_dg_delete_to_doc_end() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("dG")
+        .run()
+        .await;
+    // dG from line 0 deletes all lines (to end of document)
+    result.assert_buffer_eq("");
+}
+
+/// dgg - delete from current line to start of document
+/// Note: Gdgg from last line deletes all lines (to start of document)
+#[tokio::test]
+async fn test_dgg_delete_to_doc_start() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("Gdgg")
+        .run()
+        .await;
+    // G moves to last line, dgg deletes all lines (to start)
+    result.assert_buffer_eq("");
+}
+
+// ============================================================================
+// COUNT PREFIX WITH MOTIONS (Issue #415)
+// ============================================================================
+
+/// d2j - delete 3 lines (current + 2 down)
+#[tokio::test]
+async fn test_d2j_delete_three_lines() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3\nline 4\nline 5")
+        .send_keys("d2j")
+        .run()
+        .await;
+    result.assert_buffer_eq("line 4\nline 5");
+}
+
+/// 3dw - delete 3 words
+#[tokio::test]
+async fn test_3dw_delete_three_words() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("one two three four five")
+        .send_keys("3dw")
+        .run()
+        .await;
+    result.assert_buffer_eq("four five");
+}
+
+/// y2j then p - yank 3 lines and paste
+#[tokio::test]
+async fn test_y2j_yank_three_lines() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3\nline 4")
+        .send_keys("y2jGp")
+        .run()
+        .await;
+    // Yank lines 0-2, paste after line 3
+    result.assert_buffer_eq("line 1\nline 2\nline 3\nline 4\nline 1\nline 2\nline 3");
+}
+
+// ============================================================================
+// STEPTEST WITH ASSERTIONS (Issue #415, #428)
+// ============================================================================
+
+use runner::testing::StepTest;
+
+/// StepTest: dj with per-step mode verification
+#[tokio::test]
+async fn test_step_dj_with_assertions() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .step("d")
+        .expect_mode_contains("DELETE")
+        .expect_buffer("line 1\nline 2\nline 3") // No change yet
+        .step("j")
+        .expect_buffer("line 3")
+        .expect_cursor(0, 0)
+        .expect_mode_contains("NORMAL")
+        .run()
+        .await;
+    trace.assert_ok();
+}
+
+/// StepTest: yj with register verification at each step
+#[tokio::test]
+async fn test_step_yj_with_register() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .step("y")
+        .expect_mode_contains("YANK")
+        .step("j")
+        .expect_mode_contains("NORMAL")
+        .expect_register("\"", "line 1\nline 2\n", "linewise")
+        .expect_cursor(0, 0) // Cursor restored to start of yank range
+        .run()
+        .await;
+    trace.assert_ok();
+}
+
+/// StepTest: cw with mode transition verification
+/// Note: cw deletes to end of word but preserves trailing space (Vim behavior)
+#[tokio::test]
+async fn test_step_cw_mode_transition() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .step("c")
+        .expect_mode_contains("CHANGE")
+        .step("w")
+        .expect_buffer(" world") // cw preserves trailing space
+        .expect_mode_contains("INSERT")
+        .run()
+        .await;
+    trace.assert_ok();
+}
+
+/// StepTest: d$ with inclusive motion handling
+#[tokio::test]
+async fn test_step_d_dollar_inclusive() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .with_cursor_at(0, 2) // Start at 'l' in "hello"
+        .step("d")
+        .expect_mode_contains("DELETE")
+        .step("$")
+        .expect_buffer("he")
+        .expect_mode_contains("NORMAL")
+        .run()
+        .await;
+    trace.assert_ok();
+}
+
+// ============================================================================
+// STEP-BY-STEP DEBUG TESTS
+// ============================================================================
+
+/// Debug test for `dj` - delete two lines
+/// Expected: "line 1\nline 2\nline 3" -> "line 3" (delete lines 0 and 1)
+#[tokio::test]
+async fn debug_step_dj() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .step("d")
+        .step("j")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    // Verify final state
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+    eprintln!("Final cursor: ({}, {})", final_state.cursor_line, final_state.cursor_column);
+    eprintln!("Final mode: {}", final_state.mode_display);
+}
+
+/// Debug test for `yj` - yank two lines
+/// Expected: yank lines 0 and 1, then paste duplicates them
+#[tokio::test]
+async fn debug_step_yj() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .step("y")
+        .step("j")
+        .step("p")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+}
+
+/// Debug test for `cw` - change word
+/// Expected: "hello world" with cw should delete "hello" and enter insert
+#[tokio::test]
+async fn debug_step_cw() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .step("c")
+        .step("w")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+    eprintln!("Final mode: {} ({})", final_state.mode_display, final_state.edit_mode);
+}
+
+/// Debug test for `dw` - delete word (this one works!)
+/// Compare against cw to understand the difference
+#[tokio::test]
+async fn debug_step_dw() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .step("d")
+        .step("w")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+}
+
+/// Debug test for `2cw` - change 2 words
+#[tokio::test]
+async fn debug_step_2cw() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("one two three")
+        .step("2")
+        .step("c")
+        .step("w")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+    eprintln!("Final mode: {} ({})", final_state.mode_display, final_state.edit_mode);
+}
+
+/// Debug test for `d$` - delete to end of line (this should work after inclusive fix)
+#[tokio::test]
+async fn debug_step_d_dollar() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .with_cursor_at(0, 2) // Start at 'l' in "hello"
+        .step("d")
+        .step("$")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nExpected buffer: \"he\"");
+    eprintln!("Actual buffer: {:?}", final_state.buffer);
 }

--- a/modules/vim/tests/operators.rs
+++ b/modules/vim/tests/operators.rs
@@ -114,7 +114,6 @@ async fn test_3x_count_delete() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_dw_delete_word() {
     let result = IntegrationTest::new()
         .await
@@ -150,7 +149,6 @@ async fn test_dj_delete_two_lines() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_db_delete_backward_word() {
     let result = IntegrationTest::new()
         .await
@@ -226,7 +224,6 @@ async fn test_2yy_yank_count() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode (d/y/c + motion)"]
 async fn test_dd_p_paste_after() {
     let result = IntegrationTest::new()
         .await
@@ -312,7 +309,6 @@ async fn test_c_dollar_change_to_eol() {
 }
 
 #[tokio::test]
-#[ignore = "cc cursor positioning (#421)"]
 async fn test_cc_change_line() {
     let result = IntegrationTest::new()
         .await
@@ -408,7 +404,6 @@ async fn test_count_yank_exceeds_lines() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_large_count_movement() {
     // 999j on 3 lines clamps to last line
     let result = IntegrationTest::new()
@@ -422,7 +417,6 @@ async fn test_large_count_movement() {
 }
 
 #[tokio::test]
-#[ignore = "cursor always at (0,0) (#425)"]
 async fn test_dollar_then_count_h() {
     // Go to EOL then move back with count
     let result = IntegrationTest::new()
@@ -433,4 +427,53 @@ async fn test_dollar_then_count_h() {
         .await;
     // At 'd' (col 10), 3h -> col 7 ('o' in "world")
     result.assert_cursor(0, 7);
+}
+
+// Debug test for #421
+#[tokio::test]
+async fn debug_cc_no_text() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("jcc<Esc>")
+        .run()
+        .await;
+
+    eprintln!("DEBUG cc without text:");
+    eprintln!("  Buffer: {:?}", result.buffer_content);
+    eprintln!("  Cursor: ({}, {})", result.cursor_line, result.cursor_column);
+    eprintln!("  Mode: {}", result.edit_mode);
+
+    result.assert_buffer_eq("line 1\n\nline 3");
+}
+
+#[tokio::test]
+async fn debug_cc_single_char() {
+    // First check state after cc (before typing)
+    let after_cc = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("jcc")
+        .run()
+        .await;
+
+    eprintln!("DEBUG after jcc (in insert mode):");
+    eprintln!("  Buffer: {:?}", after_cc.buffer_content);
+    eprintln!("  Cursor: ({}, {})", after_cc.cursor_line, after_cc.cursor_column);
+    eprintln!("  Mode: {}", after_cc.edit_mode);
+
+    // Now check what happens when we type X
+    let after_x = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("jccX<Esc>")
+        .run()
+        .await;
+
+    eprintln!("DEBUG after jccX<Esc>:");
+    eprintln!("  Buffer: {:?}", after_x.buffer_content);
+    eprintln!("  Cursor: ({}, {})", after_x.cursor_line, after_x.cursor_column);
+    eprintln!("  Mode: {}", after_x.edit_mode);
+
+    after_x.assert_buffer_eq("line 1\nX\nline 3");
 }

--- a/modules/vim/tests/registers.rs
+++ b/modules/vim/tests/registers.rs
@@ -33,7 +33,6 @@ async fn test_dd_populates_unnamed_register() {
 }
 
 #[tokio::test]
-#[ignore = "requires operator-pending mode for yw motion"]
 async fn test_yw_char_yank_type() {
     let result = IntegrationTest::new()
         .await

--- a/runner/src/server/rpc/handlers/input.rs
+++ b/runner/src/server/rpc/handlers/input.rs
@@ -267,15 +267,17 @@ async fn handle_mode_transition_async(ctx: &RpcContext, transition: ModeTransiti
         }
 
         ModeTransition::Pop { result } => {
-            // Handle pop result before actually popping
-            if let Some(ref pop_result) = result {
-                handle_pop_result_async(ctx, pop_result).await;
-            }
+            // Pop first, THEN handle result
+            // This ensures commands that transition to a new mode (like change→insert)
+            // operate on the base mode, not the mode being popped.
             ctx.session
                 .with_state_mut(|state| {
                     state.mode_stack_mut().pop();
                 })
                 .await;
+            if let Some(ref pop_result) = result {
+                handle_pop_result_async(ctx, pop_result).await;
+            }
         }
 
         ModeTransition::Set { mode, context: _ } => {

--- a/runner/src/server/rpc/handlers/state.rs
+++ b/runner/src/server/rpc/handlers/state.rs
@@ -88,12 +88,15 @@ pub fn state_cursor(ctx: RpcContext, _params: serde_json::Value) -> HandlerFutur
         }; // Lock dropped before acquiring session lock
 
         // Query cursor position from session state
-        // Falls back to (0, 0) if no active buffer
+        // Falls back to session's active buffer if client viewport has none,
+        // then to (0, 0) if no buffer at all
         let cursor = ctx
             .session
             .with_state(|state| {
-                // Get cursor from client's active buffer
-                if let Some(buffer_id) = active_buffer
+                // Try client's active buffer first, fall back to session's active buffer
+                let buffer_id = active_buffer.or_else(|| state.session_active_buffer());
+
+                if let Some(buffer_id) = buffer_id
                     && let Some(buffer_arc) = state.app.kernel.buffers.get(buffer_id)
                 {
                     let pos = buffer_arc.read().position();
@@ -102,7 +105,7 @@ pub fn state_cursor(ctx: RpcContext, _params: serde_json::Value) -> HandlerFutur
                         column: pos.column,
                     };
                 }
-                // Fallback when no active buffer
+                // Fallback when no buffer at all
                 CursorInfo { line: 0, column: 0 }
             })
             .await;

--- a/runner/src/testing/harness.rs
+++ b/runner/src/testing/harness.rs
@@ -2,21 +2,28 @@
 //!
 //! This is the core **mechanism** for integration testing - it handles
 //! server lifecycle without any knowledge of what's being tested.
+//!
+//! # Log Capture (#428)
+//!
+//! The harness can capture server stderr to a per-test log file for debugging.
+//! Use `spawn_with_log(test_name)` to enable automatic log capture.
 
 // Test infrastructure - suppress pedantic docs requirements
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_panics_doc)]
 
 use std::{
-    path::PathBuf,
+    io::Write,
+    path::{Path, PathBuf},
     process::Stdio,
     sync::atomic::{AtomicU32, Ordering},
     time::Duration,
 };
 
 use tokio::{
-    io::{AsyncBufReadExt, BufReader},
-    process::{Child, Command},
+    io::{AsyncBufReadExt, BufReader, Lines},
+    process::{Child, ChildStderr, Command},
+    task::JoinHandle,
 };
 
 /// Counter for unique test identifiers
@@ -24,6 +31,9 @@ static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Server startup timeout
 const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default log directory for test logs
+const TEST_LOG_DIR: &str = "tmp/test-logs";
 
 /// Get path to the reovim binary
 fn binary_path() -> PathBuf {
@@ -39,7 +49,9 @@ fn binary_path() -> PathBuf {
         .join("target/debug/reovim")
 }
 
-/// Read "Listening on 127.0.0.1:<port>" from stderr
+/// Read "Listening on 127.0.0.1:<port>" from stderr, consuming the reader.
+///
+/// This is the original function that discards stderr after port extraction.
 async fn read_port_from_stderr(
     process: &mut Child,
 ) -> Result<u16, Box<dyn std::error::Error + Send + Sync>> {
@@ -60,16 +72,90 @@ async fn read_port_from_stderr(
     Err("Server exited without outputting port".into())
 }
 
+/// Read port from stderr and return the reader for continued use.
+///
+/// Unlike `read_port_from_stderr`, this returns the reader so logs can continue
+/// to be captured after port extraction.
+async fn read_port_preserving_reader(
+    stderr: ChildStderr,
+) -> Result<
+    (u16, Lines<BufReader<ChildStderr>>, Vec<String>),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let mut reader = BufReader::new(stderr).lines();
+    let mut early_lines = Vec::new();
+
+    while let Some(line) = reader.next_line().await? {
+        // Save all lines for the log file
+        early_lines.push(line.clone());
+
+        if line.starts_with("Warning:") {
+            continue;
+        }
+        if line.contains("!!!! PANIC !!!!") {
+            return Err(format!("Server panicked: {line}").into());
+        }
+        if let Some(rest) = line.strip_prefix("Listening on 127.0.0.1:") {
+            let port = rest.parse::<u16>()?;
+            return Ok((port, reader, early_lines));
+        }
+    }
+    Err("Server exited without outputting port".into())
+}
+
+/// Spawn a background task that writes stderr lines to a log file.
+fn spawn_log_capture_task(
+    mut reader: Lines<BufReader<ChildStderr>>,
+    log_path: PathBuf,
+    early_lines: Vec<String>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Ok(mut file) = std::fs::File::create(&log_path) else {
+            eprintln!("Failed to create log file: {}", log_path.display());
+            return;
+        };
+
+        // Write header
+        let _ = writeln!(file, "=== Server Log Started ===");
+
+        // Write early lines (captured during port extraction)
+        for line in early_lines {
+            let _ = writeln!(file, "{line}");
+        }
+
+        // Continue reading and writing
+        while let Ok(Some(line)) = reader.next_line().await {
+            let _ = writeln!(file, "{line}");
+        }
+
+        let _ = writeln!(file, "=== Server Log Ended ===");
+    })
+}
+
 /// Test harness that spawns a server process.
 ///
 /// Automatically cleans up the server process when dropped.
+///
+/// # Log Capture
+///
+/// Use `spawn_with_log(test_name)` to automatically capture server logs
+/// to `tmp/test-logs/{test_name}_{timestamp}.log`. This is invaluable for
+/// debugging test failures as it preserves the server's tracing output.
 pub struct TestServerHarness {
     process: Child,
     port: u16,
+    /// Path to the log file (if log capture is enabled).
+    log_file: Option<PathBuf>,
+    /// Background task capturing stderr (if log capture is enabled).
+    #[allow(dead_code)]
+    log_task: Option<JoinHandle<()>>,
 }
 
 impl TestServerHarness {
-    /// Spawn server on OS-assigned port.
+    /// Spawn server on OS-assigned port (without log capture).
+    ///
+    /// For debugging test failures, prefer `spawn_with_log()` which captures
+    /// server output to a file.
     ///
     /// # Errors
     ///
@@ -95,13 +181,97 @@ impl TestServerHarness {
                 .map_err(|_| "Server startup timed out (10s)")?
                 .map_err(|e| format!("Failed to read port: {e}"))?;
 
-        Ok(Self { process, port })
+        Ok(Self {
+            process,
+            port,
+            log_file: None,
+            log_task: None,
+        })
+    }
+
+    /// Spawn server with automatic log capture to a per-test file.
+    ///
+    /// Server stderr is captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
+    /// This is invaluable for debugging test failures as it preserves the
+    /// server's tracing output including mode transitions, command executions,
+    /// and resolver calls.
+    ///
+    /// The server is started with `REOVIM_LOG=debug` by default for full
+    /// tracing visibility.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let harness = TestServerHarness::spawn_with_log("test_yj_yank").await?;
+    /// // ... run test ...
+    /// // On failure, check: tmp/test-logs/test_yj_yank_20260124_120000.log
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Binary not found at expected path
+    /// - Server fails to start within timeout
+    /// - Server panics during startup
+    /// - Log directory cannot be created
+    pub async fn spawn_with_log(
+        test_name: &str,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        // Create log directory
+        let log_dir = PathBuf::from(TEST_LOG_DIR);
+        std::fs::create_dir_all(&log_dir)?;
+
+        // Generate log file path with timestamp
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let log_file = log_dir.join(format!("{test_name}_{timestamp}.log"));
+
+        let _test_id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        // Use debug level by default for test log capture
+        let log_level = std::env::var("REOVIM_LOG").unwrap_or_else(|_| "debug".to_string());
+
+        let mut process = Command::new(binary_path())
+            .args(["server", "--tcp", "0"])
+            .env("REOVIM_LOG", log_level)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        // Extract stderr for port reading and log capture
+        let stderr = process.stderr.take().ok_or("Failed to capture stderr")?;
+
+        // Read port while preserving the reader for continued log capture
+        let (port, reader, early_lines) =
+            tokio::time::timeout(SERVER_STARTUP_TIMEOUT, read_port_preserving_reader(stderr))
+                .await
+                .map_err(|_| "Server startup timed out (10s)")?
+                .map_err(|e| format!("Failed to read port: {e}"))?;
+
+        // Spawn background task to continue capturing logs
+        let log_task = spawn_log_capture_task(reader, log_file.clone(), early_lines);
+
+        Ok(Self {
+            process,
+            port,
+            log_file: Some(log_file),
+            log_task: Some(log_task),
+        })
     }
 
     /// Get the port the server is listening on.
     #[must_use]
     pub const fn port(&self) -> u16 {
         self.port
+    }
+
+    /// Get the path to the log file (if log capture is enabled).
+    ///
+    /// Returns `None` if the harness was created with `spawn()` instead
+    /// of `spawn_with_log()`.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&Path> {
+        self.log_file.as_deref()
     }
 }
 

--- a/runner/src/testing/integration.rs
+++ b/runner/src/testing/integration.rs
@@ -60,13 +60,22 @@ pub struct IntegrationTest {
 }
 
 impl IntegrationTest {
-    /// Create new test (spawns server).
+    /// Create new test with automatic log capture (spawns server).
+    ///
+    /// Server logs are captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
+    /// This is invaluable for debugging test failures.
     ///
     /// # Panics
     ///
     /// Panics if server fails to spawn.
     pub async fn new() -> Self {
-        let harness = TestServerHarness::spawn()
+        // Get test name from current thread (set by cargo test)
+        let test_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown_test")
+            .to_string();
+
+        let harness = TestServerHarness::spawn_with_log(&test_name)
             .await
             .expect("Failed to spawn server");
         let config = ConnectionConfig::tcp("127.0.0.1", harness.port());
@@ -78,6 +87,14 @@ impl IntegrationTest {
             key_sequences: Vec::new(),
             default_delay: DEFAULT_DELAY_MS,
         }
+    }
+
+    /// Get the path to the server log file for debugging.
+    ///
+    /// Returns `None` if log capture is not enabled.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&std::path::Path> {
+        self.harness.log_path()
     }
 
     /// Make an RPC call with a fresh connection (avoids stale notification issues).
@@ -270,7 +287,7 @@ impl IntegrationTest {
             mode_display: mode["display"].as_str().unwrap_or("").to_string(),
             edit_mode: mode["edit_mode"].as_str().unwrap_or("").to_string(),
             registers,
-            _harness: self.harness,
+            harness: self.harness,
             temp_path: Some(temp_path),
         }
     }
@@ -299,7 +316,7 @@ pub struct TestResult {
     pub edit_mode: String,
     /// Register contents.
     pub registers: HashMap<String, RegisterInfo>,
-    _harness: TestServerHarness,
+    harness: TestServerHarness,
     temp_path: Option<String>,
 }
 
@@ -312,14 +329,31 @@ impl Drop for TestResult {
 }
 
 impl TestResult {
+    /// Get the path to the server log file for debugging.
+    ///
+    /// Returns `None` if log capture is not enabled.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&std::path::Path> {
+        self.harness.log_path()
+    }
+
+    /// Format log path hint for assertion messages.
+    fn log_hint(&self) -> String {
+        self.log_path()
+            .map(|p| format!("\n\n📋 Server log: {}", p.display()))
+            .unwrap_or_default()
+    }
+
     /// Assert buffer equals expected (trimmed).
     pub fn assert_buffer_eq(&self, expected: &str) {
-        assert_eq!(
-            self.buffer_content.trim_end(),
-            expected.trim_end(),
-            "Buffer content mismatch\nExpected:\n{}\nActual:\n{}",
+        assert!(
+            self.buffer_content.trim_end() == expected.trim_end(),
+            "assertion `left == right` failed: Buffer content mismatch\n\
+             Expected:\n{}\n\
+             Actual:\n{}{}",
             expected,
-            self.buffer_content
+            self.buffer_content,
+            self.log_hint()
         );
     }
 
@@ -327,22 +361,23 @@ impl TestResult {
     pub fn assert_buffer_contains(&self, expected: &str) {
         assert!(
             self.buffer_content.contains(expected),
-            "Buffer does not contain '{}'\nActual:\n{}",
+            "Buffer does not contain '{}'\nActual:\n{}{}",
             expected,
-            self.buffer_content
+            self.buffer_content,
+            self.log_hint()
         );
     }
 
     /// Assert cursor position (line, col) - 0-indexed.
     pub fn assert_cursor(&self, line: u16, col: u16) {
-        assert_eq!(
-            (self.cursor_line, self.cursor_column),
-            (line, col),
-            "Cursor mismatch: expected (line={}, col={}), got (line={}, col={})",
+        assert!(
+            (self.cursor_line, self.cursor_column) == (line, col),
+            "Cursor mismatch: expected (line={}, col={}), got (line={}, col={}){}",
             line,
             col,
             self.cursor_line,
-            self.cursor_column
+            self.cursor_column,
+            self.log_hint()
         );
     }
 
@@ -350,56 +385,69 @@ impl TestResult {
     pub fn assert_register(&self, reg: &str, expected_content: &str, expected_type: &str) {
         let register = self.registers.get(reg).unwrap_or_else(|| {
             panic!(
-                "Register '{}' not found. Available: {:?}",
+                "Register '{}' not found. Available: {:?}{}",
                 reg,
-                self.registers.keys().collect::<Vec<_>>()
+                self.registers.keys().collect::<Vec<_>>(),
+                self.log_hint()
             )
         });
-        assert_eq!(
-            register.content.trim_end(),
-            expected_content.trim_end(),
-            "Register '{}' content mismatch\nExpected: '{}'\nActual: '{}'",
+        assert!(
+            register.content.trim_end() == expected_content.trim_end(),
+            "Register '{}' content mismatch\nExpected: '{}'\nActual: '{}'{}",
             reg,
             expected_content,
-            register.content
+            register.content,
+            self.log_hint()
         );
-        assert_eq!(
-            register.yank_type, expected_type,
-            "Register '{}' type mismatch\nExpected: '{}'\nActual: '{}'",
-            reg, expected_type, register.yank_type
+        assert!(
+            register.yank_type == expected_type,
+            "Register '{}' type mismatch\nExpected: '{}'\nActual: '{}'{}",
+            reg,
+            expected_type,
+            register.yank_type,
+            self.log_hint()
         );
     }
 
     /// Assert in normal mode.
     pub fn assert_normal_mode(&self) {
-        assert!(
-            self.edit_mode.to_lowercase().contains("normal")
-                || self.mode_display.to_uppercase().contains("NORMAL"),
-            "Expected normal mode, got: {} ({})",
-            self.mode_display,
-            self.edit_mode
-        );
+        if !self.edit_mode.to_lowercase().contains("normal")
+            && !self.mode_display.to_uppercase().contains("NORMAL")
+        {
+            panic!(
+                "Expected normal mode, got: {} ({}){}",
+                self.mode_display,
+                self.edit_mode,
+                self.log_hint()
+            );
+        }
     }
 
     /// Assert in insert mode.
     pub fn assert_insert_mode(&self) {
-        assert!(
-            self.edit_mode.to_lowercase().contains("insert")
-                || self.mode_display.to_uppercase().contains("INSERT"),
-            "Expected insert mode, got: {} ({})",
-            self.mode_display,
-            self.edit_mode
-        );
+        if !self.edit_mode.to_lowercase().contains("insert")
+            && !self.mode_display.to_uppercase().contains("INSERT")
+        {
+            panic!(
+                "Expected insert mode, got: {} ({}){}",
+                self.mode_display,
+                self.edit_mode,
+                self.log_hint()
+            );
+        }
     }
 
     /// Assert in visual mode.
     pub fn assert_visual_mode(&self) {
-        assert!(
-            self.edit_mode.to_lowercase().contains("visual")
-                || self.mode_display.to_uppercase().contains("VISUAL"),
-            "Expected visual mode, got: {} ({})",
-            self.mode_display,
-            self.edit_mode
-        );
+        if !self.edit_mode.to_lowercase().contains("visual")
+            && !self.mode_display.to_uppercase().contains("VISUAL")
+        {
+            panic!(
+                "Expected visual mode, got: {} ({}){}",
+                self.mode_display,
+                self.edit_mode,
+                self.log_hint()
+            );
+        }
     }
 }

--- a/runner/src/testing/mod.rs
+++ b/runner/src/testing/mod.rs
@@ -42,11 +42,13 @@ mod assertions;
 mod harness;
 mod integration;
 mod multi_client;
+mod step_test;
 
 pub use {
     harness::TestServerHarness,
     integration::{IntegrationTest, RegisterInfo, TestResult},
     multi_client::{MultiClientTest, TestClient},
+    step_test::{StateSnapshot, StepTest, StepTrace},
 };
 
 // Re-export macros at crate level for external use

--- a/runner/src/testing/step_test.rs
+++ b/runner/src/testing/step_test.rs
@@ -1,0 +1,652 @@
+//! Step-by-step integration test builder with per-key state tracking.
+//!
+//! Provides a fluent API for testing key-by-key behavior, capturing state
+//! (cursor, mode, registers) after each key and allowing assertions at each step.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let trace = StepTest::new()
+//!     .await
+//!     .with_buffer("hello world")
+//!     .step("d")
+//!         .expect_mode_contains("delete")
+//!     .step("w")
+//!         .expect_buffer("world")
+//!         .expect_cursor(0, 0)
+//!         .expect_register("\"", "hello ", "characterwise")
+//!     .run()
+//!     .await;
+//! trace.print_trace();
+//! ```
+
+// Test infrastructure - suppress pedantic docs requirements
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+
+use std::{
+    collections::HashMap,
+    io::Write,
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
+
+use serde_json::json;
+
+use crate::client::common::{ConnectionConfig, RpcClient};
+
+use super::{harness::TestServerHarness, integration::RegisterInfo};
+
+/// Counter for unique temp file names
+static STEP_TEMP_FILE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Connection retry settings
+const MAX_CONNECT_ATTEMPTS: u32 = 20;
+const RETRY_BASE_MS: u64 = 50;
+const RETRY_MAX_MS: u64 = 200;
+
+/// Default delay after each key (allows event processing)
+const DEFAULT_STEP_DELAY_MS: u64 = 30;
+
+/// State snapshot captured after a key.
+#[derive(Debug, Clone)]
+pub struct StateSnapshot {
+    /// Key that was pressed to reach this state.
+    pub key: String,
+    /// Buffer content after this key.
+    pub buffer: String,
+    /// Cursor line (0-indexed).
+    pub cursor_line: u16,
+    /// Cursor column (0-indexed).
+    pub cursor_column: u16,
+    /// Mode display name (e.g., "NORMAL", "DELETE").
+    pub mode_display: String,
+    /// Edit mode string (e.g., "vim:normal", "vim:delete").
+    pub edit_mode: String,
+    /// Register contents.
+    pub registers: HashMap<String, RegisterInfo>,
+}
+
+impl StateSnapshot {
+    /// Format as compact single line: "key -> mode (line:col)"
+    #[must_use]
+    pub fn compact(&self) -> String {
+        format!(
+            "{} -> {} ({}:{})",
+            self.key, self.mode_display, self.cursor_line, self.cursor_column
+        )
+    }
+
+    /// Format with buffer preview.
+    #[must_use]
+    pub fn verbose(&self) -> String {
+        let buf_preview = if self.buffer.len() > 40 {
+            format!("{}...", &self.buffer[..40])
+        } else {
+            self.buffer.clone()
+        };
+        format!(
+            "{} -> {} ({}:{}) buf={:?}",
+            self.key, self.mode_display, self.cursor_line, self.cursor_column, buf_preview
+        )
+    }
+}
+
+/// Per-step expectation to be verified after the key.
+#[derive(Debug, Clone)]
+enum StepExpectation {
+    /// Expect cursor at (line, col).
+    Cursor(u16, u16),
+    /// Expect buffer equals.
+    Buffer(String),
+    /// Expect buffer contains.
+    BufferContains(String),
+    /// Expect mode display contains.
+    ModeContains(String),
+    /// Expect edit mode equals.
+    EditMode(String),
+    /// Expect register content and type.
+    Register(String, String, String),
+}
+
+/// A step in the test sequence.
+struct TestStep {
+    /// Key or key sequence to send.
+    keys: String,
+    /// Delay after this step.
+    delay_ms: u64,
+    /// Expectations to verify after this step.
+    expectations: Vec<StepExpectation>,
+}
+
+/// Step-by-step test builder.
+///
+/// # Example
+///
+/// ```ignore
+/// let trace = StepTest::new()
+///     .await
+///     .with_buffer("line 1\nline 2\nline 3")
+///     .step("d")
+///         .expect_mode_contains("DELETE")
+///     .step("j")
+///         .expect_buffer("line 3")
+///         .expect_cursor(0, 0)
+///     .run()
+///     .await;
+/// trace.print_trace();
+/// ```
+pub struct StepTest {
+    harness: TestServerHarness,
+    config: ConnectionConfig,
+    initial_content: Option<String>,
+    initial_cursor: Option<(u16, u16)>,
+    steps: Vec<TestStep>,
+    default_delay: u64,
+}
+
+impl StepTest {
+    /// Create new step test with automatic log capture (spawns server).
+    ///
+    /// Server logs are captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
+    /// This is invaluable for debugging step-by-step test failures.
+    ///
+    /// # Panics
+    ///
+    /// Panics if server fails to spawn.
+    pub async fn new() -> Self {
+        // Get test name from current thread (set by cargo test)
+        let test_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown_step_test")
+            .to_string();
+
+        let harness = TestServerHarness::spawn_with_log(&test_name)
+            .await
+            .expect("Failed to spawn server");
+        let config = ConnectionConfig::tcp("127.0.0.1", harness.port());
+        Self {
+            harness,
+            config,
+            initial_content: None,
+            initial_cursor: None,
+            steps: Vec::new(),
+            default_delay: DEFAULT_STEP_DELAY_MS,
+        }
+    }
+
+    /// Get the path to the server log file for debugging.
+    ///
+    /// Returns `None` if log capture is not enabled.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&std::path::Path> {
+        self.harness.log_path()
+    }
+
+    /// Make an RPC call with a fresh connection.
+    async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let mut client = Self::connect_with_retry(&self.config).await?;
+        client.call(method, params).await.map_err(|e| e.to_string())
+    }
+
+    /// Connect to server with retry logic.
+    async fn connect_with_retry(config: &ConnectionConfig) -> Result<RpcClient, String> {
+        let mut attempts = 0;
+        loop {
+            match RpcClient::connect(config).await {
+                Ok(c) => return Ok(c),
+                Err(e) if attempts < MAX_CONNECT_ATTEMPTS => {
+                    attempts += 1;
+                    let delay = std::cmp::min(
+                        RETRY_BASE_MS + u64::from(attempts) * RETRY_BASE_MS,
+                        RETRY_MAX_MS,
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to connect after {MAX_CONNECT_ATTEMPTS} attempts: {e}"
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Capture current state from server.
+    async fn capture_state(&self, key: &str) -> StateSnapshot {
+        let buffer = self
+            .call("buffer/get_content", json!({}))
+            .await
+            .expect("Failed to get buffer content");
+        let cursor = self
+            .call("state/cursor", json!({}))
+            .await
+            .expect("Failed to get cursor");
+        let mode = self
+            .call("state/mode", json!({}))
+            .await
+            .expect("Failed to get mode");
+        let registers_result = self
+            .call("debug/registers", json!({}))
+            .await
+            .unwrap_or_else(|_| json!({ "unnamed": {}, "named": [] }));
+
+        let mut registers = HashMap::new();
+
+        // Parse unnamed register
+        if let Some(unnamed) = registers_result.get("unnamed")
+            && let (Some(name), Some(content), Some(yank_type)) = (
+                unnamed.get("name").and_then(|n| n.as_str()),
+                unnamed.get("content").and_then(|c| c.as_str()),
+                unnamed.get("yank_type").and_then(|t| t.as_str()),
+            )
+        {
+            registers.insert(
+                name.to_string(),
+                RegisterInfo {
+                    content: content.to_string(),
+                    yank_type: yank_type.to_string(),
+                },
+            );
+        }
+
+        // Parse named registers
+        if let Some(named) = registers_result.get("named").and_then(|n| n.as_array()) {
+            for entry in named {
+                if let (Some(name), Some(content), Some(yank_type)) = (
+                    entry.get("name").and_then(|n| n.as_str()),
+                    entry.get("content").and_then(|c| c.as_str()),
+                    entry.get("yank_type").and_then(|t| t.as_str()),
+                ) {
+                    registers.insert(
+                        name.to_string(),
+                        RegisterInfo {
+                            content: content.to_string(),
+                            yank_type: yank_type.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        StateSnapshot {
+            key: key.to_string(),
+            buffer: buffer["content"].as_str().unwrap_or("").to_string(),
+            cursor_line: cursor["line"].as_u64().unwrap_or(0) as u16,
+            cursor_column: cursor["column"].as_u64().unwrap_or(0) as u16,
+            mode_display: mode["display"].as_str().unwrap_or("").to_string(),
+            edit_mode: mode["edit_mode"].as_str().unwrap_or("").to_string(),
+            registers,
+        }
+    }
+
+    /// Set initial buffer content.
+    #[must_use]
+    pub fn with_buffer(mut self, content: &str) -> Self {
+        self.initial_content = Some(content.to_string());
+        self
+    }
+
+    /// Set initial cursor position (line, col) - 0-indexed.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn with_cursor_at(mut self, line: u16, col: u16) -> Self {
+        self.initial_cursor = Some((line, col));
+        self
+    }
+
+    /// Set default delay between steps (ms).
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn with_delay(mut self, ms: u64) -> Self {
+        self.default_delay = ms;
+        self
+    }
+
+    /// Add a step (key to send).
+    #[must_use]
+    pub fn step(mut self, keys: &str) -> Self {
+        self.steps.push(TestStep {
+            keys: keys.to_string(),
+            delay_ms: self.default_delay,
+            expectations: Vec::new(),
+        });
+        self
+    }
+
+    /// Add cursor expectation to last step.
+    #[must_use]
+    pub fn expect_cursor(mut self, line: u16, col: u16) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations.push(StepExpectation::Cursor(line, col));
+        }
+        self
+    }
+
+    /// Add buffer content expectation to last step.
+    #[must_use]
+    pub fn expect_buffer(mut self, expected: &str) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations
+                .push(StepExpectation::Buffer(expected.to_string()));
+        }
+        self
+    }
+
+    /// Add buffer contains expectation to last step.
+    #[must_use]
+    pub fn expect_buffer_contains(mut self, substring: &str) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations
+                .push(StepExpectation::BufferContains(substring.to_string()));
+        }
+        self
+    }
+
+    /// Add mode contains expectation to last step.
+    #[must_use]
+    pub fn expect_mode_contains(mut self, substring: &str) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations
+                .push(StepExpectation::ModeContains(substring.to_string()));
+        }
+        self
+    }
+
+    /// Add exact edit mode expectation to last step.
+    #[must_use]
+    pub fn expect_edit_mode(mut self, mode: &str) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations
+                .push(StepExpectation::EditMode(mode.to_string()));
+        }
+        self
+    }
+
+    /// Add register expectation to last step.
+    #[must_use]
+    pub fn expect_register(mut self, reg: &str, content: &str, yank_type: &str) -> Self {
+        if let Some(step) = self.steps.last_mut() {
+            step.expectations.push(StepExpectation::Register(
+                reg.to_string(),
+                content.to_string(),
+                yank_type.to_string(),
+            ));
+        }
+        self
+    }
+
+    /// Run the test and return trace.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any step expectation fails.
+    #[allow(clippy::too_many_lines)]
+    pub async fn run(self) -> StepTrace {
+        // Create buffer via temp file
+        let temp_path = {
+            let id = STEP_TEMP_FILE_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path = format!("/tmp/reovim-step-test-{}-{id}.txt", std::process::id());
+            let content = self.initial_content.as_deref().unwrap_or("");
+            let mut file = std::fs::File::create(&path).expect("Failed to create temp file");
+            file.write_all(content.as_bytes())
+                .expect("Failed to write temp file");
+            path
+        };
+        self.call("buffer/open_file", json!({ "path": &temp_path }))
+            .await
+            .expect("Failed to open buffer file");
+
+        // Set initial cursor if specified
+        if let Some((line, col)) = self.initial_cursor {
+            if line > 0 {
+                self.call("input/keys", json!({ "keys": format!("{}j", line) }))
+                    .await
+                    .expect("Failed to move cursor down");
+            }
+            if col > 0 {
+                self.call("input/keys", json!({ "keys": format!("{}l", col) }))
+                    .await
+                    .expect("Failed to move cursor right");
+            }
+        }
+
+        // Capture initial state
+        let initial = self.capture_state("(initial)").await;
+
+        let mut snapshots = Vec::new();
+        let mut failed_expectations: Vec<String> = Vec::new();
+
+        // Execute each step
+        for step in &self.steps {
+            // Send key
+            self.call("input/keys", json!({ "keys": step.keys }))
+                .await
+                .expect("Failed to inject key");
+            tokio::time::sleep(Duration::from_millis(step.delay_ms)).await;
+
+            // Capture state
+            let snapshot = self.capture_state(&step.keys).await;
+
+            // Verify expectations
+            for expectation in &step.expectations {
+                match expectation {
+                    StepExpectation::Cursor(line, col) => {
+                        if snapshot.cursor_line != *line || snapshot.cursor_column != *col {
+                            failed_expectations.push(format!(
+                                "After '{}': cursor expected ({}:{}), got ({}:{})",
+                                step.keys, line, col, snapshot.cursor_line, snapshot.cursor_column
+                            ));
+                        }
+                    }
+                    StepExpectation::Buffer(expected) => {
+                        if snapshot.buffer.trim_end() != expected.trim_end() {
+                            failed_expectations.push(format!(
+                                "After '{}': buffer expected {:?}, got {:?}",
+                                step.keys, expected, snapshot.buffer
+                            ));
+                        }
+                    }
+                    StepExpectation::BufferContains(substring) => {
+                        if !snapshot.buffer.contains(substring) {
+                            failed_expectations.push(format!(
+                                "After '{}': buffer expected to contain {:?}, got {:?}",
+                                step.keys, substring, snapshot.buffer
+                            ));
+                        }
+                    }
+                    StepExpectation::ModeContains(substring) => {
+                        let mode_lower = snapshot.mode_display.to_lowercase();
+                        let edit_lower = snapshot.edit_mode.to_lowercase();
+                        let sub_lower = substring.to_lowercase();
+                        if !mode_lower.contains(&sub_lower) && !edit_lower.contains(&sub_lower) {
+                            failed_expectations.push(format!(
+                                "After '{}': mode expected to contain {:?}, got display={:?} edit={:?}",
+                                step.keys, substring, snapshot.mode_display, snapshot.edit_mode
+                            ));
+                        }
+                    }
+                    StepExpectation::EditMode(mode) => {
+                        if snapshot.edit_mode != *mode {
+                            failed_expectations.push(format!(
+                                "After '{}': edit_mode expected {:?}, got {:?}",
+                                step.keys, mode, snapshot.edit_mode
+                            ));
+                        }
+                    }
+                    StepExpectation::Register(reg, content, yank_type) => {
+                        if let Some(register) = snapshot.registers.get(reg) {
+                            if register.content.trim_end() != content.trim_end() {
+                                failed_expectations.push(format!(
+                                    "After '{}': register '{}' content expected {:?}, got {:?}",
+                                    step.keys, reg, content, register.content
+                                ));
+                            }
+                            if register.yank_type != *yank_type {
+                                failed_expectations.push(format!(
+                                    "After '{}': register '{}' type expected {:?}, got {:?}",
+                                    step.keys, reg, yank_type, register.yank_type
+                                ));
+                            }
+                        } else {
+                            failed_expectations.push(format!(
+                                "After '{}': register '{}' not found (available: {:?})",
+                                step.keys,
+                                reg,
+                                snapshot.registers.keys().collect::<Vec<_>>()
+                            ));
+                        }
+                    }
+                }
+            }
+
+            snapshots.push(snapshot);
+        }
+
+        StepTrace {
+            initial,
+            snapshots,
+            failed_expectations,
+            harness: self.harness,
+            temp_path: Some(temp_path),
+        }
+    }
+}
+
+/// Trace of step-by-step execution.
+pub struct StepTrace {
+    /// Initial state before any keys.
+    pub initial: StateSnapshot,
+    /// State snapshots after each key.
+    pub snapshots: Vec<StateSnapshot>,
+    /// Failed expectations (if any).
+    pub failed_expectations: Vec<String>,
+    harness: TestServerHarness,
+    temp_path: Option<String>,
+}
+
+impl Drop for StepTrace {
+    fn drop(&mut self) {
+        if let Some(path) = &self.temp_path {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+impl StepTrace {
+    /// Get the path to the server log file for debugging.
+    ///
+    /// Returns `None` if log capture is not enabled.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&std::path::Path> {
+        self.harness.log_path()
+    }
+
+    /// Format log path hint for output messages.
+    fn log_hint(&self) -> String {
+        self.log_path()
+            .map(|p| format!("\n\n  Server log: {}", p.display()))
+            .unwrap_or_default()
+    }
+
+    /// Print the full trace to stderr (for debugging).
+    pub fn print_trace(&self) {
+        eprintln!("\n╔════════════════════════════════════════════════════════════╗");
+        eprintln!("║                     STEP-BY-STEP TRACE                     ║");
+        eprintln!("╚════════════════════════════════════════════════════════════╝\n");
+
+        eprintln!(
+            "Initial: {} mode={} ({}:{})",
+            self.initial.key,
+            self.initial.mode_display,
+            self.initial.cursor_line,
+            self.initial.cursor_column
+        );
+        eprintln!("  Buffer: {:?}", self.initial.buffer);
+
+        for (i, snapshot) in self.snapshots.iter().enumerate() {
+            eprintln!(
+                "\nStep {}: '{}' -> {} ({}:{})",
+                i + 1,
+                snapshot.key,
+                snapshot.mode_display,
+                snapshot.cursor_line,
+                snapshot.cursor_column
+            );
+            eprintln!("  Buffer: {:?}", snapshot.buffer);
+            if !snapshot.registers.is_empty() {
+                eprintln!("  Registers:");
+                for (name, info) in &snapshot.registers {
+                    eprintln!("    '{}': {:?} ({})", name, info.content, info.yank_type);
+                }
+            }
+        }
+
+        eprintln!("\n────────────────────────────────────────────────────────────");
+
+        if self.failed_expectations.is_empty() {
+            eprintln!("✓ All expectations passed");
+        } else {
+            eprintln!("✗ {} expectation(s) failed:", self.failed_expectations.len());
+            for failure in &self.failed_expectations {
+                eprintln!("  - {failure}");
+            }
+        }
+
+        // Always show log path at the end for debugging
+        if let Some(path) = self.log_path() {
+            eprintln!("\n  Server log: {}", path.display());
+        }
+        eprintln!();
+    }
+
+    /// Print compact single-line trace.
+    pub fn print_compact(&self) {
+        let line: String = std::iter::once(format!(
+            "[init {}:{}]",
+            self.initial.cursor_line, self.initial.cursor_column
+        ))
+        .chain(
+            self.snapshots
+                .iter()
+                .map(|s| format!("'{}' -> {}:{}", s.key, s.cursor_line, s.cursor_column)),
+        )
+        .collect::<Vec<_>>()
+        .join(" → ");
+        eprintln!("Trace: {line}");
+    }
+
+    /// Assert no expectations failed.
+    ///
+    /// # Panics
+    ///
+    /// Panics with detailed trace if any expectations failed.
+    pub fn assert_ok(&self) {
+        if !self.failed_expectations.is_empty() {
+            self.print_trace();
+            panic!(
+                "Step test failed with {} errors:\n{}{}",
+                self.failed_expectations.len(),
+                self.failed_expectations.join("\n"),
+                self.log_hint()
+            );
+        }
+    }
+
+    /// Get final state (last snapshot).
+    #[must_use]
+    pub fn final_state(&self) -> &StateSnapshot {
+        self.snapshots.last().unwrap_or(&self.initial)
+    }
+
+    /// Get state after step N (0-indexed).
+    #[must_use]
+    pub fn state_after(&self, step: usize) -> Option<&StateSnapshot> {
+        self.snapshots.get(step)
+    }
+}


### PR DESCRIPTION
## Summary

- Add per-test server log capture for debugging integration tests
- Fix cc mode transition and cursor reporting bugs
- Un-ignore tests and add enhanced coverage for operator-pending mode

## Changes

### Test Infrastructure (#428)
- `StepTest` builder for per-keystroke state validation
- Per-test log capture to `{module}/tmp/test-logs/{test_name}_{timestamp}.log`
- `tracing` dependency added to vim module for resolver instrumentation

### Bug Fixes (#425, #421)
- Fix cc mode transition not entering insert mode correctly
- Fix cursor always reporting (0,0) in tests

### Test Coverage (#415)
- 13 new operator tests using IntegrationTest/StepTest
- Un-ignore 7 passing tests (6 operators, 1 registers)
- Add intermediate state assertions with StepTest

## Test Results

```
operators.rs:   54 enabled, 1 ignored (dG - Issue #429)
registers.rs:    3 enabled, 2 ignored (named register prefix)
cursor_movement: 22 enabled
```

## Related Issues

- Closes #428 (per-test log capture)
- Closes #425 (cursor reporting fix)
- Closes #421 (cc mode transition)
- Refs #415 (operator-pending mode)