### PR TITLE
chore(cleanup): remove backward compatibility patterns (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - `ChangeCommand` starts undo batch BEFORE delete (batch includes both delete + inserts)
   - Tests: `test_undo_insert`, `test_undo_change_word`, `test_multiple_undo`, etc.
 
+- Search E2E tests for `*`, `#`, `n`, `N` commands (#310)
+  - 5 search tests passing: word forward/backward, search repeat with n, not-found, regex boundary
+  - `SearchState` session extension stores last pattern and direction for repeat
+  - Implemented `search_word()` for `*`/`#` (word under cursor + boundary)
+  - Implemented `search_and_move()` with both `set_buffer_position()` and `move_cursor()`
+  - 10 tests ignored: `/` and `?` require command-line mode (deferred to Phase 8, #338)
+
 - All operator E2E tests enabled and passing (#308)
   - 57 operator tests now pass (exceeds original 28 planned)
   - Tests migrated from `runner/tests/operators.rs` to `modules/vim/tests/operators.rs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   - `ChangeCommand` starts undo batch BEFORE delete (batch includes both delete + inserts)
   - Tests: `test_undo_insert`, `test_undo_change_word`, `test_multiple_undo`, etc.
 
-- Search E2E tests for `*`, `#`, `n`, `N` commands (#310)
-  - 5 search tests passing: word forward/backward, search repeat with n, not-found, regex boundary
-  - `SearchState` session extension stores last pattern and direction for repeat
-  - Implemented `search_word()` for `*`/`#` (word under cursor + boundary)
-  - Implemented `search_and_move()` with both `set_buffer_position()` and `move_cursor()`
-  - 10 tests ignored: `/` and `?` require command-line mode (deferred to Phase 8, #338)
+- Search input mode for `/` and `?` commands (#435)
+  - All 15 search E2E tests now pass (was 5, now includes `/` and `?` patterns)
+  - `/pattern<Enter>` searches forward, `?pattern<Enter>` searches backward
+  - `n` repeats search in same direction, `N` in opposite direction
+  - `*` and `#` search word under cursor forward/backward
+  - `SearchState` moved to driver layer for shared access between runner and modules
+  - Reuses `CommandLine` mode with `PromptType` enum (Command, SearchForward, SearchBackward)
+  - `CmdlineState` extension tracks prompt type and cancelled state
+  - Fixed backward search to properly find matches before cursor position
+  - Fixed `#` (backward word search) to skip current word and find previous occurrence
 
 - All operator E2E tests enabled and passing (#308)
   - 57 operator tests now pass (exceeds original 28 planned)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ## [Unreleased] - v0.9.1-dev
 
+### Changed
+
+- Removed backward compatibility patterns (#427)
+  - Removed `runner::fallback` re-export module (use `reovim_driver_input` directly)
+  - Removed `ModuleRegistry` type alias (use `ModuleManager`)
+  - Removed hidden legacy CLI flags (`--server`, `--listen-tcp`, `--listen-socket`, `--stdio`)
+  - Removed hidden `--socket` flag from CLI and TUI (use `-S` / `--socket-path`)
+  - `VimInsertResolver` migrated from `resolve_with_session()` to `resolve_with_keymap()`
+
+### Deprecated
+
+- `window_active_buffer()` - use `active_buffer()` instead
+- `ModeKeyResolver::resolve()` - override `resolve_with_keymap()` instead
+- `ProfileGuard` - use `profile_scope!()` macro instead
+- `KeymapRegistry::register()` - use `register_at_layer()` instead
+- `KeymapRegistry::register_for_module()` - use `register_at_layer_for_module()` instead
+
+### Removed
+
+- `ModeKeyResolver::resolve()` implementations from vim resolvers (migrated to `resolve_with_keymap()`)
+
 ### Added
 
 - Undo E2E tests fully passing with proper batching (#311)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- Undo E2E tests fully passing with proper batching (#311)
+  - All 9 undo/redo integration tests pass
+  - `VimInsertResolver` now overrides `resolve_with_session` for keymap lookup
+  - Insert mode Escape triggers `vim:exit-insert` command for proper undo batching
+  - `ChangeCommand` starts undo batch BEFORE delete (batch includes both delete + inserts)
+  - Tests: `test_undo_insert`, `test_undo_change_word`, `test_multiple_undo`, etc.
+
 - All operator E2E tests enabled and passing (#308)
   - 57 operator tests now pass (exceeds original 28 planned)
   - Tests migrated from `runner/tests/operators.rs` to `modules/vim/tests/operators.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "reovim-driver-command-types",
  "reovim-driver-session",
  "reovim-kernel",
+ "tracing",
 ]
 
 [[package]]
@@ -1516,6 +1517,7 @@ dependencies = [
  "reovim-driver-clipboard",
  "reovim-driver-command-types",
  "reovim-driver-display",
+ "reovim-driver-undo",
  "reovim-kernel",
 ]
 
@@ -1789,6 +1791,7 @@ dependencies = [
  "reovim-driver-command-types",
  "reovim-driver-input",
  "reovim-driver-session",
+ "reovim-driver-undo",
  "reovim-kernel",
  "reovim-module-editor",
  "reovim-module-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,9 +1700,11 @@ name = "reovim-module-motions"
 version = "0.9.1-dev"
 dependencies = [
  "reovim-driver-command",
+ "reovim-driver-search",
  "reovim-driver-session",
  "reovim-kernel",
  "reovim-module-macros",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,6 +1517,7 @@ dependencies = [
  "reovim-driver-clipboard",
  "reovim-driver-command-types",
  "reovim-driver-display",
+ "reovim-driver-search",
  "reovim-driver-undo",
  "reovim-kernel",
 ]
@@ -1792,6 +1793,7 @@ dependencies = [
  "reovim-driver-command",
  "reovim-driver-command-types",
  "reovim-driver-input",
+ "reovim-driver-search",
  "reovim-driver-session",
  "reovim-driver-undo",
  "reovim-kernel",

--- a/docs/architecture/drivers/input/overview.md
+++ b/docs/architecture/drivers/input/overview.md
@@ -109,7 +109,34 @@ Built-in implementations:
 
 Modules provide policy implementations (e.g., `EditorFallbackHandler` inserts characters in Insert mode).
 
+## Mode Key Resolution
+
+The input driver provides a **resolver chain** for mode-specific key handling. See [Resolver Chain Architecture](./resolver-chain.md) for the complete documentation.
+
+```rust
+pub trait ModeKeyResolver: Send + Sync {
+    fn mode_id(&self) -> &ModeId;
+    fn inherits_from(&self) -> Option<&ModeId>;
+
+    // Resolution chain (each level can be overridden)
+    fn resolve(&self, key: &KeyEvent, state: &mut ModeState) -> ResolveResult;
+    fn resolve_with_keymap(&self, ...) -> ResolveResult;      // + keymap access
+    fn resolve_with_extensions(&self, ...) -> ResolveResult;  // + extension data
+    fn resolve_with_session(&self, ...) -> ResolveResult;     // + session access
+}
+```
+
+Modules register resolvers for their modes:
+
+```rust
+// In vim module init()
+resolver_registry.register(VimNormalResolver::new());
+resolver_registry.register(VimInsertResolver::new());
+resolver_registry.register(VimVisualResolver::new());
+```
+
 ## Related Documents
 
+- [Resolver Chain Architecture](./resolver-chain.md) - Full resolver documentation
 - [Driver Overview](../overview.md) - Driver layer architecture
 - [Display Driver](../display/overview.md) - Cursor styles per mode

--- a/docs/architecture/drivers/input/resolver-chain.md
+++ b/docs/architecture/drivers/input/resolver-chain.md
@@ -1,0 +1,321 @@
+# Resolver Chain Architecture
+
+The input driver provides a **resolver chain** that enables mode-specific key handling with progressive customization levels. This is the core mechanism for translating keypresses into editor actions.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Key Event Processing                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   KeyEvent ──► ResolverRegistry.resolve_with_session()          │
+│                        │                                        │
+│                        ▼                                        │
+│              ┌──────────────────────┐                           │
+│              │ resolve_with_session │  ◄── Override for session │
+│              │   (level 4)          │      access (undo, etc.)  │
+│              └──────────┬───────────┘                           │
+│                         │ default delegates to                  │
+│                         ▼                                       │
+│              ┌───────────────────────┐                          │
+│              │resolve_with_extensions│ ◄── Override for         │
+│              │   (level 3)           │      extension data      │
+│              └──────────┬────────────┘                          │
+│                         │ default delegates to                  │
+│                         ▼                                       │
+│              ┌───────────────────────┐                          │
+│              │ resolve_with_keymap   │  ◄── Override for keymap │
+│              │   (level 2)           │      lookup access       │
+│              └──────────┬────────────┘                          │
+│                         │ default delegates to                  │
+│                         ▼                                       │
+│              ┌───────────────────────┐                          │
+│              │      resolve          │  ◄── Basic key handling  │
+│              │   (level 1)           │      (legacy/simple)     │
+│              └───────────────────────┘                          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## The ModeKeyResolver Trait
+
+```rust
+pub trait ModeKeyResolver: Send + Sync {
+    /// The mode ID this resolver handles
+    fn mode_id(&self) -> &ModeId;
+
+    /// Parent mode for inheritance (e.g., visual inherits from normal)
+    fn inherits_from(&self) -> Option<&ModeId>;
+
+    /// Level 1: Basic resolution (legacy interface)
+    fn resolve(&self, key: &KeyEvent, state: &mut ModeState) -> ResolveResult;
+
+    /// Level 2: Resolution with keymap access
+    fn resolve_with_keymap(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,  // Contains keymap query
+    ) -> ResolveResult {
+        // Default: delegate to resolve()
+        self.resolve(key, state)
+    }
+
+    /// Level 3: Resolution with extension data
+    fn resolve_with_extensions(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,
+        extensions: &mut ExtensionMap,
+    ) -> ResolveResult {
+        // Default: delegate to resolve_with_keymap()
+        self.resolve_with_keymap(key, state, input)
+    }
+
+    /// Level 4: Resolution with full session access
+    fn resolve_with_session(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,
+        session: &mut dyn SessionApiDyn,
+        extensions: &mut ExtensionMap,
+    ) -> ResolveResult {
+        // Default: delegate to resolve_with_extensions()
+        self.resolve_with_extensions(key, state, input, extensions)
+    }
+}
+```
+
+## Resolution Levels
+
+### Level 1: `resolve()` - Basic Key Handling
+
+The simplest interface. Use when you only need the key event and mode state.
+
+```rust
+impl ModeKeyResolver for SimpleResolver {
+    fn resolve(&self, key: &KeyEvent, state: &mut ModeState) -> ResolveResult {
+        match key.code {
+            KeyCode::Escape => ResolveResult::ModeTransition(/* ... */),
+            _ => ResolveResult::NotHandled,
+        }
+    }
+}
+```
+
+**Use cases:**
+- Simple mode transitions
+- Static key mappings
+- No external dependencies needed
+
+### Level 2: `resolve_with_keymap()` - Keymap Lookup
+
+Override when you need to query the keymap for bindings.
+
+```rust
+impl ModeKeyResolver for KeymapAwareResolver {
+    fn resolve_with_keymap(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,
+    ) -> ResolveResult {
+        // Query keymap for binding
+        let keys = KeySequence::from_keys(&[*key]);
+        match input.keymap.query(input.mode, &keys) {
+            KeyLookupState::ExactOnly(cmd) => ResolveResult::Execute(cmd, ctx),
+            KeyLookupState::PrefixOnly => ResolveResult::Pending,
+            KeyLookupState::NotFound => self.resolve(key, state),
+        }
+    }
+}
+```
+
+**Use cases:**
+- Dynamic key bindings
+- Multi-key sequence handling
+- Prefix detection (operator-pending)
+
+### Level 3: `resolve_with_extensions()` - Extension Data
+
+Override when you need to store/retrieve mode-specific state.
+
+```rust
+impl ModeKeyResolver for StatefulResolver {
+    fn resolve_with_extensions(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,
+        extensions: &mut ExtensionMap,
+    ) -> ResolveResult {
+        // Store pending operator in extensions
+        let pending = extensions.get_or_insert::<PendingOperator>();
+        pending.set_operator(Operator::Delete);
+        ResolveResult::ModeTransition(/* operator-pending mode */)
+    }
+}
+```
+
+**Use cases:**
+- Operator-pending state
+- Count accumulation
+- Register selection
+
+### Level 4: `resolve_with_session()` - Full Session Access
+
+Override when you need session-level operations (undo, buffers, etc.).
+
+```rust
+impl ModeKeyResolver for VimInsertResolver {
+    fn resolve_with_session(
+        &self,
+        key: &KeyEvent,
+        state: &mut ModeState,
+        input: &ResolveInput<'_>,
+        session: &mut dyn SessionApiDyn,
+        extensions: &mut ExtensionMap,
+    ) -> ResolveResult {
+        // Insertable characters: return InsertChar
+        if let Some(c) = Self::is_insertable(key) {
+            return ResolveResult::InsertChar(c);
+        }
+
+        // Non-insertable keys: query keymap for commands
+        // This allows Escape to trigger vim:exit-insert command
+        // which properly ends undo batching
+        let keys = KeySequence::from_keys(&[*key]);
+        match input.keymap.query(input.mode, &keys) {
+            KeyLookupState::ExactOnly(cmd) => {
+                ResolveResult::Execute(cmd, ResolveContext::new())
+            }
+            KeyLookupState::NotFound => ResolveResult::NotHandled,
+            _ => ResolveResult::Pending,
+        }
+    }
+}
+```
+
+**Use cases:**
+- Insert mode character handling with keymap fallback
+- Operations needing buffer access
+- Undo batching coordination
+
+## Case Study: Insert Mode Escape Handling
+
+A practical example showing why different resolution levels exist.
+
+### The Problem
+
+In insert mode:
+- Typed characters (`a`, `b`, `1`, etc.) should insert text
+- Escape should exit to normal mode AND properly end undo batching
+
+### Naive Approach (Broken)
+
+```rust
+// Level 1 only - doesn't work properly
+fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
+    if key.code == KeyCode::Escape {
+        // This exits insert mode but DOESN'T end undo batching!
+        return ResolveResult::ModeTransition(normal_mode);
+    }
+    if let KeyCode::Char(c) = key.code {
+        return ResolveResult::InsertChar(c);
+    }
+    ResolveResult::NotHandled
+}
+```
+
+The problem: Undo batching is managed by the `vim:exit-insert` command. Direct mode transitions bypass it.
+
+### Correct Approach
+
+```rust
+// Level 4 - proper keymap lookup for non-insertable keys
+fn resolve_with_session(
+    &self,
+    key: &KeyEvent,
+    _state: &mut ModeState,
+    input: &ResolveInput<'_>,
+    _session: &mut dyn SessionApiDyn,
+    _extensions: &mut ExtensionMap,
+) -> ResolveResult {
+    // Insertable characters: insert directly
+    if let Some(c) = Self::is_insertable(key) {
+        return ResolveResult::InsertChar(c);
+    }
+
+    // Non-insertable keys (Escape, Backspace, etc.): query keymap
+    // Keymap has: <Esc> -> vim:exit-insert
+    // The command properly ends undo batching
+    let keys = KeySequence::from_keys(&[*key]);
+    match input.keymap.query(input.mode, &keys) {
+        KeyLookupState::ExactOnly(cmd) => {
+            ResolveResult::Execute(cmd, ResolveContext::new())
+        }
+        KeyLookupState::NotFound => ResolveResult::NotHandled,
+        _ => ResolveResult::Pending,
+    }
+}
+```
+
+The keymap binds `<Esc>` to `vim:exit-insert`, which:
+1. Ends undo batching (groups all insert edits together)
+2. Transitions to normal mode
+3. Moves cursor back one position (vim behavior)
+
+## ResolveResult Variants
+
+```rust
+pub enum ResolveResult {
+    /// Execute a command with context
+    Execute(CommandId, ResolveContext),
+
+    /// Insert a character at cursor
+    InsertChar(char),
+
+    /// Transition to a different mode
+    ModeTransition(ModeTransition),
+
+    /// Key sequence is incomplete, wait for more keys
+    Pending,
+
+    /// Key was not handled, try fallback or parent resolver
+    NotHandled,
+
+    /// Pop pending mode with result (for operator-pending)
+    PopResult(PopResult),
+}
+```
+
+## Mode Inheritance
+
+Resolvers can inherit from parent modes:
+
+```rust
+impl ModeKeyResolver for VimVisualResolver {
+    fn inherits_from(&self) -> Option<&ModeId> {
+        Some(&VimMode::NORMAL_ID)  // Visual inherits from normal
+    }
+}
+```
+
+When a key is `NotHandled`, the registry tries the parent mode's resolver.
+
+## Best Practices
+
+1. **Start with `resolve()`** - Use the simplest level that works
+2. **Override only what you need** - Each level adds complexity
+3. **Use keymap for configurable bindings** - Don't hardcode keys
+4. **Commands for side effects** - Mode transitions with side effects (undo, etc.) should go through commands
+5. **Return `NotHandled` for unknown keys** - Let the fallback system handle them
+
+## Related Documents
+
+- [Input Driver Overview](./overview.md) - Key events, mouse, clipboard
+- [Module System](../../modules/overview.md) - How modules register resolvers
+- [Command System](../command/overview.md) - Command execution

--- a/docs/heritage/project-kernel-phases.md
+++ b/docs/heritage/project-kernel-phases.md
@@ -7,9 +7,9 @@ This document chronicles Reovim's transformation from a monolithic editor to a *
 ## Overview
 
 ```
-Phase 0-4 ──> Phase 5 ──> Phase 6 ──> Phase 7 ──> Phase 8
-Foundation    Implement   Decouple    Features    Extract
-   ✅            ✅          ✅          🚧
+Phase 0-4 ──> Phase 5 ──> Phase 6 ──> Phase 7 ──> Phase 8 ──> Phase 9 ──> Phase 10 ──> Phase 11
+Foundation    Implement   Decouple    Features    Foundation  Features    Languages    Release
+   ✅            ✅          ✅          🚧         (future)    (future)    (future)    (future)
 ```
 
 ---
@@ -224,27 +224,196 @@ All four streams developed in parallel and merged via PR #272.
 
 ---
 
-## Phase 8: Feature Extraction (Future)
+## Phase 8: Foundation (Future)
 
-**Goal:** Extract and re-implement features from `archive/` using new architecture.
+**Goal:** Complete deferred Phase 7 items + basic plugins + TUI infrastructure.
 
-Following the same **concept-extraction** methodology as Phase 5:
+This phase builds the foundation that Phase 9 features will depend on.
+
+### Deferred Phase 7 Items
+
+| Item | Description | Dependency |
+|------|-------------|------------|
+| Undo E2E (#311) | Wire `UndoApi` to SessionRuntime | None |
+| Search E2E (#310) | Implement search via command-line mode | Command-line |
+| Named registers | `"a-z` register prefix parsing | None |
+| Text objects | `iw`, `a"`, `i(`, etc. | Operators |
+| Visual mode polish | Edge cases, block mode | Selection API |
+
+### Command-Line Mode (Critical Foundation)
+
+| Feature | Keys | Enables |
+|---------|------|---------|
+| Ex-commands | `:` | `:w`, `:q`, `:e`, `:set` |
+| Forward search | `/` | Search patterns |
+| Backward search | `?` | Reverse search |
+| Input handling | `<CR>`, `<Esc>`, `<BS>` | All above |
+
+### Basic Plugins (Category A)
+
+Extracted from `archive/plugins/features/`:
+
+| Plugin | Purpose | Priority |
+|--------|---------|----------|
+| **statusline** | Mode, file, position display | High |
+| **which-key** | Key hint popups | High |
+| **notification** | User feedback messages | Medium |
+| **pair** | Auto-close brackets | Medium |
+
+### TUI Infrastructure
+
+| Component | Epic/Issue | Purpose |
+|-----------|------------|---------|
+| Window system | #403 Phase 1 | Splits, focus, `<C-w>` commands |
+| Overlay system | #403 Phase 3 | Popups, menus, hints |
+| Color/theme system | TBD | Syntax colors, UI styling |
+
+---
+
+## Phase 9: Feature Plugins (Future)
+
+**Goal:** Extract feature plugins from archive. Battle-tests Phase 8 foundation.
+
+### Code Intelligence
+
+| Plugin | Purpose | Depends On |
+|--------|---------|------------|
+| **treesitter** | Syntax parsing, highlighting | Syntax driver |
+| **lsp** | Language servers, diagnostics | Async, popups |
+| **completion** | Autocomplete menu | Overlay, LSP |
+| **cmdline-completion** | `:` command completion | Command-line mode |
+
+### Navigation
+
+| Plugin | Purpose | Depends On |
+|--------|---------|------------|
+| **microscope** | Fuzzy finder (files, symbols) | Overlay, async |
+| **pickers** | Buffer/file/help pickers | Microscope |
+| **explorer** | File tree sidebar | Window system |
+| **range-finder** | Jump labels (like hop.nvim) | Overlay |
+
+### Context
+
+| Plugin | Purpose | Depends On |
+|--------|---------|------------|
+| **context** | Cursor context tracking | Treesitter |
+| **sticky-context** | Sticky function headers | Context, treesitter |
+
+### Phase 9 Feedback Loop
+
+Phase 9 will discover Phase 8 gaps. Budget ~20% of Phase 9 time for fixing
+foundation issues exposed by feature plugin development.
+
+---
+
+## Phase 10: Language Plugins (Future)
+
+**Goal:** Extract language plugins from archive. Battle-tests Phase 8+9.
+
+### Language Support
+
+Extracted from `archive/plugins/languages/`:
+
+| Plugin | Language(s) |
+|--------|-------------|
+| **rust** | Rust (rust-analyzer) |
+| **python** | Python (pyright/pylsp) |
+| **javascript** | JS/TS (tsserver) |
+| **c** | C/C++ (clangd) |
+| **markdown** | Markdown (preview, rendering) |
+| **json** | JSON (schema validation) |
+| **toml** | TOML (config files) |
+| **bash** | Shell scripts |
+
+### Customization & Polish
+
+| Plugin | Purpose |
+|--------|---------|
+| **profiles** | User config profiles |
+| **settings-menu** | GUI settings editor |
+| **health-check** | `:checkhealth` diagnostics |
+| **landing** | Startup screen |
+
+### Advanced Window Features
+
+| Component | Epic/Issue | Purpose |
+|-----------|------------|---------|
+| Floating windows | #403 Phase 2 | Toggle float, move/resize |
+| Transparency | #403 Phase 4 | Layer opacity |
+| Tab pages | #403 Phase 5 | Workspace organization |
+
+### Phase 10 Feedback Loop
+
+Language plugins are the heaviest consumers of the feature stack. They will
+expose edge cases in LSP, treesitter, completion, and window management.
+Budget ~20% for fixing Phase 8+9 issues discovered during language plugin work.
+
+---
+
+## Phase 11: Release (Future)
+
+**Goal:** Feature parity with v0.8.1, close Epic #150.
+
+### Verification
+
+- [ ] All archive plugins extracted or explicitly deferred
+- [ ] Feature parity checklist against v0.8.1
+- [ ] Performance benchmarks meet targets
+- [ ] Documentation complete
+
+### Polish
+
+- [ ] Bug fixes from Phase 8-10 feedback
+- [ ] UX refinements from dogfooding
+- [ ] Error messages and edge cases
+
+### Release Criteria
+
+- [ ] All E2E tests passing
+- [ ] Zero known critical bugs
+- [ ] README and user guide updated
+- [ ] CHANGELOG complete
+
+### Scope Boundary
+
+**Epic #150 ends here.** New features, new language support, or broader
+expansion targets are out of scope and should be tracked in new epics.
+
+---
+
+## Beyond #150: Future Directions
+
+After Epic #150 achieves v0.8.1 feature parity, new epics may explore:
+
+| Area | Examples | Epic |
+|------|----------|------|
+| **New Languages** | Go, Zig, Lua, Ruby | TBD |
+| **GUI Client** | Native desktop app | TBD |
+| **Web Client** | Browser-based editor | TBD |
+| **Remote Editing** | SSH, containers, cloud | TBD |
+| **Plugin API** | Third-party plugin system | TBD |
+| **Collaboration** | Multi-user editing | TBD |
+
+These are explicitly **out of scope** for #150 to keep the epic bounded and measurable.
+
+---
+
+## Battle-Testing Philosophy
+
+Each phase validates the previous through actual usage:
 
 ```
-archive/plugins/features/    →    modules/
-archive/plugins/languages/   →    modules/ + lib/drivers/
-archive/lib/lsp/             →    lib/drivers/lsp/ (enhanced)
+Phase 8 (Foundation)     Phase 9 (Features)      Phase 10 (Languages)
+─────────────────────    ──────────────────      ────────────────────
+Build base               Build on Phase 8        Stress-test 8+9
+                         Discover 8's gaps       Discover 8+9's gaps
+                         Fix foundation          Fix discovered issues
+                                ↓                        ↓
+                         ~20% backflow           ~20% backflow
 ```
 
-| Category | Examples | Target |
-|----------|----------|--------|
-| **UI Components** | statusline, explorer, which-key | Modules |
-| **Editing Features** | completion, pair, snippets | Modules |
-| **Navigation** | microscope, pickers, range-finder | Modules |
-| **Language Support** | LSP, treesitter, formatters | Drivers + Modules |
-| **Rendering** | markdown decoration, table rendering | Drivers + Modules |
-
-Study archived code → Design for new architecture → Implement fresh
+You cannot design perfect abstractions without consumers using them.
+Phase 10 language plugins are the real validation of the architecture.
 
 ---
 
@@ -301,13 +470,41 @@ Patterns and insights discovered during the architecture overhaul:
 - [x] CLI client enables scripting
 - [x] Debug endpoints for introspection
 
-### Remaining (Phase 7-8)
+### Phase 7 (In Progress)
 
-- [ ] Basic editing: open, edit, save files
-- [ ] Cursor movement, visual mode, operators
-- [ ] Multi-client with independent viewports
-- [ ] ~425+ tests passing
+- [x] Basic editing: open, edit, save files
+- [x] Cursor movement, operators
+- [ ] Undo/redo E2E tests (#311)
+- [ ] Search E2E tests (#310)
+- [ ] Visual mode polish
+- [ ] Text objects
+
+### Phase 8 (Foundation)
+
+- [ ] Command-line mode (`:`, `/`, `?`)
+- [ ] Named registers (`"a-z`)
+- [ ] Basic plugins: statusline, which-key, notification, pair
+- [ ] Window system (#403 core)
+- [ ] Overlay system for popups
+
+### Phase 9 (Feature Plugins)
+
+- [ ] treesitter, lsp, completion
+- [ ] microscope, pickers, explorer
+- [ ] context, sticky-context, range-finder
+
+### Phase 10 (Language Plugins)
+
+- [ ] Language plugins from archive/
+- [ ] profiles, settings-menu, health-check
+- [ ] Advanced window features (#403 Phase 2-5)
+
+### Phase 11 (Release)
+
+- [ ] Feature parity with v0.8.1
 - [ ] Performance benchmarks
+- [ ] Documentation complete
+- [ ] Epic #150 closed
 
 ---
 

--- a/lib/drivers/input/Cargo.toml
+++ b/lib/drivers/input/Cargo.toml
@@ -18,3 +18,4 @@ reovim-arch = { path = "../../arch", version = "0.9.1-dev" }
 reovim-driver-session = { path = "../session", version = "0.9.1-dev" }
 reovim-driver-command-types = { path = "../command-types", version = "0.9.1-dev" }
 bitflags = "2.4"
+tracing = "0.1"

--- a/lib/drivers/input/src/resolver.rs
+++ b/lib/drivers/input/src/resolver.rs
@@ -272,7 +272,10 @@ pub trait ModeKeyResolver: Send + Sync {
     /// # Returns
     ///
     /// A `ResolveResult` indicating what action to take.
-    fn resolve(&self, key: &KeyEvent, state: &mut ModeState) -> ResolveResult;
+    #[deprecated(since = "0.9.5", note = "Override resolve_with_keymap() instead")]
+    fn resolve(&self, _key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
+        panic!("resolve() is removed - implement resolve_with_keymap() instead")
+    }
 
     /// Process a key event with access to keymap queries.
     ///
@@ -318,6 +321,7 @@ pub trait ModeKeyResolver: Send + Sync {
     ///     }
     /// }
     /// ```
+    #[allow(deprecated)]
     fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
@@ -325,6 +329,7 @@ pub trait ModeKeyResolver: Send + Sync {
         _input: &ResolveInput<'_>,
     ) -> ResolveResult {
         // Default: delegate to legacy resolve() for backward compatibility
+        // Note: Resolvers should override this method instead
         self.resolve(key, state)
     }
 

--- a/lib/drivers/session/Cargo.toml
+++ b/lib/drivers/session/Cargo.toml
@@ -23,6 +23,8 @@ reovim-arch = { path = "../../arch" }
 reovim-driver-clipboard = { path = "../clipboard" }
 # Undo driver for UndoApi implementation
 reovim-driver-undo = { path = "../undo" }
+# Search driver for Direction type (SearchState)
+reovim-driver-search = { path = "../search" }
 
 [lints]
 workspace = true

--- a/lib/drivers/session/Cargo.toml
+++ b/lib/drivers/session/Cargo.toml
@@ -21,6 +21,8 @@ reovim-driver-display = { path = "../display" }
 reovim-arch = { path = "../../arch" }
 # Clipboard driver for system clipboard and history (RegisterApi routing)
 reovim-driver-clipboard = { path = "../clipboard" }
+# Undo driver for UndoApi implementation
+reovim-driver-undo = { path = "../undo" }
 
 [lints]
 workspace = true

--- a/lib/drivers/session/src/api/cmdline.rs
+++ b/lib/drivers/session/src/api/cmdline.rs
@@ -1,0 +1,141 @@
+//! Command-line mode extension for session.
+//!
+//! Provides a shared prompt type that commands can set and the runner can read.
+//! This enables the runner to activate cmdline with the correct prompt type
+//! without depending on policy modules.
+
+use crate::SessionExtension;
+
+/// Command-line prompt type for session extensions.
+///
+/// This is a minimal extension that stores the pending prompt type.
+/// Commands set this when entering command-line mode, and the runner
+/// reads it to determine the display prompt character.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CmdlinePrompt {
+    /// Ex command prompt (`:`)
+    #[default]
+    Command,
+    /// Forward search prompt (`/`)
+    SearchForward,
+    /// Backward search prompt (`?`)
+    SearchBackward,
+}
+
+impl CmdlinePrompt {
+    /// Get the prompt character for display.
+    #[must_use]
+    pub const fn char(self) -> char {
+        match self {
+            Self::Command => ':',
+            Self::SearchForward => '/',
+            Self::SearchBackward => '?',
+        }
+    }
+
+    /// Check if this is a search prompt.
+    #[must_use]
+    pub const fn is_search(self) -> bool {
+        matches!(self, Self::SearchForward | Self::SearchBackward)
+    }
+}
+
+/// Session extension for command-line state.
+///
+/// Policy (modules) sets this when entering/exiting command-line mode.
+/// Mechanism (runner) reads this to sync display state.
+#[derive(Debug, Default)]
+pub struct CmdlineState {
+    /// Whether cmdline is active.
+    active: bool,
+    /// The prompt type for the current command-line session.
+    prompt: CmdlinePrompt,
+    /// Whether the exit was a cancellation (Escape) vs execution (Enter).
+    cancelled: bool,
+}
+
+impl SessionExtension for CmdlineState {
+    fn create() -> Self {
+        Self::default()
+    }
+}
+
+impl CmdlineState {
+    /// Enter cmdline mode with specified prompt type.
+    pub const fn enter(&mut self, prompt: CmdlinePrompt) {
+        self.active = true;
+        self.prompt = prompt;
+        self.cancelled = false;
+    }
+
+    /// Exit cmdline mode (execute action).
+    pub const fn exit(&mut self) {
+        self.active = false;
+        self.cancelled = false;
+        self.prompt = CmdlinePrompt::Command;
+    }
+
+    /// Cancel cmdline mode (don't execute action).
+    pub const fn cancel(&mut self) {
+        self.active = false;
+        self.cancelled = true;
+        self.prompt = CmdlinePrompt::Command;
+    }
+
+    /// Check if cmdline is active.
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Check if cmdline was cancelled (vs executed).
+    #[must_use]
+    pub const fn was_cancelled(&self) -> bool {
+        self.cancelled
+    }
+
+    /// Get the current prompt type.
+    #[must_use]
+    pub const fn prompt(&self) -> CmdlinePrompt {
+        self.prompt
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cmdline_state_default() {
+        let state = CmdlineState::default();
+        assert!(!state.is_active());
+        assert_eq!(state.prompt(), CmdlinePrompt::Command);
+    }
+
+    #[test]
+    fn test_cmdline_prompt_chars() {
+        assert_eq!(CmdlinePrompt::Command.char(), ':');
+        assert_eq!(CmdlinePrompt::SearchForward.char(), '/');
+        assert_eq!(CmdlinePrompt::SearchBackward.char(), '?');
+    }
+
+    #[test]
+    fn test_cmdline_prompt_is_search() {
+        assert!(!CmdlinePrompt::Command.is_search());
+        assert!(CmdlinePrompt::SearchForward.is_search());
+        assert!(CmdlinePrompt::SearchBackward.is_search());
+    }
+
+    #[test]
+    fn test_enter_and_exit() {
+        let mut state = CmdlineState::default();
+
+        state.enter(CmdlinePrompt::SearchForward);
+        assert!(state.is_active());
+        assert_eq!(state.prompt(), CmdlinePrompt::SearchForward);
+
+        state.exit();
+        assert!(!state.is_active());
+        assert_eq!(state.prompt(), CmdlinePrompt::Command);
+    }
+}

--- a/lib/drivers/session/src/api/mod.rs
+++ b/lib/drivers/session/src/api/mod.rs
@@ -62,16 +62,24 @@
 
 mod buffer;
 mod changes;
+mod cmdline;
 mod command;
 mod compositor;
 mod extension;
 mod mode;
 mod register;
+mod search;
 mod undo;
 mod window;
 
 // Buffer API
 pub use buffer::{BufferApi, BufferError, Selection, SelectionMode};
+
+// Cmdline state extension
+pub use cmdline::{CmdlinePrompt, CmdlineState};
+
+// Search state extension
+pub use search::SearchState;
 
 // Compositor API
 pub use compositor::{CompositorApi, CompositorError};

--- a/lib/drivers/session/src/api/mod.rs
+++ b/lib/drivers/session/src/api/mod.rs
@@ -12,6 +12,7 @@
 //! | [`BufferApi`] | Buffer content and lifecycle |
 //! | [`WindowApi`] | Window management and focus |
 //! | [`CommandApi`] | Command execution |
+//! | [`UndoApi`] | Undo/redo operations |
 //! | [`ExtensionApi`] | Module per-session state |
 //! | [`ChangeTracker`] | Accumulated change collection |
 //!
@@ -66,6 +67,7 @@ mod compositor;
 mod extension;
 mod mode;
 mod register;
+mod undo;
 mod window;
 
 // Buffer API
@@ -88,6 +90,9 @@ pub use extension::ExtensionApi;
 
 // Mode API
 pub use mode::{ModeApi, ModeError};
+
+// Undo API
+pub use undo::UndoApi;
 
 // Window API
 pub use window::{WindowApi, WindowError};
@@ -126,10 +131,16 @@ pub use window::{WindowApi, WindowError};
 ///     ResolveResult::Completed
 /// }
 /// ```
-pub trait SessionApiDyn: ModeApi + BufferApi + WindowApi + CommandApi + ChangeTracker {}
+pub trait SessionApiDyn:
+    ModeApi + BufferApi + WindowApi + CommandApi + UndoApi + ChangeTracker
+{
+}
 
 // Blanket implementation for SessionApiDyn
-impl<T> SessionApiDyn for T where T: ModeApi + BufferApi + WindowApi + CommandApi + ChangeTracker {}
+impl<T> SessionApiDyn for T where
+    T: ModeApi + BufferApi + WindowApi + CommandApi + UndoApi + ChangeTracker
+{
+}
 
 /// Full session API for generic bounds (not dyn-compatible).
 ///

--- a/lib/drivers/session/src/api/search.rs
+++ b/lib/drivers/session/src/api/search.rs
@@ -1,0 +1,120 @@
+//! Search state extension for session.
+//!
+//! Provides shared search state that both the runner and modules can access.
+//! This stores the last search pattern and direction for n/N repeat.
+
+use {crate::SessionExtension, reovim_driver_search::Direction};
+
+/// Per-session search state.
+///
+/// Stores the last search pattern and direction for n, N, *, # commands.
+/// Also tracks pending search input when user presses `/` or `?`.
+#[derive(Debug, Default)]
+pub struct SearchState {
+    /// Last search pattern (regex format).
+    pub last_pattern: Option<String>,
+
+    /// Last search direction (forward or backward).
+    pub last_direction: Direction,
+
+    /// Pending search direction (set when entering search input mode).
+    ///
+    /// When Some, indicates we're in search input mode and which direction
+    /// the search will go when Enter is pressed.
+    pub pending_search: Option<Direction>,
+}
+
+impl SessionExtension for SearchState {
+    fn create() -> Self {
+        Self::default()
+    }
+}
+
+impl SearchState {
+    /// Set the search pattern and direction.
+    pub fn set(&mut self, pattern: String, direction: Direction) {
+        self.last_pattern = Some(pattern);
+        self.last_direction = direction;
+    }
+
+    /// Get the pattern for repeat search (n).
+    #[must_use]
+    pub fn pattern_for_repeat(&self) -> Option<&str> {
+        self.last_pattern.as_deref()
+    }
+
+    /// Get the direction for repeat search (n).
+    #[must_use]
+    pub const fn direction_for_repeat(&self) -> Direction {
+        self.last_direction
+    }
+
+    /// Get the reversed direction for opposite repeat (N).
+    #[must_use]
+    pub const fn direction_for_opposite(&self) -> Direction {
+        match self.last_direction {
+            Direction::Forward => Direction::Backward,
+            Direction::Backward => Direction::Forward,
+        }
+    }
+
+    /// Start pending search (called when `/` or `?` is pressed).
+    pub const fn start_pending_search(&mut self, direction: Direction) {
+        self.pending_search = Some(direction);
+    }
+
+    /// Take the pending search direction (clears it).
+    ///
+    /// Called when command-line mode exits to get the search direction.
+    pub const fn take_pending_search(&mut self) -> Option<Direction> {
+        // Manual implementation since Option::take() is not const
+        let result = self.pending_search;
+        self.pending_search = None;
+        result
+    }
+
+    /// Check if a search is pending.
+    #[must_use]
+    pub const fn has_pending_search(&self) -> bool {
+        self.pending_search.is_some()
+    }
+
+    /// Clear pending search (called on cancel/escape).
+    pub const fn clear_pending_search(&mut self) {
+        self.pending_search = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_state_default() {
+        let state = SearchState::default();
+        assert!(state.last_pattern.is_none());
+        assert!(matches!(state.last_direction, Direction::Forward));
+    }
+
+    #[test]
+    fn test_search_state_set() {
+        let mut state = SearchState::default();
+        state.set("hello".to_string(), Direction::Backward);
+        assert_eq!(state.pattern_for_repeat(), Some("hello"));
+        assert!(matches!(state.direction_for_repeat(), Direction::Backward));
+        assert!(matches!(state.direction_for_opposite(), Direction::Forward));
+    }
+
+    #[test]
+    fn test_pending_search() {
+        let mut state = SearchState::default();
+        assert!(!state.has_pending_search());
+
+        state.start_pending_search(Direction::Forward);
+        assert!(state.has_pending_search());
+
+        let dir = state.take_pending_search();
+        assert_eq!(dir, Some(Direction::Forward));
+        assert!(!state.has_pending_search());
+    }
+}

--- a/lib/drivers/session/src/api/undo.rs
+++ b/lib/drivers/session/src/api/undo.rs
@@ -1,0 +1,77 @@
+//! Undo/redo operations API.
+//!
+//! This module provides the [`UndoApi`] trait for undo and redo operations.
+//! Commands use this to perform undo/redo on the active buffer.
+//!
+//! # Design
+//!
+//! Following Unix philosophy: this trait does ONE thing well - undo management.
+//! The actual undo tree is stored in the `UndoProvider` service, accessed via
+//! `ServiceRegistry`.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_session::api::UndoApi;
+//!
+//! fn undo_last_change<S: UndoApi>(session: &mut S) {
+//!     if let Some(buffer) = session.active_buffer() {
+//!         if let Some(result) = session.undo(buffer) {
+//!             // Apply inverse edits to buffer
+//!             // Move cursor to result.cursor
+//!         }
+//!     }
+//! }
+//! ```
+
+use reovim_kernel::api::v1::{BufferId, Edit, Position, UndoResult};
+
+/// Undo/redo operations API.
+///
+/// Provides access to undo/redo functionality for resolvers and commands.
+/// Implementations access the `UndoProvider` service from the kernel's
+/// service registry.
+pub trait UndoApi: Send {
+    /// Undo the last change for a buffer.
+    ///
+    /// Returns the edits to apply (already inverted) and cursor position
+    /// to restore. Returns `None` if there's nothing to undo.
+    ///
+    /// # Note
+    ///
+    /// The returned edits should be applied to the buffer. The cursor
+    /// position should be restored after applying edits.
+    fn undo(&mut self, buffer: BufferId) -> Option<UndoResult>;
+
+    /// Redo the last undone change for a buffer.
+    ///
+    /// Returns the edits to apply and cursor position to restore.
+    /// Returns `None` if there's nothing to redo.
+    fn redo(&mut self, buffer: BufferId) -> Option<UndoResult>;
+
+    /// Record edits for undo history.
+    ///
+    /// This should be called after making edits to a buffer so they can
+    /// be undone later. The edits are stored with cursor positions for
+    /// proper restoration.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - The buffer that was edited
+    /// * `edits` - The edits that were made
+    /// * `cursor_before` - Cursor position before the edits
+    /// * `cursor_after` - Cursor position after the edits
+    fn record_edit(
+        &mut self,
+        buffer: BufferId,
+        edits: Vec<Edit>,
+        cursor_before: Position,
+        cursor_after: Position,
+    );
+
+    /// Check if undo is available for a buffer.
+    fn can_undo(&self, buffer: BufferId) -> bool;
+
+    /// Check if redo is available for a buffer.
+    fn can_redo(&self, buffer: BufferId) -> bool;
+}

--- a/lib/drivers/session/src/lib.rs
+++ b/lib/drivers/session/src/lib.rs
@@ -105,10 +105,10 @@ pub use runtime::SessionRuntime;
 
 // Session API traits (re-export for convenience)
 pub use api::{
-    BufferApi, BufferError, ChangeTracker, CommandApi, CommandExecutor, CompositorApi,
-    CompositorError, ExtensionApi, ModeApi, ModeError as ApiModeError, RegisterApi,
-    RegisterContent, Selection, SelectionMode, SessionApi, SessionApiDyn, StateChanges, WindowApi,
-    WindowError, YankType,
+    BufferApi, BufferError, ChangeTracker, CmdlinePrompt, CmdlineState, CommandApi,
+    CommandExecutor, CompositorApi, CompositorError, ExtensionApi, ModeApi,
+    ModeError as ApiModeError, RegisterApi, RegisterContent, Selection, SelectionMode, SessionApi,
+    SessionApiDyn, StateChanges, WindowApi, WindowError, YankType,
 };
 
 // Re-export typed key and registry (Epic #417 - UniqueProvider abstraction)

--- a/lib/drivers/session/src/runtime.rs
+++ b/lib/drivers/session/src/runtime.rs
@@ -44,9 +44,10 @@ use {
         NavigateDirection, Rect, SplitDirection,
         layout::{LayerId, WindowPlacement},
     },
+    reovim_driver_undo::{UndoKey, UndoProviderRegistry},
     reovim_kernel::api::v1::{
-        BufferId, CommandId, KernelContext, ModeId, Position, SelectionMode as KernelSelectionMode,
-        WindowId,
+        BufferId, CommandId, Edit, KernelContext, ModeId, Position,
+        SelectionMode as KernelSelectionMode, UndoResult, WindowId,
     },
 };
 
@@ -55,7 +56,7 @@ use crate::{
     api::{
         BufferApi, BufferError, ChangeTracker, CommandApi, CommandExecutor, CompositorApi,
         CompositorError, ExtensionApi, ModeApi, ModeError, RegisterApi, RegisterContent, Selection,
-        SelectionMode, StateChanges, WindowApi, WindowError,
+        SelectionMode, StateChanges, UndoApi, WindowApi, WindowError,
     },
     transition::{PopResult, TransitionContext},
 };
@@ -369,14 +370,55 @@ impl BufferApi for SessionRuntime<'_> {
 
     fn insert_text(&mut self, buffer: BufferId, pos: Position, text: &str) {
         if let Some(buf) = self.kernel.buffers.get(buffer) {
+            let cursor_before = {
+                let b = buf.read();
+                b.position()
+            };
+
             buf.write().insert_at(pos, text);
+
+            let cursor_after = {
+                let b = buf.read();
+                b.position()
+            };
+
+            // Record edit for undo
+            let edit = Edit::Insert {
+                position: pos,
+                text: text.to_string(),
+            };
+            self.record_edit(buffer, vec![edit], cursor_before, cursor_after);
+
             self.changes.record_buffer_modified(buffer);
         }
     }
 
     fn delete_range(&mut self, buffer: BufferId, start: Position, end: Position) {
         if let Some(buf) = self.kernel.buffers.get(buffer) {
-            buf.write().delete_range(start, end);
+            let cursor_before = {
+                let b = buf.read();
+                b.position()
+            };
+
+            let deleted_text = {
+                let mut b = buf.write();
+                b.delete_range(start, end)
+            };
+
+            let cursor_after = {
+                let b = buf.read();
+                b.position()
+            };
+
+            // Record edit for undo
+            if !deleted_text.is_empty() {
+                let edit = Edit::Delete {
+                    position: start,
+                    text: deleted_text,
+                };
+                self.record_edit(buffer, vec![edit], cursor_before, cursor_after);
+            }
+
             self.changes.record_buffer_modified(buffer);
         }
     }
@@ -625,6 +667,104 @@ impl RegisterApi for SessionRuntime<'_> {
                 self.kernel.registers.write().set_by_name(name, content);
             }
         }
+    }
+}
+
+// === UndoApi ===
+
+impl UndoApi for SessionRuntime<'_> {
+    fn undo(&mut self, buffer: BufferId) -> Option<UndoResult> {
+        let undo_provider = self
+            .kernel
+            .services
+            .get::<UndoProviderRegistry>()?
+            .get(&UndoKey::Buffer)?;
+
+        let result = undo_provider.undo(buffer)?;
+
+        // Apply the inverse edits to the buffer
+        if let Some(buf) = self.kernel.buffers.get(buffer) {
+            let mut buf = buf.write();
+            for edit in &result.edits {
+                match edit {
+                    Edit::Insert { position, text } => {
+                        buf.insert_at(*position, text);
+                    }
+                    Edit::Delete { position, text } => {
+                        buf.delete_at(*position, text.chars().count());
+                    }
+                }
+            }
+            buf.set_position(result.cursor);
+        }
+
+        self.changes.record_buffer_modified(buffer);
+        self.changes.record_cursor_move(buffer);
+
+        Some(result)
+    }
+
+    fn redo(&mut self, buffer: BufferId) -> Option<UndoResult> {
+        let undo_provider = self
+            .kernel
+            .services
+            .get::<UndoProviderRegistry>()?
+            .get(&UndoKey::Buffer)?;
+
+        let result = undo_provider.redo(buffer)?;
+
+        // Apply the edits to the buffer
+        if let Some(buf) = self.kernel.buffers.get(buffer) {
+            let mut buf = buf.write();
+            for edit in &result.edits {
+                match edit {
+                    Edit::Insert { position, text } => {
+                        buf.insert_at(*position, text);
+                    }
+                    Edit::Delete { position, text } => {
+                        buf.delete_at(*position, text.chars().count());
+                    }
+                }
+            }
+            buf.set_position(result.cursor);
+        }
+
+        self.changes.record_buffer_modified(buffer);
+        self.changes.record_cursor_move(buffer);
+
+        Some(result)
+    }
+
+    fn record_edit(
+        &mut self,
+        buffer: BufferId,
+        edits: Vec<Edit>,
+        cursor_before: Position,
+        cursor_after: Position,
+    ) {
+        if let Some(undo_registry) = self.kernel.services.get::<UndoProviderRegistry>()
+            && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+        {
+            undo_provider.record(buffer, edits, cursor_before, cursor_after);
+        }
+    }
+
+    fn can_undo(&self, buffer: BufferId) -> bool {
+        self.kernel
+            .services
+            .get::<UndoProviderRegistry>()
+            .and_then(|registry| registry.get(&UndoKey::Buffer))
+            .and_then(|provider| provider.get_tree(buffer))
+            .is_some_and(|tree| tree.can_undo())
+    }
+
+    fn can_redo(&self, buffer: BufferId) -> bool {
+        self.kernel
+            .services
+            .get::<UndoProviderRegistry>()
+            .and_then(|registry| registry.get(&UndoKey::Buffer))
+            .and_then(|provider| provider.get_tree(buffer))
+            .is_some_and(|tree| tree.can_redo())
     }
 }
 

--- a/lib/drivers/session/src/types.rs
+++ b/lib/drivers/session/src/types.rs
@@ -459,6 +459,7 @@ impl Session {
     ///
     /// This is kept for backward compatibility. Prefer `active_buffer()`.
     #[must_use]
+    #[deprecated(since = "0.9.5", note = "Use active_buffer() instead")]
     pub fn window_active_buffer(&self) -> Option<BufferId> {
         self.windows.active().and_then(|w| w.buffer_id)
     }
@@ -617,6 +618,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_session_window_active_buffer() {
         let mode = test_mode();
         let mut session = Session::new(ClientId::new(1), mode);

--- a/lib/drivers/undo/src/provider.rs
+++ b/lib/drivers/undo/src/provider.rs
@@ -87,6 +87,39 @@ pub trait UndoProvider: Send + Sync {
     fn get_tree(&self, buffer_id: BufferId) -> Option<UndoTree>;
 
     // ========================================================================
+    // Batch Methods (Insert Mode Undo Grouping)
+    // ========================================================================
+
+    /// Begin a batch for accumulating edits.
+    ///
+    /// While a batch is active, `record()` calls accumulate edits instead of
+    /// creating separate undo entries. Call `end_batch()` to commit all
+    /// accumulated edits as a single undo entry.
+    ///
+    /// This is used for Vim-style insert mode undo: all characters typed
+    /// during a single insert session become one undo entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer_id` - The buffer to start batching for
+    /// * `cursor_before` - Cursor position at batch start (for undo restoration)
+    fn begin_batch(&self, buffer_id: BufferId, cursor_before: Position);
+
+    /// End the current batch and commit accumulated edits.
+    ///
+    /// All edits recorded since `begin_batch()` are committed as a single
+    /// undo entry. If no edits were recorded, nothing is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer_id` - The buffer to end batching for
+    /// * `cursor_after` - Cursor position at batch end (for redo restoration)
+    fn end_batch(&self, buffer_id: BufferId, cursor_after: Position);
+
+    /// Check if a batch is currently active for a buffer.
+    fn is_batching(&self, buffer_id: BufferId) -> bool;
+
+    // ========================================================================
     // Persistence Methods (Epic #417 Part 2)
     // ========================================================================
 

--- a/lib/kernel/src/api/v1.rs
+++ b/lib/kernel/src/api/v1.rs
@@ -235,6 +235,7 @@ pub use super::debug::{
 // Profiling (debug/profiler.rs)
 // ============================================================================
 
+#[allow(deprecated)]
 pub use crate::debug::{
     // Profiler trait and types
     NopProfiler,

--- a/lib/kernel/src/debug/mod.rs
+++ b/lib/kernel/src/debug/mod.rs
@@ -66,7 +66,7 @@ pub use trace::{TraceEvent, TracePoint, TraceSink, emit_trace, set_trace_sink};
 pub use metrics::{Counter, Histogram, MetricsRegistry, MetricsSnapshot, metrics};
 
 // Re-export profiler types
-#[allow(unused_imports)]
+#[allow(unused_imports, deprecated)]
 pub use profiler::{
     NopProfiler, ProfileGuard, ProfileScope, Profiler, SetProfilerError, SpanData, SpanId,
     profiler, set_profiler,

--- a/lib/kernel/src/debug/profiler.rs
+++ b/lib/kernel/src/debug/profiler.rs
@@ -424,11 +424,13 @@ impl Drop for ProfileScope {
 ///     // ... do work ...
 /// } // time recorded to histogram when guard drops
 /// ```
+#[deprecated(since = "0.9.5", note = "Use profile_scope!() macro instead")]
 pub struct ProfileGuard {
     name: &'static str,
     start: Instant,
 }
 
+#[allow(deprecated)]
 impl ProfileGuard {
     /// Create a new profile guard that will record to the named histogram.
     #[must_use]
@@ -440,6 +442,7 @@ impl ProfileGuard {
     }
 }
 
+#[allow(deprecated)]
 impl Drop for ProfileGuard {
     #[allow(clippy::cast_possible_truncation)] // Microsecond truncation acceptable
     fn drop(&mut self) {
@@ -561,6 +564,7 @@ macro_rules! profile {
 // =============================================================================
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::{
         sync::atomic::{AtomicU64, Ordering},

--- a/modules/editor/src/command/mod.rs
+++ b/modules/editor/src/command/mod.rs
@@ -689,9 +689,8 @@ mod tests {
     }
 
     #[test]
-    fn test_undo_command_returns_success() {
-        // Commands now return Success - actual undo logic
-        // will be handled by SessionRuntime (see #394 for API gap)
+    fn test_undo_command_returns_error_without_buffer() {
+        // Undo requires an active buffer - returns error when none is set
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -699,11 +698,12 @@ mod tests {
         let args = CommandContext::new();
 
         let result = UndoCommand.execute(&mut runtime, &args);
-        assert!(result.is_success());
+        assert!(result.is_error());
     }
 
     #[test]
-    fn test_redo_command_returns_success() {
+    fn test_redo_command_returns_error_without_buffer() {
+        // Redo requires an active buffer - returns error when none is set
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -711,11 +711,12 @@ mod tests {
         let args = CommandContext::new();
 
         let result = RedoCommand.execute(&mut runtime, &args);
-        assert!(result.is_success());
+        assert!(result.is_error());
     }
 
     #[test]
     fn test_undo_command_with_count() {
+        // Undo with count still requires an active buffer
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -724,13 +725,12 @@ mod tests {
         args.set("count", ArgValue::Count(5));
 
         let result = UndoCommand.execute(&mut runtime, &args);
-        // Commands return Success - count is accessed but actual undo
-        // will be handled by SessionRuntime (see #394)
-        assert!(result.is_success());
+        assert!(result.is_error()); // No buffer = error
     }
 
     #[test]
     fn test_redo_command_with_count() {
+        // Redo with count still requires an active buffer
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -739,7 +739,7 @@ mod tests {
         args.set("count", ArgValue::Count(3));
 
         let result = RedoCommand.execute(&mut runtime, &args);
-        assert!(result.is_success());
+        assert!(result.is_error()); // No buffer = error
     }
 
     #[test]
@@ -767,8 +767,8 @@ mod tests {
     }
 
     #[test]
-    fn test_undo_command_does_not_require_buffer_id() {
-        // Undo commands return Success without requiring buffer_id
+    fn test_undo_command_requires_active_buffer() {
+        // Undo commands DO require an active buffer (from session, not from args)
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -776,12 +776,12 @@ mod tests {
         let args = CommandContext::new();
 
         let result = UndoCommand.execute(&mut runtime, &args);
-        assert!(!result.is_error());
-        assert!(result.is_success());
+        assert!(result.is_error()); // No active buffer = error
     }
 
     #[test]
-    fn test_redo_command_does_not_require_buffer_id() {
+    fn test_redo_command_requires_active_buffer() {
+        // Redo commands DO require an active buffer (from session, not from args)
         let mut session = Session::new(ClientId::new(1), test_mode());
         let kernel = KernelContext::default();
         let executor = StubExecutor;
@@ -789,8 +789,7 @@ mod tests {
         let args = CommandContext::new();
 
         let result = RedoCommand.execute(&mut runtime, &args);
-        assert!(!result.is_error());
-        assert!(result.is_success());
+        assert!(result.is_error()); // No active buffer = error
     }
 
     // =========================================================================

--- a/modules/editor/src/command/undo.rs
+++ b/modules/editor/src/command/undo.rs
@@ -4,16 +4,19 @@
 //! - `UndoCommand` (u)
 //! - `RedoCommand` (Ctrl-R)
 //!
-//! # Architecture (Epic #385)
+//! # Architecture
 //!
-//! These commands are stubs that will be implemented when `SessionRuntime`
-//! provides direct access to undo state. See #394 for API gap tracking.
+//! These commands use the `UndoApi` trait to perform undo/redo operations.
+//! The actual undo tree is managed by the undo module's `UndoRegistry`.
 
 use {
     reovim_driver_command::{
         ArgKind, ArgSpec, Command, CommandContext, CommandHandler, CommandResult,
     },
-    reovim_driver_session::SessionRuntime,
+    reovim_driver_session::{
+        SessionRuntime,
+        api::{BufferApi, UndoApi},
+    },
     reovim_kernel::api::v1::CommandId,
 };
 
@@ -21,7 +24,8 @@ use crate::ids;
 
 /// Undo the last change.
 ///
-/// Note: Will be implemented via `SessionRuntime` when API supports this (#394).
+/// Uses `UndoApi` to traverse the undo tree and apply inverse edits.
+/// Supports count argument to undo multiple changes at once.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UndoCommand;
 
@@ -48,15 +52,34 @@ impl Command for UndoCommand {
 }
 
 impl CommandHandler for UndoCommand {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        let Some(buffer) = runtime.active_buffer() else {
+            return CommandResult::Error("No active buffer".to_string());
+        };
+
+        let count = args.count().unwrap_or(1);
+        let mut undone = 0;
+
+        for _ in 0..count {
+            if runtime.undo(buffer).is_some() {
+                undone += 1;
+            } else {
+                break; // Nothing left to undo
+            }
+        }
+
+        if undone == 0 {
+            CommandResult::Error("Already at oldest change".to_string())
+        } else {
+            CommandResult::Success
+        }
     }
 }
 
 /// Redo the last undone change.
 ///
-/// Note: Will be implemented via `SessionRuntime` when API supports this (#394).
+/// Uses `UndoApi` to traverse the undo tree and apply edits.
+/// Supports count argument to redo multiple changes at once.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RedoCommand;
 
@@ -83,8 +106,26 @@ impl Command for RedoCommand {
 }
 
 impl CommandHandler for RedoCommand {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        let Some(buffer) = runtime.active_buffer() else {
+            return CommandResult::Error("No active buffer".to_string());
+        };
+
+        let count = args.count().unwrap_or(1);
+        let mut redone = 0;
+
+        for _ in 0..count {
+            if runtime.redo(buffer).is_some() {
+                redone += 1;
+            } else {
+                break; // Nothing left to redo
+            }
+        }
+
+        if redone == 0 {
+            CommandResult::Error("Already at newest change".to_string())
+        } else {
+            CommandResult::Success
+        }
     }
 }

--- a/modules/motions/Cargo.toml
+++ b/modules/motions/Cargo.toml
@@ -17,7 +17,9 @@ dynamic = []  # Enable FFI entry points for standalone dynamic loading
 reovim-kernel = { workspace = true }
 reovim-driver-command = { workspace = true }
 reovim-driver-session = { workspace = true }
+reovim-driver-search = { workspace = true }
 reovim-module-macros = { path = "../../lib/module-macros" }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/modules/motions/src/lib.rs
+++ b/modules/motions/src/lib.rs
@@ -32,7 +32,10 @@ pub mod find_char;
 pub mod ids;
 pub mod line;
 pub mod search;
+pub mod search_state;
 pub mod word;
+
+pub use search_state::SearchState;
 
 /// Module identifier for motions module.
 pub const MOTIONS_MODULE: ModuleId = ModuleId::new("motions");

--- a/modules/motions/src/search.rs
+++ b/modules/motions/src/search.rs
@@ -15,14 +15,16 @@
 //!
 //! # Current Status
 //!
-//! - `*`, `#`, `n`, `N` are fully implemented
-//! - `/`, `?` require command-line mode (#435)
+//! All search commands are fully implemented:
+//! - `/` and `?` - forward/backward search with pattern input (uses `CommandLine` mode)
+//! - `n` and `N` - repeat search in same/opposite direction
+//! - `*` and `#` - search word under cursor forward/backward
 
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
     reovim_driver_search::{Direction, SearchKey, SearchProviderRegistry},
     reovim_driver_session::{SessionRuntime, api::ExtensionApi},
-    reovim_kernel::api::v1::CommandId,
+    reovim_kernel::api::{Position, v1::CommandId},
 };
 
 use crate::{ids, search_state::SearchState};
@@ -270,11 +272,44 @@ fn search_word(
         return CommandResult::error("Regex search engine not registered");
     };
 
-    // Get word under cursor
-    let Some(Some(word_pattern)) = runtime
-        .with_buffer_read(buffer_id, |buffer| search_provider.word_at_cursor(buffer, cursor))
-    else {
-        return CommandResult::Success; // No word under cursor - silent fail like vim
+    // Get word under cursor and find word start position for backward search
+    let (word_pattern, search_cursor) = {
+        let Some(Some((pattern, word_start))) = runtime.with_buffer_read(buffer_id, |buffer| {
+            // Get word pattern
+            let pattern = search_provider.word_at_cursor(buffer, cursor)?;
+
+            // Find word start position for backward search
+            let line = buffer.line(cursor.line)?;
+            let chars: Vec<char> = line.chars().collect();
+
+            if cursor.column >= chars.len() {
+                return Some((pattern, cursor));
+            }
+
+            // Find word start
+            let mut start = cursor.column;
+            while start > 0 && (chars[start - 1].is_alphanumeric() || chars[start - 1] == '_') {
+                start -= 1;
+            }
+
+            let word_start = Position {
+                line: cursor.line,
+                column: start,
+            };
+
+            Some((pattern, word_start))
+        }) else {
+            return CommandResult::Success; // No word under cursor - silent fail like vim
+        };
+
+        // For backward search (#), use word start position to skip current word.
+        // For forward search (*), use cursor position (search starts after cursor).
+        let search_pos = match direction {
+            Direction::Backward => word_start,
+            Direction::Forward => cursor,
+        };
+
+        (pattern, search_pos)
     };
 
     // Store pattern and direction for n/N repeat
@@ -283,8 +318,8 @@ fn search_word(
         search.set(word_pattern.clone(), direction);
     }
 
-    // Search for the word
-    search_and_move(runtime, args, &word_pattern, direction)
+    // Search for the word using the appropriate search position
+    search_and_move_from(runtime, args, &word_pattern, direction, search_cursor)
 }
 
 /// Search for pattern and move cursor to match.
@@ -327,14 +362,49 @@ fn search_and_move(
             runtime.record_cursor_move(buffer_id);
             CommandResult::Success
         }
-        Some(Ok(None)) => {
-            // No match found - silent, like vim
+        Some(Ok(None) | Err(_)) => {
+            // No match or invalid pattern - silent failure like vim
             CommandResult::Success
         }
-        Some(Err(_)) => {
-            // Invalid pattern - silent failure like vim
+        None => CommandResult::error("Buffer not found"),
+    }
+}
+
+/// Search for pattern from a specific position and move cursor to match.
+/// Used by word search (*/#) which needs to start from word boundaries.
+fn search_and_move_from(
+    runtime: &mut SessionRuntime<'_>,
+    args: &CommandContext,
+    pattern: &str,
+    direction: Direction,
+    search_from: Position,
+) -> CommandResult {
+    use reovim_driver_session::api::{BufferApi, ChangeTracker};
+
+    let Some(buffer_id) = args.buffer_id() else {
+        return CommandResult::error("No active buffer");
+    };
+
+    let Some(search_registry) = runtime.kernel().services.get::<SearchProviderRegistry>() else {
+        return CommandResult::error("Search provider not available");
+    };
+
+    let Some(search_provider) = search_registry.get(&SearchKey::Regex) else {
+        return CommandResult::error("Regex search engine not registered");
+    };
+
+    let search_result = runtime.with_buffer_read(buffer_id, |buffer| {
+        search_provider.find_next(buffer, search_from, pattern, direction, true)
+    });
+
+    match search_result {
+        Some(Ok(Some(m))) => {
+            runtime.set_buffer_position(buffer_id, m.start);
+            runtime.move_cursor(buffer_id, m.start);
+            runtime.record_cursor_move(buffer_id);
             CommandResult::Success
         }
+        Some(Ok(None) | Err(_)) => CommandResult::Success,
         None => CommandResult::error("Buffer not found"),
     }
 }

--- a/modules/motions/src/search.rs
+++ b/modules/motions/src/search.rs
@@ -2,19 +2,30 @@
 //!
 //! Implements vim search commands: `/`, `?`, `n`, `N`, `*`, `#`, `:noh`.
 //!
-//! # Architecture (Epic #385)
+//! # Architecture
 //!
-//! These commands are stubs that will be implemented when `SessionRuntime`
-//! provides direct access to search state (#394). The actual search functionality
-//! will be handled by the vim resolver or a dedicated search module.
+//! - **Mechanism**: `SearchProvider` trait (in `reovim-driver-search`)
+//! - **Policy**: These commands wire keys to search functionality
+//!
+//! # Search State
+//!
+//! The `SearchState` session extension stores:
+//! - Last search pattern (for n/N repeat)
+//! - Last search direction (for correct n/N behavior)
+//!
+//! # Current Status
+//!
+//! - `*`, `#`, `n`, `N` are fully implemented
+//! - `/`, `?` require command-line mode (#435)
 
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
-    reovim_driver_session::SessionRuntime,
+    reovim_driver_search::{Direction, SearchKey, SearchProviderRegistry},
+    reovim_driver_session::{SessionRuntime, api::ExtensionApi},
     reovim_kernel::api::v1::CommandId,
 };
 
-use crate::ids;
+use crate::{ids, search_state::SearchState};
 
 // =============================================================================
 // Search Forward (/)
@@ -39,7 +50,8 @@ impl Command for SearchForward {
 
 impl CommandHandler for SearchForward {
     fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
+        // TODO(#338): Implement via command-line mode
+        // Currently requires command-line input mode which is deferred to Phase 8
         CommandResult::Success
     }
 }
@@ -67,7 +79,8 @@ impl Command for SearchBackward {
 
 impl CommandHandler for SearchBackward {
     fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
+        // TODO(#338): Implement via command-line mode
+        // Currently requires command-line input mode which is deferred to Phase 8
         CommandResult::Success
     }
 }
@@ -94,9 +107,17 @@ impl Command for SearchNext {
 }
 
 impl CommandHandler for SearchNext {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        // Get last search pattern and direction
+        let (pattern, direction) = {
+            let search = runtime.ext_mut::<SearchState>();
+            match search.pattern_for_repeat() {
+                Some(p) => (p.to_string(), search.direction_for_repeat()),
+                None => return CommandResult::Success, // No pattern to repeat
+            }
+        };
+
+        search_and_move(runtime, args, &pattern, direction)
     }
 }
 
@@ -122,9 +143,17 @@ impl Command for SearchPrevious {
 }
 
 impl CommandHandler for SearchPrevious {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        // Get last search pattern and REVERSED direction
+        let (pattern, direction) = {
+            let search = runtime.ext_mut::<SearchState>();
+            match search.pattern_for_repeat() {
+                Some(p) => (p.to_string(), search.direction_for_opposite()),
+                None => return CommandResult::Success, // No pattern to repeat
+            }
+        };
+
+        search_and_move(runtime, args, &pattern, direction)
     }
 }
 
@@ -150,9 +179,8 @@ impl Command for SearchWordForward {
 }
 
 impl CommandHandler for SearchWordForward {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        search_word(runtime, args, Direction::Forward)
     }
 }
 
@@ -178,9 +206,8 @@ impl Command for SearchWordBackward {
 }
 
 impl CommandHandler for SearchWordBackward {
-    fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
-        CommandResult::Success
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        search_word(runtime, args, Direction::Backward)
     }
 }
 
@@ -207,8 +234,108 @@ impl Command for ClearSearchHighlight {
 
 impl CommandHandler for ClearSearchHighlight {
     fn execute(&self, _runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
-        // TODO(#394): Implement via SessionRuntime (escape hatch until API supports this)
+        // TODO: When highlighting is implemented, clear it here
+        // For now, this is a no-op since highlighting isn't implemented yet
         CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Search for word under cursor in the given direction.
+fn search_word(
+    runtime: &mut SessionRuntime<'_>,
+    args: &CommandContext,
+    direction: Direction,
+) -> CommandResult {
+    use reovim_driver_session::api::BufferApi;
+
+    // Get active buffer and cursor position
+    let Some(buffer_id) = args.buffer_id() else {
+        return CommandResult::error("No active buffer");
+    };
+
+    let Some(cursor) = runtime.buffer_position(buffer_id) else {
+        return CommandResult::error("No cursor position");
+    };
+
+    // Get search provider from kernel services
+    let Some(search_registry) = runtime.kernel().services.get::<SearchProviderRegistry>() else {
+        return CommandResult::error("Search provider not available");
+    };
+
+    let Some(search_provider) = search_registry.get(&SearchKey::Regex) else {
+        return CommandResult::error("Regex search engine not registered");
+    };
+
+    // Get word under cursor
+    let Some(Some(word_pattern)) = runtime
+        .with_buffer_read(buffer_id, |buffer| search_provider.word_at_cursor(buffer, cursor))
+    else {
+        return CommandResult::Success; // No word under cursor - silent fail like vim
+    };
+
+    // Store pattern and direction for n/N repeat
+    {
+        let search = runtime.ext_mut::<SearchState>();
+        search.set(word_pattern.clone(), direction);
+    }
+
+    // Search for the word
+    search_and_move(runtime, args, &word_pattern, direction)
+}
+
+/// Search for pattern and move cursor to match.
+fn search_and_move(
+    runtime: &mut SessionRuntime<'_>,
+    args: &CommandContext,
+    pattern: &str,
+    direction: Direction,
+) -> CommandResult {
+    use reovim_driver_session::api::{BufferApi, ChangeTracker};
+
+    // Get active buffer and cursor position
+    let Some(buffer_id) = args.buffer_id() else {
+        return CommandResult::error("No active buffer");
+    };
+
+    let Some(cursor) = runtime.buffer_position(buffer_id) else {
+        return CommandResult::error("No cursor position");
+    };
+
+    // Get search provider
+    let Some(search_registry) = runtime.kernel().services.get::<SearchProviderRegistry>() else {
+        return CommandResult::error("Search provider not available");
+    };
+
+    let Some(search_provider) = search_registry.get(&SearchKey::Regex) else {
+        return CommandResult::error("Regex search engine not registered");
+    };
+
+    // Search for pattern
+    let search_result = runtime.with_buffer_read(buffer_id, |buffer| {
+        search_provider.find_next(buffer, cursor, pattern, direction, true)
+    });
+
+    match search_result {
+        Some(Ok(Some(m))) => {
+            // Move cursor to match start - update BOTH buffer position and window cursor
+            runtime.set_buffer_position(buffer_id, m.start);
+            runtime.move_cursor(buffer_id, m.start);
+            runtime.record_cursor_move(buffer_id);
+            CommandResult::Success
+        }
+        Some(Ok(None)) => {
+            // No match found - silent, like vim
+            CommandResult::Success
+        }
+        Some(Err(_)) => {
+            // Invalid pattern - silent failure like vim
+            CommandResult::Success
+        }
+        None => CommandResult::error("Buffer not found"),
     }
 }
 

--- a/modules/motions/src/search_state.rs
+++ b/modules/motions/src/search_state.rs
@@ -1,0 +1,73 @@
+//! Search state - per-session state for vim-style search.
+//!
+//! Stores the last search pattern and direction for n/N repeat.
+
+use {reovim_driver_search::Direction, reovim_driver_session::SessionExtension};
+
+/// Per-session search state.
+///
+/// Stores the last search pattern and direction for n, N, *, # commands.
+#[derive(Debug, Default)]
+pub struct SearchState {
+    /// Last search pattern (regex format).
+    pub last_pattern: Option<String>,
+
+    /// Last search direction (forward or backward).
+    pub last_direction: Direction,
+}
+
+impl SessionExtension for SearchState {
+    fn create() -> Self {
+        Self::default()
+    }
+}
+
+impl SearchState {
+    /// Set the search pattern and direction.
+    pub fn set(&mut self, pattern: String, direction: Direction) {
+        self.last_pattern = Some(pattern);
+        self.last_direction = direction;
+    }
+
+    /// Get the pattern for repeat search (n).
+    #[must_use]
+    pub fn pattern_for_repeat(&self) -> Option<&str> {
+        self.last_pattern.as_deref()
+    }
+
+    /// Get the direction for repeat search (n).
+    #[must_use]
+    pub const fn direction_for_repeat(&self) -> Direction {
+        self.last_direction
+    }
+
+    /// Get the reversed direction for opposite repeat (N).
+    #[must_use]
+    pub const fn direction_for_opposite(&self) -> Direction {
+        match self.last_direction {
+            Direction::Forward => Direction::Backward,
+            Direction::Backward => Direction::Forward,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_state_default() {
+        let state = SearchState::default();
+        assert!(state.last_pattern.is_none());
+        assert!(matches!(state.last_direction, Direction::Forward));
+    }
+
+    #[test]
+    fn test_search_state_set() {
+        let mut state = SearchState::default();
+        state.set("hello".to_string(), Direction::Backward);
+        assert_eq!(state.pattern_for_repeat(), Some("hello"));
+        assert!(matches!(state.direction_for_repeat(), Direction::Backward));
+        assert!(matches!(state.direction_for_opposite(), Direction::Forward));
+    }
+}

--- a/modules/motions/src/search_state.rs
+++ b/modules/motions/src/search_state.rs
@@ -1,73 +1,7 @@
 //! Search state - per-session state for vim-style search.
 //!
-//! Stores the last search pattern and direction for n/N repeat.
+//! Re-exports `SearchState` from the session driver for use by motion commands.
+//! The driver owns the type definition so both modules and runner can access it.
 
-use {reovim_driver_search::Direction, reovim_driver_session::SessionExtension};
-
-/// Per-session search state.
-///
-/// Stores the last search pattern and direction for n, N, *, # commands.
-#[derive(Debug, Default)]
-pub struct SearchState {
-    /// Last search pattern (regex format).
-    pub last_pattern: Option<String>,
-
-    /// Last search direction (forward or backward).
-    pub last_direction: Direction,
-}
-
-impl SessionExtension for SearchState {
-    fn create() -> Self {
-        Self::default()
-    }
-}
-
-impl SearchState {
-    /// Set the search pattern and direction.
-    pub fn set(&mut self, pattern: String, direction: Direction) {
-        self.last_pattern = Some(pattern);
-        self.last_direction = direction;
-    }
-
-    /// Get the pattern for repeat search (n).
-    #[must_use]
-    pub fn pattern_for_repeat(&self) -> Option<&str> {
-        self.last_pattern.as_deref()
-    }
-
-    /// Get the direction for repeat search (n).
-    #[must_use]
-    pub const fn direction_for_repeat(&self) -> Direction {
-        self.last_direction
-    }
-
-    /// Get the reversed direction for opposite repeat (N).
-    #[must_use]
-    pub const fn direction_for_opposite(&self) -> Direction {
-        match self.last_direction {
-            Direction::Forward => Direction::Backward,
-            Direction::Backward => Direction::Forward,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_search_state_default() {
-        let state = SearchState::default();
-        assert!(state.last_pattern.is_none());
-        assert!(matches!(state.last_direction, Direction::Forward));
-    }
-
-    #[test]
-    fn test_search_state_set() {
-        let mut state = SearchState::default();
-        state.set("hello".to_string(), Direction::Backward);
-        assert_eq!(state.pattern_for_repeat(), Some("hello"));
-        assert!(matches!(state.direction_for_repeat(), Direction::Backward));
-        assert!(matches!(state.direction_for_opposite(), Direction::Forward));
-    }
-}
+// Re-export SearchState from driver layer
+pub use reovim_driver_session::api::SearchState;

--- a/modules/search/Cargo.toml
+++ b/modules/search/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [lints]
 workspace = true
 

--- a/modules/search/src/engine.rs
+++ b/modules/search/src/engine.rs
@@ -125,28 +125,35 @@ fn find_backward(
     wrap: bool,
     buffer: &Buffer,
 ) -> Option<SearchMatch> {
-    let search_end = cursor_byte.min(content.len());
+    // Search the entire content and filter by match start position.
+    // Vim's backward search finds matches where match.start() < cursor.
+    // This handles matches that span across the cursor position correctly.
+    let all_matches: Vec<_> = regex.find_iter(content).collect();
 
-    // Search before cursor
-    if search_end > 0 {
-        let matches: Vec<_> = regex.find_iter(&content[..search_end]).collect();
-        if let Some(m) = matches.last() {
+    // Find matches that start before cursor
+    let before_cursor: Vec<_> = all_matches
+        .iter()
+        .filter(|m| m.start() < cursor_byte)
+        .collect();
+
+    if let Some(m) = before_cursor.last() {
+        return Some(SearchMatch {
+            start: byte_to_position(buffer, m.start()),
+            end: byte_to_position(buffer, m.end()),
+        });
+    }
+
+    // Wrap to end if enabled - find matches that start at or after cursor
+    if wrap {
+        let at_or_after: Vec<_> = all_matches
+            .iter()
+            .filter(|m| m.start() >= cursor_byte)
+            .collect();
+
+        if let Some(m) = at_or_after.last() {
             return Some(SearchMatch {
                 start: byte_to_position(buffer, m.start()),
                 end: byte_to_position(buffer, m.end()),
-            });
-        }
-    }
-
-    // Wrap to end if enabled
-    if wrap && cursor_byte < content.len() {
-        let matches: Vec<_> = regex.find_iter(&content[cursor_byte..]).collect();
-        if let Some(m) = matches.last() {
-            let start_byte = cursor_byte + m.start();
-            let end_byte = cursor_byte + m.end();
-            return Some(SearchMatch {
-                start: byte_to_position(buffer, start_byte),
-                end: byte_to_position(buffer, end_byte),
             });
         }
     }
@@ -344,13 +351,9 @@ mod tests {
     fn test_find_wrap_backward() {
         let engine = SearchEngine;
         let buffer = create_test_buffer("hello world hello");
-        let result = engine.find_next(
-            &buffer,
-            Position::new(0, 2), // After first "hello"
-            "hello",
-            Direction::Backward,
-            true,
-        );
+        // Cursor at column 0 - no matches start before this position
+        let result =
+            engine.find_next(&buffer, Position::new(0, 0), "hello", Direction::Backward, true);
 
         assert!(result.is_ok());
         let m = result.unwrap().unwrap();

--- a/modules/search/tests/search.rs
+++ b/modules/search/tests/search.rs
@@ -1,8 +1,7 @@
 //! Search integration tests (/, ?, n, N, *, #).
 //!
-//! **Status**: 2 tests enabled, 13 tests require additional features.
-//! - 10 tests require command-line mode for `/` and `?` search patterns (#338)
-//! - 3 tests require `*` and `#` word search implementation (#385)
+//! **Status**: 5 tests enabled, 10 tests require search input mode.
+//! - 10 tests require search input mode for `/` and `?` patterns (#435)
 //!
 //! Run `cargo test --ignored` to run the remaining ignored tests.
 
@@ -13,7 +12,7 @@ use runner::testing::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -25,7 +24,7 @@ async fn test_search_forward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -37,7 +36,7 @@ async fn test_search_forward_multiline() {
 }
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_wrap() {
     let result = IntegrationTest::new()
         .await
@@ -55,7 +54,7 @@ async fn test_search_forward_wrap() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires command-line mode for ? search (#338)"]
+#[ignore = "requires search input mode for ? (#435)"]
 async fn test_search_backward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -69,7 +68,7 @@ async fn test_search_backward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires command-line mode for ? search (#338)"]
+#[ignore = "requires search input mode for ? (#435)"]
 async fn test_search_backward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -86,7 +85,7 @@ async fn test_search_backward_multiline() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_next() {
     let result = IntegrationTest::new()
         .await
@@ -100,7 +99,7 @@ async fn test_search_next() {
 }
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_next_multiple() {
     let result = IntegrationTest::new()
         .await
@@ -114,7 +113,7 @@ async fn test_search_next_multiple() {
 }
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_previous() {
     let result = IntegrationTest::new()
         .await
@@ -133,7 +132,6 @@ async fn test_search_previous() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search implementation via SessionContext (#385)"]
 async fn test_search_word_forward() {
     let result = IntegrationTest::new()
         .await
@@ -146,7 +144,6 @@ async fn test_search_word_forward() {
 }
 
 #[tokio::test]
-#[ignore = "requires search implementation via SessionContext (#385)"]
 async fn test_search_word_backward() {
     let result = IntegrationTest::new()
         .await
@@ -160,7 +157,6 @@ async fn test_search_word_backward() {
 }
 
 #[tokio::test]
-#[ignore = "requires search implementation via SessionContext (#385)"]
 async fn test_search_word_with_n() {
     let result = IntegrationTest::new()
         .await
@@ -178,7 +174,7 @@ async fn test_search_word_with_n() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_cancel_with_escape() {
     let result = IntegrationTest::new()
         .await
@@ -195,7 +191,7 @@ async fn test_search_cancel_with_escape() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires command-line mode for / search (#338)"]
+#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_regex_pattern() {
     let result = IntegrationTest::new()
         .await

--- a/modules/search/tests/search.rs
+++ b/modules/search/tests/search.rs
@@ -1,9 +1,6 @@
 //! Search integration tests (/, ?, n, N, *, #).
 //!
-//! **Status**: 5 tests enabled, 10 tests require search input mode.
-//! - 10 tests require search input mode for `/` and `?` patterns (#435)
-//!
-//! Run `cargo test --ignored` to run the remaining ignored tests.
+//! **Status**: All 15 tests enabled after implementing search input mode (#435).
 
 use runner::testing::IntegrationTest;
 
@@ -12,7 +9,6 @@ use runner::testing::IntegrationTest;
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -24,7 +20,6 @@ async fn test_search_forward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -36,7 +31,6 @@ async fn test_search_forward_multiline() {
 }
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_forward_wrap() {
     let result = IntegrationTest::new()
         .await
@@ -54,7 +48,6 @@ async fn test_search_forward_wrap() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search input mode for ? (#435)"]
 async fn test_search_backward_basic() {
     let result = IntegrationTest::new()
         .await
@@ -68,7 +61,6 @@ async fn test_search_backward_basic() {
 }
 
 #[tokio::test]
-#[ignore = "requires search input mode for ? (#435)"]
 async fn test_search_backward_multiline() {
     let result = IntegrationTest::new()
         .await
@@ -85,7 +77,6 @@ async fn test_search_backward_multiline() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_next() {
     let result = IntegrationTest::new()
         .await
@@ -94,12 +85,11 @@ async fn test_search_next() {
         .send_keys("n")
         .run()
         .await;
-    // First search lands on "foo" at 0, n moves to next "foo" at 8
-    result.assert_cursor(0, 8);
+    // /foo<Enter> finds NEXT match at 8, n finds next at 16
+    result.assert_cursor(0, 16);
 }
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_next_multiple() {
     let result = IntegrationTest::new()
         .await
@@ -108,12 +98,11 @@ async fn test_search_next_multiple() {
         .send_keys("nn")
         .run()
         .await;
-    // First search lands on "foo" at 0, nn moves to "foo" at 16
-    result.assert_cursor(0, 16);
+    // /foo<Enter> → 8, n → 16, n → 0 (wraps)
+    result.assert_cursor(0, 0);
 }
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_previous() {
     let result = IntegrationTest::new()
         .await
@@ -174,7 +163,6 @@ async fn test_search_word_with_n() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_cancel_with_escape() {
     let result = IntegrationTest::new()
         .await
@@ -191,7 +179,6 @@ async fn test_search_cancel_with_escape() {
 // ============================================================================
 
 #[tokio::test]
-#[ignore = "requires search input mode for / (#435)"]
 async fn test_search_regex_pattern() {
     let result = IntegrationTest::new()
         .await

--- a/modules/undo/src/registry.rs
+++ b/modules/undo/src/registry.rs
@@ -62,6 +62,17 @@ pub struct UndoRegistry {
     trees: RwLock<HashMap<BufferId, UndoTree>>,
     /// Base directory for undo files (e.g., `~/.local/share/reovim/undo/`).
     undo_dir: PathBuf,
+    /// Active batches for insert mode undo grouping.
+    batches: RwLock<HashMap<BufferId, PendingBatch>>,
+}
+
+/// Pending batch of edits for insert mode undo grouping.
+#[derive(Debug)]
+struct PendingBatch {
+    /// Accumulated edits in order.
+    edits: Vec<Edit>,
+    /// Cursor position at batch start.
+    cursor_before: Position,
 }
 
 impl Default for UndoRegistry {
@@ -89,6 +100,7 @@ impl UndoRegistry {
         Self {
             trees: RwLock::new(HashMap::new()),
             undo_dir: data_dir.join(UNDO_SUBDIR),
+            batches: RwLock::new(HashMap::new()),
         }
     }
 
@@ -156,6 +168,17 @@ impl UndoProvider for UndoRegistry {
         cursor_before: Position,
         cursor_after: Position,
     ) {
+        // Check if batching is active for this buffer
+        let mut batches = self.batches.write();
+        if let Some(batch) = batches.get_mut(&buffer_id) {
+            // Accumulate edits into the batch
+            batch.edits.extend(edits);
+            // cursor_before is set at batch start, cursor_after will be set at end
+            return;
+        }
+        drop(batches);
+
+        // No active batch - record immediately
         self.trees
             .write()
             .entry(buffer_id)
@@ -177,6 +200,39 @@ impl UndoProvider for UndoRegistry {
 
     fn get_tree(&self, buffer_id: BufferId) -> Option<UndoTree> {
         self.get_tree_cloned(buffer_id)
+    }
+
+    fn begin_batch(&self, buffer_id: BufferId, cursor_before: Position) {
+        let mut batches = self.batches.write();
+        batches.insert(
+            buffer_id,
+            PendingBatch {
+                edits: Vec::new(),
+                cursor_before,
+            },
+        );
+    }
+
+    fn end_batch(&self, buffer_id: BufferId, cursor_after: Position) {
+        let batch = {
+            let mut batches = self.batches.write();
+            batches.remove(&buffer_id)
+        };
+
+        // If there was an active batch with edits, commit them
+        if let Some(batch) = batch
+            && !batch.edits.is_empty()
+        {
+            self.trees.write().entry(buffer_id).or_default().push(
+                batch.edits,
+                batch.cursor_before,
+                cursor_after,
+            );
+        }
+    }
+
+    fn is_batching(&self, buffer_id: BufferId) -> bool {
+        self.batches.read().contains_key(&buffer_id)
     }
 
     fn persist(

--- a/modules/undo/tests/undo_redo.rs
+++ b/modules/undo/tests/undo_redo.rs
@@ -7,10 +7,9 @@
 //!
 //! Run `cargo test --ignored` to run the remaining ignored tests.
 
-use runner::testing::IntegrationTest;
+use runner::testing::{IntegrationTest, StepTest};
 
 #[tokio::test]
-#[ignore = "undo E2E tests pending (#311)"]
 async fn test_undo_delete_line() {
     let result = IntegrationTest::new()
         .await
@@ -33,7 +32,6 @@ async fn test_redo_after_undo() {
 }
 
 #[tokio::test]
-#[ignore = "undo E2E tests pending (#311)"]
 async fn test_multiple_undo() {
     let result = IntegrationTest::new()
         .await
@@ -45,7 +43,6 @@ async fn test_multiple_undo() {
 }
 
 #[tokio::test]
-#[ignore = "undo E2E tests pending (#311)"]
 async fn test_undo_insert() {
     let result = IntegrationTest::new()
         .await
@@ -68,7 +65,6 @@ async fn test_multiple_redo() {
 }
 
 #[tokio::test]
-#[ignore = "undo E2E tests pending (#311)"]
 async fn test_undo_change_word() {
     let result = IntegrationTest::new()
         .await
@@ -101,4 +97,38 @@ async fn test_redo_nothing_to_redo() {
         .run()
         .await;
     result.assert_buffer_eq("hello");
+}
+
+// ============================================================================
+// DEBUG: Step-by-step tests to trace insert mode issue
+// ============================================================================
+
+/// Debug test for insert mode - trace each key step by step
+#[tokio::test]
+async fn debug_step_insert_escape() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("")
+        .step("i")
+        .expect_mode_contains("INSERT")
+        .step("h")
+        .expect_buffer("h")
+        .step("e")
+        .expect_buffer("he")
+        .step("l")
+        .step("l")
+        .step("o")
+        .expect_buffer("hello")
+        .step("<Esc>")
+        .expect_mode_contains("NORMAL")
+        .step("u")
+        .expect_buffer("")
+        .run()
+        .await;
+
+    trace.print_trace();
+
+    let final_state = trace.final_state();
+    eprintln!("\nFinal buffer: {:?}", final_state.buffer);
+    eprintln!("Final mode: {} ({})", final_state.mode_display, final_state.edit_mode);
 }

--- a/modules/vim/Cargo.toml
+++ b/modules/vim/Cargo.toml
@@ -26,6 +26,7 @@ reovim-module-motions = { path = "../motions" }
 reovim-module-textobjects = { path = "../textobjects" }
 reovim-driver-clipboard = { path = "../../lib/drivers/clipboard" }
 reovim-driver-undo = { path = "../../lib/drivers/undo" }
+reovim-driver-search = { path = "../../lib/drivers/search" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/modules/vim/Cargo.toml
+++ b/modules/vim/Cargo.toml
@@ -25,6 +25,7 @@ reovim-module-motions = { path = "../motions" }
 # Note: operators module merged into vim (Epic #385)
 reovim-module-textobjects = { path = "../textobjects" }
 reovim-driver-clipboard = { path = "../../lib/drivers/clipboard" }
+reovim-driver-undo = { path = "../../lib/drivers/undo" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/modules/vim/src/bindings/commandline.rs
+++ b/modules/vim/src/bindings/commandline.rs
@@ -11,18 +11,19 @@ use crate::ids as vim;
 pub fn bindings() -> Vec<KeybindingRegistration> {
     vec![
         // ====================================================================
-        // Exit command-line mode
+        // Cancel command-line mode (Escape)
         // ====================================================================
-        KeybindingRegistration::new("<Esc>", vim::EXIT_COMMANDLINE)
+        KeybindingRegistration::new("<Esc>", vim::CANCEL_COMMANDLINE)
             .with_modes(&["vim:command"])
             .with_category("mode")
             .with_description("Cancel and exit command-line mode"),
-        KeybindingRegistration::new("<C-c>", vim::EXIT_COMMANDLINE)
+        KeybindingRegistration::new("<C-c>", vim::CANCEL_COMMANDLINE)
             .with_modes(&["vim:command"])
             .with_category("mode")
             .with_description("Cancel and exit command-line mode"),
-        // Note: Enter key for executing commands will be added when command
-        // execution is implemented. For now, Enter just exits.
+        // ====================================================================
+        // Execute command-line (Enter)
+        // ====================================================================
         KeybindingRegistration::new("<CR>", vim::EXIT_COMMANDLINE)
             .with_modes(&["vim:command"])
             .with_category("mode")

--- a/modules/vim/src/bindings/normal.rs
+++ b/modules/vim/src/bindings/normal.rs
@@ -272,13 +272,13 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
             .with_category("scroll")
             .with_description("Scroll cursor line to bottom"),
         // ====================================================================
-        // Search
+        // Search (#435 - Search Input Mode)
         // ====================================================================
-        KeybindingRegistration::new("/", motions::SEARCH_FORWARD)
+        KeybindingRegistration::new("/", vim::ENTER_SEARCH_FORWARD)
             .with_modes(&["vim:normal"])
             .with_category("search")
             .with_description("Search forward"),
-        KeybindingRegistration::new("?", motions::SEARCH_BACKWARD)
+        KeybindingRegistration::new("?", vim::ENTER_SEARCH_BACKWARD)
             .with_modes(&["vim:normal"])
             .with_category("search")
             .with_description("Search backward"),

--- a/modules/vim/src/commands/mod.rs
+++ b/modules/vim/src/commands/mod.rs
@@ -25,8 +25,9 @@ pub use {
     change::{ChangeLine, ChangeToEndOfLine},
     find_char::ExecuteFindChar,
     mode::{
-        CancelToNormal, EnterCommandLineMode, EnterInsertMode, EnterInsertModeAppend,
-        EnterWindowMode, ExitCommandLineMode, ExitToNormal,
+        CancelCommandLineMode, CancelToNormal, EnterCommandLineMode, EnterInsertMode,
+        EnterInsertModeAppend, EnterSearchBackward, EnterSearchForward, EnterWindowMode,
+        ExitCommandLineMode, ExitToNormal,
     },
     mode_entry::{EnterInsertEndOfLine, EnterInsertFirstNonBlank, OpenLineAbove, OpenLineBelow},
 };
@@ -45,6 +46,10 @@ pub fn mode_commands() -> Vec<Box<dyn CommandHandler>> {
         Box::new(CancelToNormal),
         Box::new(EnterCommandLineMode),
         Box::new(ExitCommandLineMode),
+        Box::new(CancelCommandLineMode),
+        // Search mode entry (#435)
+        Box::new(EnterSearchForward),
+        Box::new(EnterSearchBackward),
         // Mode entry variations
         Box::new(EnterInsertFirstNonBlank),
         Box::new(EnterInsertEndOfLine),

--- a/modules/vim/src/commands/mode.rs
+++ b/modules/vim/src/commands/mode.rs
@@ -20,10 +20,35 @@
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
     reovim_driver_session::{BufferApi, SessionRuntime, TransitionContext, api::ModeApi},
+    reovim_driver_undo::{UndoKey, UndoProviderRegistry},
     reovim_kernel::api::v1::{CommandId, Position},
 };
 
 use crate::{ids, modes::VimMode};
+
+/// Start undo batching for insert mode.
+///
+/// All edits until `end_insert_batch` are grouped as a single undo entry.
+fn begin_insert_batch(runtime: &SessionRuntime<'_>, buffer_id: reovim_kernel::api::v1::BufferId) {
+    if let Some(pos) = runtime.buffer_position(buffer_id)
+        && let Some(undo_registry) = runtime.kernel().services.get::<UndoProviderRegistry>()
+        && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+    {
+        undo_provider.begin_batch(buffer_id, pos);
+    }
+}
+
+/// End undo batching for insert mode.
+///
+/// Commits all accumulated edits as a single undo entry.
+fn end_insert_batch(runtime: &SessionRuntime<'_>, buffer_id: reovim_kernel::api::v1::BufferId) {
+    if let Some(pos) = runtime.buffer_position(buffer_id)
+        && let Some(undo_registry) = runtime.kernel().services.get::<UndoProviderRegistry>()
+        && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+    {
+        undo_provider.end_batch(buffer_id, pos);
+    }
+}
 
 /// Enter insert mode (before cursor).
 #[derive(Debug, Clone, Copy, Default)]
@@ -40,7 +65,11 @@ impl Command for EnterInsertMode {
 }
 
 impl CommandHandler for EnterInsertMode {
-    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
+        // Start undo batching for insert mode
+        if let Some(buffer_id) = args.buffer_id() {
+            begin_insert_batch(runtime, buffer_id);
+        }
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
         CommandResult::Success
     }
@@ -63,14 +92,17 @@ impl Command for EnterInsertModeAppend {
 impl CommandHandler for EnterInsertModeAppend {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
         // Move cursor right first, then enter insert mode
-        if let Some(buffer_id) = args.buffer_id()
-            && let Some(pos) = runtime.buffer_position(buffer_id)
-            && let Some(line_len) = runtime.buffer_line_len(buffer_id, pos.line)
-        {
-            // Move right only if not at end of line
-            if pos.column < line_len {
-                runtime.set_buffer_position(buffer_id, Position::new(pos.line, pos.column + 1));
+        if let Some(buffer_id) = args.buffer_id() {
+            if let Some(pos) = runtime.buffer_position(buffer_id)
+                && let Some(line_len) = runtime.buffer_line_len(buffer_id, pos.line)
+            {
+                // Move right only if not at end of line
+                if pos.column < line_len {
+                    runtime.set_buffer_position(buffer_id, Position::new(pos.line, pos.column + 1));
+                }
             }
+            // Start undo batching for insert mode
+            begin_insert_batch(runtime, buffer_id);
         }
 
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
@@ -94,12 +126,16 @@ impl Command for ExitToNormal {
 
 impl CommandHandler for ExitToNormal {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
-        // Move cursor left one position when exiting insert mode (Vim behavior)
-        if let Some(buffer_id) = args.buffer_id()
-            && let Some(pos) = runtime.buffer_position(buffer_id)
-            && pos.column > 0
-        {
-            runtime.set_buffer_position(buffer_id, Position::new(pos.line, pos.column - 1));
+        if let Some(buffer_id) = args.buffer_id() {
+            // End undo batching - commits all insert edits as one undo entry
+            end_insert_batch(runtime, buffer_id);
+
+            // Move cursor left one position when exiting insert mode (Vim behavior)
+            if let Some(pos) = runtime.buffer_position(buffer_id)
+                && pos.column > 0
+            {
+                runtime.set_buffer_position(buffer_id, Position::new(pos.line, pos.column - 1));
+            }
         }
 
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());

--- a/modules/vim/src/commands/mode.rs
+++ b/modules/vim/src/commands/mode.rs
@@ -19,7 +19,11 @@
 
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
-    reovim_driver_session::{BufferApi, SessionRuntime, TransitionContext, api::ModeApi},
+    reovim_driver_search::Direction,
+    reovim_driver_session::{
+        BufferApi, CmdlinePrompt, CmdlineState, SessionRuntime, TransitionContext,
+        api::{ExtensionApi, ModeApi, SearchState},
+    },
     reovim_driver_undo::{UndoKey, UndoProviderRegistry},
     reovim_kernel::api::v1::{CommandId, Position},
 };
@@ -212,6 +216,10 @@ impl Command for EnterCommandLineMode {
 
 impl CommandHandler for EnterCommandLineMode {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        // Activate cmdline with command prompt
+        runtime
+            .ext_mut::<CmdlineState>()
+            .enter(CmdlinePrompt::Command);
         runtime.set_mode(VimMode::COMMANDLINE_ID, TransitionContext::new());
         CommandResult::Success
     }
@@ -235,7 +243,119 @@ impl Command for ExitCommandLineMode {
 
 impl CommandHandler for ExitCommandLineMode {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        // Check if this is a search (pending_search set)
+        let pending = {
+            let search_state = runtime.ext_mut::<SearchState>();
+            search_state.take_pending_search()
+        };
+
+        if let Some(direction) = pending {
+            // Store the direction for the runner to execute search
+            runtime.ext_mut::<SearchState>().last_direction = direction;
+        }
+
+        // Deactivate cmdline
+        runtime.ext_mut::<CmdlineState>().exit();
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
+        CommandResult::Success
+    }
+}
+
+/// Cancel command-line mode without executing (Escape).
+///
+/// Unlike `ExitCommandLineMode`, this clears the pending search and cmdline
+/// input without executing any action.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CancelCommandLineMode;
+
+impl Command for CancelCommandLineMode {
+    fn id(&self) -> CommandId {
+        ids::CANCEL_COMMANDLINE
+    }
+
+    fn description(&self) -> &'static str {
+        "Cancel command-line mode without executing"
+    }
+}
+
+impl CommandHandler for CancelCommandLineMode {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        // Clear any pending search - we're canceling, not executing
+        runtime.ext_mut::<SearchState>().clear_pending_search();
+
+        // Cancel cmdline (signals to runner: don't execute)
+        runtime.ext_mut::<CmdlineState>().cancel();
+        runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
+        CommandResult::Success
+    }
+}
+
+// =============================================================================
+// Search Mode Entry Commands (#435)
+// =============================================================================
+
+/// Enter search forward mode (`/`).
+///
+/// Sets pending search direction to Forward and enters command-line mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterSearchForward;
+
+impl Command for EnterSearchForward {
+    fn id(&self) -> CommandId {
+        ids::ENTER_SEARCH_FORWARD
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter search forward mode (/)"
+    }
+}
+
+impl CommandHandler for EnterSearchForward {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        eprintln!("[DEBUG] EnterSearchForward command executed");
+        // Set pending search direction
+        runtime
+            .ext_mut::<SearchState>()
+            .start_pending_search(Direction::Forward);
+        // Activate cmdline with search forward prompt
+        runtime
+            .ext_mut::<CmdlineState>()
+            .enter(CmdlinePrompt::SearchForward);
+        // Enter command-line mode
+        runtime.set_mode(VimMode::COMMANDLINE_ID, TransitionContext::new());
+        eprintln!("[DEBUG] Entered commandline mode with SearchForward prompt");
+        CommandResult::Success
+    }
+}
+
+/// Enter search backward mode (`?`).
+///
+/// Sets pending search direction to Backward and enters command-line mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EnterSearchBackward;
+
+impl Command for EnterSearchBackward {
+    fn id(&self) -> CommandId {
+        ids::ENTER_SEARCH_BACKWARD
+    }
+
+    fn description(&self) -> &'static str {
+        "Enter search backward mode (?)"
+    }
+}
+
+impl CommandHandler for EnterSearchBackward {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        // Set pending search direction
+        runtime
+            .ext_mut::<SearchState>()
+            .start_pending_search(Direction::Backward);
+        // Activate cmdline with search backward prompt
+        runtime
+            .ext_mut::<CmdlineState>()
+            .enter(CmdlinePrompt::SearchBackward);
+        // Enter command-line mode
+        runtime.set_mode(VimMode::COMMANDLINE_ID, TransitionContext::new());
         CommandResult::Success
     }
 }

--- a/modules/vim/src/commands/mode_entry.rs
+++ b/modules/vim/src/commands/mode_entry.rs
@@ -14,10 +14,21 @@
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
     reovim_driver_session::{BufferApi, SessionRuntime, TransitionContext, api::ModeApi},
-    reovim_kernel::api::v1::{CommandId, OptionScopeId, Position},
+    reovim_driver_undo::{UndoKey, UndoProviderRegistry},
+    reovim_kernel::api::v1::{BufferId, CommandId, OptionScopeId, Position},
 };
 
 use crate::{ids, modes::VimMode};
+
+/// Start undo batching for insert mode.
+fn begin_insert_batch(runtime: &SessionRuntime<'_>, buffer_id: BufferId) {
+    if let Some(pos) = runtime.buffer_position(buffer_id)
+        && let Some(undo_registry) = runtime.kernel().services.get::<UndoProviderRegistry>()
+        && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+    {
+        undo_provider.begin_batch(buffer_id, pos);
+    }
+}
 
 /// Extract the leading whitespace (indent) from a line.
 ///
@@ -48,16 +59,18 @@ impl Command for EnterInsertFirstNonBlank {
 
 impl CommandHandler for EnterInsertFirstNonBlank {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
-        if let Some(buffer_id) = args.buffer_id()
-            && let Some(pos) = runtime.buffer_position(buffer_id)
-        {
-            // Find first non-blank character on current line
-            let first_non_blank = runtime
-                .buffer_line(buffer_id, pos.line)
-                .map(|line| line.chars().position(|c| !c.is_whitespace()).unwrap_or(0))
-                .unwrap_or(0);
+        if let Some(buffer_id) = args.buffer_id() {
+            if let Some(pos) = runtime.buffer_position(buffer_id) {
+                // Find first non-blank character on current line
+                let first_non_blank = runtime
+                    .buffer_line(buffer_id, pos.line)
+                    .map(|line| line.chars().position(|c| !c.is_whitespace()).unwrap_or(0))
+                    .unwrap_or(0);
 
-            runtime.set_buffer_position(buffer_id, Position::new(pos.line, first_non_blank));
+                runtime.set_buffer_position(buffer_id, Position::new(pos.line, first_non_blank));
+            }
+            // Start undo batching for insert mode
+            begin_insert_batch(runtime, buffer_id);
         }
 
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
@@ -82,12 +95,14 @@ impl Command for EnterInsertEndOfLine {
 
 impl CommandHandler for EnterInsertEndOfLine {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
-        if let Some(buffer_id) = args.buffer_id()
-            && let Some(pos) = runtime.buffer_position(buffer_id)
-        {
-            // Move cursor to end of current line
-            let line_len = runtime.buffer_line_len(buffer_id, pos.line).unwrap_or(0);
-            runtime.set_buffer_position(buffer_id, Position::new(pos.line, line_len));
+        if let Some(buffer_id) = args.buffer_id() {
+            if let Some(pos) = runtime.buffer_position(buffer_id) {
+                // Move cursor to end of current line
+                let line_len = runtime.buffer_line_len(buffer_id, pos.line).unwrap_or(0);
+                runtime.set_buffer_position(buffer_id, Position::new(pos.line, line_len));
+            }
+            // Start undo batching for insert mode
+            begin_insert_batch(runtime, buffer_id);
         }
 
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
@@ -150,6 +165,9 @@ impl CommandHandler for OpenLineBelow {
         let indent_len = indent.chars().count();
         runtime.set_buffer_position(buffer_id, Position::new(pos.line + 1, indent_len));
 
+        // Start undo batching for insert mode
+        begin_insert_batch(runtime, buffer_id);
+
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
 
         CommandResult::Success
@@ -206,6 +224,9 @@ impl CommandHandler for OpenLineAbove {
         // Position cursor at end of indent on the new line (which is now at pos.line)
         let indent_len = indent.chars().count();
         runtime.set_buffer_position(buffer_id, Position::new(pos.line, indent_len));
+
+        // Start undo batching for insert mode
+        begin_insert_batch(runtime, buffer_id);
 
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
 

--- a/modules/vim/src/ids.rs
+++ b/modules/vim/src/ids.rs
@@ -177,7 +177,10 @@ pub const EXIT_VISUAL: CommandId = CommandId::new(MODULE, "exit-visual");
 /// Enter command-line mode (:).
 pub const ENTER_COMMANDLINE: CommandId = CommandId::new(MODULE, "enter-commandline");
 
-/// Exit command-line mode (Esc).
+/// Cancel command-line mode without executing (Esc).
+pub const CANCEL_COMMANDLINE: CommandId = CommandId::new(MODULE, "cancel-commandline");
+
+/// Execute command-line and exit (Enter).
 pub const EXIT_COMMANDLINE: CommandId = CommandId::new(MODULE, "exit-commandline");
 
 /// Enter window mode (Ctrl-w).
@@ -188,6 +191,20 @@ pub const ENTER_WINDOW_MODE: CommandId = CommandId::new(MODULE, "enter-window-mo
 /// Used by operator modes (delete, yank, change) when escape is pressed.
 /// Unlike `EXIT_INSERT`, this does not adjust cursor position.
 pub const CANCEL_TO_NORMAL: CommandId = CommandId::new(MODULE, "cancel-to-normal");
+
+// =============================================================================
+// Search Mode Entry (#435)
+// =============================================================================
+
+/// Enter search forward mode (/).
+///
+/// Sets pending search direction to Forward and enters command-line mode.
+pub const ENTER_SEARCH_FORWARD: CommandId = CommandId::new(MODULE, "enter-search-forward");
+
+/// Enter search backward mode (?).
+///
+/// Sets pending search direction to Backward and enters command-line mode.
+pub const ENTER_SEARCH_BACKWARD: CommandId = CommandId::new(MODULE, "enter-search-backward");
 
 // =============================================================================
 // Find-Char Motion Execution (Epic #385 - Resolver-based)

--- a/modules/vim/src/lib.rs
+++ b/modules/vim/src/lib.rs
@@ -86,13 +86,15 @@ pub use fallback::VimFallbackHandler;
 // Re-export mode commands (Epic #372 - Mode Ownership)
 pub use commands::{
     ChangeLine, ChangeToEndOfLine, EnterCommandLineMode, EnterInsertEndOfLine,
-    EnterInsertFirstNonBlank, EnterInsertMode, EnterInsertModeAppend, EnterWindowMode,
-    ExecuteFindChar, ExitCommandLineMode, ExitToNormal, OpenLineAbove, OpenLineBelow,
+    EnterInsertFirstNonBlank, EnterInsertMode, EnterInsertModeAppend, EnterSearchBackward,
+    EnterSearchForward, EnterWindowMode, ExecuteFindChar, ExitCommandLineMode, ExitToNormal,
+    OpenLineAbove, OpenLineBelow,
 };
 
 // Re-export resolvers
 pub use resolvers::{
-    VimChangeResolver, VimDeleteResolver, VimInsertResolver, VimNormalResolver, VimYankResolver,
+    VimChangeResolver, VimCommandLineResolver, VimDeleteResolver, VimInsertResolver,
+    VimNormalResolver, VimYankResolver,
 };
 
 // Re-export visual mode commands
@@ -174,6 +176,7 @@ impl Module for VimModule {
         resolver_registry.register(resolvers::VimDeleteResolver::new());
         resolver_registry.register(resolvers::VimYankResolver::new());
         resolver_registry.register(resolvers::VimChangeResolver::new());
+        resolver_registry.register(resolvers::VimCommandLineResolver::new());
 
         // Epic #417 Part 3: Self-register commands
         let command_store = ctx.services.get_or_create::<CommandHandlerStore>();

--- a/modules/vim/src/operators/change.rs
+++ b/modules/vim/src/operators/change.rs
@@ -2,7 +2,10 @@
 //!
 //! Reference: lib/core/src/command/builtin/operator.rs (concept-extraction, not migration)
 
-use reovim_kernel::api::v1::RegisterContent;
+use {
+    reovim_driver_undo::{UndoKey, UndoProviderRegistry},
+    reovim_kernel::api::v1::{Edit, RegisterContent},
+};
 
 use super::{Operator, OperatorContext, OperatorError, Range, registers};
 
@@ -41,6 +44,9 @@ impl Operator for ChangeOperator {
 
         let mut buffer = buffer_arc.write();
 
+        // Capture cursor before changes for undo
+        let cursor_before = buffer.position();
+
         // Get text before deleting
         let start = range.start;
         let end = range.end;
@@ -49,6 +55,9 @@ impl Operator for ChangeOperator {
         let mut deleted_text = String::new();
         let lines = buffer.lines();
         let line_count = lines.len();
+
+        // Track what was actually deleted for undo
+        let delete_pos;
 
         if range.is_linewise {
             // Linewise change: delete content of lines from start.line to end.line (inclusive)
@@ -93,6 +102,7 @@ impl Operator for ChangeOperator {
                 reovim_kernel::api::v1::Position::new(clamped_end, 0)
             };
 
+            delete_pos = delete_start;
             buffer.delete_range(delete_start, delete_end);
         } else if start.line == end.line {
             // Single line characterwise change
@@ -103,6 +113,7 @@ impl Operator for ChangeOperator {
                     deleted_text.push_str(&line[start_col..end_col]);
                 }
             }
+            delete_pos = start;
             buffer.delete_range(start, end);
         } else {
             // Multi-line characterwise change
@@ -121,9 +132,26 @@ impl Operator for ChangeOperator {
                     }
                 }
             }
+            delete_pos = start;
             buffer.delete_range(start, end);
         }
+
+        // Capture cursor after changes
+        let cursor_after = buffer.position();
+
         drop(buffer);
+
+        // Record edit for undo
+        if !deleted_text.is_empty()
+            && let Some(undo_registry) = ctx.kernel.services.get::<UndoProviderRegistry>()
+            && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+        {
+            let edit = Edit::Delete {
+                position: delete_pos,
+                text: deleted_text.clone(),
+            };
+            undo_provider.record(ctx.buffer_id, vec![edit], cursor_before, cursor_after);
+        }
 
         // Store in register - linewise if the range was linewise (handles +/* via ClipboardProvider)
         let content = if range.is_linewise {

--- a/modules/vim/src/operators/commands.rs
+++ b/modules/vim/src/operators/commands.rs
@@ -132,7 +132,22 @@ impl Command for ChangeCommand {
 
 impl CommandHandler for ChangeCommand {
     fn execute(&self, runtime: &mut SessionRuntime<'_>, args: &CommandContext) -> CommandResult {
-        use {super::ChangeOperator, crate::modes::VimMode};
+        use {
+            super::ChangeOperator,
+            crate::modes::VimMode,
+            reovim_driver_session::BufferApi,
+            reovim_driver_undo::{UndoKey, UndoProviderRegistry},
+        };
+
+        // Start undo batching BEFORE the delete - both the delete and subsequent
+        // insert edits should be grouped as a single undo entry
+        if let Some(buffer_id) = args.buffer_id()
+            && let Some(pos) = runtime.buffer_position(buffer_id)
+            && let Some(undo_registry) = runtime.kernel().services.get::<UndoProviderRegistry>()
+            && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+        {
+            undo_provider.begin_batch(buffer_id, pos);
+        }
 
         // Execute the change operator (delete text)
         let result = execute_operator(&ChangeOperator, runtime, args);

--- a/modules/vim/src/operators/delete.rs
+++ b/modules/vim/src/operators/delete.rs
@@ -2,7 +2,10 @@
 //!
 //! Reference: lib/core/src/command/builtin/operator.rs (concept-extraction, not migration)
 
-use reovim_kernel::api::v1::RegisterContent;
+use {
+    reovim_driver_undo::{UndoKey, UndoProviderRegistry},
+    reovim_kernel::api::v1::{Edit, RegisterContent},
+};
 
 use super::{Operator, OperatorContext, OperatorError, Range, registers};
 
@@ -82,8 +85,25 @@ impl Operator for DeleteOperator {
             registers::store_to_register(ctx.kernel, ctx.register, &content);
             registers::push_to_history(ctx.kernel, &content);
 
+            // Record cursor before delete
+            let cursor_before = buffer.position();
+
             // Delete entire lines
             buffer.delete_range(delete_start, delete_end);
+
+            // Record cursor after delete and record edit for undo
+            let cursor_after = buffer.position();
+
+            // Record edit for undo
+            if let Some(undo_registry) = ctx.kernel.services.get::<UndoProviderRegistry>()
+                && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+            {
+                let edit = Edit::Delete {
+                    position: delete_start,
+                    text: deleted_text.clone(),
+                };
+                undo_provider.record(ctx.buffer_id, vec![edit], cursor_before, cursor_after);
+            }
         } else {
             // Characterwise deletion
             if start.line == end.line {
@@ -115,12 +135,29 @@ impl Operator for DeleteOperator {
             }
 
             // Store in register as characterwise (handles +/* via ClipboardProvider)
-            let content = RegisterContent::characterwise(deleted_text);
+            let content = RegisterContent::characterwise(deleted_text.clone());
             registers::store_to_register(ctx.kernel, ctx.register, &content);
             registers::push_to_history(ctx.kernel, &content);
 
+            // Record cursor before delete
+            let cursor_before = buffer.position();
+
             // Delete the text from buffer
             buffer.delete_range(start, end);
+
+            // Record cursor after delete and record edit for undo
+            let cursor_after = buffer.position();
+
+            // Record edit for undo
+            if let Some(undo_registry) = ctx.kernel.services.get::<UndoProviderRegistry>()
+                && let Some(undo_provider) = undo_registry.get(&UndoKey::Buffer)
+            {
+                let edit = Edit::Delete {
+                    position: start,
+                    text: deleted_text,
+                };
+                undo_provider.record(ctx.buffer_id, vec![edit], cursor_before, cursor_after);
+            }
         }
 
         drop(buffer);

--- a/modules/vim/src/resolvers/change.rs
+++ b/modules/vim/src/resolvers/change.rs
@@ -88,47 +88,6 @@ impl Default for VimChangeResolver {
 }
 
 impl ModeKeyResolver for VimChangeResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape cancels the operator
-        if is_escape(key) {
-            self.clear_state();
-            return ResolveResult::ModeTransition(build_cancelled());
-        }
-
-        let mut state = self.state.write().expect("lock poisoned");
-
-        // Check for count digit
-        if is_count_digit(key, state.has_motion_count()) {
-            state.accumulate_motion_count(key);
-            return ResolveResult::Pending;
-        }
-
-        // Check for line operator (cc)
-        if is_line_operator_key(key, OperatorType::Change) {
-            let count = state.operator_count;
-            let motion_count = state.take_motion_count().unwrap_or(1);
-            let register = state.register;
-            drop(state);
-
-            return ResolveResult::ModeTransition(ModeTransition::Pop {
-                result: Some(build_operator_execute(
-                    OperatorType::Change,
-                    Position::new(0, 0),
-                    Position::new(0, 0),
-                    true, // linewise
-                    Some(count.unwrap_or(1) * motion_count),
-                    register,
-                )),
-            });
-        }
-
-        // Add to pending keys for motion lookup
-        state.push_key(*key);
-        drop(state);
-
-        ResolveResult::NotHandled
-    }
-
     fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
@@ -433,8 +392,8 @@ impl ModeKeyResolver for VimChangeResolver {
 #[cfg(test)]
 mod tests {
     use {
-        reovim_driver_input::{KeyCode, PopResult},
-        reovim_kernel::api::v1::CommandId,
+        reovim_driver_input::{KeyCode, KeyLookupState, KeySequence, KeymapQuery, PopResult},
+        reovim_kernel::api::v1::{CommandId, ModuleId},
     };
 
     use super::*;
@@ -445,6 +404,51 @@ mod tests {
 
     fn test_state() -> ModeState {
         ModeState::new(VimMode::CHANGE_ID)
+    }
+
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    const TEST_MODULE: ModuleId = ModuleId::new("test");
+    const EDITOR_MODULE: ModuleId = ModuleId::new("editor");
+
+    struct MockKeymap {
+        response: KeyLookupState,
+    }
+
+    impl MockKeymap {
+        fn exact_only(cmd: &'static str) -> Self {
+            Self {
+                response: KeyLookupState::ExactOnly(CommandId::new(TEST_MODULE, cmd)),
+            }
+        }
+
+        /// Create a keymap that returns ExactWithLonger (simulating 'c' with 'cc' as longer match)
+        fn exact_with_longer_editor(cmd: &'static str) -> Self {
+            Self {
+                response: KeyLookupState::ExactWithLonger {
+                    exact: CommandId::new(EDITOR_MODULE, cmd),
+                },
+            }
+        }
+    }
+
+    impl KeymapQuery for MockKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            self.response.clone()
+        }
+    }
+
+    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::CHANGE_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]
@@ -458,8 +462,11 @@ mod tests {
     fn test_escape_cancels() {
         let resolver = VimChangeResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             assert!(matches!(r, PopResult::Cancelled));
@@ -472,8 +479,10 @@ mod tests {
     fn test_line_operator_cc() {
         let resolver = VimChangeResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('c'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('c'), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             if let PopResult::ExecuteCommand { args, .. } = r {
@@ -493,61 +502,12 @@ mod tests {
     fn test_count_digit() {
         let resolver = VimChangeResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('3'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('3'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.state().motion_count, Some(3));
-    }
-
-    // =========================================================================
-    // Keymap-aware tests
-    // =========================================================================
-
-    use reovim_driver_input::{KeySequence, KeymapQuery};
-
-    use reovim_kernel::api::v1::ModuleId;
-
-    const TEST_MODULE: ModuleId = ModuleId::new("test");
-    const EDITOR_MODULE: ModuleId = ModuleId::new("editor");
-
-    struct MockKeymap {
-        response: reovim_driver_input::KeyLookupState,
-    }
-
-    impl MockKeymap {
-        fn exact_only(cmd: &'static str) -> Self {
-            Self {
-                response: reovim_driver_input::KeyLookupState::ExactOnly(CommandId::new(
-                    TEST_MODULE,
-                    cmd,
-                )),
-            }
-        }
-
-        /// Create a keymap that returns ExactWithLonger (simulating 'c' with 'cc' as longer match)
-        fn exact_with_longer_editor(cmd: &'static str) -> Self {
-            Self {
-                response: reovim_driver_input::KeyLookupState::ExactWithLonger {
-                    exact: CommandId::new(EDITOR_MODULE, cmd),
-                },
-            }
-        }
-    }
-
-    impl KeymapQuery for MockKeymap {
-        fn query(
-            &self,
-            _mode: &ModeId,
-            _keys: &KeySequence,
-        ) -> reovim_driver_input::KeyLookupState {
-            self.response.clone()
-        }
-    }
-
-    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
-        static EMPTY_KEYS: KeySequence = KeySequence::new();
-        static MODE: ModeId = VimMode::CHANGE_ID;
-        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]

--- a/modules/vim/src/resolvers/commandline.rs
+++ b/modules/vim/src/resolvers/commandline.rs
@@ -52,22 +52,6 @@ impl VimCommandLineResolver {
             _ => None,
         }
     }
-
-    /// Check if this is an escape key to cancel command-line mode.
-    fn is_escape(key: &KeyEvent) -> bool {
-        key.code == KeyCode::Escape
-            || (key.code == KeyCode::Char('[') && key.modifiers.contains(Modifiers::CTRL))
-    }
-
-    /// Check if this is the enter key to execute.
-    const fn is_enter(key: &KeyEvent) -> bool {
-        matches!(key.code, KeyCode::Enter)
-    }
-
-    /// Check if this is backspace.
-    const fn is_backspace(key: &KeyEvent) -> bool {
-        matches!(key.code, KeyCode::Backspace)
-    }
 }
 
 impl Default for VimCommandLineResolver {
@@ -77,21 +61,6 @@ impl Default for VimCommandLineResolver {
 }
 
 impl ModeKeyResolver for VimCommandLineResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape, Enter, Backspace are handled by keybindings
-        if Self::is_escape(key) || Self::is_enter(key) || Self::is_backspace(key) {
-            return ResolveResult::NotHandled;
-        }
-
-        // Check for insertable character
-        if let Some(c) = Self::is_insertable(key) {
-            return ResolveResult::InsertChar(c);
-        }
-
-        // Other keys (arrows, etc.) - let keymap handle
-        ResolveResult::NotHandled
-    }
-
     fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
@@ -140,6 +109,8 @@ impl ModeKeyResolver for VimCommandLineResolver {
 
 #[cfg(test)]
 mod tests {
+    use reovim_driver_input::KeymapQuery;
+
     use super::*;
 
     fn key(c: char) -> KeyEvent {
@@ -154,6 +125,21 @@ mod tests {
         ModeState::new(VimMode::COMMANDLINE_ID)
     }
 
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::COMMANDLINE_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
+    }
+
     #[test]
     fn test_new_resolver() {
         let resolver = VimCommandLineResolver::new();
@@ -164,14 +150,16 @@ mod tests {
     fn test_insert_character() {
         let resolver = VimCommandLineResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('w'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('w'), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('w')));
 
-        let result = resolver.resolve(&key('q'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('q'), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('q')));
 
-        let result = resolver.resolve(&key(' '), &mut state);
+        let result = resolver.resolve_with_keymap(&key(' '), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar(' ')));
     }
 
@@ -179,8 +167,11 @@ mod tests {
     fn test_escape_not_handled() {
         let resolver = VimCommandLineResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -188,8 +179,11 @@ mod tests {
     fn test_enter_not_handled() {
         let resolver = VimCommandLineResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Enter), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Enter), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -197,8 +191,11 @@ mod tests {
     fn test_backspace_not_handled() {
         let resolver = VimCommandLineResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Backspace), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Backspace), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -206,8 +203,11 @@ mod tests {
     fn test_ctrl_char_not_inserted() {
         let resolver = VimCommandLineResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key_with_mod('c', Modifiers::CTRL), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&key_with_mod('c', Modifiers::CTRL), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 

--- a/modules/vim/src/resolvers/commandline.rs
+++ b/modules/vim/src/resolvers/commandline.rs
@@ -1,0 +1,225 @@
+//! Vim command-line mode key resolver.
+//!
+//! In command-line mode (`:`, `/`, `?`), typed characters accumulate in
+//! the command-line buffer. Enter executes, Escape cancels.
+
+use {
+    reovim_driver_input::{
+        KeyCode, KeyEvent, KeyLookupState, KeySequence, ModeKeyResolver, ModeState, Modifiers,
+        ResolveContext, ResolveInput, ResolveResult,
+    },
+    reovim_kernel::api::v1::ModeId,
+};
+
+use crate::modes::VimMode;
+
+/// Vim command-line mode key resolver.
+///
+/// Handles input for `:` (Ex commands), `/` (forward search), and `?` (backward search).
+/// Characters are accumulated in the command-line buffer until Enter or Escape.
+///
+/// # Behavior
+///
+/// - Printable characters → `InsertChar` (goes to cmdline buffer)
+/// - Enter → `NotHandled` (keybinding executes command/search)
+/// - Escape → `NotHandled` (keybinding cancels)
+/// - Backspace → `NotHandled` (keybinding deletes char)
+pub struct VimCommandLineResolver {
+    mode_id: ModeId,
+}
+
+impl VimCommandLineResolver {
+    /// Create a new command-line mode resolver.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            mode_id: VimMode::COMMANDLINE_ID,
+        }
+    }
+
+    /// Check if a key should insert a character into the command-line buffer.
+    const fn is_insertable(key: &KeyEvent) -> Option<char> {
+        // Only consider keys without control/alt modifiers for insertion
+        if key.modifiers.contains(Modifiers::CTRL) || key.modifiers.contains(Modifiers::ALT) {
+            return None;
+        }
+
+        match key.code {
+            KeyCode::Char(c) => Some(c),
+            // Space is insertable
+            // Tab could be for completion (future)
+            // Enter is NOT insertable - it executes
+            _ => None,
+        }
+    }
+
+    /// Check if this is an escape key to cancel command-line mode.
+    fn is_escape(key: &KeyEvent) -> bool {
+        key.code == KeyCode::Escape
+            || (key.code == KeyCode::Char('[') && key.modifiers.contains(Modifiers::CTRL))
+    }
+
+    /// Check if this is the enter key to execute.
+    const fn is_enter(key: &KeyEvent) -> bool {
+        matches!(key.code, KeyCode::Enter)
+    }
+
+    /// Check if this is backspace.
+    const fn is_backspace(key: &KeyEvent) -> bool {
+        matches!(key.code, KeyCode::Backspace)
+    }
+}
+
+impl Default for VimCommandLineResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ModeKeyResolver for VimCommandLineResolver {
+    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
+        // Escape, Enter, Backspace are handled by keybindings
+        if Self::is_escape(key) || Self::is_enter(key) || Self::is_backspace(key) {
+            return ResolveResult::NotHandled;
+        }
+
+        // Check for insertable character
+        if let Some(c) = Self::is_insertable(key) {
+            return ResolveResult::InsertChar(c);
+        }
+
+        // Other keys (arrows, etc.) - let keymap handle
+        ResolveResult::NotHandled
+    }
+
+    fn resolve_with_keymap(
+        &self,
+        key: &KeyEvent,
+        _state: &mut ModeState,
+        input: &ResolveInput<'_>,
+    ) -> ResolveResult {
+        // Check for insertable character first
+        if let Some(c) = Self::is_insertable(key) {
+            return ResolveResult::InsertChar(c);
+        }
+
+        // For non-insertable keys (Escape, Enter, Backspace, etc.), look up in keymap
+        let mut keys = KeySequence::new();
+        keys.push(*key);
+        let lookup_state = input.keymap.query(input.mode, &keys);
+
+        match lookup_state {
+            KeyLookupState::ExactWithLonger { exact, .. } | KeyLookupState::ExactOnly(exact) => {
+                // Execute the command
+                ResolveResult::Execute(exact, ResolveContext::default())
+            }
+            KeyLookupState::PrefixOnly => {
+                // Wait for more keys
+                ResolveResult::Pending
+            }
+            KeyLookupState::NotFound => {
+                // No binding found
+                ResolveResult::NotHandled
+            }
+        }
+    }
+
+    fn mode_id(&self) -> &ModeId {
+        &self.mode_id
+    }
+
+    fn inherits_from(&self) -> Option<&ModeId> {
+        // Command-line mode doesn't inherit from other modes
+        None
+    }
+
+    fn reset(&mut self) {
+        // No state to reset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c))
+    }
+
+    fn key_with_mod(c: char, modifiers: Modifiers) -> KeyEvent {
+        KeyEvent::with_modifiers(KeyCode::Char(c), modifiers)
+    }
+
+    fn test_state() -> ModeState {
+        ModeState::new(VimMode::COMMANDLINE_ID)
+    }
+
+    #[test]
+    fn test_new_resolver() {
+        let resolver = VimCommandLineResolver::new();
+        assert_eq!(resolver.mode_id(), &VimMode::COMMANDLINE_ID);
+    }
+
+    #[test]
+    fn test_insert_character() {
+        let resolver = VimCommandLineResolver::new();
+        let mut state = test_state();
+
+        let result = resolver.resolve(&key('w'), &mut state);
+        assert!(matches!(result, ResolveResult::InsertChar('w')));
+
+        let result = resolver.resolve(&key('q'), &mut state);
+        assert!(matches!(result, ResolveResult::InsertChar('q')));
+
+        let result = resolver.resolve(&key(' '), &mut state);
+        assert!(matches!(result, ResolveResult::InsertChar(' ')));
+    }
+
+    #[test]
+    fn test_escape_not_handled() {
+        let resolver = VimCommandLineResolver::new();
+        let mut state = test_state();
+
+        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        assert!(matches!(result, ResolveResult::NotHandled));
+    }
+
+    #[test]
+    fn test_enter_not_handled() {
+        let resolver = VimCommandLineResolver::new();
+        let mut state = test_state();
+
+        let result = resolver.resolve(&KeyEvent::new(KeyCode::Enter), &mut state);
+        assert!(matches!(result, ResolveResult::NotHandled));
+    }
+
+    #[test]
+    fn test_backspace_not_handled() {
+        let resolver = VimCommandLineResolver::new();
+        let mut state = test_state();
+
+        let result = resolver.resolve(&KeyEvent::new(KeyCode::Backspace), &mut state);
+        assert!(matches!(result, ResolveResult::NotHandled));
+    }
+
+    #[test]
+    fn test_ctrl_char_not_inserted() {
+        let resolver = VimCommandLineResolver::new();
+        let mut state = test_state();
+
+        let result = resolver.resolve(&key_with_mod('c', Modifiers::CTRL), &mut state);
+        assert!(matches!(result, ResolveResult::NotHandled));
+    }
+
+    #[test]
+    fn test_mode_id() {
+        let resolver = VimCommandLineResolver::new();
+        assert_eq!(resolver.mode_id().name(), "command");
+    }
+
+    #[test]
+    fn test_inherits_from() {
+        let resolver = VimCommandLineResolver::new();
+        assert!(resolver.inherits_from().is_none());
+    }
+}

--- a/modules/vim/src/resolvers/delete.rs
+++ b/modules/vim/src/resolvers/delete.rs
@@ -93,50 +93,6 @@ impl Default for VimDeleteResolver {
 }
 
 impl ModeKeyResolver for VimDeleteResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape cancels the operator
-        if is_escape(key) {
-            self.clear_state();
-            return ResolveResult::ModeTransition(build_cancelled());
-        }
-
-        let mut state = self.state.write().expect("lock poisoned");
-
-        // Check for count digit
-        if is_count_digit(key, state.has_motion_count()) {
-            state.accumulate_motion_count(key);
-            return ResolveResult::Pending;
-        }
-
-        // Check for line operator (dd)
-        if is_line_operator_key(key, OperatorType::Delete) {
-            let count = state.operator_count;
-            let motion_count = state.take_motion_count().unwrap_or(1);
-            let register = state.register;
-            drop(state);
-
-            // For dd, we return a linewise delete
-            // Runner will calculate the actual line range from cursor position
-            return ResolveResult::ModeTransition(ModeTransition::Pop {
-                result: Some(build_operator_execute(
-                    OperatorType::Delete,
-                    Position::new(0, 0), // Placeholder - runner calculates
-                    Position::new(0, 0),
-                    true, // linewise
-                    Some(count.unwrap_or(1) * motion_count),
-                    register,
-                )),
-            });
-        }
-
-        // Add to pending keys for motion lookup
-        state.push_key(*key);
-        drop(state);
-
-        // Legacy: return NotHandled to delegate to keymap lookup
-        ResolveResult::NotHandled
-    }
-
     fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
@@ -457,8 +413,8 @@ impl ModeKeyResolver for VimDeleteResolver {
 #[cfg(test)]
 mod tests {
     use {
-        reovim_driver_input::{KeyCode, PopResult},
-        reovim_kernel::api::v1::CommandId,
+        reovim_driver_input::{KeyCode, KeyLookupState, KeySequence, KeymapQuery, PopResult},
+        reovim_kernel::api::v1::{CommandId, ModuleId},
     };
 
     use super::*;
@@ -469,6 +425,47 @@ mod tests {
 
     fn test_state() -> ModeState {
         ModeState::new(VimMode::DELETE_ID)
+    }
+
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    const TEST_MODULE: ModuleId = ModuleId::new("test");
+
+    struct MockKeymap {
+        response: KeyLookupState,
+    }
+
+    impl MockKeymap {
+        fn exact_only(cmd: &'static str) -> Self {
+            Self {
+                response: KeyLookupState::ExactOnly(CommandId::new(TEST_MODULE, cmd)),
+            }
+        }
+
+        fn not_found() -> Self {
+            Self {
+                response: KeyLookupState::NotFound,
+            }
+        }
+    }
+
+    impl KeymapQuery for MockKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            self.response.clone()
+        }
+    }
+
+    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::DELETE_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]
@@ -482,8 +479,11 @@ mod tests {
     fn test_escape_cancels() {
         let resolver = VimDeleteResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             assert!(matches!(r, PopResult::Cancelled));
@@ -496,12 +496,14 @@ mod tests {
     fn test_count_digit() {
         let resolver = VimDeleteResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('3'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('3'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.state().motion_count, Some(3));
 
-        let result = resolver.resolve(&key('5'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('5'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.state().motion_count, Some(35));
     }
@@ -510,8 +512,10 @@ mod tests {
     fn test_line_operator_dd() {
         let resolver = VimDeleteResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('d'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('d'), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             if let PopResult::ExecuteCommand { args, .. } = r {
@@ -531,9 +535,12 @@ mod tests {
     fn test_motion_key_not_handled() {
         let resolver = VimDeleteResolver::new();
         let mut state = test_state();
+        let keymap = MockKeymap::not_found();
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('w'), &mut state);
-        assert!(matches!(result, ResolveResult::NotHandled));
+        let result = resolver.resolve_with_keymap(&key('w'), &mut state, &input);
+        // With NotFound keymap, motion key results in ModeTransition::Pop with Cancelled
+        assert!(matches!(result, ResolveResult::ModeTransition(ModeTransition::Pop { .. })));
     }
 
     #[test]
@@ -543,53 +550,6 @@ mod tests {
 
         assert_eq!(state.operator_count, Some(3));
         assert_eq!(state.register, Some('a'));
-    }
-
-    // =========================================================================
-    // Keymap-aware tests
-    // =========================================================================
-
-    use reovim_driver_input::{KeySequence, KeymapQuery};
-
-    use reovim_kernel::api::v1::ModuleId;
-
-    const TEST_MODULE: ModuleId = ModuleId::new("test");
-
-    struct MockKeymap {
-        response: reovim_driver_input::KeyLookupState,
-    }
-
-    impl MockKeymap {
-        fn exact_only(cmd: &'static str) -> Self {
-            Self {
-                response: reovim_driver_input::KeyLookupState::ExactOnly(CommandId::new(
-                    TEST_MODULE,
-                    cmd,
-                )),
-            }
-        }
-
-        fn not_found() -> Self {
-            Self {
-                response: reovim_driver_input::KeyLookupState::NotFound,
-            }
-        }
-    }
-
-    impl KeymapQuery for MockKeymap {
-        fn query(
-            &self,
-            _mode: &ModeId,
-            _keys: &KeySequence,
-        ) -> reovim_driver_input::KeyLookupState {
-            self.response.clone()
-        }
-    }
-
-    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
-        static EMPTY_KEYS: KeySequence = KeySequence::new();
-        static MODE: ModeId = VimMode::DELETE_ID;
-        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]

--- a/modules/vim/src/resolvers/insert.rs
+++ b/modules/vim/src/resolvers/insert.rs
@@ -5,8 +5,8 @@
 
 use {
     reovim_driver_input::{
-        ExtensionMap, KeyCode, KeyEvent, KeyLookupState, KeySequence, ModeKeyResolver, ModeState,
-        Modifiers, ResolveContext, ResolveInput, ResolveResult, SessionApiDyn,
+        KeyCode, KeyEvent, KeyLookupState, KeySequence, ModeKeyResolver, ModeState, Modifiers,
+        ResolveContext, ResolveInput, ResolveResult,
     },
     reovim_kernel::api::v1::ModeId,
 };
@@ -63,13 +63,6 @@ impl VimInsertResolver {
             _ => None,
         }
     }
-
-    /// Check if this is an escape key to exit insert mode.
-    fn is_escape(key: &KeyEvent) -> bool {
-        // Escape or Ctrl+[ both exit insert mode
-        key.code == KeyCode::Escape
-            || (key.code == KeyCode::Char('[') && key.modifiers.contains(Modifiers::CTRL))
-    }
 }
 
 impl Default for VimInsertResolver {
@@ -79,25 +72,7 @@ impl Default for VimInsertResolver {
 }
 
 impl ModeKeyResolver for VimInsertResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape is NOT handled here - let keybinding call EXIT_INSERT command
-        // This ensures undo batching is properly ended via the command.
-        // The keybinding for <Esc> maps to vim:exit-insert command.
-        if Self::is_escape(key) {
-            return ResolveResult::NotHandled;
-        }
-
-        // Check for insertable character
-        if let Some(c) = Self::is_insertable(key) {
-            return ResolveResult::InsertChar(c);
-        }
-
-        // Other keys (Backspace, arrows, Ctrl+sequences) go to keymap lookup
-        // Return NotHandled to let the runner do the lookup
-        ResolveResult::NotHandled
-    }
-
-    /// Insert mode key resolution with session access.
+    /// Insert mode key resolution with keymap lookup.
     ///
     /// This method handles keymap lookup for non-insertable keys like Escape,
     /// Backspace, and arrow keys. When a key is not insertable, we query the
@@ -111,13 +86,11 @@ impl ModeKeyResolver for VimInsertResolver {
     ///
     /// This enables Escape to trigger the `vim:exit-insert` command, which
     /// properly ends undo batching before switching to normal mode.
-    fn resolve_with_session(
+    fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
         _state: &mut ModeState,
         input: &ResolveInput<'_>,
-        _session: &mut dyn SessionApiDyn,
-        _extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         // Check for insertable character first
         if let Some(c) = Self::is_insertable(key) {
@@ -162,6 +135,11 @@ impl ModeKeyResolver for VimInsertResolver {
 
 #[cfg(test)]
 mod tests {
+    use {
+        reovim_driver_input::{KeyLookupState, KeySequence, KeymapQuery},
+        reovim_kernel::api::v1::ModeId,
+    };
+
     use super::*;
 
     fn key(c: char) -> KeyEvent {
@@ -176,6 +154,21 @@ mod tests {
         ModeState::new(VimMode::INSERT_ID)
     }
 
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::INSERT_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
+    }
+
     #[test]
     fn test_new_resolver() {
         let resolver = VimInsertResolver::new();
@@ -186,17 +179,19 @@ mod tests {
     fn test_insert_character() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('a'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('a'), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('a')));
 
-        let result = resolver.resolve(&key('Z'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('Z'), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('Z')));
 
-        let result = resolver.resolve(&key('5'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('5'), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('5')));
 
-        let result = resolver.resolve(&key(' '), &mut state);
+        let result = resolver.resolve_with_keymap(&key(' '), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar(' ')));
     }
 
@@ -204,8 +199,10 @@ mod tests {
     fn test_insert_tab() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Tab), &mut state);
+        let result = resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Tab), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('\t')));
     }
 
@@ -213,8 +210,11 @@ mod tests {
     fn test_insert_enter() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Enter), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Enter), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('\n')));
     }
 
@@ -224,8 +224,11 @@ mod tests {
         // This ensures undo batching is properly ended via the command.
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -234,8 +237,11 @@ mod tests {
         // Ctrl+[ is NOT handled by resolver - let keybinding call EXIT_INSERT command
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key_with_mod('[', Modifiers::CTRL), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&key_with_mod('[', Modifiers::CTRL), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -243,9 +249,12 @@ mod tests {
     fn test_ctrl_char_not_inserted() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
         // Ctrl+H should NOT insert 'h', but go to keymap (for backspace behavior)
-        let result = resolver.resolve(&key_with_mod('h', Modifiers::CTRL), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&key_with_mod('h', Modifiers::CTRL), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -253,9 +262,12 @@ mod tests {
     fn test_alt_char_not_inserted() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
         // Alt+a should NOT insert 'a'
-        let result = resolver.resolve(&key_with_mod('a', Modifiers::ALT), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&key_with_mod('a', Modifiers::ALT), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -263,9 +275,12 @@ mod tests {
     fn test_backspace_not_handled() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
         // Backspace goes to keymap lookup
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Backspace), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Backspace), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -273,11 +288,14 @@ mod tests {
     fn test_arrow_keys_not_handled() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Left), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Left), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Up), &mut state);
+        let result = resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Up), &mut state, &input);
         assert!(matches!(result, ResolveResult::NotHandled));
     }
 
@@ -297,9 +315,12 @@ mod tests {
     fn test_shift_allowed_for_uppercase() {
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
         // Shift+a (uppercase A) should insert
-        let result = resolver.resolve(&key_with_mod('A', Modifiers::SHIFT), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&key_with_mod('A', Modifiers::SHIFT), &mut state, &input);
         assert!(matches!(result, ResolveResult::InsertChar('A')));
     }
 }

--- a/modules/vim/src/resolvers/insert.rs
+++ b/modules/vim/src/resolvers/insert.rs
@@ -5,8 +5,8 @@
 
 use {
     reovim_driver_input::{
-        KeyCode, KeyEvent, ModeKeyResolver, ModeState, ModeTransition, Modifiers, ResolveResult,
-        TransitionContext,
+        ExtensionMap, KeyCode, KeyEvent, KeyLookupState, KeySequence, ModeKeyResolver, ModeState,
+        Modifiers, ResolveContext, ResolveInput, ResolveResult, SessionApiDyn,
     },
     reovim_kernel::api::v1::ModeId,
 };
@@ -80,12 +80,11 @@ impl Default for VimInsertResolver {
 
 impl ModeKeyResolver for VimInsertResolver {
     fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape exits insert mode
+        // Escape is NOT handled here - let keybinding call EXIT_INSERT command
+        // This ensures undo batching is properly ended via the command.
+        // The keybinding for <Esc> maps to vim:exit-insert command.
         if Self::is_escape(key) {
-            return ResolveResult::ModeTransition(ModeTransition::Set {
-                mode: VimMode::NORMAL_ID,
-                context: TransitionContext::new(),
-            });
+            return ResolveResult::NotHandled;
         }
 
         // Check for insertable character
@@ -96,6 +95,54 @@ impl ModeKeyResolver for VimInsertResolver {
         // Other keys (Backspace, arrows, Ctrl+sequences) go to keymap lookup
         // Return NotHandled to let the runner do the lookup
         ResolveResult::NotHandled
+    }
+
+    /// Insert mode key resolution with session access.
+    ///
+    /// This method handles keymap lookup for non-insertable keys like Escape,
+    /// Backspace, and arrow keys. When a key is not insertable, we query the
+    /// keymap to find a bound command.
+    ///
+    /// # Architecture
+    ///
+    /// Insert mode differs from normal mode:
+    /// - Insertable characters (letters, numbers, etc.) return `InsertChar`
+    /// - Non-insertable keys (Escape, Backspace, arrows) query the keymap
+    ///
+    /// This enables Escape to trigger the `vim:exit-insert` command, which
+    /// properly ends undo batching before switching to normal mode.
+    fn resolve_with_session(
+        &self,
+        key: &KeyEvent,
+        _state: &mut ModeState,
+        input: &ResolveInput<'_>,
+        _session: &mut dyn SessionApiDyn,
+        _extensions: &mut ExtensionMap,
+    ) -> ResolveResult {
+        // Check for insertable character first
+        if let Some(c) = Self::is_insertable(key) {
+            return ResolveResult::InsertChar(c);
+        }
+
+        // Non-insertable key - query keymap for binding
+        // Use single-key lookup (insert mode has no multi-key sequences)
+        let keys = KeySequence::from_keys(&[*key]);
+        let lookup_state = input.keymap.query(input.mode, &keys);
+
+        match lookup_state {
+            KeyLookupState::ExactOnly(cmd) | KeyLookupState::ExactWithLonger { exact: cmd, .. } => {
+                // Found a binding - execute it
+                ResolveResult::Execute(cmd, ResolveContext::new())
+            }
+            KeyLookupState::PrefixOnly => {
+                // Waiting for more keys (unlikely in insert mode)
+                ResolveResult::Pending
+            }
+            KeyLookupState::NotFound => {
+                // No binding - let runner handle (may be ignored)
+                ResolveResult::NotHandled
+            }
+        }
     }
 
     fn mode_id(&self) -> &ModeId {
@@ -172,31 +219,24 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_exits() {
+    fn test_escape_not_handled() {
+        // Escape is NOT handled by resolver - let keybinding call EXIT_INSERT command
+        // This ensures undo batching is properly ended via the command.
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
 
         let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
-
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
-        } else {
-            panic!("expected ModeTransition::Set");
-        }
+        assert!(matches!(result, ResolveResult::NotHandled));
     }
 
     #[test]
-    fn test_ctrl_bracket_exits() {
+    fn test_ctrl_bracket_not_handled() {
+        // Ctrl+[ is NOT handled by resolver - let keybinding call EXIT_INSERT command
         let resolver = VimInsertResolver::new();
         let mut state = test_state();
 
         let result = resolver.resolve(&key_with_mod('[', Modifiers::CTRL), &mut state);
-
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
-        } else {
-            panic!("expected ModeTransition::Set for Ctrl+[");
-        }
+        assert!(matches!(result, ResolveResult::NotHandled));
     }
 
     #[test]

--- a/modules/vim/src/resolvers/mod.rs
+++ b/modules/vim/src/resolvers/mod.rs
@@ -3,6 +3,7 @@
 //! Implements Vim-style key handling policy for each mode:
 //! - Normal: count prefixes, register selection, operator entry
 //! - Insert: character insertion, escape handling
+//! - CommandLine: input capture for `:`, `/`, `?`
 //! - Delete/Yank/Change: dedicated operator modes
 //!
 //! # Architecture (Epic #415, #417)
@@ -18,6 +19,7 @@
 //! - Statusline shows "DELETE"/"YANK"/"CHANGE"
 
 mod change;
+mod commandline;
 mod delete;
 mod insert;
 mod normal;
@@ -28,4 +30,6 @@ mod yank;
 pub use {change::VimChangeResolver, delete::VimDeleteResolver, yank::VimYankResolver};
 
 // Other resolvers
-pub use {insert::VimInsertResolver, normal::VimNormalResolver};
+pub use {
+    commandline::VimCommandLineResolver, insert::VimInsertResolver, normal::VimNormalResolver,
+};

--- a/modules/vim/src/resolvers/normal.rs
+++ b/modules/vim/src/resolvers/normal.rs
@@ -344,39 +344,6 @@ impl Default for VimNormalResolver {
 }
 
 impl ModeKeyResolver for VimNormalResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Handle escape - reset state and stay in normal mode
-        if key.code == KeyCode::Escape {
-            self.clear_state();
-            return ResolveResult::NotHandled;
-        }
-
-        // Check for register prefix waiting for character
-        if self.is_waiting_for_register() {
-            return self.handle_register_char(key);
-        }
-
-        // Check for register prefix start
-        if Self::is_register_prefix(key) {
-            *self.pending_register.write().expect("lock poisoned") = Some('"'); // Sentinel
-            return ResolveResult::Pending;
-        }
-
-        // Check for count digit
-        if self.is_count_digit(key) {
-            self.accumulate_count(key);
-            return ResolveResult::Pending;
-        }
-
-        // Add to pending keys for lookup
-        self.push_pending_key(*key);
-        let _keys = self.get_pending_keys();
-
-        // Legacy: return NotHandled to let the runner do the lookup
-        // Use resolve_with_keymap for keymap-aware resolution
-        ResolveResult::NotHandled
-    }
-
     /// Vim-style key resolution with keymap access.
     ///
     /// This method queries the keymap and applies Vim policy to determine
@@ -622,6 +589,10 @@ impl ModeKeyResolver for VimNormalResolver {
 
 #[cfg(test)]
 mod tests {
+    use reovim_driver_input::{KeyLookupState, KeySequence, KeymapQuery};
+
+    use reovim_kernel::api::v1::{CommandId, ModuleId};
+
     use super::*;
 
     fn key(c: char) -> KeyEvent {
@@ -634,6 +605,22 @@ mod tests {
 
     fn test_state() -> ModeState {
         ModeState::new(VimMode::NORMAL_ID)
+    }
+
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    fn resolve_input_notfound() -> ResolveInput<'static> {
+        static KEYMAP: NotFoundKeymap = NotFoundKeymap;
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::NORMAL_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, &KEYMAP)
     }
 
     #[test]
@@ -782,11 +769,13 @@ mod tests {
     fn test_resolve_escape_resets() {
         let resolver = VimNormalResolver::new();
         let mut state = test_state();
+        let input = resolve_input_notfound();
 
         resolver.accumulate_count(&key('3'));
         *resolver.pending_register.write().unwrap() = Some('a');
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
         assert!(matches!(result, ResolveResult::NotHandled));
         assert!(resolver.pending_count().is_none());
@@ -797,12 +786,13 @@ mod tests {
     fn test_resolve_count_digit() {
         let resolver = VimNormalResolver::new();
         let mut state = test_state();
+        let input = resolve_input_notfound();
 
-        let result = resolver.resolve(&key('3'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('3'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.pending_count(), Some(3));
 
-        let result = resolver.resolve(&key('5'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('5'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.pending_count(), Some(35));
     }
@@ -811,12 +801,13 @@ mod tests {
     fn test_resolve_register_prefix() {
         let resolver = VimNormalResolver::new();
         let mut state = test_state();
+        let input = resolve_input_notfound();
 
-        let result = resolver.resolve(&key('"'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('"'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert!(resolver.is_waiting_for_register());
 
-        let result = resolver.resolve(&key('a'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('a'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.pending_register(), Some('a'));
     }
@@ -839,10 +830,6 @@ mod tests {
     //
     // These tests verify that resolve_with_keymap correctly applies Vim policy
     // based on the KeyLookupState returned by the keymap.
-
-    use reovim_driver_input::KeymapQuery;
-
-    use reovim_kernel::api::v1::{CommandId, ModuleId};
 
     /// Test module ID for creating command IDs.
     const TEST_MODULE: ModuleId = ModuleId::new("test");

--- a/modules/vim/src/resolvers/normal.rs
+++ b/modules/vim/src/resolvers/normal.rs
@@ -543,6 +543,7 @@ impl ModeKeyResolver for VimNormalResolver {
 
         // Query keymap for facts about what bindings exist
         let lookup_state = input.keymap.query(input.mode, &keys);
+        tracing::warn!(?key.code, %input.mode, %keys, ?lookup_state, "Normal resolver query");
 
         // Apply Vim policy
         match lookup_state {

--- a/modules/vim/src/resolvers/yank.rs
+++ b/modules/vim/src/resolvers/yank.rs
@@ -86,47 +86,6 @@ impl Default for VimYankResolver {
 }
 
 impl ModeKeyResolver for VimYankResolver {
-    fn resolve(&self, key: &KeyEvent, _state: &mut ModeState) -> ResolveResult {
-        // Escape cancels the operator
-        if is_escape(key) {
-            self.clear_state();
-            return ResolveResult::ModeTransition(build_cancelled());
-        }
-
-        let mut state = self.state.write().expect("lock poisoned");
-
-        // Check for count digit
-        if is_count_digit(key, state.has_motion_count()) {
-            state.accumulate_motion_count(key);
-            return ResolveResult::Pending;
-        }
-
-        // Check for line operator (yy)
-        if is_line_operator_key(key, OperatorType::Yank) {
-            let count = state.operator_count;
-            let motion_count = state.take_motion_count().unwrap_or(1);
-            let register = state.register;
-            drop(state);
-
-            return ResolveResult::ModeTransition(ModeTransition::Pop {
-                result: Some(build_operator_execute(
-                    OperatorType::Yank,
-                    Position::new(0, 0),
-                    Position::new(0, 0),
-                    true, // linewise
-                    Some(count.unwrap_or(1) * motion_count),
-                    register,
-                )),
-            });
-        }
-
-        // Add to pending keys for motion lookup
-        state.push_key(*key);
-        drop(state);
-
-        ResolveResult::NotHandled
-    }
-
     fn resolve_with_keymap(
         &self,
         key: &KeyEvent,
@@ -415,8 +374,8 @@ impl ModeKeyResolver for VimYankResolver {
 #[cfg(test)]
 mod tests {
     use {
-        reovim_driver_input::{KeyCode, PopResult},
-        reovim_kernel::api::v1::CommandId,
+        reovim_driver_input::{KeyCode, KeyLookupState, KeySequence, KeymapQuery, PopResult},
+        reovim_kernel::api::v1::{CommandId, ModuleId},
     };
 
     use super::*;
@@ -427,6 +386,41 @@ mod tests {
 
     fn test_state() -> ModeState {
         ModeState::new(VimMode::YANK_ID)
+    }
+
+    /// Mock keymap that always returns NotFound (no bindings).
+    struct NotFoundKeymap;
+
+    impl KeymapQuery for NotFoundKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            KeyLookupState::NotFound
+        }
+    }
+
+    const TEST_MODULE: ModuleId = ModuleId::new("test");
+
+    struct MockKeymap {
+        response: KeyLookupState,
+    }
+
+    impl MockKeymap {
+        fn exact_only(cmd: &'static str) -> Self {
+            Self {
+                response: KeyLookupState::ExactOnly(CommandId::new(TEST_MODULE, cmd)),
+            }
+        }
+    }
+
+    impl KeymapQuery for MockKeymap {
+        fn query(&self, _mode: &ModeId, _keys: &KeySequence) -> KeyLookupState {
+            self.response.clone()
+        }
+    }
+
+    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
+        static EMPTY_KEYS: KeySequence = KeySequence::new();
+        static MODE: ModeId = VimMode::YANK_ID;
+        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]
@@ -440,8 +434,11 @@ mod tests {
     fn test_escape_cancels() {
         let resolver = VimYankResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&KeyEvent::new(KeyCode::Escape), &mut state);
+        let result =
+            resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             assert!(matches!(r, PopResult::Cancelled));
@@ -454,8 +451,10 @@ mod tests {
     fn test_line_operator_yy() {
         let resolver = VimYankResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('y'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('y'), &mut state, &input);
 
         if let ResolveResult::ModeTransition(ModeTransition::Pop { result: Some(r) }) = result {
             if let PopResult::ExecuteCommand { args, .. } = r {
@@ -475,51 +474,12 @@ mod tests {
     fn test_count_digit() {
         let resolver = VimYankResolver::new();
         let mut state = test_state();
+        let keymap = NotFoundKeymap;
+        let input = resolve_input(&keymap);
 
-        let result = resolver.resolve(&key('2'), &mut state);
+        let result = resolver.resolve_with_keymap(&key('2'), &mut state, &input);
         assert!(matches!(result, ResolveResult::Pending));
         assert_eq!(resolver.state().motion_count, Some(2));
-    }
-
-    // =========================================================================
-    // Keymap-aware tests
-    // =========================================================================
-
-    use reovim_driver_input::{KeySequence, KeymapQuery};
-
-    use reovim_kernel::api::v1::ModuleId;
-
-    const TEST_MODULE: ModuleId = ModuleId::new("test");
-
-    struct MockKeymap {
-        response: reovim_driver_input::KeyLookupState,
-    }
-
-    impl MockKeymap {
-        fn exact_only(cmd: &'static str) -> Self {
-            Self {
-                response: reovim_driver_input::KeyLookupState::ExactOnly(CommandId::new(
-                    TEST_MODULE,
-                    cmd,
-                )),
-            }
-        }
-    }
-
-    impl KeymapQuery for MockKeymap {
-        fn query(
-            &self,
-            _mode: &ModeId,
-            _keys: &KeySequence,
-        ) -> reovim_driver_input::KeyLookupState {
-            self.response.clone()
-        }
-    }
-
-    fn resolve_input(keymap: &impl KeymapQuery) -> ResolveInput<'_> {
-        static EMPTY_KEYS: KeySequence = KeySequence::new();
-        static MODE: ModeId = VimMode::YANK_ID;
-        ResolveInput::new(&EMPTY_KEYS, &MODE, keymap)
     }
 
     #[test]

--- a/modules/vim/tests/registers.rs
+++ b/modules/vim/tests/registers.rs
@@ -45,7 +45,7 @@ async fn test_yw_char_yank_type() {
 }
 
 #[tokio::test]
-#[ignore = "requires register selection prefix (\"a) support"]
+#[ignore = "Named register prefix (#434)"]
 async fn test_named_register_a() {
     let result = IntegrationTest::new()
         .await
@@ -58,7 +58,7 @@ async fn test_named_register_a() {
 }
 
 #[tokio::test]
-#[ignore = "requires register selection (\"a) prefix support"]
+#[ignore = "Named register prefix (#434)"]
 async fn test_named_register_paste() {
     let result = IntegrationTest::new()
         .await

--- a/runner/src/client/cli/mod.rs
+++ b/runner/src/client/cli/mod.rs
@@ -44,11 +44,6 @@ pub struct CliArgs {
     #[arg(long, value_name = "ADDR")]
     pub tcp: Option<String>,
 
-    /// Connect to server via Unix socket (legacy, use -S instead).
-    #[cfg(unix)]
-    #[arg(long, value_name = "PATH", hide = true)]
-    pub socket: Option<PathBuf>,
-
     /// Start interactive REPL mode.
     #[arg(short = 'i', long)]
     pub repl: bool,
@@ -71,9 +66,8 @@ impl CliArgs {
     /// `ConnectionConfig::from_flags` directly.
     #[must_use]
     pub fn into_config(&self) -> ConnectionConfig {
-        // Handle legacy --socket flag (maps to -S)
         #[cfg(unix)]
-        let socket_path = self.socket_path.as_ref().or(self.socket.as_ref());
+        let socket_path = self.socket_path.as_ref();
         #[cfg(not(unix))]
         let socket_path = self.socket_path.as_ref();
 

--- a/runner/src/client/tui/mod.rs
+++ b/runner/src/client/tui/mod.rs
@@ -109,11 +109,6 @@ pub struct TuiArgs {
     #[arg(long, value_name = "ADDR")]
     pub tcp: Option<String>,
 
-    /// Connect to server via Unix socket (legacy, use -S instead).
-    #[cfg(unix)]
-    #[arg(long, value_name = "PATH", hide = true)]
-    pub socket: Option<PathBuf>,
-
     /// Enable debug mode (statusline + frame capture).
     ///
     /// Shows a debug statusline at the bottom of the screen and
@@ -143,9 +138,8 @@ impl TuiArgs {
     /// `ConnectionConfig::from_flags` directly.
     #[must_use]
     pub fn into_config(self) -> ConnectionConfig {
-        // Handle legacy --socket flag (maps to -S)
         #[cfg(unix)]
-        let socket_path = self.socket_path.or(self.socket);
+        let socket_path = self.socket_path;
         #[cfg(not(unix))]
         let socket_path = self.socket_path;
 

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -151,14 +151,3 @@ pub use server::{
 // Re-export submodules for backwards compatibility
 // Note: server::client is NOT re-exported to avoid conflict with runner::client (TUI/CLI)
 pub use server::{module, notification, registry, session, transport};
-
-// Backwards compat: allow `runner::fallback::*`
-pub mod fallback {
-    //! Fallback handlers for unhandled input.
-    //!
-    //! These types are now defined in `reovim-driver-input` but re-exported here
-    //! for backwards compatibility.
-    pub use reovim_driver_input::{
-        BeepFallback, FallbackContext, FallbackResult, InputFallbackHandler, NoOpFallback,
-    };
-}

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -68,20 +68,6 @@ struct Args {
     /// Files to open on startup.
     #[arg(value_name = "FILE")]
     files: Vec<PathBuf>,
-
-    // Legacy flags (hidden for backwards compatibility)
-    #[arg(short, long, hide = true)]
-    server: bool,
-
-    #[arg(long, hide = true)]
-    listen_tcp: Option<u16>,
-
-    #[cfg(unix)]
-    #[arg(long, hide = true)]
-    listen_socket: Option<PathBuf>,
-
-    #[arg(long, hide = true)]
-    stdio: bool,
 }
 
 /// Main command dispatcher.
@@ -121,12 +107,6 @@ enum ManagerAction {
 fn main() {
     let args = Args::parse();
 
-    // Handle legacy flags
-    if args.command.is_none() && has_legacy_flags(&args) {
-        run_server(build_legacy_server_config(&args));
-        return;
-    }
-
     match args.command {
         Some(Command::Server(srv_args)) => {
             run_server(srv_args.into_config());
@@ -164,29 +144,6 @@ fn main() {
                 run_integrated(&args.files, debug_config);
             }
         }
-    }
-}
-
-const fn has_legacy_flags(args: &Args) -> bool {
-    #[cfg(unix)]
-    return args.server || args.listen_tcp.is_some() || args.listen_socket.is_some() || args.stdio;
-    #[cfg(not(unix))]
-    return args.server || args.listen_tcp.is_some() || args.stdio;
-}
-
-#[allow(clippy::option_if_let_else)]
-fn build_legacy_server_config(args: &Args) -> ServerConfig {
-    #[cfg(unix)]
-    if let Some(ref path) = args.listen_socket {
-        return ServerConfig::unix_socket(path);
-    }
-
-    if args.stdio {
-        ServerConfig::stdio()
-    } else if let Some(port) = args.listen_tcp {
-        ServerConfig::tcp(port)
-    } else {
-        ServerConfig::tcp_with_fallback()
     }
 }
 

--- a/runner/src/server/app/cmdline.rs
+++ b/runner/src/server/app/cmdline.rs
@@ -1,24 +1,58 @@
-//! Command-line mode state for : commands.
+//! Command-line mode state for `:`, `/`, and `?` commands.
 //!
-//! Tracks input buffer and command history for Vim-style Ex commands.
-//! Similar to search.rs but for command-line mode instead of search.
+//! Tracks input buffer and prompt type for Vim-style Ex commands and search.
+//! History support can be added later.
 
 // ============================================================================
 // Command-line Infrastructure
 // ============================================================================
 
+/// Type of prompt being displayed.
+///
+/// Distinguishes between Ex commands (`:`) and search patterns (`/`, `?`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PromptType {
+    /// Ex command prompt (`:`)
+    #[default]
+    Command,
+    /// Forward search prompt (`/`)
+    SearchForward,
+    /// Backward search prompt (`?`)
+    SearchBackward,
+}
+
+impl PromptType {
+    /// Get the prompt character for display.
+    #[must_use]
+    pub const fn char(self) -> char {
+        match self {
+            Self::Command => ':',
+            Self::SearchForward => '/',
+            Self::SearchBackward => '?',
+        }
+    }
+
+    /// Check if this is a search prompt.
+    #[must_use]
+    pub const fn is_search(self) -> bool {
+        matches!(self, Self::SearchForward | Self::SearchBackward)
+    }
+}
+
 /// Command-line state for the session.
 ///
 /// Tracks input buffer and whether command-line mode is active.
-/// History support can be added later.
+/// Used for Ex commands (`:`) and search patterns (`/`, `?`).
 #[derive(Debug, Clone, Default)]
 pub struct CommandLineState {
-    /// Input buffer for current command.
+    /// Input buffer for current command/pattern.
     pub input_buffer: String,
     /// Whether we're in command-line mode.
     pub active: bool,
     /// Cursor position within input buffer.
     pub cursor_pos: usize,
+    /// Type of prompt (command or search).
+    pub prompt_type: PromptType,
 }
 
 impl CommandLineState {
@@ -28,11 +62,17 @@ impl CommandLineState {
         Self::default()
     }
 
-    /// Enter command-line mode.
+    /// Enter command-line mode with default (Command) prompt.
     pub fn enter(&mut self) {
+        self.enter_with_prompt(PromptType::Command);
+    }
+
+    /// Enter command-line mode with specified prompt type.
+    pub fn enter_with_prompt(&mut self, prompt: PromptType) {
         self.active = true;
         self.input_buffer.clear();
         self.cursor_pos = 0;
+        self.prompt_type = prompt;
     }
 
     /// Cancel command-line mode (Esc).
@@ -40,11 +80,13 @@ impl CommandLineState {
         self.active = false;
         self.input_buffer.clear();
         self.cursor_pos = 0;
+        self.prompt_type = PromptType::Command;
     }
 
-    /// Complete command-line input and return the command.
+    /// Complete command-line input and return the input string.
     ///
     /// Returns None if no input or not active.
+    /// The `prompt_type` is preserved for the caller to check.
     pub fn complete(&mut self) -> Option<String> {
         if !self.active || self.input_buffer.is_empty() {
             self.active = false;
@@ -54,10 +96,17 @@ impl CommandLineState {
         }
 
         self.active = false;
-        let command = std::mem::take(&mut self.input_buffer);
+        let input = std::mem::take(&mut self.input_buffer);
         self.cursor_pos = 0;
+        // Note: prompt_type is preserved so caller can check it
 
-        Some(command)
+        Some(input)
+    }
+
+    /// Get the current prompt type.
+    #[must_use]
+    pub const fn prompt_type(&self) -> PromptType {
+        self.prompt_type
     }
 
     /// Insert a character at cursor position.

--- a/runner/src/server/app/mod.rs
+++ b/runner/src/server/app/mod.rs
@@ -6,7 +6,7 @@
 
 mod cmdline;
 
-pub use cmdline::CommandLineState;
+pub use cmdline::{CommandLineState, PromptType};
 
 use {
     crate::server::window::WindowRegistry,
@@ -89,10 +89,9 @@ pub struct AppState {
     /// cursor position, allowing multiple views of the same buffer.
     pub windows: WindowRegistry,
 
-    /// Command-line mode state for : commands.
+    /// Command-line mode state for `:`, `/`, and `?` commands.
     ///
-    /// Tracks input buffer and whether command-line mode is active.
-    /// Used for Ex-style commands like `:w`, `:q`, `:set`, etc.
+    /// Tracks input buffer and prompt type for Ex commands and search patterns.
     pub cmdline: CommandLineState,
 
     /// Per-session module extensions (Epic #385).

--- a/runner/src/server/app/mod.rs
+++ b/runner/src/server/app/mod.rs
@@ -124,9 +124,13 @@ impl AppState {
     /// Use `SessionState::driver_session` for these values.
     #[must_use]
     pub fn new(kernel: KernelContext) -> Self {
+        // Use the kernel's service registry - modules registered their services there
+        // during init() (e.g., UndoProviderRegistry, ClipboardProvider).
+        // Previously this created a new empty ServiceRegistry, which broke undo.
+        let services = Arc::clone(&kernel.services);
         Self {
             kernel,
-            services: Arc::new(ServiceRegistry::new()),
+            services,
             pending_keys: KeySequence::new(),
             running: true,
             terminal_width: 80,

--- a/runner/src/server/event_loop/mod.rs
+++ b/runner/src/server/event_loop/mod.rs
@@ -58,9 +58,11 @@ use {
 const KEY_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
 use super::{
-    AppState,
+    AppState, PromptType,
     registry::{CommandRegistry, KeymapRegistry, ModeRegistry},
 };
+
+use reovim_driver_session::{CmdlinePrompt, CmdlineState};
 
 use reovim_driver_input::ResolverRegistry;
 
@@ -298,12 +300,117 @@ impl EventLoop {
         if let Some((result, _changes)) = self.try_resolver(&key) {
             self.handle_resolve_result(result);
 
+            // Sync cmdline state with current mode (#435)
+            self.sync_cmdline_state();
+
             // TODO: Broadcast state changes to clients
             // if changes.has_changes() {
             //     self.broadcast_state_changes(&changes);
             // }
         }
         // No resolver = key ignored (resolver handles everything)
+    }
+
+    /// Sync cmdline state based on `CmdlineState` extension.
+    ///
+    /// Policy (modules) sets `CmdlineState.active` when entering cmdline mode.
+    /// Mechanism (runner) syncs the display state accordingly.
+    fn sync_cmdline_state(&mut self) {
+        let ext_state = self.app.extensions.get::<CmdlineState>();
+
+        // Check if policy has activated cmdline (via extension)
+        let policy_active = ext_state.is_some_and(CmdlineState::is_active);
+
+        if policy_active && !self.app.cmdline.is_active() {
+            // Policy activated cmdline: sync prompt type
+            let prompt_type = ext_state.map_or(CmdlinePrompt::Command, CmdlineState::prompt);
+
+            let runner_prompt = match prompt_type {
+                CmdlinePrompt::Command => PromptType::Command,
+                CmdlinePrompt::SearchForward => PromptType::SearchForward,
+                CmdlinePrompt::SearchBackward => PromptType::SearchBackward,
+            };
+
+            self.app.cmdline.enter_with_prompt(runner_prompt);
+            eprintln!("[DEBUG] Activated cmdline with prompt: {runner_prompt:?}");
+        } else if !policy_active && self.app.cmdline.is_active() {
+            // Policy deactivated cmdline: execute any pending action, then sync
+            self.execute_cmdline_action();
+            self.app.cmdline.cancel();
+            eprintln!("[DEBUG] Deactivated cmdline");
+        }
+    }
+
+    /// Execute the cmdline action based on prompt type.
+    ///
+    /// For search prompts, this executes the search and moves cursor.
+    fn execute_cmdline_action(&mut self) {
+        use reovim_driver_search::{Direction, SearchKey, SearchProviderRegistry};
+
+        let prompt = self.app.cmdline.prompt_type();
+        let input = self.app.cmdline.input().to_string();
+
+        if input.is_empty() {
+            return;
+        }
+
+        match prompt {
+            PromptType::SearchForward | PromptType::SearchBackward => {
+                let direction = if prompt == PromptType::SearchForward {
+                    Direction::Forward
+                } else {
+                    Direction::Backward
+                };
+
+                // Execute search using SearchProviderRegistry
+                if let Some(search_registry) = self.app.services.get::<SearchProviderRegistry>()
+                    && let Some(buffer_id) = self.driver_session.active_buffer()
+                {
+                    // Get cursor position from active window
+                    let cursor_pos = self
+                        .app
+                        .windows
+                        .active_window()
+                        .and_then(|win_id| self.app.windows.get(win_id))
+                        .map(|state| state.cursor)
+                        .unwrap_or_default();
+
+                    if let Some(buffer_arc) = self.app.kernel.buffers.get(buffer_id) {
+                        // Find the match position (with read lock)
+                        let search_result = {
+                            let buffer = buffer_arc.read();
+                            search_registry.get(&SearchKey::Regex).and_then(|provider| {
+                                provider
+                                    .find_next(&buffer, cursor_pos, &input, direction, true)
+                                    .ok()
+                                    .flatten()
+                            })
+                        }; // Read lock dropped
+
+                        match search_result {
+                            Some(m) => {
+                                // Update buffer's internal cursor position (SSOT for RPC)
+                                buffer_arc.write().set_position(m.start);
+                                // Update window registry cursor (for rendering)
+                                if let Some(win_id) = self.app.windows.active_window()
+                                    && let Some(state) = self.app.windows.get_mut(win_id)
+                                {
+                                    state.cursor = m.start;
+                                }
+                                eprintln!("[DEBUG] Search found at {m_start:?}", m_start = m.start);
+                            }
+                            None => {
+                                self.set_error(format!("Pattern not found: {input}"));
+                            }
+                        }
+                    }
+                }
+            }
+            PromptType::Command => {
+                // TODO: Execute Ex command
+                eprintln!("[DEBUG] Ex command: {input}");
+            }
+        }
     }
 
     /// Convert driver `KeyEvent` to kernel `KeyInput`.
@@ -503,14 +610,20 @@ impl EventLoop {
                 self.handle_mode_transition(transition);
             }
 
+            // InsertChar: insert character into current input context (cmdline or buffer)
+            ResolveResult::InsertChar(ch) => {
+                // Command-line mode: insert into cmdline buffer
+                if self.app.cmdline.is_active() {
+                    self.app.cmdline.insert_char(ch);
+                    eprintln!("[DEBUG] InsertChar '{ch}' → cmdline: {}", self.app.cmdline.input());
+                }
+                // Note: For regular insert mode, the resolver returns Execute with insert command
+            }
+
             // Pending: wait for more keys
-            // InsertChar: resolvers should return Execute with insert command
             // NotHandled: key not handled, ignore
             // Completed: resolver already did everything via SessionApi, changes are tracked
-            ResolveResult::Pending
-            | ResolveResult::InsertChar(_)
-            | ResolveResult::NotHandled
-            | ResolveResult::Completed => {}
+            ResolveResult::Pending | ResolveResult::NotHandled | ResolveResult::Completed => {}
         }
     }
 

--- a/runner/src/server/event_loop/runtime_adapter.rs
+++ b/runner/src/server/event_loop/runtime_adapter.rs
@@ -32,11 +32,13 @@ use {
         PopResult, SessionExtension, SessionRuntime, TransitionContext,
         api::{
             BufferApi, BufferError, ChangeTracker, CommandApi, ExtensionApi, ModeApi, ModeError,
-            RegisterApi, RegisterContent, Selection, SelectionMode, StateChanges, WindowApi,
-            WindowError,
+            RegisterApi, RegisterContent, Selection, SelectionMode, StateChanges, UndoApi,
+            WindowApi, WindowError,
         },
     },
-    reovim_kernel::api::v1::{BufferId, CommandId, KernelContext, ModeId, Position, WindowId},
+    reovim_kernel::api::v1::{
+        BufferId, CommandId, Edit, KernelContext, ModeId, Position, UndoResult, WindowId,
+    },
 };
 
 use crate::server::window::WindowRegistry;
@@ -330,6 +332,38 @@ impl RegisterApi for RuntimeAdapter<'_> {
 
     fn set_register(&mut self, name: Option<char>, content: RegisterContent) {
         self.session_runtime.set_register(name, content);
+    }
+}
+
+// === UndoApi ===
+// Delegate to SessionRuntime
+
+impl UndoApi for RuntimeAdapter<'_> {
+    fn undo(&mut self, buffer: BufferId) -> Option<UndoResult> {
+        self.session_runtime.undo(buffer)
+    }
+
+    fn redo(&mut self, buffer: BufferId) -> Option<UndoResult> {
+        self.session_runtime.redo(buffer)
+    }
+
+    fn record_edit(
+        &mut self,
+        buffer: BufferId,
+        edits: Vec<Edit>,
+        cursor_before: Position,
+        cursor_after: Position,
+    ) {
+        self.session_runtime
+            .record_edit(buffer, edits, cursor_before, cursor_after);
+    }
+
+    fn can_undo(&self, buffer: BufferId) -> bool {
+        self.session_runtime.can_undo(buffer)
+    }
+
+    fn can_redo(&self, buffer: BufferId) -> bool {
+        self.session_runtime.can_redo(buffer)
     }
 }
 

--- a/runner/src/server/mod.rs
+++ b/runner/src/server/mod.rs
@@ -67,7 +67,7 @@ pub mod window;
 
 // Re-exports for public API
 pub use {
-    app::AppState,
+    app::{AppState, PromptType},
     // CLI arguments (Epic #417 Part 2)
     args::SrvArgs,
     event_loop::{EventLoop, EventLoopError},

--- a/runner/src/server/module/mod.rs
+++ b/runner/src/server/module/mod.rs
@@ -80,9 +80,3 @@ pub use {
         WiringStats, wire_module_commands, wire_module_keybindings,
     },
 };
-
-// Backwards compatibility alias: ModuleRegistry -> ModuleManager
-// This allows existing code to use the old name during migration
-#[doc(hidden)]
-#[deprecated(since = "0.9.0", note = "Use ModuleManager instead")]
-pub type ModuleRegistry = ModuleManager;

--- a/runner/src/server/module/wiring/keybindings.rs
+++ b/runner/src/server/module/wiring/keybindings.rs
@@ -118,6 +118,7 @@ impl std::error::Error for WiringError {}
 /// Mode names are looked up in the mode registry to get the correct `ModeId`
 /// with proper discriminant. If a mode is not found, it falls back to creating
 /// a `ModeId` with discriminant 0 (for forward compatibility with new modes).
+#[allow(deprecated)]
 pub fn wire_module_keybindings(
     module_id: &ModuleId,
     keybindings: &[KeybindingRegistration],

--- a/runner/src/server/registry/keymap.rs
+++ b/runner/src/server/registry/keymap.rs
@@ -300,6 +300,7 @@ impl KeymapRegistry {
     /// * `mode` - The mode in which this binding is active
     /// * `keys` - The key sequence that triggers the binding
     /// * `command` - The command to execute
+    #[deprecated(since = "0.9.5", note = "Use register_at_layer() instead")]
     pub fn register(&mut self, mode: &ModeId, keys: KeySequence, command: CommandId) {
         self.register_at_layer(BindingLayer::Policy, mode, keys, command);
     }
@@ -307,6 +308,7 @@ impl KeymapRegistry {
     /// Register a keybinding at the Policy layer with module ownership.
     ///
     /// This is the legacy API. New code should use [`Self::register_at_layer_for_module`].
+    #[deprecated(since = "0.9.5", note = "Use register_at_layer_for_module() instead")]
     pub fn register_for_module(
         &mut self,
         mode: &ModeId,
@@ -343,6 +345,7 @@ impl KeymapRegistry {
     ///
     /// Convenience method that parses the key sequence from a string.
     /// Returns `false` if the string couldn't be parsed.
+    #[allow(deprecated)]
     pub fn register_str(&mut self, mode: &ModeId, keys: &str, command: CommandId) -> bool {
         KeySequence::parse(keys).is_some_and(|seq| {
             self.register(mode, seq, command);
@@ -482,6 +485,7 @@ impl KeymapQuery for KeymapRegistry {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use {super::*, reovim_kernel::api::v1::ModuleId};
 
@@ -515,6 +519,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_keymap_registry_register() {
         let mut registry = KeymapRegistry::new();
         let mode = test_mode();

--- a/runner/src/server/rpc/handlers/input.rs
+++ b/runner/src/server/rpc/handlers/input.rs
@@ -41,6 +41,7 @@ use {
 ///
 /// This function will not panic as `InputKeysResult` serialization is infallible.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn input_keys(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
     Box::pin(async move {
         // Parse params
@@ -61,11 +62,11 @@ pub fn input_keys(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
         for key in keys.as_slice() {
             let key_event = KeyEvent::with_modifiers(key.code, key.modifiers);
 
-            tracing::debug!(?key_event, "Processing key through resolver");
+            tracing::warn!(?key_event, "Processing key through resolver");
 
             // Resolve the key using mode resolvers
             if let Some((result, _changes)) = ctx.session.resolve_key(&key_event).await {
-                tracing::debug!(?result, "Resolver returned result");
+                tracing::warn!(?result, "Resolver returned result");
 
                 match result {
                     ResolveResult::Execute(cmd_id, resolve_ctx) => {
@@ -104,6 +105,10 @@ pub fn input_keys(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
                             {
                                 handle_mode_transition_async(&ctx, transition).await;
                             }
+
+                            // Per #435: Execute cmdline action if cmdline was deactivated
+                            // (e.g., Enter in search mode executes the search)
+                            ctx.session.execute_cmdline_and_deactivate().await;
                         }
 
                         any_handled = true;
@@ -121,7 +126,14 @@ pub fn input_keys(ctx: RpcContext, params: serde_json::Value) -> HandlerFuture {
                     }
 
                     ResolveResult::InsertChar(ch) => {
-                        ctx.session.insert_char(ch).await;
+                        // Route character to appropriate target:
+                        // - Cmdline buffer when cmdline is active (/, ?, :)
+                        // - Document buffer otherwise (insert mode)
+                        if ctx.session.is_cmdline_active().await {
+                            ctx.session.cmdline_insert_char(ch).await;
+                        } else {
+                            ctx.session.insert_char(ch).await;
+                        }
                         any_handled = true;
                         final_pending = false;
                     }

--- a/runner/src/server/session/session.rs
+++ b/runner/src/server/session/session.rs
@@ -213,6 +213,214 @@ impl Session {
         self.state.read().await.mode_accepts_char_input()
     }
 
+    /// Check if command-line mode is active.
+    ///
+    /// When cmdline is active, character input should go to the cmdline buffer
+    /// instead of the document buffer.
+    ///
+    /// This checks the `CmdlineState` session extension set by commands like
+    /// `enter-search-forward`, NOT the `app.cmdline` state which is synced
+    /// by the event loop.
+    ///
+    /// Acquires a read lock on the session state.
+    pub async fn is_cmdline_active(&self) -> bool {
+        use reovim_driver_session::api::CmdlineState;
+        self.state
+            .read()
+            .await
+            .driver_session
+            .extensions
+            .get::<CmdlineState>()
+            .is_some_and(CmdlineState::is_active)
+    }
+
+    /// Insert a character into the command-line buffer.
+    ///
+    /// Use this when cmdline is active to route characters to the cmdline
+    /// instead of the document buffer.
+    ///
+    /// This first syncs the cmdline state from `driver_session.extensions` to
+    /// `app.cmdline` (if needed), then inserts the character.
+    ///
+    /// Acquires a write lock on the session state.
+    pub async fn cmdline_insert_char(&self, ch: char) {
+        use {
+            crate::server::PromptType,
+            reovim_driver_session::api::{CmdlinePrompt, CmdlineState},
+        };
+
+        self.with_state_mut(|state| {
+            // Sync cmdline state from extension (like event loop does)
+            let ext_active = state
+                .driver_session
+                .extensions
+                .get::<CmdlineState>()
+                .is_some_and(CmdlineState::is_active);
+
+            if ext_active && !state.app.cmdline.is_active() {
+                // Sync prompt type from extension to app.cmdline
+                let prompt_type = state
+                    .driver_session
+                    .extensions
+                    .get::<CmdlineState>()
+                    .map_or(CmdlinePrompt::Command, CmdlineState::prompt);
+
+                let runner_prompt = match prompt_type {
+                    CmdlinePrompt::Command => PromptType::Command,
+                    CmdlinePrompt::SearchForward => PromptType::SearchForward,
+                    CmdlinePrompt::SearchBackward => PromptType::SearchBackward,
+                };
+
+                state.app.cmdline.enter_with_prompt(runner_prompt);
+            }
+
+            state.app.cmdline.insert_char(ch);
+        })
+        .await;
+    }
+
+    /// Execute the cmdline action and deactivate cmdline.
+    ///
+    /// Called when a command deactivates cmdline (e.g., Enter in search mode).
+    /// This executes the search if the prompt was `/` or `?`.
+    ///
+    /// Acquires a write lock on the session state.
+    #[allow(clippy::too_many_lines)]
+    pub async fn execute_cmdline_and_deactivate(&self) {
+        use {
+            crate::server::PromptType,
+            reovim_driver_search::{Direction, SearchKey, SearchProviderRegistry},
+            reovim_driver_session::api::{CmdlinePrompt, CmdlineState, SearchState},
+        };
+
+        self.with_state_mut(|state| {
+            // First sync cmdline if needed (in case chars were inserted)
+            let ext_active = state
+                .driver_session
+                .extensions
+                .get::<CmdlineState>()
+                .is_some_and(CmdlineState::is_active);
+
+            if ext_active && !state.app.cmdline.is_active() {
+                // Sync prompt type from extension to app.cmdline
+                let prompt_type = state
+                    .driver_session
+                    .extensions
+                    .get::<CmdlineState>()
+                    .map_or(CmdlinePrompt::Command, CmdlineState::prompt);
+
+                let runner_prompt = match prompt_type {
+                    CmdlinePrompt::Command => PromptType::Command,
+                    CmdlinePrompt::SearchForward => PromptType::SearchForward,
+                    CmdlinePrompt::SearchBackward => PromptType::SearchBackward,
+                };
+
+                state.app.cmdline.enter_with_prompt(runner_prompt);
+            }
+
+            // Check if cmdline was deactivated (extension is inactive)
+            let ext_inactive = state
+                .driver_session
+                .extensions
+                .get::<CmdlineState>()
+                .is_none_or(|s| !s.is_active());
+
+            if ext_inactive && state.app.cmdline.is_active() {
+                // Execute the cmdline action based on prompt type
+                let prompt = state.app.cmdline.prompt_type();
+                let input = state.app.cmdline.input().to_string();
+
+                // Check if cmdline was cancelled (Escape) vs executed (Enter)
+                let was_cancelled = state
+                    .driver_session
+                    .extensions
+                    .get::<CmdlineState>()
+                    .is_some_and(CmdlineState::was_cancelled);
+
+                if !input.is_empty() && !was_cancelled {
+                    match prompt {
+                        PromptType::SearchForward | PromptType::SearchBackward => {
+                            let direction = if prompt == PromptType::SearchForward {
+                                Direction::Forward
+                            } else {
+                                Direction::Backward
+                            };
+
+                            // Get search provider
+                            if let Some(search_registry) =
+                                state.app.services.get::<SearchProviderRegistry>()
+                            {
+                                // Get cursor position
+                                let cursor_pos = state
+                                    .session_active_buffer()
+                                    .and_then(|id| state.app.kernel.buffers.get(id))
+                                    .map(|b| b.read().position())
+                                    .unwrap_or_default();
+
+                                // Get buffer
+                                let buffer_id = state.session_active_buffer();
+                                let buffer_arc =
+                                    buffer_id.and_then(|id| state.app.kernel.buffers.get(id));
+
+                                if let Some(buffer_arc) = buffer_arc {
+                                    // Find the match
+                                    let search_result = {
+                                        let buffer = buffer_arc.read();
+                                        tracing::warn!(
+                                            ?cursor_pos,
+                                            ?direction,
+                                            ?input,
+                                            "Executing search"
+                                        );
+                                        search_registry.get(&SearchKey::Regex).and_then(
+                                            |provider| {
+                                                provider
+                                                    .find_next(
+                                                        &buffer, cursor_pos, &input, direction,
+                                                        true,
+                                                    )
+                                                    .ok()
+                                                    .flatten()
+                                            },
+                                        )
+                                    };
+                                    tracing::warn!(?search_result, "Search result");
+
+                                    if let Some(m) = search_result {
+                                        // Update buffer's cursor
+                                        buffer_arc.write().set_position(m.start);
+
+                                        // Update window registry cursor
+                                        if let Some(win_id) = state.app.windows.active_window()
+                                            && let Some(win_state) =
+                                                state.app.windows.get_mut(win_id)
+                                        {
+                                            win_state.cursor = m.start;
+                                        }
+                                    }
+
+                                    // Store pattern for n/N repeat (#435)
+                                    state
+                                        .driver_session
+                                        .extensions
+                                        .get_or_insert::<SearchState>()
+                                        .set(input, direction);
+                                }
+                            }
+                        }
+                        PromptType::Command => {
+                            // Ex command execution - not implemented yet
+                        }
+                    }
+                }
+
+                // Deactivate cmdline
+                state.app.cmdline.cancel();
+            }
+        })
+        .await;
+    }
+
     /// Insert a character at the cursor position in the active buffer.
     ///
     /// This is the fallback behavior for unmatched keys in modes that accept

--- a/tools/bench/benches/profiler_overhead.rs
+++ b/tools/bench/benches/profiler_overhead.rs
@@ -19,6 +19,7 @@ fn bench_profile_scope_nop(c: &mut Criterion) {
 }
 
 /// Benchmark: ProfileGuard (legacy, records to MetricsRegistry).
+#[allow(deprecated)]
 fn bench_profile_guard(c: &mut Criterion) {
     c.bench_function("profiler/guard_legacy", |b| {
         b.iter(|| {


### PR DESCRIPTION
## Summary

**Phase 7 Epic Finale** - Clean up ALL deprecated patterns
- Remove legacy re-exports and type aliases
- Add `#[deprecated]` attributes with clear migration paths
- Migrate vim resolvers from `resolve()` to `resolve_with_keymap()`
- Update tests to use new API with mock keymaps

## Changes

### Changed
- Removed `runner::fallback` re-export module (use `reovim_driver_input` directly)
- Removed `ModuleRegistry` type alias (use `ModuleManager`)
- Removed hidden legacy CLI flags (`--server`, `--listen-tcp`, `--listen-socket`, `--stdio`)
- `VimInsertResolver` migrated from `resolve_with_session()` to `resolve_with_keymap()`

### Deprecated
- `window_active_buffer()` - use `active_buffer()` instead
- `ModeKeyResolver::resolve()` - override `resolve_with_keymap()` instead
- `ProfileGuard` - use `profile_scope!()` macro instead
- `KeymapRegistry::register()` - use `register_at_layer()` instead
- `KeymapRegistry::register_for_module()` - use `register_at_layer_for_module()` instead

### Removed
- `ModeKeyResolver::resolve()` implementations from all 6 vim resolvers
- Tests migrated to use `resolve_with_keymap()` with `NotFoundKeymap` mock

## Test plan

- [x] `./scripts/check.sh` passes (format, build, clippy, all tests)
- [x] All 621 runner tests pass
- [x] All 228 vim module tests pass
- [x] Zero warnings in build

## Related
- Closes #307
- Closes #310
- Closes #311
- Closes #313
- Closes #427
- Closes #435
- Parts of #307 (Phase 7 Epic)