### PR TITLE
Phase 7: Test infrastructure and operator E2E completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,18 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
-- Per-test server log capture for integration tests (#428)
-  - `TestServerHarness::spawn_with_log(test_name)` captures server stderr to per-test log files
+- Per-test server log capture for integration tests (#428, #431)
+  - All test harness spawn methods now capture server stderr to per-test log files
+  - `TestServerHarness::spawn()` auto-extracts test name from thread (recommended)
+  - `TestServerHarness::spawn_with_name(name)` for explicit test naming
   - Logs saved to `tmp/test-logs/{test_name}_{timestamp}.log`
   - Background tokio task streams logs during test execution
   - `REOVIM_LOG=debug` by default for full tracing visibility
-  - `IntegrationTest::log_path()` and `StepTest::log_path()` expose log location
+  - `IntegrationTest`, `StepTest`, and `MultiClientTest` all capture logs
+  - `log_path()` accessor available on all test builders
   - `TestResult` assertions include log path hint on failure
   - `StepTrace::print_trace()` shows log path for debugging
-  - Replaces manual file-based debug logging with proper `tracing::debug!()` calls
-  - Added `tracing` dependency to vim module for resolver instrumentation
-  - Operator resolvers (delete, yank, change) now emit debug traces for count flow
+  - Warning: Do not use `std::fs::OpenOptions` for debug logging - use harness log capture
 
 - UniqueProvider service abstraction Phase 6b - runner cleanup (#417)
   - Deleted 924 lines of redundant code from runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- All operator E2E tests enabled and passing (#308)
+  - 57 operator tests now pass (exceeds original 28 planned)
+  - Tests migrated from `runner/tests/operators.rs` to `modules/vim/tests/operators.rs`
+  - Zero `#[ignore]` attributes remaining in operator tests
+  - Coverage includes: delete (d, dd, x, X), yank (y, yy), change (c, cc), paste (p, P)
+  - Count prefixes: 5dd, 3x, 2dj, 2cw all working
+  - Step-by-step debug tests with per-key assertions
+
 - Per-test server log capture for integration tests (#428, #431)
   - All test harness spawn methods now capture server stderr to per-test log files
   - `TestServerHarness::spawn()` auto-extracts test name from thread (recommended)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - Keybinding configuration is policy - left to editor personality modules
   - Part of Epic #403 (Window Subsystem)
 
+### Fixed
+
+- `dG` motion now correctly deletes to end of document (#429)
+  - Added `explicit_count()` method to `OperatorState` to preserve "no count" vs "count=1" semantics
+  - Motions like `G` (last line without count) and `1G` (line 1 with explicit count) now work correctly
+  - Updated delete, yank, and change operator resolvers to use `explicit_count()`
+  - `dgg`, `yG`, `cgg` and similar operator+motion combinations now behave correctly
+
 ### Changed
 
 - Unified `WindowId` to single kernel definition (#410)

--- a/modules/vim/src/operators/delete.rs
+++ b/modules/vim/src/operators/delete.rs
@@ -78,7 +78,7 @@ impl Operator for DeleteOperator {
             };
 
             // Store in register as linewise (handles +/* via ClipboardProvider)
-            let content = RegisterContent::linewise(deleted_text);
+            let content = RegisterContent::linewise(deleted_text.clone());
             registers::store_to_register(ctx.kernel, ctx.register, &content);
             registers::push_to_history(ctx.kernel, &content);
 

--- a/modules/vim/src/resolvers/change.rs
+++ b/modules/vim/src/resolvers/change.rs
@@ -182,14 +182,14 @@ impl ModeKeyResolver for VimChangeResolver {
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                // Calculate effective count BEFORE taking motion_count
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified
+                let explicit_count = state.explicit_count();
                 let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -301,15 +301,13 @@ impl ModeKeyResolver for VimChangeResolver {
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                // Calculate effective count BEFORE taking motion_count
-                // For 2cw: operator_count=2, motion_count=None → effective=2
-                // For c2w: operator_count=None, motion_count=2 → effective=2
-                // For 2c3w: operator_count=2, motion_count=3 → effective=6
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified.
+                // This preserves "no count" semantics for motions like G/gg.
+                let explicit_count = state.explicit_count();
                 tracing::debug!(
                     operator_count = ?state.operator_count,
                     motion_count = ?state.motion_count,
-                    effective_count,
+                    explicit_count = ?explicit_count,
                     cmd = %cmd,
                     "change resolver: executing motion"
                 );
@@ -333,7 +331,7 @@ impl ModeKeyResolver for VimChangeResolver {
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),

--- a/modules/vim/src/resolvers/delete.rs
+++ b/modules/vim/src/resolvers/delete.rs
@@ -195,15 +195,15 @@ impl ModeKeyResolver for VimDeleteResolver {
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                // Calculate effective count BEFORE taking motion_count
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified
+                let explicit_count = state.explicit_count();
                 let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
-                // Build context with effective count (operator_count * motion_count)
+                // Build context with explicit count (None if not specified)
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -327,15 +327,14 @@ impl ModeKeyResolver for VimDeleteResolver {
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                // Calculate effective count BEFORE taking motion_count
-                // For 2dw: operator_count=2, motion_count=None → effective=2
-                // For d2w: operator_count=None, motion_count=2 → effective=2
-                // For 2d3w: operator_count=2, motion_count=3 → effective=6
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified, Some(n) if specified.
+                // This preserves "no count" semantics for motions like G/gg where
+                // "G" (no count) means last line, but "1G" means line 1.
+                let explicit_count = state.explicit_count();
                 tracing::debug!(
                     operator_count = ?state.operator_count,
                     motion_count = ?state.motion_count,
-                    effective_count,
+                    explicit_count = ?explicit_count,
                     cmd = %cmd,
                     linewise,
                     "delete resolver: executing motion"
@@ -361,9 +360,10 @@ impl ModeKeyResolver for VimDeleteResolver {
 
                 drop(state);
 
-                // Build context with effective count (operator_count * motion_count)
+                // Build context with explicit count (None if not specified)
+                // This allows motions like G to distinguish "no count" from "count=1"
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),

--- a/modules/vim/src/resolvers/operator_common.rs
+++ b/modules/vim/src/resolvers/operator_common.rs
@@ -384,6 +384,23 @@ impl OperatorState {
         op * motion
     }
 
+    /// Get count only if explicitly specified (not defaulted).
+    ///
+    /// Returns `None` if no count was given, `Some(n)` if count was given.
+    /// This preserves the distinction between "no count" and "count=1" for
+    /// motions like G/gg where these have different semantics:
+    /// - `G` (no count) → last line
+    /// - `1G` (count=1) → line 1
+    #[must_use]
+    pub fn explicit_count(&self) -> Option<usize> {
+        match (self.operator_count, self.motion_count) {
+            (None, None) => None,
+            (Some(op), None) => Some(op),
+            (None, Some(motion)) => Some(motion),
+            (Some(op), Some(motion)) => Some(op * motion),
+        }
+    }
+
     /// Check if we have a motion count.
     #[must_use]
     pub fn has_motion_count(&self) -> bool {
@@ -550,6 +567,24 @@ mod tests {
 
         state.motion_count = Some(3);
         assert_eq!(state.effective_count(), 6); // 2 * 3
+    }
+
+    #[test]
+    fn test_operator_state_explicit_count() {
+        // #429: explicit_count() returns None when no count specified
+        let mut state = OperatorState::new(OperatorType::Delete);
+        assert_eq!(state.explicit_count(), None); // No counts -> None
+
+        state.operator_count = Some(2);
+        assert_eq!(state.explicit_count(), Some(2)); // Only operator count
+
+        state.operator_count = None;
+        state.motion_count = Some(3);
+        assert_eq!(state.explicit_count(), Some(3)); // Only motion count
+
+        state.operator_count = Some(2);
+        state.motion_count = Some(3);
+        assert_eq!(state.explicit_count(), Some(6)); // Both -> product
     }
 
     #[test]

--- a/modules/vim/src/resolvers/yank.rs
+++ b/modules/vim/src/resolvers/yank.rs
@@ -180,14 +180,14 @@ impl ModeKeyResolver for VimYankResolver {
 
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
-                // Calculate effective count BEFORE taking motion_count
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified
+                let explicit_count = state.explicit_count();
                 let _motion_count = state.take_motion_count();
                 state.clear_keys();
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),
@@ -297,15 +297,13 @@ impl ModeKeyResolver for VimYankResolver {
         match apply_keymap_policy(&lookup_state) {
             KeymapAction::Execute(cmd) => {
                 let linewise = is_linewise_motion(&cmd);
-                // Calculate effective count BEFORE taking motion_count
-                // For 2yw: operator_count=2, motion_count=None → effective=2
-                // For y2w: operator_count=None, motion_count=2 → effective=2
-                // For 2y3w: operator_count=2, motion_count=3 → effective=6
-                let effective_count = state.effective_count();
+                // Get explicit count - None if no count specified.
+                // This preserves "no count" semantics for motions like G/gg.
+                let explicit_count = state.explicit_count();
                 tracing::debug!(
                     operator_count = ?state.operator_count,
                     motion_count = ?state.motion_count,
-                    effective_count,
+                    explicit_count = ?explicit_count,
                     cmd = %cmd,
                     linewise,
                     "yank resolver: executing motion"
@@ -330,7 +328,7 @@ impl ModeKeyResolver for VimYankResolver {
                 drop(state);
 
                 let ctx = ResolveContext {
-                    count: Some(effective_count),
+                    count: explicit_count,
                     register: None,
                     keys,
                     metadata: std::collections::HashMap::new(),

--- a/modules/vim/tests/operators.rs
+++ b/modules/vim/tests/operators.rs
@@ -538,9 +538,8 @@ async fn test_de_delete_to_word_end() {
 }
 
 /// dG - delete from current line to end of document
-/// Issue #429: G motion with delete operator not working correctly
+/// Fixed in #429: explicit_count() preserves "no count" semantics for G motion
 #[tokio::test]
-#[ignore = "G motion with delete operator needs investigation - Issue #429"]
 async fn test_dg_delete_to_doc_end() {
     let result = IntegrationTest::new()
         .await
@@ -564,6 +563,34 @@ async fn test_dgg_delete_to_doc_start() {
         .await;
     // G moves to last line, dgg deletes all lines (to start)
     result.assert_buffer_eq("");
+}
+
+/// d2G - delete from current line to line 2 (explicit count)
+/// Verifies that explicit count still works with G motion (#429)
+#[tokio::test]
+async fn test_d2g_delete_to_line_2() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3\nline 4")
+        .send_keys("d2G")
+        .run()
+        .await;
+    // d2G from line 0 deletes to line 1 (2G = line 2, 0-indexed = line 1)
+    result.assert_buffer_eq("line 3\nline 4");
+}
+
+/// dgg from middle of buffer
+/// Verifies gg motion works correctly with delete (#429)
+#[tokio::test]
+async fn test_dgg_from_middle() {
+    let result = IntegrationTest::new()
+        .await
+        .with_buffer("line 1\nline 2\nline 3")
+        .send_keys("jdgg")
+        .run()
+        .await;
+    // j moves to line 1, dgg deletes lines 0-1
+    result.assert_buffer_eq("line 3");
 }
 
 // ============================================================================

--- a/runner/src/testing/harness.rs
+++ b/runner/src/testing/harness.rs
@@ -3,10 +3,22 @@
 //! This is the core **mechanism** for integration testing - it handles
 //! server lifecycle without any knowledge of what's being tested.
 //!
-//! # Log Capture (#428)
+//! # Log Capture (#428, #431)
 //!
-//! The harness can capture server stderr to a per-test log file for debugging.
-//! Use `spawn_with_log(test_name)` to enable automatic log capture.
+//! All spawned servers automatically capture stderr to per-test log files.
+//! Use `spawn()` for automatic test name extraction from thread name, or
+//! `spawn_with_name(name)` for explicit naming.
+//!
+//! # Debug Logging
+//!
+//! **DO NOT use `std::fs::OpenOptions` for debug logging in tests.**
+//!
+//! If you need debug output during test development, use the built-in log
+//! capture infrastructure (`spawn()` or `spawn_with_name()`). Writing directly
+//! to files with `OpenOptions` creates cleanup burdens and can leave debug
+//! artifacts in the codebase.
+//!
+//! Server logs are automatically captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
 
 // Test infrastructure - suppress pedantic docs requirements
 #![allow(clippy::missing_errors_doc)]
@@ -49,33 +61,9 @@ fn binary_path() -> PathBuf {
         .join("target/debug/reovim")
 }
 
-/// Read "Listening on 127.0.0.1:<port>" from stderr, consuming the reader.
-///
-/// This is the original function that discards stderr after port extraction.
-async fn read_port_from_stderr(
-    process: &mut Child,
-) -> Result<u16, Box<dyn std::error::Error + Send + Sync>> {
-    let stderr = process.stderr.take().ok_or("Failed to capture stderr")?;
-    let mut reader = BufReader::new(stderr).lines();
-
-    while let Some(line) = reader.next_line().await? {
-        if line.starts_with("Warning:") {
-            continue;
-        }
-        if line.contains("!!!! PANIC !!!!") {
-            return Err(format!("Server panicked: {line}").into());
-        }
-        if let Some(rest) = line.strip_prefix("Listening on 127.0.0.1:") {
-            return rest.parse::<u16>().map_err(Into::into);
-        }
-    }
-    Err("Server exited without outputting port".into())
-}
-
 /// Read port from stderr and return the reader for continued use.
 ///
-/// Unlike `read_port_from_stderr`, this returns the reader so logs can continue
-/// to be captured after port extraction.
+/// Returns the reader so logs can continue to be captured after port extraction.
 async fn read_port_preserving_reader(
     stderr: ChildStderr,
 ) -> Result<
@@ -138,9 +126,9 @@ fn spawn_log_capture_task(
 ///
 /// # Log Capture
 ///
-/// Use `spawn_with_log(test_name)` to automatically capture server logs
-/// to `tmp/test-logs/{test_name}_{timestamp}.log`. This is invaluable for
-/// debugging test failures as it preserves the server's tracing output.
+/// All spawn methods capture server logs to `tmp/test-logs/{test_name}_{timestamp}.log`.
+/// - `spawn()` - Auto-extracts test name from thread (recommended)
+/// - `spawn_with_name(name)` - Explicit test name for custom naming
 pub struct TestServerHarness {
     process: Child,
     port: u16,
@@ -152,10 +140,12 @@ pub struct TestServerHarness {
 }
 
 impl TestServerHarness {
-    /// Spawn server on OS-assigned port (without log capture).
+    /// Spawn server with automatic log capture.
     ///
-    /// For debugging test failures, prefer `spawn_with_log()` which captures
-    /// server output to a file.
+    /// Server stderr is captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
+    /// Test name is auto-extracted from the current thread name (set by cargo test).
+    ///
+    /// For explicit test naming, use `spawn_with_name()`.
     ///
     /// # Errors
     ///
@@ -163,33 +153,16 @@ impl TestServerHarness {
     /// - Binary not found at expected path
     /// - Server fails to start within timeout
     /// - Server panics during startup
+    /// - Log directory cannot be created
     pub async fn spawn() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let log_level = std::env::var("REOVIM_LOG").unwrap_or_else(|_| "warn".to_string());
-        let _test_id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
-
-        let mut process = Command::new(binary_path())
-            .args(["server", "--tcp", "0"])
-            .env("REOVIM_LOG", log_level)
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()?;
-
-        let port =
-            tokio::time::timeout(SERVER_STARTUP_TIMEOUT, read_port_from_stderr(&mut process))
-                .await
-                .map_err(|_| "Server startup timed out (10s)")?
-                .map_err(|e| format!("Failed to read port: {e}"))?;
-
-        Ok(Self {
-            process,
-            port,
-            log_file: None,
-            log_task: None,
-        })
+        let test_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown_test")
+            .to_string();
+        Self::spawn_with_name(&test_name).await
     }
 
-    /// Spawn server with automatic log capture to a per-test file.
+    /// Spawn server with explicit test name for log capture.
     ///
     /// Server stderr is captured to `tmp/test-logs/{test_name}_{timestamp}.log`.
     /// This is invaluable for debugging test failures as it preserves the
@@ -199,12 +172,15 @@ impl TestServerHarness {
     /// The server is started with `REOVIM_LOG=debug` by default for full
     /// tracing visibility.
     ///
+    /// Use this when you need a custom test name (e.g., multi-client tests
+    /// with a `_server` suffix).
+    ///
     /// # Example
     ///
     /// ```ignore
-    /// let harness = TestServerHarness::spawn_with_log("test_yj_yank").await?;
+    /// let harness = TestServerHarness::spawn_with_name("test_multi_client_server").await?;
     /// // ... run test ...
-    /// // On failure, check: tmp/test-logs/test_yj_yank_20260124_120000.log
+    /// // On failure, check: tmp/test-logs/test_multi_client_server_20260124_120000.log
     /// ```
     ///
     /// # Errors
@@ -214,7 +190,7 @@ impl TestServerHarness {
     /// - Server fails to start within timeout
     /// - Server panics during startup
     /// - Log directory cannot be created
-    pub async fn spawn_with_log(
+    pub async fn spawn_with_name(
         test_name: &str,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Create log directory
@@ -265,10 +241,10 @@ impl TestServerHarness {
         self.port
     }
 
-    /// Get the path to the log file (if log capture is enabled).
+    /// Get the path to the log file.
     ///
-    /// Returns `None` if the harness was created with `spawn()` instead
-    /// of `spawn_with_log()`.
+    /// Returns the path to the log file where server stderr is captured.
+    /// All spawn methods enable log capture, so this always returns `Some`.
     #[must_use]
     pub fn log_path(&self) -> Option<&Path> {
         self.log_file.as_deref()

--- a/runner/src/testing/integration.rs
+++ b/runner/src/testing/integration.rs
@@ -69,13 +69,7 @@ impl IntegrationTest {
     ///
     /// Panics if server fails to spawn.
     pub async fn new() -> Self {
-        // Get test name from current thread (set by cargo test)
-        let test_name = std::thread::current()
-            .name()
-            .unwrap_or("unknown_test")
-            .to_string();
-
-        let harness = TestServerHarness::spawn_with_log(&test_name)
+        let harness = TestServerHarness::spawn()
             .await
             .expect("Failed to spawn server");
         let config = ConnectionConfig::tcp("127.0.0.1", harness.port());
@@ -340,7 +334,7 @@ impl TestResult {
     /// Format log path hint for assertion messages.
     fn log_hint(&self) -> String {
         self.log_path()
-            .map(|p| format!("\n\n📋 Server log: {}", p.display()))
+            .map(|p| format!("\n\nServer log: {}", p.display()))
             .unwrap_or_default()
     }
 

--- a/runner/src/testing/multi_client.rs
+++ b/runner/src/testing/multi_client.rs
@@ -117,17 +117,31 @@ pub struct MultiClientTest {
 impl MultiClientTest {
     /// Create test with N clients.
     ///
+    /// Server logs are captured to `tmp/test-logs/{test_name}_server_{timestamp}.log`.
+    ///
     /// # Panics
     ///
     /// Panics if server fails to spawn.
     pub async fn with_clients(n: usize) -> Self {
+        // Extract test name with suffix for unique log files
+        let test_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown_multi_test")
+            .to_string();
+
         Self {
-            harness: TestServerHarness::spawn()
+            harness: TestServerHarness::spawn_with_name(&format!("{test_name}_server"))
                 .await
                 .expect("Failed to spawn server"),
             client_count: n,
             initial_content: None,
         }
+    }
+
+    /// Get the path to the server log file for debugging.
+    #[must_use]
+    pub fn log_path(&self) -> Option<&std::path::Path> {
+        self.harness.log_path()
     }
 
     /// Set initial buffer content (shared by all clients).

--- a/runner/src/testing/step_test.rs
+++ b/runner/src/testing/step_test.rs
@@ -155,13 +155,7 @@ impl StepTest {
     ///
     /// Panics if server fails to spawn.
     pub async fn new() -> Self {
-        // Get test name from current thread (set by cargo test)
-        let test_name = std::thread::current()
-            .name()
-            .unwrap_or("unknown_step_test")
-            .to_string();
-
-        let harness = TestServerHarness::spawn_with_log(&test_name)
+        let harness = TestServerHarness::spawn()
             .await
             .expect("Failed to spawn server");
         let config = ConnectionConfig::tcp("127.0.0.1", harness.port());
@@ -590,9 +584,9 @@ impl StepTrace {
         eprintln!("\n────────────────────────────────────────────────────────────");
 
         if self.failed_expectations.is_empty() {
-            eprintln!("✓ All expectations passed");
+            eprintln!("OK: All expectations passed");
         } else {
-            eprintln!("✗ {} expectation(s) failed:", self.failed_expectations.len());
+            eprintln!("FAIL: {} expectation(s) failed:", self.failed_expectations.len());
             for failure in &self.failed_expectations {
                 eprintln!("  - {failure}");
             }


### PR DESCRIPTION
## Summary

Phase 7 test infrastructure improvements and operator E2E test completion.

## Changes

### Test Infrastructure
- Per-test server log capture for debugging (#428)
- Consolidate spawn_with_log as default test harness (#431)

### Bug Fixes
- Fix dG motion to correctly delete to end of document (#429)
- Fix cc mode transition and cursor reporting (#425, #421)

### Test Coverage
- Un-ignore tests and add enhanced coverage (#415)
- All 57 operator E2E tests enabled and passing (#308)

## Test Status

| Category | Passing | Ignored |
|----------|---------|---------|
| Operators | 57 | 0 |
| Cursor Movement | 22 | 0 |
| Edge Cases | 10 | 0 |
| Registers | 3 | 2 (Phase 8) |

## Remaining Phase 7 Issues

- #310 - Search E2E tests (requires search command implementation)
- #311 - Undo E2E tests (requires undo command implementation)
- #313 - Register E2E tests (3 pass, 2 deferred to Phase 8)

## Related

- Part of Epic #150 (Project Kernel)
- Part of Epic #307 (E2E Test Epic)

Closes: #308, Closes: #415, Closes: #421, Closes: #425, Closes: #428, Closes: #429, Closes: #431