### PR TITLE
feat: Phase 8 - Floating windows, overlays, themes, and pair module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,22 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   tiled and float windows without stealing focus. Infrastructure only; consumer
   systems (autocomplete, hover, command palette) to follow. (#399)
 - **Color and theme system**: Implemented centralized theme system with 3 built-in
-  themes (dark, light, tokyo-night-orange). Themes define 34 highlight groups for
+  themes (dark, light, tokyo-night-orange). Themes define 41 highlight groups for
   syntax (keyword, function, string, comment, etc.), UI elements (statusline,
-  line numbers, cursor, selection, borders), and diagnostics (error, warning,
-  info, hint). Switch themes at runtime with `:colorscheme <name>`. Theme system
-  follows mechanism/policy separation: driver layer provides `ThemeProvider` trait
-  and `ThemeManager`, module layer provides `:colorscheme` command. Supports 16,
-  256, and true color terminals with automatic color mode detection. (#439)
+  line numbers, cursor, selection, borders), diagnostics (error, warning, info,
+  hint), and rainbow brackets (6 colors + unmatched). Switch themes at runtime
+  with `:colorscheme <name>`. Theme system follows mechanism/policy separation:
+  driver layer provides `ThemeProvider` trait and `ThemeManager`, module layer
+  provides `:colorscheme` command. Supports 16, 256, and true color terminals
+  with automatic color mode detection. (#439)
+- **Pair plugin**: Added bracket assistance module with three features: (1)
+  Auto-close brackets - typing `(`, `[`, `{`, backtick, `'`, or `"` inserts the
+  closing character with cursor positioned between. Symmetric pairs (quotes)
+  use atomic tracking to prevent infinite recursion. (2) Rainbow bracket
+  highlighting - nested brackets colored by depth using a 6-color palette that
+  cycles. (3) Matched pair indicator - cursor on a bracket highlights its match
+  with bold + underline. Module registers `SharedPairState` service and subscribes
+  to `CursorMoved`, `BufferModified`, `BufferClosed` events. (#440)
 
 ### Changed
 
@@ -53,6 +62,16 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   appending. This gives the environment variable highest priority, matching
   the convention of `LD_LIBRARY_PATH`, `PYTHONPATH`, etc. Users who relied
   on the previous append behavior should adjust their module organization. (#433)
+- **Display driver mechanism/policy separation**: Refactored display driver to
+  remove all policy leakage. (1) Decoration registry now uses string-based
+  `DecorationSourceKey` instead of enum variants - modules define their own keys
+  (e.g., `"pair.rainbow"`). (2) `StyleGroupRegistry` allows modules to register
+  default styles - rainbow bracket colors moved from driver to pair module.
+  (3) Added idiomatic `FromStr`/`Display` traits for `Color` and `Attributes`
+  with proper error types. (4) `Style::from_wire()` provides unified RPC
+  deserialization, eliminating ~100 lines of duplicated parsing code. The
+  `ThemeManager` now uses 4-tier lookup: user overrides → theme → module
+  defaults → theme fallback. (#440)
 
 ### Fixed
 
@@ -75,6 +94,16 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 - **Module FFI symbols**: Fixed hot-reload-demo module missing FFI entry points
   by enabling the `dynamic` feature by default. This resolved 9 failing
   module_loading integration tests. (#448)
+- **Pair plugin cursor position**: Fixed cursor position after auto-pair insertion.
+  Now cursor is positioned between brackets `(|)` instead of after `()|`. Added
+  `set_position()` call after `insert_at()` to restore cursor position. (#440)
+- **Pair plugin decoration wiring**: Wired rainbow bracket decorations into TUI
+  rendering pipeline. Created `BufferDecorationSourceRegistry` and
+  `BufferDecorationSourceKey` in display driver for generic decoration lookup.
+  Pair module registers in registry during init. Screen handler queries registry
+  and embeds colors in `cell_grid` format. TUI parses cell_grid and applies
+  per-cell styles to frame buffer. Proper mechanism/policy separation maintained:
+  display driver defines traits, pair module implements them. (#440)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   per layer with automatic clamping to screen bounds. Overlays render above all
   tiled and float windows without stealing focus. Infrastructure only; consumer
   systems (autocomplete, hover, command palette) to follow. (#399)
+- **Color and theme system**: Implemented centralized theme system with 3 built-in
+  themes (dark, light, tokyo-night-orange). Themes define 34 highlight groups for
+  syntax (keyword, function, string, comment, etc.), UI elements (statusline,
+  line numbers, cursor, selection, borders), and diagnostics (error, warning,
+  info, hint). Switch themes at runtime with `:colorscheme <name>`. Theme system
+  follows mechanism/policy separation: driver layer provides `ThemeProvider` trait
+  and `ThemeManager`, module layer provides `:colorscheme` command. Supports 16,
+  256, and true color terminals with automatic color mode detection. (#439)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   Float windows are rendered above tiled windows and can be reordered with
   `<C-w>]` (raise) and `<C-w>[` (lower). Navigation (h/j/k/l) and cycling (w/W)
   work seamlessly between tiled and float windows using spatial proximity. (#398)
+- **Overlay/popup layer**: Implemented overlay zone within the nested compositor
+  for temporary UI elements (popups, menus, tooltips, autocomplete). Overlays
+  use anchor-based positioning: Cursor (below text cursor), Screen (absolute),
+  Center (screen center), or Below (below a window). Supports up to 50 overlays
+  per layer with automatic clamping to screen bounds. Overlays render above all
+  tiled and float windows without stealing focus. Infrastructure only; consumer
+  systems (autocomplete, hover, command palette) to follow. (#399)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 - **Compositor infrastructure**: Layout module now self-registers 15 window
   commands via `CommandHandlerStore`. Runner no longer imports from policy
   modules, fixing architecture violation. (#438)
+- **Floating window layer**: Implemented float zone within the nested compositor
+  architecture. Windows can toggle between tiled and floating with `<C-w>f`.
+  Float windows are rendered above tiled windows and can be reordered with
+  `<C-w>]` (raise) and `<C-w>[` (lower). Navigation (h/j/k/l) and cycling (w/W)
+  work seamlessly between tiled and float windows using spatial proximity. (#398)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,8 +1595,11 @@ dependencies = [
 name = "reovim-module-commands"
 version = "0.9.2-dev"
 dependencies = [
+ "reovim-arch",
+ "reovim-driver-display",
  "reovim-kernel",
  "reovim-module-macros",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "reovim-module-layout",
  "reovim-module-macros",
  "reovim-module-motions",
+ "reovim-module-pair",
  "reovim-module-scratch-buffer",
  "reovim-module-search",
  "reovim-module-undo",
@@ -1716,6 +1717,18 @@ version = "0.9.2-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
+]
+
+[[package]]
+name = "reovim-module-pair"
+version = "0.9.2-dev"
+dependencies = [
+ "reovim-arch",
+ "reovim-driver-buffer",
+ "reovim-driver-display",
+ "reovim-kernel",
+ "reovim-module-macros",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ reovim-module-undo = { path = "./modules/undo", version = "0.9.2-dev" }
 reovim-module-buffer-simple = { path = "./modules/buffer-simple", version = "0.9.2-dev" }
 reovim-module-search = { path = "./modules/search", version = "0.9.2-dev" }
 reovim-module-clipboard = { path = "./modules/clipboard", version = "0.9.2-dev" }
+reovim-module-pair = { path = "./modules/pair", version = "0.9.2-dev" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/lib/arch/src/lib.rs
+++ b/lib/arch/src/lib.rs
@@ -37,7 +37,7 @@ pub mod error;
 pub mod sync;
 pub mod traits;
 
-// Re-export all public types from traits
+// Re-export all public types from traits (including ParseColorError, ParseColorErrorKind)
 pub use traits::*;
 
 #[cfg(unix)]

--- a/lib/arch/src/traits.rs
+++ b/lib/arch/src/traits.rs
@@ -5,7 +5,7 @@
 //!
 //! All types defined here have NO external dependencies (std only).
 
-use std::{io, time::Duration};
+use std::{fmt, io, str::FromStr, time::Duration};
 
 // =============================================================================
 // Color
@@ -63,6 +63,229 @@ pub enum Color {
         /// Blue component (0-255).
         b: u8,
     },
+}
+
+// =============================================================================
+// Color Parsing and Display
+// =============================================================================
+
+/// Error type for color parsing with detailed diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseColorError {
+    /// The input that failed to parse.
+    pub input: String,
+    /// The kind of error.
+    pub kind: ParseColorErrorKind,
+}
+
+/// Specific error kind for color parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseColorErrorKind {
+    /// Invalid hex color length (must be 3 or 6 hex digits after #).
+    InvalidHexLength,
+    /// Invalid hex digit in color string.
+    InvalidHexDigit,
+    /// Invalid RGB function format.
+    InvalidRgbFormat,
+    /// Invalid ANSI index (must be 0-255).
+    InvalidAnsiIndex,
+    /// Unknown color name.
+    UnknownColorName,
+}
+
+impl fmt::Display for ParseColorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ParseColorErrorKind::InvalidHexLength => {
+                write!(f, "invalid hex color '{}': must be #rgb or #rrggbb", self.input)
+            }
+            ParseColorErrorKind::InvalidHexDigit => {
+                write!(f, "invalid hex digit in color '{}'", self.input)
+            }
+            ParseColorErrorKind::InvalidRgbFormat => {
+                write!(f, "invalid RGB format '{}': use rgb(r,g,b)", self.input)
+            }
+            ParseColorErrorKind::InvalidAnsiIndex => {
+                write!(f, "invalid ANSI index '{}': must be 0-255", self.input)
+            }
+            ParseColorErrorKind::UnknownColorName => {
+                write!(f, "unknown color name '{}'", self.input)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseColorError {}
+
+impl FromStr for Color {
+    type Err = ParseColorError;
+
+    /// Parse a color from string.
+    ///
+    /// Supports multiple formats:
+    /// - Named colors: `red`, `green`, `blue`, etc. (case-insensitive)
+    /// - Hex colors: `#rgb`, `#rrggbb`
+    /// - ANSI 256 colors: `ansi:N` where N is 0-255
+    /// - RGB function: `rgb(r,g,b)`
+    /// - Default/reset: `default`, `reset`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use reovim_arch::Color;
+    ///
+    /// assert_eq!("red".parse::<Color>().unwrap(), Color::Red);
+    /// assert_eq!("#ff0000".parse::<Color>().unwrap(), Color::Rgb { r: 255, g: 0, b: 0 });
+    /// assert_eq!("ansi:196".parse::<Color>().unwrap(), Color::AnsiValue(196));
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_lowercase();
+        let err = |kind| ParseColorError {
+            input: s.to_string(),
+            kind,
+        };
+
+        // Named colors (case-insensitive)
+        match lower.as_str() {
+            "default" | "reset" => return Ok(Self::Reset),
+            "black" => return Ok(Self::Black),
+            "red" => return Ok(Self::Red),
+            "green" => return Ok(Self::Green),
+            "yellow" => return Ok(Self::Yellow),
+            "blue" => return Ok(Self::Blue),
+            "magenta" => return Ok(Self::Magenta),
+            "cyan" => return Ok(Self::Cyan),
+            "white" => return Ok(Self::White),
+            "grey" | "gray" => return Ok(Self::Grey),
+            "darkgrey" | "darkgray" => return Ok(Self::DarkGrey),
+            "darkred" => return Ok(Self::DarkRed),
+            "darkgreen" => return Ok(Self::DarkGreen),
+            "darkyellow" => return Ok(Self::DarkYellow),
+            "darkblue" => return Ok(Self::DarkBlue),
+            "darkmagenta" => return Ok(Self::DarkMagenta),
+            "darkcyan" => return Ok(Self::DarkCyan),
+            _ => {}
+        }
+
+        // Hex colors: #rgb or #rrggbb
+        if let Some(hex) = s.strip_prefix('#') {
+            return Self::parse_hex(hex, s);
+        }
+
+        // ANSI 256 colors: ansi:N
+        if let Some(n_str) = lower.strip_prefix("ansi:") {
+            return n_str
+                .parse::<u8>()
+                .map(Self::AnsiValue)
+                .map_err(|_| err(ParseColorErrorKind::InvalidAnsiIndex));
+        }
+
+        // RGB function: rgb(r,g,b)
+        if lower.starts_with("rgb(") && lower.ends_with(')') {
+            return Self::parse_rgb_func(&lower[4..lower.len() - 1], s);
+        }
+
+        Err(err(ParseColorErrorKind::UnknownColorName))
+    }
+}
+
+impl Color {
+    /// Parse a hex color string (without the # prefix).
+    fn parse_hex(hex: &str, original: &str) -> Result<Self, ParseColorError> {
+        let err = |kind| ParseColorError {
+            input: original.to_string(),
+            kind,
+        };
+
+        match hex.len() {
+            6 => {
+                let r = u8::from_str_radix(&hex[0..2], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                let g = u8::from_str_radix(&hex[2..4], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                let b = u8::from_str_radix(&hex[4..6], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                Ok(Self::Rgb { r, g, b })
+            }
+            3 => {
+                // #rgb -> #rrggbb (double each digit)
+                let r = u8::from_str_radix(&hex[0..1], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                let g = u8::from_str_radix(&hex[1..2], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                let b = u8::from_str_radix(&hex[2..3], 16)
+                    .map_err(|_| err(ParseColorErrorKind::InvalidHexDigit))?;
+                Ok(Self::Rgb {
+                    r: r * 17,
+                    g: g * 17,
+                    b: b * 17,
+                })
+            }
+            _ => Err(err(ParseColorErrorKind::InvalidHexLength)),
+        }
+    }
+
+    /// Parse RGB function content: "r,g,b".
+    fn parse_rgb_func(content: &str, original: &str) -> Result<Self, ParseColorError> {
+        let err = || ParseColorError {
+            input: original.to_string(),
+            kind: ParseColorErrorKind::InvalidRgbFormat,
+        };
+
+        let parts: Vec<&str> = content.split(',').map(str::trim).collect();
+        if parts.len() != 3 {
+            return Err(err());
+        }
+
+        let r: u8 = parts[0].parse().map_err(|_| err())?;
+        let g: u8 = parts[1].parse().map_err(|_| err())?;
+        let b: u8 = parts[2].parse().map_err(|_| err())?;
+
+        Ok(Self::Rgb { r, g, b })
+    }
+
+    /// Convenience method that returns `Option` instead of `Result`.
+    ///
+    /// Wraps `FromStr` for compatibility with existing code.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        s.parse().ok()
+    }
+}
+
+impl fmt::Display for Color {
+    /// Format color as a canonical string representation.
+    ///
+    /// Output format:
+    /// - Named colors: lowercase name (e.g., `red`, `darkblue`)
+    /// - RGB colors: `#rrggbb` hex format
+    /// - ANSI 256 colors: `ansi:N`
+    /// - Reset: `default`
+    ///
+    /// Guarantees round-trip safety: `color.to_string().parse() == Ok(color)`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reset => write!(f, "default"),
+            Self::Black => write!(f, "black"),
+            Self::Red => write!(f, "red"),
+            Self::Green => write!(f, "green"),
+            Self::Yellow => write!(f, "yellow"),
+            Self::Blue => write!(f, "blue"),
+            Self::Magenta => write!(f, "magenta"),
+            Self::Cyan => write!(f, "cyan"),
+            Self::White => write!(f, "white"),
+            Self::Grey => write!(f, "grey"),
+            Self::DarkGrey => write!(f, "darkgrey"),
+            Self::DarkRed => write!(f, "darkred"),
+            Self::DarkGreen => write!(f, "darkgreen"),
+            Self::DarkYellow => write!(f, "darkyellow"),
+            Self::DarkBlue => write!(f, "darkblue"),
+            Self::DarkMagenta => write!(f, "darkmagenta"),
+            Self::DarkCyan => write!(f, "darkcyan"),
+            Self::Rgb { r, g, b } => write!(f, "#{r:02x}{g:02x}{b:02x}"),
+            Self::AnsiValue(n) => write!(f, "ansi:{n}"),
+        }
+    }
 }
 
 // =============================================================================
@@ -615,6 +838,179 @@ pub trait SignalHandler: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // Color Parsing Tests
+    // =========================================================================
+
+    #[test]
+    fn test_color_parse_named() {
+        assert_eq!("red".parse::<Color>().unwrap(), Color::Red);
+        assert_eq!("RED".parse::<Color>().unwrap(), Color::Red);
+        assert_eq!("Red".parse::<Color>().unwrap(), Color::Red);
+        assert_eq!("green".parse::<Color>().unwrap(), Color::Green);
+        assert_eq!("blue".parse::<Color>().unwrap(), Color::Blue);
+        assert_eq!("yellow".parse::<Color>().unwrap(), Color::Yellow);
+        assert_eq!("magenta".parse::<Color>().unwrap(), Color::Magenta);
+        assert_eq!("cyan".parse::<Color>().unwrap(), Color::Cyan);
+        assert_eq!("white".parse::<Color>().unwrap(), Color::White);
+        assert_eq!("black".parse::<Color>().unwrap(), Color::Black);
+        assert_eq!("grey".parse::<Color>().unwrap(), Color::Grey);
+        assert_eq!("gray".parse::<Color>().unwrap(), Color::Grey);
+        assert_eq!("darkred".parse::<Color>().unwrap(), Color::DarkRed);
+        assert_eq!("darkgrey".parse::<Color>().unwrap(), Color::DarkGrey);
+        assert_eq!("darkgray".parse::<Color>().unwrap(), Color::DarkGrey);
+    }
+
+    #[test]
+    fn test_color_parse_default() {
+        assert_eq!("default".parse::<Color>().unwrap(), Color::Reset);
+        assert_eq!("reset".parse::<Color>().unwrap(), Color::Reset);
+    }
+
+    #[test]
+    fn test_color_parse_hex() {
+        assert_eq!("#ff0000".parse::<Color>().unwrap(), Color::Rgb { r: 255, g: 0, b: 0 });
+        assert_eq!("#00ff00".parse::<Color>().unwrap(), Color::Rgb { r: 0, g: 255, b: 0 });
+        assert_eq!("#0000ff".parse::<Color>().unwrap(), Color::Rgb { r: 0, g: 0, b: 255 });
+        assert_eq!(
+            "#abcdef".parse::<Color>().unwrap(),
+            Color::Rgb {
+                r: 171,
+                g: 205,
+                b: 239
+            }
+        );
+    }
+
+    #[test]
+    fn test_color_parse_hex_short() {
+        // #rgb expands to #rrggbb
+        assert_eq!("#f00".parse::<Color>().unwrap(), Color::Rgb { r: 255, g: 0, b: 0 });
+        assert_eq!("#0f0".parse::<Color>().unwrap(), Color::Rgb { r: 0, g: 255, b: 0 });
+        assert_eq!(
+            "#abc".parse::<Color>().unwrap(),
+            Color::Rgb {
+                r: 170,
+                g: 187,
+                b: 204
+            }
+        );
+    }
+
+    #[test]
+    fn test_color_parse_ansi() {
+        assert_eq!("ansi:196".parse::<Color>().unwrap(), Color::AnsiValue(196));
+        assert_eq!("ansi:0".parse::<Color>().unwrap(), Color::AnsiValue(0));
+        assert_eq!("ansi:255".parse::<Color>().unwrap(), Color::AnsiValue(255));
+        assert_eq!("ANSI:100".parse::<Color>().unwrap(), Color::AnsiValue(100));
+    }
+
+    #[test]
+    fn test_color_parse_rgb_func() {
+        assert_eq!("rgb(255,0,0)".parse::<Color>().unwrap(), Color::Rgb { r: 255, g: 0, b: 0 });
+        assert_eq!("rgb(0, 255, 0)".parse::<Color>().unwrap(), Color::Rgb { r: 0, g: 255, b: 0 });
+        assert_eq!(
+            "RGB(100,150,200)".parse::<Color>().unwrap(),
+            Color::Rgb {
+                r: 100,
+                g: 150,
+                b: 200
+            }
+        );
+    }
+
+    #[test]
+    fn test_color_parse_errors() {
+        assert!("#ff00".parse::<Color>().is_err()); // Wrong length
+        assert!("#gggggg".parse::<Color>().is_err()); // Invalid hex
+        assert!("ansi:300".parse::<Color>().is_err()); // Out of range
+        assert!("unknown".parse::<Color>().is_err()); // Unknown name
+        assert!("rgb(1,2)".parse::<Color>().is_err()); // Missing component
+    }
+
+    #[test]
+    fn test_color_display() {
+        assert_eq!(Color::Red.to_string(), "red");
+        assert_eq!(Color::DarkBlue.to_string(), "darkblue");
+        assert_eq!(Color::Reset.to_string(), "default");
+        assert_eq!(Color::Rgb { r: 255, g: 0, b: 0 }.to_string(), "#ff0000");
+        assert_eq!(
+            Color::Rgb {
+                r: 171,
+                g: 205,
+                b: 239
+            }
+            .to_string(),
+            "#abcdef"
+        );
+        assert_eq!(Color::AnsiValue(196).to_string(), "ansi:196");
+    }
+
+    #[test]
+    fn test_color_roundtrip() {
+        // All named colors should roundtrip
+        let named_colors = [
+            Color::Reset,
+            Color::Black,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::Blue,
+            Color::Magenta,
+            Color::Cyan,
+            Color::White,
+            Color::Grey,
+            Color::DarkGrey,
+            Color::DarkRed,
+            Color::DarkGreen,
+            Color::DarkYellow,
+            Color::DarkBlue,
+            Color::DarkMagenta,
+            Color::DarkCyan,
+        ];
+        for color in named_colors {
+            let s = color.to_string();
+            let parsed: Color = s.parse().unwrap();
+            assert_eq!(parsed, color, "roundtrip failed for {color:?}");
+        }
+
+        // RGB colors should roundtrip
+        let rgb_colors = [
+            Color::Rgb { r: 255, g: 0, b: 0 },
+            Color::Rgb { r: 0, g: 255, b: 0 },
+            Color::Rgb { r: 0, g: 0, b: 255 },
+            Color::Rgb {
+                r: 171,
+                g: 205,
+                b: 239,
+            },
+        ];
+        for color in rgb_colors {
+            let s = color.to_string();
+            let parsed: Color = s.parse().unwrap();
+            assert_eq!(parsed, color, "roundtrip failed for {color:?}");
+        }
+
+        // ANSI colors should roundtrip
+        for n in [0, 15, 100, 196, 255] {
+            let color = Color::AnsiValue(n);
+            let s = color.to_string();
+            let parsed: Color = s.parse().unwrap();
+            assert_eq!(parsed, color, "roundtrip failed for {color:?}");
+        }
+    }
+
+    #[test]
+    fn test_color_parse_convenience() {
+        assert_eq!(Color::parse("red"), Some(Color::Red));
+        assert_eq!(Color::parse("#ff0000"), Some(Color::Rgb { r: 255, g: 0, b: 0 }));
+        assert_eq!(Color::parse("invalid"), None);
+    }
+
+    // =========================================================================
+    // Existing Tests
+    // =========================================================================
 
     #[test]
     fn test_modifiers_operations() {

--- a/lib/drivers/display/src/decoration/key.rs
+++ b/lib/drivers/display/src/decoration/key.rs
@@ -1,0 +1,136 @@
+//! Decoration provider key - typed key for decoration provider lookup.
+
+use std::sync::Arc;
+
+use reovim_kernel::api::v1::ServiceKey;
+
+/// Typed key for per-buffer decoration provider lookup.
+///
+/// Used with `DecorationProviderFactory` to create per-buffer providers.
+/// For global providers that take `buffer_id`, use `DecorationSourceKey`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DecorationProviderKey {
+    /// Syntax highlighting provider (per-buffer).
+    Syntax,
+    /// Diagnostic markers (LSP, per-buffer).
+    Diagnostic,
+}
+
+impl ServiceKey for DecorationProviderKey {
+    fn service_name() -> &'static str {
+        "DecorationProvider"
+    }
+}
+
+/// String-based key for global buffer decoration source lookup.
+///
+/// Modules define their own keys using a namespace convention:
+/// - `"pair.rainbow"` (from pair module)
+/// - `"search.match"` (from search module)
+/// - `"visual.selection"` (from editor/vim module)
+///
+/// # Architecture
+///
+/// This is purely **mechanism** - the driver defines the key type but has
+/// zero knowledge of which modules exist or what keys they register.
+///
+/// ```text
+/// lib/drivers/display/   -> DecorationSourceKey (mechanism)
+/// modules/pair/          -> "pair.rainbow" key (policy)
+/// modules/search/        -> "search.match" key (policy)
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_driver_display::DecorationSourceKey;
+///
+/// // Module defines its key
+/// const RAINBOW_KEY: &str = "pair.rainbow";
+///
+/// // In init():
+/// let key = DecorationSourceKey::new(RAINBOW_KEY);
+/// registry.register(key, state.clone());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DecorationSourceKey(Arc<str>);
+
+impl DecorationSourceKey {
+    /// Create a new decoration source key.
+    ///
+    /// # Convention
+    ///
+    /// Use format: `<module>.<feature>` (e.g., `"pair.rainbow"`, `"search.match"`)
+    #[must_use]
+    pub fn new(key: impl Into<Arc<str>>) -> Self {
+        Self(key.into())
+    }
+
+    /// Get the key as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&'static str> for DecorationSourceKey {
+    fn from(s: &'static str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for DecorationSourceKey {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl ServiceKey for DecorationSourceKey {
+    fn service_name() -> &'static str {
+        "BufferDecorationSource"
+    }
+}
+
+impl std::fmt::Display for DecorationSourceKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decoration_source_key_new() {
+        let key = DecorationSourceKey::new("pair.rainbow");
+        assert_eq!(key.as_str(), "pair.rainbow");
+    }
+
+    #[test]
+    fn test_decoration_source_key_from_static() {
+        let key: DecorationSourceKey = "search.match".into();
+        assert_eq!(key.as_str(), "search.match");
+    }
+
+    #[test]
+    fn test_decoration_source_key_from_string() {
+        let key: DecorationSourceKey = String::from("visual.selection").into();
+        assert_eq!(key.as_str(), "visual.selection");
+    }
+
+    #[test]
+    fn test_decoration_source_key_equality() {
+        let key1 = DecorationSourceKey::new("pair.rainbow");
+        let key2 = DecorationSourceKey::new("pair.rainbow");
+        let key3 = DecorationSourceKey::new("other");
+        assert_eq!(key1, key2);
+        assert_ne!(key1, key3);
+    }
+
+    #[test]
+    fn test_decoration_source_key_display() {
+        let key = DecorationSourceKey::new("pair.rainbow");
+        assert_eq!(key.to_string(), "pair.rainbow");
+    }
+}

--- a/lib/drivers/display/src/decoration/mod.rs
+++ b/lib/drivers/display/src/decoration/mod.rs
@@ -50,13 +50,17 @@
 //! ```
 
 mod conceal;
+mod key;
 mod provider;
+mod registry;
 mod store;
 mod types;
 
 pub use {
     conceal::{ConcealedLine, apply_conceals, display_to_source_col, source_to_display_col},
-    provider::{DecorationProvider, DecorationProviderFactory},
+    key::{DecorationProviderKey, DecorationSourceKey},
+    provider::{BufferDecorationSource, DecorationProvider, DecorationProviderFactory},
+    registry::{BufferDecorationSourceRegistry, DecorationProviderRegistry},
     store::{BufferDecorations, DecorationRef, DecorationStore},
     types::{Decoration, DecorationGroup, Span},
 };

--- a/lib/drivers/display/src/decoration/provider.rs
+++ b/lib/drivers/display/src/decoration/provider.rs
@@ -2,8 +2,28 @@
 //!
 //! Plugins implement `DecorationProvider` to supply decorations for their
 //! specific functionality (e.g., markdown concealment, search highlighting).
+//!
+//! Two provider types are available:
+//!
+//! - `DecorationProvider`: Per-buffer provider, refreshed with buffer content
+//! - `BufferDecorationSource`: Global provider that takes `buffer_id` in queries
+//!
+//! # Architecture
+//!
+//! ```text
+//! Per-buffer: DecorationProvider (created by factory for each buffer)
+//!   - Markdown concealment
+//!   - Syntax highlighting
+//!
+//! Global: BufferDecorationSource (single instance, queries with buffer_id)
+//!   - Rainbow brackets (SharedPairState)
+//!   - Search highlighting
+//! ```
 
-use super::types::{Decoration, DecorationGroup};
+use {
+    super::types::{Decoration, DecorationGroup},
+    reovim_kernel::api::v1::BufferId,
+};
 
 /// Trait for decoration sources.
 ///
@@ -78,6 +98,68 @@ pub trait DecorationProviderFactory: Send + Sync {
     fn supported_languages(&self) -> &[&str] {
         &[]
     }
+}
+
+// ============================================================================
+// Buffer Decoration Source (global providers with buffer_id awareness)
+// ============================================================================
+
+/// Trait for global decoration sources that manage state across all buffers.
+///
+/// Unlike `DecorationProvider` which is per-buffer, `BufferDecorationSource`
+/// maintains global state and accepts `buffer_id` in queries. This is suitable
+/// for features like rainbow brackets where a single service tracks all buffers.
+///
+/// # Example
+///
+/// ```ignore
+/// // Pair module implements this trait
+/// impl BufferDecorationSource for SharedPairState {
+///     fn name(&self) -> &'static str { "rainbow-brackets" }
+///     fn group(&self) -> DecorationGroup { DecorationGroup::Syntax }
+///
+///     fn decorations_for_buffer(
+///         &self,
+///         buffer_id: BufferId,
+///         content: &str,
+///         cursor: (usize, usize),
+///     ) -> Vec<Decoration> {
+///         // Generate rainbow bracket decorations for this buffer
+///     }
+/// }
+/// ```
+///
+/// # Architecture
+///
+/// This follows mechanism/policy separation:
+/// - **Mechanism** (this driver): Trait definition
+/// - **Policy** (modules): Implementations like `SharedPairState`
+pub trait BufferDecorationSource: Send + Sync {
+    /// Source name for debugging and logging.
+    fn name(&self) -> &'static str;
+
+    /// Priority group for layering.
+    ///
+    /// Decorations from higher-priority groups override those from lower groups.
+    fn group(&self) -> DecorationGroup;
+
+    /// Get decorations for a specific buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer_id` - The buffer to get decorations for
+    /// * `content` - Current buffer content (for computing bracket positions)
+    /// * `cursor` - Current cursor position (line, col) for matched pair highlighting
+    ///
+    /// # Returns
+    ///
+    /// Vector of decorations for the buffer
+    fn decorations_for_buffer(
+        &self,
+        buffer_id: BufferId,
+        content: &str,
+        cursor: (usize, usize),
+    ) -> Vec<Decoration>;
 }
 
 #[cfg(test)]

--- a/lib/drivers/display/src/decoration/registry.rs
+++ b/lib/drivers/display/src/decoration/registry.rs
@@ -1,0 +1,57 @@
+//! Decoration provider registry.
+//!
+//! Provides type-safe lookup for decoration providers registered by modules.
+
+use {
+    super::{
+        key::{DecorationProviderKey, DecorationSourceKey},
+        provider::{BufferDecorationSource, DecorationProvider},
+    },
+    reovim_kernel::api::v1::MultiServiceRegistry,
+};
+
+/// Registry for per-buffer decoration providers, keyed by type.
+///
+/// Used with `DecorationProviderFactory` pattern for per-buffer providers.
+/// For global providers with `buffer_id` awareness, use `BufferDecorationSourceRegistry`.
+///
+/// # Architecture
+///
+/// This follows the mechanism/policy separation:
+/// - **Mechanism** (this driver): Registry and key types
+/// - **Policy** (modules): Actual provider implementations
+pub type DecorationProviderRegistry =
+    MultiServiceRegistry<DecorationProviderKey, dyn DecorationProvider>;
+
+/// Registry for global buffer decoration sources, keyed by string-based keys.
+///
+/// Modules register their decoration sources during init using string keys.
+/// The runner queries providers generically without knowing about specific modules.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_driver_display::decoration::{
+///     DecorationSourceKey, BufferDecorationSourceRegistry,
+/// };
+///
+/// // Module registers source during init
+/// let registry = BufferDecorationSourceRegistry::new();
+/// let key = DecorationSourceKey::new("pair.rainbow");
+/// registry.register(key, Arc::new(pair_state));
+///
+/// // Runner iterates all sources generically
+/// for key in registry.keys() {
+///     if let Some(source) = registry.get(&key) {
+///         let decorations = source.decorations_for_buffer(buffer_id, content, cursor);
+///     }
+/// }
+/// ```
+///
+/// # Architecture
+///
+/// This follows the mechanism/policy separation:
+/// - **Mechanism** (this driver): Registry and key types
+/// - **Policy** (modules): Key definitions and source implementations
+pub type BufferDecorationSourceRegistry =
+    MultiServiceRegistry<DecorationSourceKey, dyn BufferDecorationSource>;

--- a/lib/drivers/display/src/highlight.rs
+++ b/lib/drivers/display/src/highlight.rs
@@ -4,6 +4,8 @@
 //! dependency cycle. The display driver owns these types as they are
 //! fundamentally about display/rendering.
 
+use std::{fmt, str::FromStr};
+
 use reovim_arch::Color;
 
 // =============================================================================
@@ -130,6 +132,111 @@ impl Attributes {
             || self.contains(Self::CURLY_UNDERLINE)
             || self.contains(Self::DOTTED_UNDERLINE)
             || self.contains(Self::DASHED_UNDERLINE)
+    }
+}
+
+/// Parse comma-separated attribute names into `Attributes`.
+///
+/// # Supported Names
+///
+/// Standard: `bold`, `italic`, `underline`, `strikethrough`, `reverse`, `blink`, `dim`
+/// Extended: `double_underline`, `curly_underline`, `dotted_underline`, `dashed_underline`,
+///           `overline`, `hidden`
+///
+/// # Example
+///
+/// ```ignore
+/// let attrs: Attributes = "bold,italic,underline".parse().unwrap();
+/// assert!(attrs.contains(Attributes::BOLD));
+/// ```
+impl FromStr for Attributes {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut attrs = Self::new();
+        for attr in s.split(',') {
+            match attr.trim().to_lowercase().as_str() {
+                "bold" => attrs.set(Self::BOLD),
+                "italic" => attrs.set(Self::ITALIC),
+                "underline" => attrs.set(Self::UNDERLINE),
+                "strikethrough" => attrs.set(Self::STRIKETHROUGH),
+                "reverse" => attrs.set(Self::REVERSE),
+                "blink" => attrs.set(Self::BLINK),
+                "dim" => attrs.set(Self::DIM),
+                "double_underline" => attrs.set(Self::DOUBLE_UNDERLINE),
+                "curly_underline" => attrs.set(Self::CURLY_UNDERLINE),
+                "dotted_underline" => attrs.set(Self::DOTTED_UNDERLINE),
+                "dashed_underline" => attrs.set(Self::DASHED_UNDERLINE),
+                "overline" => attrs.set(Self::OVERLINE),
+                "hidden" => attrs.set(Self::HIDDEN),
+                _ => {} // Ignore unknown attributes
+            }
+        }
+        Ok(attrs)
+    }
+}
+
+/// Display attributes as comma-separated canonical names.
+///
+/// The output order is deterministic: standard attributes first (in bit order),
+/// then extended attributes.
+///
+/// # Example
+///
+/// ```ignore
+/// let attrs = Attributes::new();
+/// attrs.set(Attributes::BOLD);
+/// attrs.set(Attributes::ITALIC);
+/// assert_eq!(attrs.to_string(), "bold,italic");
+/// ```
+impl fmt::Display for Attributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut parts = Vec::new();
+
+        // Standard attributes (bits 0-6)
+        if self.contains(Self::BOLD) {
+            parts.push("bold");
+        }
+        if self.contains(Self::ITALIC) {
+            parts.push("italic");
+        }
+        if self.contains(Self::UNDERLINE) {
+            parts.push("underline");
+        }
+        if self.contains(Self::STRIKETHROUGH) {
+            parts.push("strikethrough");
+        }
+        if self.contains(Self::REVERSE) {
+            parts.push("reverse");
+        }
+        if self.contains(Self::BLINK) {
+            parts.push("blink");
+        }
+        if self.contains(Self::DIM) {
+            parts.push("dim");
+        }
+
+        // Extended attributes (bits 7-12)
+        if self.contains(Self::DOUBLE_UNDERLINE) {
+            parts.push("double_underline");
+        }
+        if self.contains(Self::CURLY_UNDERLINE) {
+            parts.push("curly_underline");
+        }
+        if self.contains(Self::DOTTED_UNDERLINE) {
+            parts.push("dotted_underline");
+        }
+        if self.contains(Self::DASHED_UNDERLINE) {
+            parts.push("dashed_underline");
+        }
+        if self.contains(Self::OVERLINE) {
+            parts.push("overline");
+        }
+        if self.contains(Self::HIDDEN) {
+            parts.push("hidden");
+        }
+
+        write!(f, "{}", parts.join(","))
     }
 }
 
@@ -352,6 +459,48 @@ impl Style {
     #[must_use]
     pub const fn ansi_reset() -> &'static str {
         RESET_STYLE
+    }
+
+    /// Build `Style` from wire format strings (RPC deserialization).
+    ///
+    /// This is the inverse of the JSON cell format used in `screen_content`.
+    /// Uses `Color::parse()` for colors and `Attributes::from_str()` for attributes.
+    ///
+    /// # Wire Format
+    ///
+    /// The special value `"default"` means "no color specified - use terminal default".
+    /// This is different from `Color::Reset` which explicitly resets styling.
+    ///
+    /// # Arguments
+    ///
+    /// * `fg` - Foreground color string (e.g., "red", "#ff0000", "ansi:196", "default")
+    /// * `bg` - Background color string
+    /// * `attrs` - Comma-separated attribute names (e.g., "bold,italic")
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let style = Style::from_wire(Some("red"), Some("#000000"), Some("bold,underline"));
+    /// assert_eq!(style.fg, Some(Color::Red));
+    /// assert!(style.attributes.contains(Attributes::BOLD));
+    /// ```
+    #[must_use]
+    pub fn from_wire(fg: Option<&str>, bg: Option<&str>, attrs: Option<&str>) -> Self {
+        // Helper: parse color, treating "default" as None (terminal default)
+        let parse_wire_color = |s: &str| -> Option<Color> {
+            if s == "default" {
+                None
+            } else {
+                Color::parse(s)
+            }
+        };
+
+        Self {
+            fg: fg.and_then(parse_wire_color),
+            bg: bg.and_then(parse_wire_color),
+            attributes: attrs.map_or_else(Attributes::new, |s| s.parse().unwrap_or_default()),
+            underline_color: None,
+        }
     }
 }
 
@@ -614,5 +763,149 @@ mod tests {
         let rgb = Color::Rgb { r: 255, g: 0, b: 0 };
         let converted = downgrade_color(rgb, ColorMode::Color256);
         assert!(matches!(converted, Color::AnsiValue(_)));
+    }
+
+    // =========================================================================
+    // Attributes FromStr / Display tests
+    // =========================================================================
+
+    #[test]
+    fn test_attributes_from_str_single() {
+        let attrs: Attributes = "bold".parse().unwrap();
+        assert!(attrs.contains(Attributes::BOLD));
+        assert!(!attrs.contains(Attributes::ITALIC));
+    }
+
+    #[test]
+    fn test_attributes_from_str_multiple() {
+        let attrs: Attributes = "bold,italic,underline".parse().unwrap();
+        assert!(attrs.contains(Attributes::BOLD));
+        assert!(attrs.contains(Attributes::ITALIC));
+        assert!(attrs.contains(Attributes::UNDERLINE));
+        assert!(!attrs.contains(Attributes::REVERSE));
+    }
+
+    #[test]
+    fn test_attributes_from_str_case_insensitive() {
+        let attrs: Attributes = "BOLD,Italic,UNDERLINE".parse().unwrap();
+        assert!(attrs.contains(Attributes::BOLD));
+        assert!(attrs.contains(Attributes::ITALIC));
+        assert!(attrs.contains(Attributes::UNDERLINE));
+    }
+
+    #[test]
+    fn test_attributes_from_str_with_spaces() {
+        let attrs: Attributes = "bold , italic , underline".parse().unwrap();
+        assert!(attrs.contains(Attributes::BOLD));
+        assert!(attrs.contains(Attributes::ITALIC));
+        assert!(attrs.contains(Attributes::UNDERLINE));
+    }
+
+    #[test]
+    fn test_attributes_from_str_extended() {
+        let attrs: Attributes = "curly_underline,overline,hidden".parse().unwrap();
+        assert!(attrs.contains(Attributes::CURLY_UNDERLINE));
+        assert!(attrs.contains(Attributes::OVERLINE));
+        assert!(attrs.contains(Attributes::HIDDEN));
+    }
+
+    #[test]
+    fn test_attributes_from_str_unknown_ignored() {
+        let attrs: Attributes = "bold,foobar,italic".parse().unwrap();
+        assert!(attrs.contains(Attributes::BOLD));
+        assert!(attrs.contains(Attributes::ITALIC));
+    }
+
+    #[test]
+    fn test_attributes_display_single() {
+        let mut attrs = Attributes::new();
+        attrs.set(Attributes::BOLD);
+        assert_eq!(attrs.to_string(), "bold");
+    }
+
+    #[test]
+    fn test_attributes_display_multiple() {
+        let mut attrs = Attributes::new();
+        attrs.set(Attributes::BOLD);
+        attrs.set(Attributes::ITALIC);
+        attrs.set(Attributes::UNDERLINE);
+        assert_eq!(attrs.to_string(), "bold,italic,underline");
+    }
+
+    #[test]
+    fn test_attributes_display_empty() {
+        let attrs = Attributes::new();
+        assert_eq!(attrs.to_string(), "");
+    }
+
+    #[test]
+    fn test_attributes_roundtrip() {
+        // Test that parse(to_string()) == original
+        let mut original = Attributes::new();
+        original.set(Attributes::BOLD);
+        original.set(Attributes::ITALIC);
+        original.set(Attributes::CURLY_UNDERLINE);
+
+        let s = original.to_string();
+        let parsed: Attributes = s.parse().unwrap();
+        assert_eq!(parsed.0, original.0);
+    }
+
+    // =========================================================================
+    // Style::from_wire tests
+    // =========================================================================
+
+    #[test]
+    fn test_style_from_wire_full() {
+        let style = Style::from_wire(Some("red"), Some("#000000"), Some("bold,italic"));
+        assert_eq!(style.fg, Some(Color::Red));
+        assert_eq!(style.bg, Some(Color::Rgb { r: 0, g: 0, b: 0 }));
+        assert!(style.attributes.contains(Attributes::BOLD));
+        assert!(style.attributes.contains(Attributes::ITALIC));
+    }
+
+    #[test]
+    fn test_style_from_wire_colors_only() {
+        let style = Style::from_wire(Some("blue"), Some("ansi:196"), None);
+        assert_eq!(style.fg, Some(Color::Blue));
+        assert_eq!(style.bg, Some(Color::AnsiValue(196)));
+        assert_eq!(style.attributes.0, 0);
+    }
+
+    #[test]
+    fn test_style_from_wire_none() {
+        let style = Style::from_wire(None, None, None);
+        assert!(style.fg.is_none());
+        assert!(style.bg.is_none());
+        assert_eq!(style.attributes.0, 0);
+    }
+
+    #[test]
+    fn test_style_from_wire_default_color() {
+        // "default" means no color (uses terminal default)
+        let style = Style::from_wire(Some("default"), Some("default"), None);
+        assert!(style.fg.is_none());
+        assert!(style.bg.is_none());
+    }
+
+    #[test]
+    fn test_style_from_wire_hex_colors() {
+        let style = Style::from_wire(Some("#ff5500"), Some("#003366"), None);
+        assert_eq!(
+            style.fg,
+            Some(Color::Rgb {
+                r: 255,
+                g: 85,
+                b: 0
+            })
+        );
+        assert_eq!(
+            style.bg,
+            Some(Color::Rgb {
+                r: 0,
+                g: 51,
+                b: 102
+            })
+        );
     }
 }

--- a/lib/drivers/display/src/layout/compositor.rs
+++ b/lib/drivers/display/src/layout/compositor.rs
@@ -264,6 +264,9 @@ pub trait WindowLayerCompositor: Send + Sync {
     /// Bring to front within float zone.
     fn raise_float(&mut self, window: WindowId);
 
+    /// Send to back within float zone.
+    fn lower_float(&mut self, window: WindowId);
+
     /// Close floating window.
     fn close_float(&mut self, window: WindowId);
 

--- a/lib/drivers/display/src/layout/compositor.rs
+++ b/lib/drivers/display/src/layout/compositor.rs
@@ -277,12 +277,13 @@ pub trait WindowLayerCompositor: Send + Sync {
     fn toggle_float(&mut self, window: WindowId);
 
     // ========================================================================
-    // Overlay Zone
+    // Overlay Zone (#399)
     // ========================================================================
 
     /// Show overlay with constraints.
     ///
     /// Creates a new overlay positioned according to the constraints.
+    /// Overlays do NOT auto-focus (they are temporary UI above content).
     fn show_overlay(&mut self, constraints: OverlayConstraints) -> WindowId;
 
     /// Hide overlay.
@@ -290,6 +291,9 @@ pub trait WindowLayerCompositor: Send + Sync {
 
     /// Update overlay size.
     fn resize_overlay(&mut self, window: WindowId, width: u16, height: u16);
+
+    /// Hide all overlays in this layer.
+    fn hide_all_overlays(&mut self);
 
     // ========================================================================
     // Focus

--- a/lib/drivers/display/src/layout/overlay.rs
+++ b/lib/drivers/display/src/layout/overlay.rs
@@ -4,9 +4,15 @@
 //! all other windows, such as autocomplete popups, hover documentation,
 //! and command palettes.
 //!
-//! # Future Work
+//! # Anchor Resolution
 //!
-//! This trait will be implemented in Phase 3 (#399).
+//! Overlays use anchor-based positioning. The `arrange()` method receives
+//! `window_placements` from the compositor so that anchors like `Cursor`
+//! and `Below` can resolve positions relative to other windows.
+//!
+//! # Implementation
+//!
+//! See `modules/layout/src/overlayzone.rs` for the policy implementation.
 
 use {
     super::layer::{OverlayConstraints, WindowPlacement, ZOrder},
@@ -41,11 +47,14 @@ pub trait OverlayLayer: Send + Sync {
     /// # Arguments
     ///
     /// * `screen` - Screen bounds for computing overlay positions
+    /// * `window_placements` - Existing window placements from tiled/float zones,
+    ///   used for anchor resolution (e.g., `Anchor::Cursor` needs to know where
+    ///   the referenced window is positioned)
     ///
     /// # Returns
     ///
     /// Window placements sorted by z-order (lowest first).
-    fn arrange(&self, screen: Rect) -> Vec<WindowPlacement>;
+    fn arrange(&self, screen: Rect, window_placements: &[WindowPlacement]) -> Vec<WindowPlacement>;
 
     /// Show an overlay with constraints.
     ///

--- a/lib/drivers/display/src/lib.rs
+++ b/lib/drivers/display/src/lib.rs
@@ -129,9 +129,10 @@ pub use builder::{ComponentId, DisplayInfo, DisplayInfoBuilder, DisplayRegistry}
 // ============================================================================
 
 pub use decoration::{
-    BufferDecorations, ConcealedLine, Decoration, DecorationGroup, DecorationProvider,
-    DecorationProviderFactory, DecorationRef, DecorationStore, Span, apply_conceals,
-    display_to_source_col, source_to_display_col,
+    BufferDecorationSource, BufferDecorationSourceRegistry, BufferDecorations, ConcealedLine,
+    Decoration, DecorationGroup, DecorationProvider, DecorationProviderFactory,
+    DecorationProviderKey, DecorationProviderRegistry, DecorationRef, DecorationSourceKey,
+    DecorationStore, Span, apply_conceals, display_to_source_col, source_to_display_col,
 };
 
 // ============================================================================
@@ -140,7 +141,7 @@ pub use decoration::{
 
 pub use style::{
     BuiltinFileIconProvider, BuiltinTheme, IconDef, IconProvider, IconRegistry, IconSet,
-    ThemeManager, ThemeProvider,
+    StyleGroupRegistry, ThemeManager, ThemeProvider,
 };
 
 // ============================================================================

--- a/lib/drivers/display/src/style/builtin.rs
+++ b/lib/drivers/display/src/style/builtin.rs
@@ -1,12 +1,15 @@
 //! Built-in theme color definitions.
 //!
-//! Each theme provides complete color definitions for all 34 highlight groups.
+//! Each theme provides complete color definitions for all 34 built-in highlight groups.
 //! Uses `std::sync::LazyLock` for efficient one-time initialization.
 //!
 //! # Architecture
 //!
 //! This is part of the **mechanism layer**. It provides the actual color data
 //! that themes need, but doesn't decide WHEN to use these colors (that's policy).
+//!
+//! Module-specific groups (e.g., rainbow brackets) are registered by modules
+//! via `StyleGroupRegistry` at runtime.
 //!
 //! # Available Themes
 //!

--- a/lib/drivers/display/src/style/builtin.rs
+++ b/lib/drivers/display/src/style/builtin.rs
@@ -1,0 +1,1155 @@
+//! Built-in theme color definitions.
+//!
+//! Each theme provides complete color definitions for all 34 highlight groups.
+//! Uses `std::sync::LazyLock` for efficient one-time initialization.
+//!
+//! # Architecture
+//!
+//! This is part of the **mechanism layer**. It provides the actual color data
+//! that themes need, but doesn't decide WHEN to use these colors (that's policy).
+//!
+//! # Available Themes
+//!
+//! - **Dark** (default): OneDark-inspired dark theme
+//! - **Light**: High-contrast light theme
+//! - **`TokyoNightOrange`**: Tokyo Night variant with orange accents
+
+use std::{collections::HashMap, sync::LazyLock};
+
+use reovim_arch::Color;
+
+use {super::groups, crate::highlight::Style};
+
+// =============================================================================
+// Dark Theme (OneDark-inspired)
+// =============================================================================
+
+/// Dark theme palette (OneDark-inspired).
+///
+/// Base colors:
+/// - Background: #282c34 (Dark grey-blue)
+/// - Foreground: #abb2bf (Light grey)
+static DARK_PALETTE: LazyLock<HashMap<&'static str, Style>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+
+    // -------------------------------------------------------------------------
+    // Syntax colors (13 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::KEYWORD,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 198,
+                g: 120,
+                b: 221,
+            }) // #c678dd Purple
+            .bold(),
+    );
+    m.insert(
+        groups::FUNCTION,
+        Style::new().fg(Color::Rgb {
+            r: 97,
+            g: 175,
+            b: 239,
+        }), // #61afef Blue
+    );
+    m.insert(
+        groups::TYPE,
+        Style::new().fg(Color::Rgb {
+            r: 229,
+            g: 192,
+            b: 123,
+        }), // #e5c07b Yellow
+    );
+    m.insert(
+        groups::STRING,
+        Style::new().fg(Color::Rgb {
+            r: 152,
+            g: 195,
+            b: 121,
+        }), // #98c379 Green
+    );
+    m.insert(
+        groups::NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 209,
+            g: 154,
+            b: 102,
+        }), // #d19a66 Orange
+    );
+    m.insert(
+        groups::COMMENT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 92,
+                g: 99,
+                b: 112,
+            }) // #5c6370 Grey
+            .italic(),
+    );
+    m.insert(
+        groups::OPERATOR,
+        Style::new().fg(Color::Rgb {
+            r: 86,
+            g: 182,
+            b: 194,
+        }), // #56b6c2 Cyan
+    );
+    m.insert(
+        groups::PUNCTUATION,
+        Style::new().fg(Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        }), // #abb2bf Foreground
+    );
+    m.insert(
+        groups::VARIABLE,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 108,
+            b: 117,
+        }), // #e06c75 Red
+    );
+    m.insert(
+        groups::CONSTANT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 209,
+                g: 154,
+                b: 102,
+            }) // #d19a66 Orange
+            .bold(),
+    );
+    m.insert(
+        groups::ATTRIBUTE,
+        Style::new().fg(Color::Rgb {
+            r: 229,
+            g: 192,
+            b: 123,
+        }), // #e5c07b Yellow
+    );
+    m.insert(
+        groups::PROPERTY,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 108,
+            b: 117,
+        }), // #e06c75 Red
+    );
+    m.insert(
+        groups::TAG,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 108,
+            b: 117,
+        }), // #e06c75 Red
+    );
+
+    // -------------------------------------------------------------------------
+    // UI colors (17 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::BACKGROUND,
+        Style::new().bg(Color::Rgb {
+            r: 40,
+            g: 44,
+            b: 52,
+        }), // #282c34
+    );
+    m.insert(
+        groups::FOREGROUND,
+        Style::new().fg(Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        }), // #abb2bf
+    );
+    m.insert(
+        groups::CURSOR,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 97,
+                g: 175,
+                b: 239,
+            }) // #61afef Blue
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            }), // #282c34
+    );
+    m.insert(
+        groups::SELECTION,
+        Style::new().bg(Color::Rgb {
+            r: 62,
+            g: 68,
+            b: 81,
+        }), // #3e4451
+    );
+    m.insert(
+        groups::LINE_NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 76,
+            g: 82,
+            b: 99,
+        }), // #4b5263
+    );
+    m.insert(
+        groups::LINE_NUMBER_ACTIVE,
+        Style::new().fg(Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        }), // #abb2bf
+    );
+
+    // Statusline
+    m.insert(
+        groups::STATUSLINE_BG,
+        Style::new().bg(Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        }), // #21252b
+    );
+    m.insert(
+        groups::STATUSLINE_FG,
+        Style::new().fg(Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        }), // #abb2bf
+    );
+
+    // Mode indicators
+    m.insert(
+        groups::MODE_NORMAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            })
+            .bg(Color::Rgb {
+                r: 97,
+                g: 175,
+                b: 239,
+            }) // Blue
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_INSERT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            })
+            .bg(Color::Rgb {
+                r: 152,
+                g: 195,
+                b: 121,
+            }) // Green
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_VISUAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            })
+            .bg(Color::Rgb {
+                r: 198,
+                g: 120,
+                b: 221,
+            }) // Purple
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_COMMAND,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            })
+            .bg(Color::Rgb {
+                r: 229,
+                g: 192,
+                b: 123,
+            }) // Yellow
+            .bold(),
+    );
+
+    // UI elements
+    m.insert(
+        groups::BORDER,
+        Style::new().fg(Color::Rgb {
+            r: 62,
+            g: 68,
+            b: 81,
+        }), // #3e4451
+    );
+    m.insert(
+        groups::POPUP_BG,
+        Style::new().bg(Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        }), // #21252b
+    );
+    m.insert(
+        groups::POPUP_FG,
+        Style::new().fg(Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        }), // #abb2bf
+    );
+    m.insert(
+        groups::MENU_SELECTED,
+        Style::new().bg(Color::Rgb {
+            r: 62,
+            g: 68,
+            b: 81,
+        }), // #3e4451
+    );
+    m.insert(
+        groups::SEARCH_MATCH,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 229,
+                g: 192,
+                b: 123,
+            }) // Yellow
+            .fg(Color::Rgb {
+                r: 40,
+                g: 44,
+                b: 52,
+            }), // Dark bg
+    );
+
+    // -------------------------------------------------------------------------
+    // Diagnostics (4 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::DIAGNOSTIC_ERROR,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 108,
+            b: 117,
+        }), // Red
+    );
+    m.insert(
+        groups::DIAGNOSTIC_WARN,
+        Style::new().fg(Color::Rgb {
+            r: 229,
+            g: 192,
+            b: 123,
+        }), // Yellow
+    );
+    m.insert(
+        groups::DIAGNOSTIC_INFO,
+        Style::new().fg(Color::Rgb {
+            r: 97,
+            g: 175,
+            b: 239,
+        }), // Blue
+    );
+    m.insert(
+        groups::DIAGNOSTIC_HINT,
+        Style::new().fg(Color::Rgb {
+            r: 86,
+            g: 182,
+            b: 194,
+        }), // Cyan
+    );
+
+    m
+});
+
+// =============================================================================
+// Light Theme
+// =============================================================================
+
+/// Light theme palette.
+///
+/// Base colors:
+/// - Background: #fafafa (Almost white)
+/// - Foreground: #383a42 (Dark grey)
+static LIGHT_PALETTE: LazyLock<HashMap<&'static str, Style>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+
+    // -------------------------------------------------------------------------
+    // Syntax colors (13 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::KEYWORD,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 166,
+                g: 38,
+                b: 164,
+            }) // #a626a4 Magenta
+            .bold(),
+    );
+    m.insert(
+        groups::FUNCTION,
+        Style::new().fg(Color::Rgb {
+            r: 64,
+            g: 120,
+            b: 242,
+        }), // #4078f2 Blue
+    );
+    m.insert(
+        groups::TYPE,
+        Style::new().fg(Color::Rgb {
+            r: 193,
+            g: 132,
+            b: 1,
+        }), // #c18401 Yellow
+    );
+    m.insert(
+        groups::STRING,
+        Style::new().fg(Color::Rgb {
+            r: 80,
+            g: 161,
+            b: 79,
+        }), // #50a14f Green
+    );
+    m.insert(
+        groups::NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 152,
+            g: 104,
+            b: 1,
+        }), // #986801 Orange
+    );
+    m.insert(
+        groups::COMMENT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 160,
+                g: 161,
+                b: 167,
+            }) // #a0a1a7 Grey
+            .italic(),
+    );
+    m.insert(
+        groups::OPERATOR,
+        Style::new().fg(Color::Rgb {
+            r: 1,
+            g: 132,
+            b: 188,
+        }), // #0184bc Cyan
+    );
+    m.insert(
+        groups::PUNCTUATION,
+        Style::new().fg(Color::Rgb {
+            r: 56,
+            g: 58,
+            b: 66,
+        }), // #383a42 Foreground
+    );
+    m.insert(
+        groups::VARIABLE,
+        Style::new().fg(Color::Rgb {
+            r: 228,
+            g: 86,
+            b: 73,
+        }), // #e45649 Red
+    );
+    m.insert(
+        groups::CONSTANT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 152,
+                g: 104,
+                b: 1,
+            }) // #986801 Orange
+            .bold(),
+    );
+    m.insert(
+        groups::ATTRIBUTE,
+        Style::new().fg(Color::Rgb {
+            r: 193,
+            g: 132,
+            b: 1,
+        }), // #c18401 Yellow
+    );
+    m.insert(
+        groups::PROPERTY,
+        Style::new().fg(Color::Rgb {
+            r: 228,
+            g: 86,
+            b: 73,
+        }), // #e45649 Red
+    );
+    m.insert(
+        groups::TAG,
+        Style::new().fg(Color::Rgb {
+            r: 228,
+            g: 86,
+            b: 73,
+        }), // #e45649 Red
+    );
+
+    // -------------------------------------------------------------------------
+    // UI colors (17 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::BACKGROUND,
+        Style::new().bg(Color::Rgb {
+            r: 250,
+            g: 250,
+            b: 250,
+        }), // #fafafa
+    );
+    m.insert(
+        groups::FOREGROUND,
+        Style::new().fg(Color::Rgb {
+            r: 56,
+            g: 58,
+            b: 66,
+        }), // #383a42
+    );
+    m.insert(
+        groups::CURSOR,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 64,
+                g: 120,
+                b: 242,
+            }) // Blue
+            .fg(Color::Rgb {
+                r: 250,
+                g: 250,
+                b: 250,
+            }), // White
+    );
+    m.insert(
+        groups::SELECTION,
+        Style::new().bg(Color::Rgb {
+            r: 216,
+            g: 222,
+            b: 233,
+        }), // Light blue-grey
+    );
+    m.insert(
+        groups::LINE_NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 160,
+            g: 161,
+            b: 167,
+        }), // Grey
+    );
+    m.insert(
+        groups::LINE_NUMBER_ACTIVE,
+        Style::new().fg(Color::Rgb {
+            r: 56,
+            g: 58,
+            b: 66,
+        }), // Dark
+    );
+
+    // Statusline
+    m.insert(
+        groups::STATUSLINE_BG,
+        Style::new().bg(Color::Rgb {
+            r: 233,
+            g: 233,
+            b: 236,
+        }), // #e9e9ec
+    );
+    m.insert(
+        groups::STATUSLINE_FG,
+        Style::new().fg(Color::Rgb {
+            r: 56,
+            g: 58,
+            b: 66,
+        }), // #383a42
+    );
+
+    // Mode indicators
+    m.insert(
+        groups::MODE_NORMAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 250,
+                g: 250,
+                b: 250,
+            })
+            .bg(Color::Rgb {
+                r: 64,
+                g: 120,
+                b: 242,
+            }) // Blue
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_INSERT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 250,
+                g: 250,
+                b: 250,
+            })
+            .bg(Color::Rgb {
+                r: 80,
+                g: 161,
+                b: 79,
+            }) // Green
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_VISUAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 250,
+                g: 250,
+                b: 250,
+            })
+            .bg(Color::Rgb {
+                r: 166,
+                g: 38,
+                b: 164,
+            }) // Magenta
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_COMMAND,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 56,
+                g: 58,
+                b: 66,
+            })
+            .bg(Color::Rgb {
+                r: 193,
+                g: 132,
+                b: 1,
+            }) // Yellow
+            .bold(),
+    );
+
+    // UI elements
+    m.insert(
+        groups::BORDER,
+        Style::new().fg(Color::Rgb {
+            r: 216,
+            g: 222,
+            b: 233,
+        }), // Light border
+    );
+    m.insert(
+        groups::POPUP_BG,
+        Style::new().bg(Color::Rgb {
+            r: 233,
+            g: 233,
+            b: 236,
+        }), // #e9e9ec
+    );
+    m.insert(
+        groups::POPUP_FG,
+        Style::new().fg(Color::Rgb {
+            r: 56,
+            g: 58,
+            b: 66,
+        }), // #383a42
+    );
+    m.insert(
+        groups::MENU_SELECTED,
+        Style::new().bg(Color::Rgb {
+            r: 216,
+            g: 222,
+            b: 233,
+        }), // Light blue-grey
+    );
+    m.insert(
+        groups::SEARCH_MATCH,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 193,
+                g: 132,
+                b: 1,
+            }) // Yellow
+            .fg(Color::Rgb {
+                r: 250,
+                g: 250,
+                b: 250,
+            }), // White
+    );
+
+    // -------------------------------------------------------------------------
+    // Diagnostics (4 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::DIAGNOSTIC_ERROR,
+        Style::new().fg(Color::Rgb {
+            r: 228,
+            g: 86,
+            b: 73,
+        }), // Red
+    );
+    m.insert(
+        groups::DIAGNOSTIC_WARN,
+        Style::new().fg(Color::Rgb {
+            r: 193,
+            g: 132,
+            b: 1,
+        }), // Yellow
+    );
+    m.insert(
+        groups::DIAGNOSTIC_INFO,
+        Style::new().fg(Color::Rgb {
+            r: 64,
+            g: 120,
+            b: 242,
+        }), // Blue
+    );
+    m.insert(
+        groups::DIAGNOSTIC_HINT,
+        Style::new().fg(Color::Rgb {
+            r: 1,
+            g: 132,
+            b: 188,
+        }), // Cyan
+    );
+
+    m
+});
+
+// =============================================================================
+// Tokyo Night Orange Theme
+// =============================================================================
+
+/// Tokyo Night Orange theme palette.
+///
+/// Based on Tokyo Night with orange accent.
+/// Background: #1a1b26
+static TOKYO_NIGHT_ORANGE_PALETTE: LazyLock<HashMap<&'static str, Style>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+
+    // -------------------------------------------------------------------------
+    // Syntax colors (13 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::KEYWORD,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 187,
+                g: 154,
+                b: 247,
+            }) // #bb9af7 Purple
+            .bold(),
+    );
+    m.insert(
+        groups::FUNCTION,
+        Style::new().fg(Color::Rgb {
+            r: 122,
+            g: 162,
+            b: 247,
+        }), // #7aa2f7 Blue
+    );
+    m.insert(
+        groups::TYPE,
+        Style::new().fg(Color::Rgb {
+            r: 255,
+            g: 158,
+            b: 100,
+        }), // #ff9e64 Orange
+    );
+    m.insert(
+        groups::STRING,
+        Style::new().fg(Color::Rgb {
+            r: 158,
+            g: 206,
+            b: 106,
+        }), // #9ece6a Green
+    );
+    m.insert(
+        groups::NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 255,
+            g: 158,
+            b: 100,
+        }), // #ff9e64 Orange
+    );
+    m.insert(
+        groups::COMMENT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 86,
+                g: 95,
+                b: 137,
+            }) // #565f89 Grey
+            .italic(),
+    );
+    m.insert(
+        groups::OPERATOR,
+        Style::new().fg(Color::Rgb {
+            r: 137,
+            g: 221,
+            b: 255,
+        }), // #89ddff Cyan
+    );
+    m.insert(
+        groups::PUNCTUATION,
+        Style::new().fg(Color::Rgb {
+            r: 169,
+            g: 177,
+            b: 214,
+        }), // #a9b1d6 Foreground
+    );
+    m.insert(
+        groups::VARIABLE,
+        Style::new().fg(Color::Rgb {
+            r: 247,
+            g: 118,
+            b: 142,
+        }), // #f7768e Red
+    );
+    m.insert(
+        groups::CONSTANT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 255,
+                g: 158,
+                b: 100,
+            }) // #ff9e64 Orange
+            .bold(),
+    );
+    m.insert(
+        groups::ATTRIBUTE,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 175,
+            b: 104,
+        }), // #e0af68 Yellow
+    );
+    m.insert(
+        groups::PROPERTY,
+        Style::new().fg(Color::Rgb {
+            r: 115,
+            g: 218,
+            b: 202,
+        }), // #73daca Teal
+    );
+    m.insert(
+        groups::TAG,
+        Style::new().fg(Color::Rgb {
+            r: 247,
+            g: 118,
+            b: 142,
+        }), // #f7768e Red
+    );
+
+    // -------------------------------------------------------------------------
+    // UI colors (17 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::BACKGROUND,
+        Style::new().bg(Color::Rgb {
+            r: 26,
+            g: 27,
+            b: 38,
+        }), // #1a1b26
+    );
+    m.insert(
+        groups::FOREGROUND,
+        Style::new().fg(Color::Rgb {
+            r: 169,
+            g: 177,
+            b: 214,
+        }), // #a9b1d6
+    );
+    m.insert(
+        groups::CURSOR,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 255,
+                g: 158,
+                b: 100,
+            }) // Orange
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            }), // Dark bg
+    );
+    m.insert(
+        groups::SELECTION,
+        Style::new().bg(Color::Rgb {
+            r: 40,
+            g: 52,
+            b: 87,
+        }), // #283457
+    );
+    m.insert(
+        groups::LINE_NUMBER,
+        Style::new().fg(Color::Rgb {
+            r: 59,
+            g: 66,
+            b: 97,
+        }), // #3b4261
+    );
+    m.insert(
+        groups::LINE_NUMBER_ACTIVE,
+        Style::new().fg(Color::Rgb {
+            r: 255,
+            g: 158,
+            b: 100,
+        }), // Orange
+    );
+
+    // Statusline
+    m.insert(
+        groups::STATUSLINE_BG,
+        Style::new().bg(Color::Rgb {
+            r: 22,
+            g: 22,
+            b: 30,
+        }), // #16161e
+    );
+    m.insert(
+        groups::STATUSLINE_FG,
+        Style::new().fg(Color::Rgb {
+            r: 169,
+            g: 177,
+            b: 214,
+        }), // #a9b1d6
+    );
+
+    // Mode indicators (Orange theme accents)
+    m.insert(
+        groups::MODE_NORMAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            })
+            .bg(Color::Rgb {
+                r: 255,
+                g: 158,
+                b: 100,
+            }) // Orange
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_INSERT,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            })
+            .bg(Color::Rgb {
+                r: 158,
+                g: 206,
+                b: 106,
+            }) // Green
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_VISUAL,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            })
+            .bg(Color::Rgb {
+                r: 187,
+                g: 154,
+                b: 247,
+            }) // Purple
+            .bold(),
+    );
+    m.insert(
+        groups::MODE_COMMAND,
+        Style::new()
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            })
+            .bg(Color::Rgb {
+                r: 224,
+                g: 175,
+                b: 104,
+            }) // Yellow
+            .bold(),
+    );
+
+    // UI elements
+    m.insert(
+        groups::BORDER,
+        Style::new().fg(Color::Rgb {
+            r: 59,
+            g: 66,
+            b: 97,
+        }), // #3b4261
+    );
+    m.insert(
+        groups::POPUP_BG,
+        Style::new().bg(Color::Rgb {
+            r: 22,
+            g: 22,
+            b: 30,
+        }), // #16161e
+    );
+    m.insert(
+        groups::POPUP_FG,
+        Style::new().fg(Color::Rgb {
+            r: 169,
+            g: 177,
+            b: 214,
+        }), // #a9b1d6
+    );
+    m.insert(
+        groups::MENU_SELECTED,
+        Style::new().bg(Color::Rgb {
+            r: 40,
+            g: 52,
+            b: 87,
+        }), // #283457
+    );
+    m.insert(
+        groups::SEARCH_MATCH,
+        Style::new()
+            .bg(Color::Rgb {
+                r: 255,
+                g: 158,
+                b: 100,
+            }) // Orange
+            .fg(Color::Rgb {
+                r: 26,
+                g: 27,
+                b: 38,
+            }), // Dark bg
+    );
+
+    // -------------------------------------------------------------------------
+    // Diagnostics (4 groups)
+    // -------------------------------------------------------------------------
+    m.insert(
+        groups::DIAGNOSTIC_ERROR,
+        Style::new().fg(Color::Rgb {
+            r: 247,
+            g: 118,
+            b: 142,
+        }), // Red
+    );
+    m.insert(
+        groups::DIAGNOSTIC_WARN,
+        Style::new().fg(Color::Rgb {
+            r: 224,
+            g: 175,
+            b: 104,
+        }), // Yellow
+    );
+    m.insert(
+        groups::DIAGNOSTIC_INFO,
+        Style::new().fg(Color::Rgb {
+            r: 122,
+            g: 162,
+            b: 247,
+        }), // Blue
+    );
+    m.insert(
+        groups::DIAGNOSTIC_HINT,
+        Style::new().fg(Color::Rgb {
+            r: 115,
+            g: 218,
+            b: 202,
+        }), // Teal
+    );
+
+    m
+});
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Get the palette for a builtin theme variant.
+///
+/// Returns a reference to the lazily-initialized palette `HashMap`.
+pub fn get_palette(variant: super::BuiltinTheme) -> &'static HashMap<&'static str, Style> {
+    match variant {
+        super::BuiltinTheme::Dark => &DARK_PALETTE,
+        super::BuiltinTheme::Light => &LIGHT_PALETTE,
+        super::BuiltinTheme::TokyoNightOrange => &TOKYO_NIGHT_ORANGE_PALETTE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::highlight::Attributes};
+
+    #[test]
+    fn test_dark_palette_all_groups() {
+        let palette = &DARK_PALETTE;
+        for group in groups::ALL_GROUPS {
+            assert!(palette.contains_key(group), "Dark palette missing group: {group}");
+        }
+        assert_eq!(palette.len(), groups::ALL_GROUPS.len());
+    }
+
+    #[test]
+    fn test_light_palette_all_groups() {
+        let palette = &LIGHT_PALETTE;
+        for group in groups::ALL_GROUPS {
+            assert!(palette.contains_key(group), "Light palette missing group: {group}");
+        }
+        assert_eq!(palette.len(), groups::ALL_GROUPS.len());
+    }
+
+    #[test]
+    fn test_tokyo_night_palette_all_groups() {
+        let palette = &TOKYO_NIGHT_ORANGE_PALETTE;
+        for group in groups::ALL_GROUPS {
+            assert!(palette.contains_key(group), "TokyoNightOrange palette missing group: {group}");
+        }
+        assert_eq!(palette.len(), groups::ALL_GROUPS.len());
+    }
+
+    #[test]
+    fn test_get_palette_returns_correct_variant() {
+        let dark = get_palette(super::super::BuiltinTheme::Dark);
+        let light = get_palette(super::super::BuiltinTheme::Light);
+        let tokyo = get_palette(super::super::BuiltinTheme::TokyoNightOrange);
+
+        // Each should be different (they have different colors)
+        let dark_keyword = dark.get(groups::KEYWORD).unwrap();
+        let light_keyword = light.get(groups::KEYWORD).unwrap();
+        let tokyo_keyword = tokyo.get(groups::KEYWORD).unwrap();
+
+        assert_ne!(dark_keyword.fg, light_keyword.fg);
+        assert_ne!(dark_keyword.fg, tokyo_keyword.fg);
+    }
+
+    #[test]
+    fn test_dark_theme_has_bold_keywords() {
+        let palette = &DARK_PALETTE;
+        let keyword = palette.get(groups::KEYWORD).unwrap();
+        assert!(keyword.attributes.contains(Attributes::BOLD));
+    }
+
+    #[test]
+    fn test_all_themes_have_italic_comments() {
+        for variant in super::super::BuiltinTheme::all() {
+            let palette = get_palette(*variant);
+            let comment = palette.get(groups::COMMENT).unwrap();
+            assert!(
+                comment.attributes.contains(Attributes::ITALIC),
+                "{} theme should have italic comments",
+                variant.name()
+            );
+        }
+    }
+}

--- a/lib/drivers/display/src/style/groups.rs
+++ b/lib/drivers/display/src/style/groups.rs
@@ -15,6 +15,9 @@
 //! - **UI** (17 groups): Editor chrome like statusline, line numbers, borders
 //! - **Diagnostic** (4 groups): LSP diagnostics like errors and warnings
 //!
+//! Additional groups (e.g., rainbow brackets) are registered by modules via
+//! `StyleGroupRegistry` at runtime.
+//!
 //! # Example
 //!
 //! ```ignore
@@ -141,9 +144,11 @@ pub const DIAGNOSTIC_HINT: &str = "diagnostic.hint";
 // All Groups (for testing completeness)
 // ============================================================================
 
-/// All highlight groups (34 total).
+/// All built-in highlight groups (34 total).
 ///
 /// Used by tests to verify theme completeness.
+/// Additional groups (e.g., rainbow brackets) are registered by modules
+/// via `StyleGroupRegistry` at runtime.
 pub const ALL_GROUPS: &[&str] = &[
     // Syntax (13)
     KEYWORD,
@@ -191,6 +196,7 @@ mod tests {
     #[test]
     fn test_all_groups_count() {
         // 13 syntax + 17 UI + 4 diagnostic = 34 groups
+        // Module-specific groups (e.g., rainbow brackets) are registered via StyleGroupRegistry
         assert_eq!(ALL_GROUPS.len(), 34);
     }
 

--- a/lib/drivers/display/src/style/groups.rs
+++ b/lib/drivers/display/src/style/groups.rs
@@ -1,0 +1,258 @@
+//! Highlight group constants.
+//!
+//! Defines the standard highlight groups used by themes. Groups are string-based
+//! for flexibility; themes map group names to styles.
+//!
+//! # Architecture
+//!
+//! This is part of the **mechanism layer**. It defines WHAT highlight groups exist,
+//! but not HOW they are styled. Themes (in `builtin.rs`) provide the actual colors.
+//!
+//! # Groups
+//!
+//! Groups are organized into three categories:
+//! - **Syntax** (13 groups): Code elements like keywords, functions, strings
+//! - **UI** (17 groups): Editor chrome like statusline, line numbers, borders
+//! - **Diagnostic** (4 groups): LSP diagnostics like errors and warnings
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_display::style::groups;
+//!
+//! let style = theme.get_style(groups::KEYWORD);
+//! ```
+
+// ============================================================================
+// Syntax Groups (13 groups)
+// ============================================================================
+
+/// Keyword highlight (if, else, fn, let, match, loop, etc.)
+pub const KEYWORD: &str = "keyword";
+
+/// Function names
+pub const FUNCTION: &str = "function";
+
+/// Type names (struct, enum, trait)
+pub const TYPE: &str = "type";
+
+/// String literals ("hello")
+pub const STRING: &str = "string";
+
+/// Numeric literals (42, 3.14, 0xff)
+pub const NUMBER: &str = "number";
+
+/// Comments (// and /* */)
+pub const COMMENT: &str = "comment";
+
+/// Operators (+, -, *, /, =, ==)
+pub const OPERATOR: &str = "operator";
+
+/// Punctuation ((), {}, [], ;, :)
+pub const PUNCTUATION: &str = "punctuation";
+
+/// Variable names
+pub const VARIABLE: &str = "variable";
+
+/// Constants (`CONSTANT_NAME`)
+pub const CONSTANT: &str = "constant";
+
+/// Attributes (#[derive], @decorator)
+pub const ATTRIBUTE: &str = "attribute";
+
+/// Object/struct properties
+pub const PROPERTY: &str = "property";
+
+/// HTML/XML tags
+pub const TAG: &str = "tag";
+
+// ============================================================================
+// UI Groups (17 groups)
+// ============================================================================
+
+/// Default background color
+pub const BACKGROUND: &str = "background";
+
+/// Default foreground color
+pub const FOREGROUND: &str = "foreground";
+
+/// Cursor color
+pub const CURSOR: &str = "cursor";
+
+/// Visual selection highlight
+pub const SELECTION: &str = "selection";
+
+/// Line number column
+pub const LINE_NUMBER: &str = "line_number";
+
+/// Active/cursor line number
+pub const LINE_NUMBER_ACTIVE: &str = "line_number_active";
+
+/// Statusline background
+pub const STATUSLINE_BG: &str = "statusline_bg";
+
+/// Statusline foreground
+pub const STATUSLINE_FG: &str = "statusline_fg";
+
+/// Normal mode indicator
+pub const MODE_NORMAL: &str = "mode_normal";
+
+/// Insert mode indicator
+pub const MODE_INSERT: &str = "mode_insert";
+
+/// Visual mode indicator
+pub const MODE_VISUAL: &str = "mode_visual";
+
+/// Command mode indicator
+pub const MODE_COMMAND: &str = "mode_command";
+
+/// UI borders
+pub const BORDER: &str = "border";
+
+/// Popup/floating window background
+pub const POPUP_BG: &str = "popup_bg";
+
+/// Popup/floating window foreground
+pub const POPUP_FG: &str = "popup_fg";
+
+/// Menu selected item
+pub const MENU_SELECTED: &str = "menu_selected";
+
+/// Search match highlight
+pub const SEARCH_MATCH: &str = "search_match";
+
+// ============================================================================
+// Diagnostic Groups (4 groups)
+// ============================================================================
+
+/// Error diagnostic
+pub const DIAGNOSTIC_ERROR: &str = "diagnostic.error";
+
+/// Warning diagnostic
+pub const DIAGNOSTIC_WARN: &str = "diagnostic.warn";
+
+/// Info diagnostic
+pub const DIAGNOSTIC_INFO: &str = "diagnostic.info";
+
+/// Hint diagnostic
+pub const DIAGNOSTIC_HINT: &str = "diagnostic.hint";
+
+// ============================================================================
+// All Groups (for testing completeness)
+// ============================================================================
+
+/// All highlight groups (34 total).
+///
+/// Used by tests to verify theme completeness.
+pub const ALL_GROUPS: &[&str] = &[
+    // Syntax (13)
+    KEYWORD,
+    FUNCTION,
+    TYPE,
+    STRING,
+    NUMBER,
+    COMMENT,
+    OPERATOR,
+    PUNCTUATION,
+    VARIABLE,
+    CONSTANT,
+    ATTRIBUTE,
+    PROPERTY,
+    TAG,
+    // UI (17)
+    BACKGROUND,
+    FOREGROUND,
+    CURSOR,
+    SELECTION,
+    LINE_NUMBER,
+    LINE_NUMBER_ACTIVE,
+    STATUSLINE_BG,
+    STATUSLINE_FG,
+    MODE_NORMAL,
+    MODE_INSERT,
+    MODE_VISUAL,
+    MODE_COMMAND,
+    BORDER,
+    POPUP_BG,
+    POPUP_FG,
+    MENU_SELECTED,
+    SEARCH_MATCH,
+    // Diagnostic (4)
+    DIAGNOSTIC_ERROR,
+    DIAGNOSTIC_WARN,
+    DIAGNOSTIC_INFO,
+    DIAGNOSTIC_HINT,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_groups_count() {
+        // 13 syntax + 17 UI + 4 diagnostic = 34 groups
+        assert_eq!(ALL_GROUPS.len(), 34);
+    }
+
+    #[test]
+    fn test_syntax_groups_count() {
+        let syntax_groups = [
+            KEYWORD,
+            FUNCTION,
+            TYPE,
+            STRING,
+            NUMBER,
+            COMMENT,
+            OPERATOR,
+            PUNCTUATION,
+            VARIABLE,
+            CONSTANT,
+            ATTRIBUTE,
+            PROPERTY,
+            TAG,
+        ];
+        assert_eq!(syntax_groups.len(), 13);
+    }
+
+    #[test]
+    fn test_ui_groups_count() {
+        let ui_groups = [
+            BACKGROUND,
+            FOREGROUND,
+            CURSOR,
+            SELECTION,
+            LINE_NUMBER,
+            LINE_NUMBER_ACTIVE,
+            STATUSLINE_BG,
+            STATUSLINE_FG,
+            MODE_NORMAL,
+            MODE_INSERT,
+            MODE_VISUAL,
+            MODE_COMMAND,
+            BORDER,
+            POPUP_BG,
+            POPUP_FG,
+            MENU_SELECTED,
+            SEARCH_MATCH,
+        ];
+        assert_eq!(ui_groups.len(), 17);
+    }
+
+    #[test]
+    fn test_diagnostic_groups_count() {
+        let diagnostic_groups = [
+            DIAGNOSTIC_ERROR,
+            DIAGNOSTIC_WARN,
+            DIAGNOSTIC_INFO,
+            DIAGNOSTIC_HINT,
+        ];
+        assert_eq!(diagnostic_groups.len(), 4);
+    }
+
+    #[test]
+    fn test_no_duplicate_groups() {
+        use std::collections::HashSet;
+        let unique: HashSet<_> = ALL_GROUPS.iter().collect();
+        assert_eq!(unique.len(), ALL_GROUPS.len(), "duplicate group names found");
+    }
+}

--- a/lib/drivers/display/src/style/manager.rs
+++ b/lib/drivers/display/src/style/manager.rs
@@ -1,12 +1,21 @@
 //! Theme manager for runtime theme management.
 //!
 //! Provides centralized theme management with support for overrides.
+//!
+//! # Lookup Order
+//!
+//! When getting a style for a group, the 4-tier lookup is:
+//!
+//! 1. **User overrides** (`set_override`)
+//! 2. **Current theme** (`ThemeProvider.get_style`)
+//! 3. **Module defaults** (`StyleGroupRegistry`) - modules register their defaults
+//! 4. **Theme default** (`ThemeProvider.default_style`)
 
 use std::{collections::HashMap, sync::Arc};
 
 use crate::highlight::Style;
 
-use super::theme::ThemeProvider;
+use super::{registry::StyleGroupRegistry, theme::ThemeProvider};
 
 /// Manages the current theme and user overrides.
 ///
@@ -14,6 +23,15 @@ use super::theme::ThemeProvider;
 ///
 /// The runner creates and owns the `ThemeManager`. This is a policy decision
 /// (which theme to use), not mechanism.
+///
+/// # 4-Tier Lookup
+///
+/// ```text
+/// 1. User overrides (set_override)
+/// 2. Current theme (ThemeProvider.get_style)
+/// 3. Module defaults (StyleGroupRegistry)
+/// 4. ThemeProvider.default_style()
+/// ```
 ///
 /// # Example
 ///
@@ -26,7 +44,7 @@ use super::theme::ThemeProvider;
 /// // Override a specific style
 /// manager.set_override("keyword", keyword_style);
 ///
-/// // Get style (checks overrides first, then theme)
+/// // Get style (checks 4 tiers: overrides → theme → module defaults → fallback)
 /// let style = manager.get_style("keyword");
 /// ```
 pub struct ThemeManager {
@@ -34,6 +52,8 @@ pub struct ThemeManager {
     current: Arc<dyn ThemeProvider>,
     /// User style overrides (take precedence over theme)
     overrides: HashMap<String, Style>,
+    /// Module-provided style defaults (fallback when theme doesn't define a group)
+    module_defaults: Option<Arc<StyleGroupRegistry>>,
 }
 
 impl ThemeManager {
@@ -43,6 +63,7 @@ impl ThemeManager {
         Self {
             current: theme,
             overrides: HashMap::new(),
+            module_defaults: None,
         }
     }
 
@@ -61,6 +82,20 @@ impl ThemeManager {
     #[must_use]
     pub fn current_theme_name(&self) -> &str {
         self.current.name()
+    }
+
+    /// Set the module defaults registry.
+    ///
+    /// Modules register their style group defaults here during `init()`.
+    /// The registry is used as tier 3 in the lookup order.
+    pub fn set_module_defaults(&mut self, registry: Arc<StyleGroupRegistry>) {
+        self.module_defaults = Some(registry);
+    }
+
+    /// Get the module defaults registry.
+    #[must_use]
+    pub const fn module_defaults(&self) -> Option<&Arc<StyleGroupRegistry>> {
+        self.module_defaults.as_ref()
     }
 
     /// Set a style override for a highlight group.
@@ -94,30 +129,58 @@ impl ThemeManager {
 
     /// Get the style for a highlight group.
     ///
-    /// Checks overrides first, then falls back to the theme.
-    /// If neither has the group, returns the theme's default style.
+    /// Uses 4-tier lookup order:
+    /// 1. User overrides (`set_override`)
+    /// 2. Current theme (`ThemeProvider.get_style`)
+    /// 3. Module defaults (`StyleGroupRegistry`)
+    /// 4. Theme default (`ThemeProvider.default_style`)
     #[must_use]
     pub fn get_style(&self, group: &str) -> Style {
-        // Check overrides first
+        // Tier 1: User overrides
         if let Some(style) = self.overrides.get(group) {
             return style.clone();
         }
 
-        // Fall back to theme
-        self.current
-            .get_style(group)
-            .unwrap_or_else(|| self.current.default_style())
+        // Tier 2: Current theme
+        if let Some(style) = self.current.get_style(group) {
+            return style;
+        }
+
+        // Tier 3: Module defaults
+        if let Some(ref registry) = self.module_defaults
+            && let Some(style) = registry.get(group)
+        {
+            return style;
+        }
+
+        // Tier 4: Theme default
+        self.current.default_style()
     }
 
     /// Get the style for a highlight group, returning None if not found.
     ///
-    /// Unlike `get_style`, this doesn't fall back to a default.
+    /// Checks tiers 1-3 only (overrides → theme → module defaults).
+    /// Unlike `get_style`, this doesn't fall back to the theme's default style.
     #[must_use]
     pub fn try_get_style(&self, group: &str) -> Option<Style> {
-        self.overrides
-            .get(group)
-            .cloned()
-            .or_else(|| self.current.get_style(group))
+        // Tier 1: User overrides
+        if let Some(style) = self.overrides.get(group) {
+            return Some(style.clone());
+        }
+
+        // Tier 2: Current theme
+        if let Some(style) = self.current.get_style(group) {
+            return Some(style);
+        }
+
+        // Tier 3: Module defaults
+        if let Some(ref registry) = self.module_defaults
+            && let Some(style) = registry.get(group)
+        {
+            return Some(style);
+        }
+
+        None
     }
 }
 
@@ -157,6 +220,17 @@ impl SharedThemeManager {
     #[must_use]
     pub fn new(theme: Arc<dyn super::theme::ThemeProvider>) -> Self {
         Self(RwLock::new(ThemeManager::new(theme)))
+    }
+
+    /// Create a new shared theme manager with module defaults registry.
+    #[must_use]
+    pub fn with_module_defaults(
+        theme: Arc<dyn super::theme::ThemeProvider>,
+        registry: Arc<StyleGroupRegistry>,
+    ) -> Self {
+        let mut manager = ThemeManager::new(theme);
+        manager.set_module_defaults(registry);
+        Self(RwLock::new(manager))
     }
 
     /// Acquire a read lock on the theme manager.
@@ -239,5 +313,59 @@ mod tests {
 
         manager.set_theme(BuiltinTheme::Light.load());
         assert_eq!(manager.current_theme_name(), "light");
+    }
+
+    #[test]
+    fn test_theme_manager_four_tier_lookup() {
+        use super::StyleGroupRegistry;
+
+        let mut manager = ThemeManager::new(BuiltinTheme::Dark.load());
+
+        // Create module defaults registry
+        let registry = Arc::new(StyleGroupRegistry::new());
+        let module_style = Style::new().fg(Color::Cyan);
+        registry.register("module.custom", module_style);
+        manager.set_module_defaults(registry);
+
+        // Tier 3: Module defaults - not in theme, not in overrides
+        let style = manager.get_style("module.custom");
+        assert_eq!(style.fg, Some(Color::Cyan));
+
+        // Tier 2: Theme takes precedence over module defaults
+        // keyword is in theme, so it should come from theme
+        let theme_style = manager.get_style("keyword");
+        assert!(theme_style.fg.is_some());
+        assert_ne!(theme_style.fg, Some(Color::Cyan)); // Different from module style
+
+        // Tier 1: Override takes precedence over everything
+        let override_style = Style::new().fg(Color::Magenta);
+        manager.set_override("module.custom", override_style);
+        let style = manager.get_style("module.custom");
+        assert_eq!(style.fg, Some(Color::Magenta));
+
+        // Tier 4: Fallback to theme default for unknown groups
+        let unknown_style = manager.get_style("nonexistent.group");
+        assert_eq!(unknown_style, manager.current_theme().default_style());
+    }
+
+    #[test]
+    fn test_theme_manager_try_get_style_tiers() {
+        use super::StyleGroupRegistry;
+
+        let mut manager = ThemeManager::new(BuiltinTheme::Dark.load());
+
+        // Create module defaults registry
+        let registry = Arc::new(StyleGroupRegistry::new());
+        registry.register("module.test", Style::new().fg(Color::Green));
+        manager.set_module_defaults(registry);
+
+        // Should find in module defaults (tier 3)
+        assert!(manager.try_get_style("module.test").is_some());
+
+        // Should find in theme (tier 2)
+        assert!(manager.try_get_style("keyword").is_some());
+
+        // Should not find unknown (no tier 4 fallback in try_get_style)
+        assert!(manager.try_get_style("nonexistent").is_none());
     }
 }

--- a/lib/drivers/display/src/style/manager.rs
+++ b/lib/drivers/display/src/style/manager.rs
@@ -121,6 +121,57 @@ impl ThemeManager {
     }
 }
 
+// Implement Service marker trait for ServiceRegistry integration (#439)
+impl reovim_kernel::api::v1::Service for ThemeManager {}
+
+// ============================================================================
+// SharedThemeManager - RwLock wrapper for ServiceRegistry (#439)
+// ============================================================================
+
+use reovim_arch::sync::RwLock;
+
+/// Thread-safe wrapper for `ThemeManager` for `ServiceRegistry`.
+///
+/// This newtype wrapper allows `ThemeManager` to be stored in `ServiceRegistry`
+/// while enabling mutation via `RwLock`. Use `read()` and `write()` to access
+/// the inner manager.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_driver_display::style::SharedThemeManager;
+///
+/// // Register in ServiceRegistry
+/// let manager = SharedThemeManager::new(BuiltinTheme::Dark.load());
+/// services.register(Arc::new(manager));
+///
+/// // Access later
+/// let shared = services.get::<SharedThemeManager>().unwrap();
+/// let name = shared.read().current_theme_name();
+/// shared.write().set_theme(BuiltinTheme::Light.load());
+/// ```
+pub struct SharedThemeManager(RwLock<ThemeManager>);
+
+impl SharedThemeManager {
+    /// Create a new shared theme manager.
+    #[must_use]
+    pub fn new(theme: Arc<dyn super::theme::ThemeProvider>) -> Self {
+        Self(RwLock::new(ThemeManager::new(theme)))
+    }
+
+    /// Acquire a read lock on the theme manager.
+    pub fn read(&self) -> reovim_arch::sync::RwLockReadGuard<'_, ThemeManager> {
+        self.0.read()
+    }
+
+    /// Acquire a write lock on the theme manager.
+    pub fn write(&self) -> reovim_arch::sync::RwLockWriteGuard<'_, ThemeManager> {
+        self.0.write()
+    }
+}
+
+impl reovim_kernel::api::v1::Service for SharedThemeManager {}
+
 #[cfg(test)]
 mod tests {
     use reovim_arch::Color;

--- a/lib/drivers/display/src/style/mod.rs
+++ b/lib/drivers/display/src/style/mod.rs
@@ -48,14 +48,17 @@
 //! for now. This theme system uses string-based group names for flexibility.
 //! Future Phase 6 may migrate `HighlightGroup` to this driver.
 
+mod builtin;
+pub mod groups;
 mod icons;
 mod manager;
 mod theme;
 
 pub use {
+    groups::ALL_GROUPS,
     icons::{
         BuiltinFileIconProvider, IconDef, IconProvider, IconRegistry, IconSet, file_icons, ui_icons,
     },
-    manager::ThemeManager,
+    manager::{SharedThemeManager, ThemeManager},
     theme::{BuiltinTheme, ThemeProvider},
 };

--- a/lib/drivers/display/src/style/mod.rs
+++ b/lib/drivers/display/src/style/mod.rs
@@ -52,6 +52,7 @@ mod builtin;
 pub mod groups;
 mod icons;
 mod manager;
+mod registry;
 mod theme;
 
 pub use {
@@ -60,5 +61,6 @@ pub use {
         BuiltinFileIconProvider, IconDef, IconProvider, IconRegistry, IconSet, file_icons, ui_icons,
     },
     manager::{SharedThemeManager, ThemeManager},
+    registry::StyleGroupRegistry,
     theme::{BuiltinTheme, ThemeProvider},
 };

--- a/lib/drivers/display/src/style/registry.rs
+++ b/lib/drivers/display/src/style/registry.rs
@@ -1,0 +1,176 @@
+//! Style group registry for module-provided style defaults.
+//!
+//! This module provides a mechanism for modules to register their own style groups
+//! with default styles. The `ThemeManager` uses this registry as a fallback when
+//! the current theme doesn't define a requested group.
+//!
+//! # Architecture
+//!
+//! This follows mechanism/policy separation:
+//! - **Mechanism** (this driver): `StyleGroupRegistry` and registration API
+//! - **Policy** (modules): Group names and default styles
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_driver_display::style::StyleGroupRegistry;
+//!
+//! // Module defines its groups
+//! const RAINBOW_1: &str = "rainbow.bracket.1";
+//! let default_style = Style::new().fg(Color::Red);
+//!
+//! // In module init():
+//! let registry = ctx.services.get_or_create::<StyleGroupRegistry>();
+//! registry.register(RAINBOW_1, default_style);
+//! ```
+
+use std::collections::HashMap;
+
+use {reovim_arch::sync::RwLock, reovim_kernel::api::v1::Service};
+
+use crate::highlight::Style;
+
+/// Registry for module-provided style group defaults.
+///
+/// Modules register their style groups during `init()`. The `ThemeManager`
+/// uses this registry as a fallback when the current theme doesn't
+/// define a requested group.
+///
+/// # Lookup Order (in `ThemeManager`)
+///
+/// ```text
+/// 1. User overrides (set_override)
+/// 2. Current theme (ThemeProvider.get_style)
+/// 3. Module defaults (StyleGroupRegistry)  <-- this registry
+/// 4. ThemeProvider.default_style()
+/// ```
+pub struct StyleGroupRegistry {
+    /// Map from group name to default style.
+    groups: RwLock<HashMap<&'static str, Style>>,
+}
+
+impl StyleGroupRegistry {
+    /// Create a new empty style group registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            groups: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a single style group with its default style.
+    ///
+    /// # Arguments
+    ///
+    /// * `group` - The group name (e.g., `"rainbow.bracket.1"`)
+    /// * `default_style` - The style to use when theme doesn't define this group
+    pub fn register(&self, group: &'static str, default_style: Style) {
+        self.groups.write().insert(group, default_style);
+    }
+
+    /// Register multiple style groups at once.
+    ///
+    /// Convenience method for modules that define many groups.
+    pub fn register_batch(&self, registrations: &[(&'static str, Style)]) {
+        let mut groups = self.groups.write();
+        for (group, style) in registrations {
+            groups.insert(*group, style.clone());
+        }
+    }
+
+    /// Get the default style for a group.
+    ///
+    /// Returns `None` if the group is not registered.
+    #[must_use]
+    pub fn get(&self, group: &str) -> Option<Style> {
+        self.groups.read().get(group).cloned()
+    }
+
+    /// List all registered groups.
+    #[must_use]
+    pub fn registered_groups(&self) -> Vec<&'static str> {
+        self.groups.read().keys().copied().collect()
+    }
+
+    /// Check if a group is registered.
+    #[must_use]
+    pub fn contains(&self, group: &str) -> bool {
+        self.groups.read().contains_key(group)
+    }
+
+    /// Get the number of registered groups.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.groups.read().len()
+    }
+
+    /// Check if the registry is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.groups.read().is_empty()
+    }
+}
+
+impl Default for StyleGroupRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Service for StyleGroupRegistry {}
+
+#[cfg(test)]
+mod tests {
+    use reovim_arch::Color;
+
+    use super::*;
+
+    #[test]
+    fn test_style_group_registry_new() {
+        let registry = StyleGroupRegistry::new();
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_style_group_registry_register() {
+        let registry = StyleGroupRegistry::new();
+        let style = Style::new().fg(Color::Red);
+        registry.register("test.group", style.clone());
+
+        assert_eq!(registry.len(), 1);
+        assert!(registry.contains("test.group"));
+        assert_eq!(registry.get("test.group"), Some(style));
+    }
+
+    #[test]
+    fn test_style_group_registry_register_batch() {
+        let registry = StyleGroupRegistry::new();
+        let registrations = [
+            ("group.1", Style::new().fg(Color::Red)),
+            ("group.2", Style::new().fg(Color::Blue)),
+        ];
+        registry.register_batch(&registrations);
+
+        assert_eq!(registry.len(), 2);
+        assert!(registry.contains("group.1"));
+        assert!(registry.contains("group.2"));
+    }
+
+    #[test]
+    fn test_style_group_registry_get_nonexistent() {
+        let registry = StyleGroupRegistry::new();
+        assert!(registry.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_style_group_registry_registered_groups() {
+        let registry = StyleGroupRegistry::new();
+        registry.register("a", Style::new());
+        registry.register("b", Style::new());
+
+        let groups = registry.registered_groups();
+        assert_eq!(groups.len(), 2);
+        assert!(groups.contains(&"a"));
+        assert!(groups.contains(&"b"));
+    }
+}

--- a/lib/drivers/display/src/style/theme.rs
+++ b/lib/drivers/display/src/style/theme.rs
@@ -86,14 +86,20 @@ struct SimpleBuiltinTheme {
 }
 
 impl ThemeProvider for SimpleBuiltinTheme {
-    fn get_style(&self, _group: &str) -> Option<Style> {
-        // TODO: Implement actual theme lookups with full style definitions
-        // For now, return None to use default styles
-        None
+    fn get_style(&self, group: &str) -> Option<Style> {
+        super::builtin::get_palette(self.variant)
+            .get(group)
+            .cloned()
     }
 
     fn name(&self) -> &str {
         self.variant.name()
+    }
+
+    fn default_style(&self) -> Style {
+        // Return foreground style as default
+        self.get_style(super::groups::FOREGROUND)
+            .unwrap_or_default()
     }
 }
 
@@ -118,5 +124,57 @@ mod tests {
     fn test_builtin_theme_all() {
         let all = BuiltinTheme::all();
         assert_eq!(all.len(), 3);
+    }
+
+    // =========================================================================
+    // Theme Completeness Tests (#439)
+    // =========================================================================
+
+    #[test]
+    fn test_dark_theme_all_groups_defined() {
+        let theme = BuiltinTheme::Dark.load();
+        for group in super::super::groups::ALL_GROUPS {
+            assert!(theme.get_style(group).is_some(), "Dark theme missing group: {group}");
+        }
+    }
+
+    #[test]
+    fn test_light_theme_all_groups_defined() {
+        let theme = BuiltinTheme::Light.load();
+        for group in super::super::groups::ALL_GROUPS {
+            assert!(theme.get_style(group).is_some(), "Light theme missing group: {group}");
+        }
+    }
+
+    #[test]
+    fn test_tokyo_night_all_groups_defined() {
+        let theme = BuiltinTheme::TokyoNightOrange.load();
+        for group in super::super::groups::ALL_GROUPS {
+            assert!(
+                theme.get_style(group).is_some(),
+                "TokyoNightOrange theme missing group: {group}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_theme_colors_are_different() {
+        let dark = BuiltinTheme::Dark.load();
+        let light = BuiltinTheme::Light.load();
+
+        // Keywords should have different colors between themes
+        let dark_keyword = dark.get_style(super::super::groups::KEYWORD).unwrap();
+        let light_keyword = light.get_style(super::super::groups::KEYWORD).unwrap();
+        assert_ne!(dark_keyword.fg, light_keyword.fg);
+    }
+
+    #[test]
+    fn test_default_style_returns_foreground() {
+        let theme = BuiltinTheme::Dark.load();
+        let default = theme.default_style();
+        let foreground = theme.get_style(super::super::groups::FOREGROUND).unwrap();
+
+        // Default style should match foreground
+        assert_eq!(default.fg, foreground.fg);
     }
 }

--- a/lib/drivers/display/src/window_renderer.rs
+++ b/lib/drivers/display/src/window_renderer.rs
@@ -24,6 +24,27 @@
 //! │   gutter width   content area              │
 //! └─────────────────────────────────────────────┘
 //! ```
+//!
+//! # Theme Integration
+//!
+//! Use `WindowRendererConfig::from_theme()` to create a config with theme colors:
+//!
+//! ```ignore
+//! use reovim_driver_display::style::{SharedThemeManager, groups};
+//! use reovim_driver_display::window_renderer::{WindowRenderer, WindowRendererConfig};
+//!
+//! // Get ThemeManager from ServiceRegistry
+//! let shared = services.get::<SharedThemeManager>().unwrap();
+//! let manager = shared.read();
+//!
+//! // Create themed config
+//! let config = WindowRendererConfig::from_theme(&manager);
+//! let default_style = manager.get_style(groups::FOREGROUND);
+//!
+//! // Render with theme colors
+//! let renderer = WindowRenderer::with_config(config);
+//! renderer.render(&content, bounds, &mut buffer, &default_style);
+//! ```
 
 use crate::{
     compositor::Style,
@@ -68,6 +89,35 @@ impl Default for WindowRendererConfig {
             show_cursor: true,
             line_number_style: Style::default(),
             cursor_line_number_style: Style::default(),
+        }
+    }
+}
+
+impl WindowRendererConfig {
+    /// Create a config from a `ThemeManager`.
+    ///
+    /// Extracts line number styles from the theme's highlight groups.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use reovim_driver_display::style::SharedThemeManager;
+    /// use reovim_driver_display::window_renderer::WindowRendererConfig;
+    ///
+    /// let manager = services.get::<SharedThemeManager>().unwrap();
+    /// let config = WindowRendererConfig::from_theme(&manager.read());
+    /// let renderer = WindowRenderer::with_config(config);
+    /// ```
+    #[must_use]
+    pub fn from_theme(manager: &crate::style::ThemeManager) -> Self {
+        use crate::style::groups;
+
+        Self {
+            line_numbers: LineNumberMode::Absolute,
+            line_number_width: 0, // Auto-calculate
+            show_cursor: true,
+            line_number_style: manager.get_style(groups::LINE_NUMBER),
+            cursor_line_number_style: manager.get_style(groups::LINE_NUMBER_ACTIVE),
         }
     }
 }

--- a/lib/drivers/session/src/api/compositor.rs
+++ b/lib/drivers/session/src/api/compositor.rs
@@ -199,6 +199,41 @@ pub trait CompositorApi {
 
     /// Update screen size (on terminal resize).
     fn set_screen(&mut self, screen: Rect);
+
+    // =========================================================================
+    // Float Zone Operations (#398)
+    // =========================================================================
+
+    /// Toggle the current window between tiled and float zones.
+    ///
+    /// If the window is tiled, it becomes a floating window (80% centered).
+    /// If the window is floating, it returns to the tiled zone.
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    /// - `NoFocusedWindow` - No window is focused
+    fn toggle_float(&mut self) -> Result<(), CompositorError>;
+
+    /// Raise the current float window to the front.
+    ///
+    /// No-op if the current window is not a float.
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    /// - `NoFocusedWindow` - No window is focused
+    fn raise_float(&mut self) -> Result<(), CompositorError>;
+
+    /// Lower the current float window to the back.
+    ///
+    /// No-op if the current window is not a float.
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    /// - `NoFocusedWindow` - No window is focused
+    fn lower_float(&mut self) -> Result<(), CompositorError>;
 }
 
 #[cfg(test)]

--- a/lib/drivers/session/src/api/compositor.rs
+++ b/lib/drivers/session/src/api/compositor.rs
@@ -18,9 +18,15 @@
 //! WindowLayerCompositor.navigate_tiled(from, Left)
 //! ```
 //!
+//! # Overlay Operations (#399)
+//!
+//! Overlays are temporary UI elements (popups, menus, tooltips) that appear
+//! above all other windows. They do NOT auto-focus when shown - focus remains
+//! on the underlying tiled/float window.
+//!
 use reovim_driver_display::{
     NavigateDirection, Rect, SplitDirection, WindowId,
-    layout::{LayerId, WindowPlacement},
+    layout::{LayerId, OverlayConstraints, WindowPlacement},
 };
 
 /// Errors from compositor operations.
@@ -234,6 +240,66 @@ pub trait CompositorApi {
     /// - `NoActiveLayer` - No layer is active
     /// - `NoFocusedWindow` - No window is focused
     fn lower_float(&mut self) -> Result<(), CompositorError>;
+
+    // =========================================================================
+    // Overlay Zone Operations (#399)
+    // =========================================================================
+
+    /// Show an overlay with constraints.
+    ///
+    /// Creates a new overlay positioned according to the constraints.
+    /// Overlays do NOT auto-focus - they are temporary UI elements that
+    /// appear above content without stealing keyboard input.
+    ///
+    /// # Arguments
+    ///
+    /// * `constraints` - Positioning constraints (anchor, preferred size, max size)
+    ///
+    /// # Returns
+    ///
+    /// The window ID of the new overlay.
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    fn show_overlay(
+        &mut self,
+        constraints: OverlayConstraints,
+    ) -> Result<WindowId, CompositorError>;
+
+    /// Hide (remove) an overlay.
+    ///
+    /// # Arguments
+    ///
+    /// * `window` - The overlay window ID to hide
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    fn hide_overlay(&mut self, window: WindowId) -> Result<(), CompositorError>;
+
+    /// Resize an overlay.
+    ///
+    /// Updates the preferred size of the overlay.
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    fn resize_overlay(
+        &mut self,
+        window: WindowId,
+        width: u16,
+        height: u16,
+    ) -> Result<(), CompositorError>;
+
+    /// Hide all overlays in the active layer.
+    ///
+    /// Useful for commands like "dismiss all popups" (Escape key behavior).
+    ///
+    /// # Errors
+    ///
+    /// - `NoActiveLayer` - No layer is active
+    fn hide_all_overlays(&mut self) -> Result<(), CompositorError>;
 }
 
 #[cfg(test)]

--- a/lib/drivers/session/src/runtime.rs
+++ b/lib/drivers/session/src/runtime.rs
@@ -42,7 +42,7 @@ use {
     reovim_driver_command_types::{CommandContext, CommandResult},
     reovim_driver_display::{
         NavigateDirection, Rect, SplitDirection,
-        layout::{LayerId, WindowPlacement},
+        layout::{LayerId, OverlayConstraints, WindowPlacement},
     },
     reovim_driver_undo::{UndoKey, UndoProviderRegistry},
     reovim_kernel::api::v1::{
@@ -1197,6 +1197,95 @@ impl CompositorApi for SessionRuntime<'_> {
 
         layer.lower_float(current);
 
+        Ok(())
+    }
+
+    // =========================================================================
+    // Overlay Zone Operations (#399)
+    // =========================================================================
+
+    fn show_overlay(
+        &mut self,
+        constraints: OverlayConstraints,
+    ) -> Result<WindowId, CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        let id = layer.show_overlay(constraints);
+        // Note: Overlays do NOT auto-focus
+        Ok(id)
+    }
+
+    fn hide_overlay(&mut self, window: WindowId) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        layer.hide_overlay(window);
+        Ok(())
+    }
+
+    fn resize_overlay(
+        &mut self,
+        window: WindowId,
+        width: u16,
+        height: u16,
+    ) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        layer.resize_overlay(window, width, height);
+        Ok(())
+    }
+
+    fn hide_all_overlays(&mut self) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        layer.hide_all_overlays();
         Ok(())
     }
 }

--- a/lib/drivers/session/src/runtime.rs
+++ b/lib/drivers/session/src/runtime.rs
@@ -1128,6 +1128,77 @@ impl CompositorApi for SessionRuntime<'_> {
             compositor.set_screen(screen);
         }
     }
+
+    // =========================================================================
+    // Float Zone Operations (#398)
+    // =========================================================================
+
+    fn toggle_float(&mut self) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        let current = layer.focused().ok_or(CompositorError::NoFocusedWindow)?;
+
+        layer.toggle_float(current);
+        self.changes.window_changed = true;
+
+        Ok(())
+    }
+
+    fn raise_float(&mut self) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        let current = layer.focused().ok_or(CompositorError::NoFocusedWindow)?;
+
+        layer.raise_float(current);
+
+        Ok(())
+    }
+
+    fn lower_float(&mut self) -> Result<(), CompositorError> {
+        let compositor = self
+            .session
+            .compositor
+            .as_mut()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let active = compositor
+            .active_layer()
+            .ok_or(CompositorError::NoActiveLayer)?;
+
+        let layer = compositor
+            .layer_compositor_mut(active)
+            .ok_or(CompositorError::LayerNotFound(active))?;
+
+        let current = layer.focused().ok_or(CompositorError::NoFocusedWindow)?;
+
+        layer.lower_float(current);
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/lib/drivers/session/src/runtime.rs
+++ b/lib/drivers/session/src/runtime.rs
@@ -439,9 +439,23 @@ impl BufferApi for SessionRuntime<'_> {
             if !deleted_text.is_empty() {
                 let edit = Edit::Delete {
                     position: start,
-                    text: deleted_text,
+                    text: deleted_text.clone(),
                 };
                 self.record_edit(buffer, vec![edit], cursor_before, cursor_after);
+
+                // Emit BufferModified event for pair module and other subscribers (#440)
+                #[allow(clippy::cast_possible_truncation)]
+                {
+                    use reovim_kernel::api::v1::events::kernel::{BufferModified, Modification};
+                    self.kernel.event_bus.emit(BufferModified {
+                        buffer_id: buffer.as_usize() as u64,
+                        modification: Modification::Delete {
+                            start: (start.line as u32, start.column as u32),
+                            end: (end.line as u32, end.column as u32),
+                            text: deleted_text,
+                        },
+                    });
+                }
             }
 
             self.changes.record_buffer_modified(buffer);

--- a/lib/kernel/src/api/context.rs
+++ b/lib/kernel/src/api/context.rs
@@ -264,6 +264,37 @@ impl Default for ModuleContext {
     }
 }
 
+impl KernelContext {
+    /// Create a `KernelContext` with a shared event bus and services.
+    ///
+    /// Uses stub implementations for other fields. Useful for module
+    /// initialization where modules need to subscribe to events but
+    /// don't need buffer management yet (#440).
+    ///
+    /// # Arguments
+    ///
+    /// * `event_bus` - Shared event bus for subscriptions
+    /// * `services` - Shared service registry
+    #[must_use]
+    pub fn with_event_bus_and_services(
+        event_bus: Arc<EventBus>,
+        services: Arc<ServiceRegistry>,
+    ) -> Self {
+        use crate::core::{MarkBank, MotionEngine, RegisterBank, TextObjectEngine};
+
+        Self {
+            event_bus,
+            buffers: Arc::new(StubBufferManager),
+            motion: Arc::new(MotionEngine),
+            text_objects: Arc::new(TextObjectEngine),
+            registers: Arc::new(RwLock::new(RegisterBank::new())),
+            marks: Arc::new(RwLock::new(MarkBank::new())),
+            options: Arc::new(OptionRegistry::new()),
+            services,
+        }
+    }
+}
+
 impl Default for KernelContext {
     /// Create a default `KernelContext` for testing purposes.
     ///

--- a/modules/commands/Cargo.toml
+++ b/modules/commands/Cargo.toml
@@ -15,8 +15,11 @@ default = []
 dynamic = []  # Enable FFI entry points for standalone dynamic loading
 
 [dependencies]
+reovim-arch = { workspace = true }
+reovim-driver-display = { workspace = true }
 reovim-kernel = { workspace = true }
 reovim-module-macros = { path = "../../lib/module-macros" }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/modules/commands/src/colorscheme.rs
+++ b/modules/commands/src/colorscheme.rs
@@ -1,0 +1,155 @@
+//! Colorscheme command - switch themes at runtime.
+//!
+//! This module implements the `:colorscheme` command for changing the editor's
+//! color theme.
+//!
+//! # Usage
+//!
+//! - `:colorscheme` - Show current theme name
+//! - `:colorscheme <name>` - Switch to theme
+//! - `:colorscheme invalid` - Error with available themes
+//!
+//! # Architecture
+//!
+//! This is a **policy module** - it decides HOW users switch themes.
+//! The actual theme definitions and `ThemeManager` are **mechanism** (in the driver layer).
+
+use reovim_driver_display::style::{BuiltinTheme, SharedThemeManager};
+
+use crate::{CommandError, ExCommandContext, ExCommandHandler};
+
+/// Colorscheme command - switch color theme.
+///
+/// Behavior:
+/// - `:colorscheme` - Show current theme
+/// - `:colorscheme dark` - Switch to dark theme
+/// - `:colorscheme light` - Switch to light theme
+/// - `:colorscheme tokyo-night-orange` - Switch to Tokyo Night Orange
+///
+/// # Example
+///
+/// ```ignore
+/// let cmd = ColorschemeCommand;
+/// cmd.execute(&mut ctx, &["dark"])?; // Switch to dark theme
+/// cmd.execute(&mut ctx, &[])?;       // Show current theme
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ColorschemeCommand;
+
+impl ColorschemeCommand {
+    /// Available theme names.
+    const AVAILABLE_THEMES: &'static [&'static str] = &["dark", "light", "tokyo-night-orange"];
+}
+
+impl ExCommandHandler for ColorschemeCommand {
+    fn id(&self) -> &'static str {
+        "colorscheme"
+    }
+
+    fn names(&self) -> &[&'static str] {
+        &["colorscheme", "colors", "colo"]
+    }
+
+    fn execute(&self, ctx: &mut ExCommandContext<'_>, args: &[&str]) -> Result<(), CommandError> {
+        // Get SharedThemeManager from ServiceRegistry
+        let theme_manager = ctx
+            .kernel
+            .services
+            .get::<SharedThemeManager>()
+            .ok_or_else(|| {
+                CommandError::ExecutionFailed("Theme system not initialized".to_string())
+            })?;
+
+        if args.is_empty() {
+            // Show current theme
+            let name = theme_manager.read().current_theme_name().to_string();
+            // TODO: Display via message system when available
+            tracing::info!(theme = %name, "current colorscheme");
+            return Ok(());
+        }
+
+        // Switch to requested theme
+        let theme_name = args[0];
+        let new_theme = match theme_name {
+            "dark" => BuiltinTheme::Dark.load(),
+            "light" => BuiltinTheme::Light.load(),
+            "tokyo-night-orange" => BuiltinTheme::TokyoNightOrange.load(),
+            _ => {
+                let available = Self::AVAILABLE_THEMES.join(", ");
+                return Err(CommandError::InvalidArguments(format!(
+                    "Unknown colorscheme: {theme_name}. Available: {available}"
+                )));
+            }
+        };
+
+        theme_manager.write().set_theme(new_theme);
+        tracing::info!(theme = %theme_name, "switched colorscheme");
+
+        // Note: UI refresh is handled by the event loop detecting theme change
+        Ok(())
+    }
+
+    fn complete(&self, partial: &str) -> Vec<String> {
+        Self::AVAILABLE_THEMES
+            .iter()
+            .filter(|name| name.starts_with(partial))
+            .map(|s| (*s).to_string())
+            .collect()
+    }
+
+    fn help(&self) -> &'static str {
+        "Set or show the current color theme. Usage: :colorscheme [dark|light|tokyo-night-orange]"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_colorscheme_command_id() {
+        let cmd = ColorschemeCommand;
+        assert_eq!(cmd.id(), "colorscheme");
+    }
+
+    #[test]
+    fn test_colorscheme_command_names() {
+        let cmd = ColorschemeCommand;
+        let names = cmd.names();
+        assert!(names.contains(&"colorscheme"));
+        assert!(names.contains(&"colors"));
+        assert!(names.contains(&"colo"));
+    }
+
+    #[test]
+    fn test_colorscheme_completion() {
+        let cmd = ColorschemeCommand;
+
+        // Complete partial "d"
+        let completions = cmd.complete("d");
+        assert!(completions.contains(&"dark".to_string()));
+        assert!(!completions.contains(&"light".to_string()));
+
+        // Complete empty string - should return all
+        let completions = cmd.complete("");
+        assert_eq!(completions.len(), 3);
+        assert!(completions.contains(&"dark".to_string()));
+        assert!(completions.contains(&"light".to_string()));
+        assert!(completions.contains(&"tokyo-night-orange".to_string()));
+
+        // Complete "t"
+        let completions = cmd.complete("t");
+        assert!(completions.contains(&"tokyo-night-orange".to_string()));
+        assert!(!completions.contains(&"dark".to_string()));
+    }
+
+    #[test]
+    fn test_colorscheme_help() {
+        let cmd = ColorschemeCommand;
+        let help = cmd.help();
+        assert!(help.contains("colorscheme"));
+        assert!(help.contains("dark"));
+        assert!(help.contains("light"));
+        assert!(help.contains("tokyo-night-orange"));
+    }
+}

--- a/modules/commands/src/lib.rs
+++ b/modules/commands/src/lib.rs
@@ -24,6 +24,7 @@
 //! }
 //! ```
 
+mod colorscheme;
 mod quit;
 mod session;
 mod types;
@@ -35,6 +36,7 @@ use reovim_kernel::api::v1::{Module, ModuleContext, ModuleError, ModuleId, Probe
 pub use types::{CommandError, ExCommandContext, ExCommandHandler, Range};
 
 pub use {
+    colorscheme::ColorschemeCommand,
     quit::QuitCommand,
     session::{DetachCommand, KillServerCommand, ServersCommand},
     write::{WriteCommand, WriteQuitCommand},
@@ -47,6 +49,7 @@ pub fn commands() -> Vec<Box<dyn ExCommandHandler>> {
         Box::new(QuitCommand),
         Box::new(WriteCommand),
         Box::new(WriteQuitCommand),
+        Box::new(ColorschemeCommand),
     ];
     // Add session management commands from #350
     cmds.extend(session::commands());
@@ -107,13 +110,14 @@ mod tests {
     #[test]
     fn test_commands_list() {
         let cmds = commands();
-        assert_eq!(cmds.len(), 6); // 3 base + 3 session commands
+        assert_eq!(cmds.len(), 7); // 4 base + 3 session commands
 
         // Check commands are present
         let ids: Vec<_> = cmds.iter().map(|c| c.id()).collect();
         assert!(ids.contains(&"quit"));
         assert!(ids.contains(&"write"));
         assert!(ids.contains(&"write-quit"));
+        assert!(ids.contains(&"colorscheme")); // #439
         // Session commands from #350
         assert!(ids.contains(&"detach"));
         assert!(ids.contains(&"servers"));

--- a/modules/defaults/Cargo.toml
+++ b/modules/defaults/Cargo.toml
@@ -31,6 +31,7 @@ reovim-module-undo = { path = "../undo" }
 reovim-module-buffer-simple = { path = "../buffer-simple" }
 reovim-module-search = { path = "../search" }
 reovim-module-clipboard = { path = "../clipboard" }
+reovim-module-pair = { path = "../pair" }
 reovim-driver-session = { workspace = true }
 reovim-driver-display = { workspace = true }
 reovim-driver-vfs = { workspace = true }

--- a/modules/defaults/src/lib.rs
+++ b/modules/defaults/src/lib.rs
@@ -4,6 +4,7 @@
 //! - `vim` - Vim keybindings, operators (normal, insert, visual, operator-pending, d/y/c)
 //! - `keymap` - Keymap utilities (mechanism)
 //! - `commands` - Ex-commands (:w, :q, :wq)
+//! - `pair` - Auto-close brackets, rainbow highlighting, matched pair indicator
 //!
 //! # Purpose
 //!
@@ -37,9 +38,9 @@ use {
     reovim_module_buffer_simple as buffer_simple, reovim_module_clipboard as clipboard,
     reovim_module_commands as commands, reovim_module_editor as editor,
     reovim_module_keymap as keymap, reovim_module_layout as layout,
-    reovim_module_motions as motions, reovim_module_scratch_buffer as scratch_buffer,
-    reovim_module_search as search, reovim_module_undo as undo,
-    reovim_module_vfs_local as vfs_local, reovim_module_vim as vim,
+    reovim_module_motions as motions, reovim_module_pair as pair,
+    reovim_module_scratch_buffer as scratch_buffer, reovim_module_search as search,
+    reovim_module_undo as undo, reovim_module_vfs_local as vfs_local, reovim_module_vim as vim,
 };
 
 /// Default modules bundle.
@@ -77,6 +78,7 @@ impl DefaultsModule {
             Box::new(scratch_buffer::ScratchBufferModule::new()),
             Box::new(vfs_local::VfsLocalModule::new()),
             Box::new(clipboard::ClipboardModule::new()),
+            Box::new(pair::PairModule::new()),
             // Utility modules
             Box::new(keymap::KeymapModule),
             Box::new(commands::CommandsModule),
@@ -119,6 +121,7 @@ impl Module for DefaultsModule {
             ModuleId::new("scratch-buffer"),
             ModuleId::new("vfs-local"),
             ModuleId::new("clipboard"),
+            ModuleId::new("pair"),
             // Utility modules
             ModuleId::new("keymap"),
             ModuleId::new("commands"),
@@ -204,21 +207,21 @@ mod tests {
     fn test_defaults_has_dependencies() {
         let module = DefaultsModule::new();
         let deps = module.dependencies();
-        // Service modules (6): undo, buffer-simple, search, scratch-buffer, vfs-local, clipboard
+        // Service modules (7): undo, buffer-simple, search, scratch-buffer, vfs-local, clipboard, pair
         // Utility modules (2): keymap, commands
         // Policy modules (4): editor, motions, vim, layout
-        // Total: 12 modules (Epic #417 Part 3 + #423)
-        assert_eq!(deps.len(), 12);
+        // Total: 13 modules (Epic #417 Part 3 + #423 + #440)
+        assert_eq!(deps.len(), 13);
     }
 
     #[test]
     fn test_create_modules() {
         let modules = DefaultsModule::create_modules();
-        // Service modules (6): undo, buffer-simple, search, scratch-buffer, vfs-local, clipboard
+        // Service modules (7): undo, buffer-simple, search, scratch-buffer, vfs-local, clipboard, pair
         // Utility modules (2): keymap, commands
         // Policy modules (4): editor, motions, vim, layout
-        // Total: 12 modules (Epic #417 Part 3 + #423)
-        assert_eq!(modules.len(), 12);
+        // Total: 13 modules (Epic #417 Part 3 + #423 + #440)
+        assert_eq!(modules.len(), 13);
     }
 
     #[test]

--- a/modules/layout/src/commands.rs
+++ b/modules/layout/src/commands.rs
@@ -428,6 +428,79 @@ impl CommandHandler for ResizeEqualCmd {
 }
 
 // =============================================================================
+// Float Zone Commands (#398)
+// =============================================================================
+
+/// Toggle window between tiled and floating zones.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToggleFloatCmd;
+
+impl Command for ToggleFloatCmd {
+    fn id(&self) -> CommandId {
+        ids::TOGGLE_FLOAT
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggle window between tiled and floating"
+    }
+}
+
+impl CommandHandler for ToggleFloatCmd {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        match runtime.toggle_float() {
+            Ok(()) => CommandResult::Success,
+            Err(e) => CommandResult::Error(e.to_string()),
+        }
+    }
+}
+
+/// Raise floating window to front of float zone.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RaiseFloatCmd;
+
+impl Command for RaiseFloatCmd {
+    fn id(&self) -> CommandId {
+        ids::RAISE_FLOAT
+    }
+
+    fn description(&self) -> &'static str {
+        "Raise floating window to front"
+    }
+}
+
+impl CommandHandler for RaiseFloatCmd {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        match runtime.raise_float() {
+            Ok(()) => CommandResult::Success,
+            Err(e) => CommandResult::Error(e.to_string()),
+        }
+    }
+}
+
+/// Lower floating window to back of float zone.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LowerFloatCmd;
+
+impl Command for LowerFloatCmd {
+    fn id(&self) -> CommandId {
+        ids::LOWER_FLOAT
+    }
+
+    fn description(&self) -> &'static str {
+        "Lower floating window to back"
+    }
+}
+
+impl CommandHandler for LowerFloatCmd {
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        match runtime.lower_float() {
+            Ok(()) => CommandResult::Success,
+            Err(e) => CommandResult::Error(e.to_string()),
+        }
+    }
+}
+
+// =============================================================================
 // Command Collection
 // =============================================================================
 
@@ -458,6 +531,10 @@ pub fn all_commands() -> Vec<Box<dyn CommandHandler>> {
         Box::new(ResizeWidthIncreaseCmd),
         Box::new(ResizeWidthDecreaseCmd),
         Box::new(ResizeEqualCmd),
+        // Float zone (#398)
+        Box::new(ToggleFloatCmd),
+        Box::new(RaiseFloatCmd),
+        Box::new(LowerFloatCmd),
     ]
 }
 
@@ -469,7 +546,7 @@ mod tests {
     fn test_all_commands_not_empty() {
         let commands = all_commands();
         assert!(!commands.is_empty());
-        assert_eq!(commands.len(), 15); // 2 split + 2 close + 4 focus + 2 cycle + 5 resize
+        assert_eq!(commands.len(), 18); // 2 split + 2 close + 4 focus + 2 cycle + 5 resize + 3 float
     }
 
     #[test]

--- a/modules/layout/src/floatzone.rs
+++ b/modules/layout/src/floatzone.rs
@@ -1,0 +1,625 @@
+//! Floating window zone implementation.
+//!
+//! This module provides `FloatZone`, which implements the `FloatingLayer` trait
+//! from the display driver. Floating windows can be freely positioned and sized,
+//! rendered above tiled windows but below overlays.
+//!
+//! # Architecture
+//!
+//! Following the mechanism vs policy principle:
+//! - **Mechanism** (display driver): `FloatingLayer` trait defines WHAT can be done
+//! - **Policy** (this module): `FloatZone` decides HOW windows are managed
+//!
+//! # Z-Order
+//!
+//! Float zone uses z-order slots 10-49 within each layer (40 windows max).
+//! The `z_stack` vector maintains stacking order (index 0 = bottom, last = top).
+//!
+//! ```text
+//! Layer 0: Float windows at z = 10, 11, 12... (based on z_stack position)
+//! ```
+
+use std::collections::HashMap;
+
+use reovim_driver_display::{
+    Rect, WindowId,
+    layout::{FloatingLayer, FloatingWindow, LayerId, WindowPlacement, ZOrder, Zone},
+};
+
+/// Maximum number of floating windows per layer.
+///
+/// Z-order slots 10-49 = 40 windows maximum.
+pub const MAX_FLOAT_WINDOWS: usize = 40;
+
+/// Minimum float window width in cells.
+pub const MIN_FLOAT_WIDTH: u16 = 10;
+
+/// Minimum float window height in cells.
+pub const MIN_FLOAT_HEIGHT: u16 = 5;
+
+/// Floating window zone manager.
+///
+/// Manages freely-positioned windows within a layer's float zone.
+/// Windows can be moved, resized, and reordered in z-order.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_module_layout::FloatZone;
+/// use reovim_driver_display::{Rect, WindowId, layout::{LayerId, ZOrder, FloatingLayer}};
+///
+/// let mut zone = FloatZone::new(LayerId::new(0), ZOrder::new(0));
+/// let id = WindowId::from_raw(1);
+/// zone.create(id, Rect::new(10, 5, 60, 20));
+/// zone.raise(id);  // Bring to front
+///
+/// let placements = zone.arrange();
+/// assert_eq!(placements.len(), 1);
+/// ```
+#[derive(Debug, Clone)]
+pub struct FloatZone {
+    /// Float windows by ID.
+    windows: HashMap<WindowId, FloatingWindow>,
+    /// Z-stack: bottom to top (index 0 = lowest, last = highest).
+    z_stack: Vec<WindowId>,
+    /// Layer ID this zone belongs to.
+    layer_id: LayerId,
+    /// Base z-order for the layer.
+    z_base: ZOrder,
+}
+
+impl FloatZone {
+    /// Create a new empty float zone.
+    ///
+    /// # Arguments
+    ///
+    /// * `layer_id` - The layer this zone belongs to
+    /// * `z_base` - Base z-order for the layer
+    #[must_use]
+    pub fn new(layer_id: LayerId, z_base: ZOrder) -> Self {
+        Self {
+            windows: HashMap::new(),
+            z_stack: Vec::new(),
+            layer_id,
+            z_base,
+        }
+    }
+
+    /// Check if the zone is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.windows.is_empty()
+    }
+
+    /// Get the number of floating windows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.windows.len()
+    }
+
+    /// Check if at capacity (40 windows max).
+    #[must_use]
+    pub fn is_at_capacity(&self) -> bool {
+        self.windows.len() >= MAX_FLOAT_WINDOWS
+    }
+
+    /// Get the bounds of a floating window.
+    #[must_use]
+    pub fn bounds(&self, window: WindowId) -> Option<Rect> {
+        self.windows.get(&window).map(|fw| fw.bounds)
+    }
+
+    /// Get the z-stack position of a window (0 = bottom).
+    #[must_use]
+    pub fn z_position(&self, window: WindowId) -> Option<usize> {
+        self.z_stack.iter().position(|&id| id == window)
+    }
+}
+
+impl FloatingLayer for FloatZone {
+    /// Get all floating windows as placements, sorted by z-order.
+    ///
+    /// Windows are returned in z-stack order (lowest first), with z-order
+    /// computed as `z_base + Zone::Float.z_offset() + stack_index`.
+    fn arrange(&self) -> Vec<WindowPlacement> {
+        self.z_stack
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &window_id)| {
+                self.windows.get(&window_id).map(|fw| {
+                    WindowPlacement::new(
+                        window_id,
+                        self.layer_id,
+                        Zone::Float,
+                        fw.bounds,
+                        ZOrder::for_window(self.z_base, Zone::Float, index as u16),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    /// Create a new floating window.
+    ///
+    /// The window is added to the top of the z-stack (highest z-order).
+    /// If at capacity (40 windows), logs a warning and returns the same ID
+    /// without creating the window.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Window identifier (provided by caller)
+    /// * `bounds` - Initial position and size
+    ///
+    /// # Returns
+    ///
+    /// The window ID (same as input).
+    fn create(&mut self, id: WindowId, bounds: Rect) -> WindowId {
+        // Check capacity - silently reject if at limit (40 windows max)
+        if self.is_at_capacity() {
+            return id;
+        }
+
+        // Clamp bounds to minimum size
+        let clamped_bounds = Rect::new(
+            bounds.x,
+            bounds.y,
+            bounds.width.max(MIN_FLOAT_WIDTH),
+            bounds.height.max(MIN_FLOAT_HEIGHT),
+        );
+
+        let z_order = ZOrder::for_window(self.z_base, Zone::Float, self.z_stack.len() as u16);
+        let floating_window = FloatingWindow {
+            id,
+            bounds: clamped_bounds,
+            z_order,
+        };
+
+        self.windows.insert(id, floating_window);
+        self.z_stack.push(id); // Add to top of stack
+        id
+    }
+
+    /// Close a floating window.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the window existed and was closed.
+    fn close(&mut self, window: WindowId) -> bool {
+        if self.windows.remove(&window).is_some() {
+            self.z_stack.retain(|&id| id != window);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Move window to a new position.
+    ///
+    /// Does nothing if the window doesn't exist.
+    fn move_to(&mut self, window: WindowId, x: u16, y: u16) {
+        if let Some(fw) = self.windows.get_mut(&window) {
+            fw.bounds.x = x;
+            fw.bounds.y = y;
+        }
+    }
+
+    /// Resize window.
+    ///
+    /// Dimensions are clamped to minimum (10x5).
+    /// Does nothing if the window doesn't exist.
+    fn resize(&mut self, window: WindowId, width: u16, height: u16) {
+        if let Some(fw) = self.windows.get_mut(&window) {
+            fw.bounds.width = width.max(MIN_FLOAT_WIDTH);
+            fw.bounds.height = height.max(MIN_FLOAT_HEIGHT);
+        }
+    }
+
+    /// Bring window to front (highest z-order).
+    ///
+    /// Moves the window to the top of the z-stack.
+    /// Does nothing if the window doesn't exist.
+    fn raise(&mut self, window: WindowId) {
+        if let Some(pos) = self.z_stack.iter().position(|&id| id == window) {
+            self.z_stack.remove(pos);
+            self.z_stack.push(window);
+        }
+    }
+
+    /// Send window to back (lowest z-order in float zone).
+    ///
+    /// Moves the window to the bottom of the z-stack.
+    /// Does nothing if the window doesn't exist.
+    fn lower(&mut self, window: WindowId) {
+        if let Some(pos) = self.z_stack.iter().position(|&id| id == window) {
+            self.z_stack.remove(pos);
+            self.z_stack.insert(0, window);
+        }
+    }
+
+    /// Get all floating window IDs.
+    fn windows(&self) -> Vec<WindowId> {
+        self.z_stack.clone()
+    }
+
+    /// Check if window is in floating layer.
+    fn contains(&self, window: WindowId) -> bool {
+        self.windows.contains_key(&window)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_zone() -> FloatZone {
+        FloatZone::new(LayerId::new(0), ZOrder::new(0))
+    }
+
+    fn test_bounds() -> Rect {
+        Rect::new(10, 5, 60, 20)
+    }
+
+    #[test]
+    fn test_float_zone_new() {
+        let zone = test_zone();
+        assert!(zone.is_empty());
+        assert_eq!(zone.len(), 0);
+        assert!(!zone.is_at_capacity());
+    }
+
+    #[test]
+    fn test_create_float() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+        let bounds = test_bounds();
+
+        let returned_id = zone.create(id, bounds);
+
+        assert_eq!(returned_id, id);
+        assert!(zone.contains(id));
+        assert_eq!(zone.len(), 1);
+        assert_eq!(zone.bounds(id), Some(bounds));
+    }
+
+    #[test]
+    fn test_create_multiple_floats() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.create(id1, Rect::new(0, 0, 20, 10));
+        zone.create(id2, Rect::new(10, 5, 30, 15));
+        zone.create(id3, Rect::new(20, 10, 40, 20));
+
+        assert_eq!(zone.len(), 3);
+        assert!(zone.contains(id1));
+        assert!(zone.contains(id2));
+        assert!(zone.contains(id3));
+
+        // Z-stack order: id1 (bottom), id2, id3 (top)
+        assert_eq!(zone.z_position(id1), Some(0));
+        assert_eq!(zone.z_position(id2), Some(1));
+        assert_eq!(zone.z_position(id3), Some(2));
+    }
+
+    #[test]
+    fn test_move_float() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+        zone.create(id, Rect::new(10, 10, 40, 20));
+
+        zone.move_to(id, 50, 30);
+
+        let bounds = zone.bounds(id).unwrap();
+        assert_eq!(bounds.x, 50);
+        assert_eq!(bounds.y, 30);
+        // Size unchanged
+        assert_eq!(bounds.width, 40);
+        assert_eq!(bounds.height, 20);
+    }
+
+    #[test]
+    fn test_resize_float() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+        zone.create(id, Rect::new(10, 10, 40, 20));
+
+        zone.resize(id, 80, 30);
+
+        let bounds = zone.bounds(id).unwrap();
+        // Position unchanged
+        assert_eq!(bounds.x, 10);
+        assert_eq!(bounds.y, 10);
+        // Size changed
+        assert_eq!(bounds.width, 80);
+        assert_eq!(bounds.height, 30);
+    }
+
+    #[test]
+    fn test_resize_float_clamps_to_minimum() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+        zone.create(id, Rect::new(10, 10, 40, 20));
+
+        zone.resize(id, 5, 2); // Below minimum
+
+        let bounds = zone.bounds(id).unwrap();
+        assert_eq!(bounds.width, MIN_FLOAT_WIDTH);
+        assert_eq!(bounds.height, MIN_FLOAT_HEIGHT);
+    }
+
+    #[test]
+    fn test_raise_float() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds());
+        zone.create(id3, test_bounds());
+
+        // Initially: id1 (0), id2 (1), id3 (2)
+        assert_eq!(zone.z_position(id1), Some(0));
+
+        // Raise id1 to top
+        zone.raise(id1);
+
+        // Now: id2 (0), id3 (1), id1 (2)
+        assert_eq!(zone.z_position(id2), Some(0));
+        assert_eq!(zone.z_position(id3), Some(1));
+        assert_eq!(zone.z_position(id1), Some(2));
+    }
+
+    #[test]
+    fn test_lower_float() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds());
+        zone.create(id3, test_bounds());
+
+        // Initially: id1 (0), id2 (1), id3 (2)
+        assert_eq!(zone.z_position(id3), Some(2));
+
+        // Lower id3 to bottom
+        zone.lower(id3);
+
+        // Now: id3 (0), id1 (1), id2 (2)
+        assert_eq!(zone.z_position(id3), Some(0));
+        assert_eq!(zone.z_position(id1), Some(1));
+        assert_eq!(zone.z_position(id2), Some(2));
+    }
+
+    #[test]
+    fn test_close_float() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds());
+        assert_eq!(zone.len(), 2);
+
+        let closed = zone.close(id1);
+
+        assert!(closed);
+        assert!(!zone.contains(id1));
+        assert!(zone.contains(id2));
+        assert_eq!(zone.len(), 1);
+        assert_eq!(zone.z_position(id2), Some(0));
+    }
+
+    #[test]
+    fn test_close_nonexistent() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        let closed = zone.close(id);
+
+        assert!(!closed);
+        assert!(zone.is_empty());
+    }
+
+    #[test]
+    fn test_arrange_sorted_by_z() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.create(id1, Rect::new(0, 0, 20, 10));
+        zone.create(id2, Rect::new(10, 5, 30, 15));
+        zone.create(id3, Rect::new(20, 10, 40, 20));
+
+        let placements = zone.arrange();
+
+        assert_eq!(placements.len(), 3);
+
+        // Verify z-order increases
+        assert!(placements[0].z_order < placements[1].z_order);
+        assert!(placements[1].z_order < placements[2].z_order);
+
+        // Verify order matches z_stack
+        assert_eq!(placements[0].window_id, id1);
+        assert_eq!(placements[1].window_id, id2);
+        assert_eq!(placements[2].window_id, id3);
+
+        // Verify zone is Float
+        for p in &placements {
+            assert_eq!(p.zone, Zone::Float);
+        }
+    }
+
+    #[test]
+    fn test_windows_returns_all_ids() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds());
+
+        let windows = zone.windows();
+
+        assert_eq!(windows.len(), 2);
+        assert!(windows.contains(&id1));
+        assert!(windows.contains(&id2));
+    }
+
+    #[test]
+    fn test_contains() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds());
+
+        assert!(zone.contains(id1));
+        assert!(!zone.contains(id2));
+    }
+
+    #[test]
+    fn test_float_at_capacity_40_windows() {
+        let mut zone = test_zone();
+
+        // Create 40 windows (at capacity)
+        for i in 0..MAX_FLOAT_WINDOWS {
+            let id = WindowId::from_raw(i);
+            zone.create(id, test_bounds());
+        }
+
+        assert_eq!(zone.len(), MAX_FLOAT_WINDOWS);
+        assert!(zone.is_at_capacity());
+
+        // Try to create 41st window - should not increase count
+        let id41 = WindowId::from_raw(999);
+        zone.create(id41, test_bounds());
+
+        assert_eq!(zone.len(), MAX_FLOAT_WINDOWS);
+        assert!(!zone.contains(id41));
+    }
+
+    #[test]
+    fn test_create_clamps_to_minimum_bounds() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        // Create with bounds smaller than minimum
+        zone.create(id, Rect::new(10, 10, 5, 2));
+
+        let bounds = zone.bounds(id).unwrap();
+        assert_eq!(bounds.x, 10); // Position unchanged
+        assert_eq!(bounds.y, 10);
+        assert_eq!(bounds.width, MIN_FLOAT_WIDTH); // Clamped
+        assert_eq!(bounds.height, MIN_FLOAT_HEIGHT); // Clamped
+    }
+
+    #[test]
+    fn test_move_nonexistent_window_is_noop() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        // Should not panic
+        zone.move_to(id, 50, 50);
+
+        assert!(!zone.contains(id));
+    }
+
+    #[test]
+    fn test_resize_nonexistent_window_is_noop() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        // Should not panic
+        zone.resize(id, 100, 100);
+
+        assert!(!zone.contains(id));
+    }
+
+    #[test]
+    fn test_raise_nonexistent_window_is_noop() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        // Should not panic
+        zone.raise(id);
+
+        assert!(zone.is_empty());
+    }
+
+    #[test]
+    fn test_lower_nonexistent_window_is_noop() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        // Should not panic
+        zone.lower(id);
+
+        assert!(zone.is_empty());
+    }
+
+    #[test]
+    fn test_z_order_values_are_in_float_zone_range() {
+        let mut zone = FloatZone::new(LayerId::new(0), ZOrder::new(0));
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds());
+
+        let placements = zone.arrange();
+
+        // Float zone offset is 10
+        let float_offset = Zone::Float.z_offset();
+        assert_eq!(float_offset, 10);
+
+        // First window: z = 0 + 10 + 0 = 10
+        assert_eq!(placements[0].z_order.as_u16(), 10);
+        // Second window: z = 0 + 10 + 1 = 11
+        assert_eq!(placements[1].z_order.as_u16(), 11);
+    }
+
+    #[test]
+    fn test_arrange_empty_zone_returns_empty() {
+        let zone = test_zone();
+        let placements = zone.arrange();
+        assert!(placements.is_empty());
+    }
+
+    #[test]
+    fn test_raise_already_top_is_noop() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds());
+        zone.create(id2, test_bounds()); // id2 is already top
+
+        zone.raise(id2);
+
+        // Order should be unchanged
+        assert_eq!(zone.z_position(id1), Some(0));
+        assert_eq!(zone.z_position(id2), Some(1));
+    }
+
+    #[test]
+    fn test_lower_already_bottom_is_noop() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.create(id1, test_bounds()); // id1 is already bottom
+        zone.create(id2, test_bounds());
+
+        zone.lower(id1);
+
+        // Order should be unchanged
+        assert_eq!(zone.z_position(id1), Some(0));
+        assert_eq!(zone.z_position(id2), Some(1));
+    }
+}

--- a/modules/layout/src/ids.rs
+++ b/modules/layout/src/ids.rs
@@ -113,3 +113,16 @@ pub const SWAP_WINDOW: CommandId = CommandId::new(MODULE, "swap-window");
 
 /// Move current window to new tab (T).
 pub const MOVE_TO_NEW_TAB: CommandId = CommandId::new(MODULE, "move-to-new-tab");
+
+// =============================================================================
+// Float Zone Operations (#398)
+// =============================================================================
+
+/// Toggle window between tiled and floating zones.
+pub const TOGGLE_FLOAT: CommandId = CommandId::new(MODULE, "toggle-float");
+
+/// Raise floating window to front of float zone.
+pub const RAISE_FLOAT: CommandId = CommandId::new(MODULE, "raise-float");
+
+/// Lower floating window to back of float zone.
+pub const LOWER_FLOAT: CommandId = CommandId::new(MODULE, "lower-float");

--- a/modules/layout/src/layer.rs
+++ b/modules/layout/src/layer.rs
@@ -1,15 +1,15 @@
 //! Default layer implementation for the nested compositor.
 //!
 //! This module provides `DefaultLayer`, which implements `WindowLayerCompositor`
-//! with tiled and float zones.
+//! with tiled, float, and overlay zones.
 //!
 //! # Architecture
 //!
 //! ```text
 //! DefaultLayer (implements WindowLayerCompositor)
-//! ├── Tiled Zone  (TilingLayout)  ✓ Implemented
-//! ├── Float Zone  (FloatZone)     ✓ Implemented (#398)
-//! └── Overlay Zone (stub)         ← Phase 3
+//! ├── Tiled Zone   (TilingLayout)  ✓ Implemented
+//! ├── Float Zone   (FloatZone)     ✓ Implemented (#398)
+//! └── Overlay Zone (OverlayZone)   ✓ Implemented (#399)
 //! ```
 //!
 //! # Focus Model
@@ -20,21 +20,21 @@
 use reovim_driver_display::{
     NavigateDirection, Rect, SplitDirection, WindowId,
     layout::{
-        FloatingLayer, LayerId, OverlayConstraints, TiledLayer, WindowLayerCompositor,
-        WindowPlacement, ZOrder, Zone,
+        FloatingLayer, LayerId, OverlayConstraints, OverlayLayer, TiledLayer,
+        WindowLayerCompositor, WindowPlacement, ZOrder, Zone,
     },
 };
 
-use crate::{FloatZone, TilingLayout};
+use crate::{FloatZone, OverlayZone, TilingLayout};
 
-/// Default layer implementation with tiled and float zones.
+/// Default layer implementation with tiled, float, and overlay zones.
 ///
-/// This compositor wraps both `TilingLayout` (tiled zone) and `FloatZone`
-/// (floating windows), implementing `WindowLayerCompositor`.
+/// This compositor wraps `TilingLayout` (tiled zone), `FloatZone` (floating
+/// windows), and `OverlayZone` (popups/menus), implementing `WindowLayerCompositor`.
 ///
 /// # Thread Safety
 ///
-/// `DefaultLayer` is `Send + Sync` because both zone managers are `Send + Sync`.
+/// `DefaultLayer` is `Send + Sync` because all zone managers are `Send + Sync`.
 #[derive(Debug, Clone)]
 pub struct DefaultLayer {
     /// Layer identifier.
@@ -45,8 +45,12 @@ pub struct DefaultLayer {
     tiled: TilingLayout,
     /// Float zone manager.
     float: FloatZone,
+    /// Overlay zone manager (#399).
+    overlay: OverlayZone,
     /// Next float window ID (DefaultLayer generates IDs for float zone).
     next_float_id: usize,
+    /// Next overlay window ID (DefaultLayer generates IDs for overlay zone).
+    next_overlay_id: usize,
     /// Currently focused window.
     focused: Option<WindowId>,
     /// Cached screen bounds for navigation/cycle.
@@ -68,7 +72,9 @@ impl DefaultLayer {
             label: label.into(),
             tiled: TilingLayout::new(id, Zone::Tiled, z_base),
             float: FloatZone::new(id, z_base),
+            overlay: OverlayZone::new(id, z_base),
             next_float_id: 1000, // Start float IDs at 1000 to avoid collision with tiled
+            next_overlay_id: 2000, // Start overlay IDs at 2000 to avoid collision with float
             focused: None,
             screen: Rect::new(0, 0, 80, 24), // Default screen size
         }
@@ -125,10 +131,15 @@ impl WindowLayerCompositor for DefaultLayer {
     }
 
     fn arrange(&self, bounds: Rect) -> Vec<WindowPlacement> {
-        // Get placements from both zones
+        // Get placements from tiled and float zones first
         let mut placements = TiledLayer::arrange(&self.tiled, bounds);
         placements.extend(FloatingLayer::arrange(&self.float));
-        // Sort by z-order for correct rendering (tiled first, then float)
+
+        // Get overlay placements (needs existing placements for anchor resolution)
+        // Overlays can reference tiled/float window positions via Cursor/Below anchors
+        placements.extend(OverlayLayer::arrange(&self.overlay, bounds, &placements));
+
+        // Sort by z-order for correct rendering (tiled < float < overlay)
         placements.sort_by_key(|p| p.z_order);
         placements
     }
@@ -249,19 +260,28 @@ impl WindowLayerCompositor for DefaultLayer {
     }
 
     // =========================================================================
-    // Overlay Zone (Phase 3 stubs)
+    // Overlay Zone (#399)
     // =========================================================================
 
-    fn show_overlay(&mut self, _constraints: OverlayConstraints) -> WindowId {
-        unimplemented!("Overlay zone not implemented in Phase 1")
+    fn show_overlay(&mut self, constraints: OverlayConstraints) -> WindowId {
+        // Generate a new window ID (DefaultLayer owns ID allocation for overlays)
+        let id = WindowId::from_raw(self.next_overlay_id);
+        self.next_overlay_id += 1;
+        OverlayLayer::show(&mut self.overlay, id, constraints);
+        // Note: Overlays do NOT auto-focus (they are temporary UI above content)
+        id
     }
 
-    fn hide_overlay(&mut self, _window: WindowId) {
-        unimplemented!("Overlay zone not implemented in Phase 1")
+    fn hide_overlay(&mut self, window: WindowId) {
+        OverlayLayer::hide(&mut self.overlay, window);
     }
 
-    fn resize_overlay(&mut self, _window: WindowId, _width: u16, _height: u16) {
-        unimplemented!("Overlay zone not implemented in Phase 1")
+    fn resize_overlay(&mut self, window: WindowId, width: u16, height: u16) {
+        OverlayLayer::update_size(&mut self.overlay, window, width, height);
+    }
+
+    fn hide_all_overlays(&mut self) {
+        OverlayLayer::hide_all(&mut self.overlay);
     }
 
     // =========================================================================
@@ -280,7 +300,7 @@ impl WindowLayerCompositor for DefaultLayer {
         match zone {
             Zone::Tiled => TiledLayer::windows(&self.tiled),
             Zone::Float => FloatingLayer::windows(&self.float),
-            Zone::Overlay => Vec::new(), // Phase 3
+            Zone::Overlay => OverlayLayer::visible_overlays(&self.overlay),
         }
     }
 
@@ -289,6 +309,8 @@ impl WindowLayerCompositor for DefaultLayer {
             Some(Zone::Tiled)
         } else if FloatingLayer::contains(&self.float, window) {
             Some(Zone::Float)
+        } else if OverlayLayer::is_visible(&self.overlay, window) {
+            Some(Zone::Overlay)
         } else {
             None
         }
@@ -718,5 +740,116 @@ mod tests {
             .unwrap()
             .window_id;
         assert_eq!(top_float, float2, "float2 should be on top after lowering float1");
+    }
+
+    // =========================================================================
+    // Overlay Zone Tests (#399 Phase 2)
+    // =========================================================================
+
+    #[test]
+    fn test_default_layer_show_overlay() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let constraints = OverlayConstraints::centered().with_size(40, 10);
+
+        let id = layer.show_overlay(constraints);
+
+        assert!(layer.windows_in_zone(Zone::Overlay).contains(&id));
+        assert_eq!(layer.zone_of(id), Some(Zone::Overlay));
+    }
+
+    #[test]
+    fn test_default_layer_hide_overlay() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let id = layer.show_overlay(OverlayConstraints::centered().with_size(40, 10));
+
+        assert!(layer.windows_in_zone(Zone::Overlay).contains(&id));
+
+        layer.hide_overlay(id);
+
+        assert!(!layer.windows_in_zone(Zone::Overlay).contains(&id));
+        assert_eq!(layer.zone_of(id), None);
+    }
+
+    #[test]
+    fn test_default_layer_overlay_does_not_auto_focus() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let tiled_id = layer.add_tiled();
+
+        // Tiled window should be focused
+        assert_eq!(layer.focused(), Some(tiled_id));
+
+        // Show overlay - focus should NOT change
+        let _overlay_id = layer.show_overlay(OverlayConstraints::centered().with_size(40, 10));
+
+        // Focus should still be on tiled window
+        assert_eq!(layer.focused(), Some(tiled_id));
+    }
+
+    #[test]
+    fn test_default_layer_arrange_includes_overlay() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let tiled_id = layer.add_tiled();
+        let overlay_id = layer.show_overlay(OverlayConstraints::centered().with_size(40, 10));
+
+        let placements = layer.arrange(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(placements.len(), 2);
+        let window_ids: Vec<_> = placements.iter().map(|p| p.window_id).collect();
+        assert!(window_ids.contains(&tiled_id));
+        assert!(window_ids.contains(&overlay_id));
+    }
+
+    #[test]
+    fn test_overlay_z_order_above_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let _tiled_id = layer.add_tiled();
+        let _float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+        let _overlay_id = layer.show_overlay(OverlayConstraints::centered().with_size(40, 10));
+
+        let placements = layer.arrange(Rect::new(0, 0, 80, 24));
+
+        // Find placements by zone
+        let tiled_placement = placements.iter().find(|p| p.zone == Zone::Tiled).unwrap();
+        let float_placement = placements.iter().find(|p| p.zone == Zone::Float).unwrap();
+        let overlay_placement = placements.iter().find(|p| p.zone == Zone::Overlay).unwrap();
+
+        // Z-order: Tiled < Float < Overlay
+        assert!(tiled_placement.z_order < float_placement.z_order, "Float should be above tiled");
+        assert!(
+            float_placement.z_order < overlay_placement.z_order,
+            "Overlay should be above float"
+        );
+    }
+
+    #[test]
+    fn test_default_layer_hide_all_overlays() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let _id1 = layer.show_overlay(OverlayConstraints::at_position(10, 10).with_size(20, 5));
+        let _id2 = layer.show_overlay(OverlayConstraints::at_position(30, 15).with_size(25, 8));
+        let _id3 = layer.show_overlay(OverlayConstraints::centered().with_size(40, 10));
+
+        assert_eq!(layer.windows_in_zone(Zone::Overlay).len(), 3);
+
+        layer.hide_all_overlays();
+
+        assert_eq!(layer.windows_in_zone(Zone::Overlay).len(), 0);
+    }
+
+    #[test]
+    fn test_default_layer_resize_overlay() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let id = layer.show_overlay(OverlayConstraints::centered().with_size(20, 10));
+
+        // Resize to larger
+        layer.resize_overlay(id, 40, 15);
+
+        // Check new size in placements
+        let placements = layer.arrange(Rect::new(0, 0, 80, 24));
+        let overlay = placements.iter().find(|p| p.window_id == id).unwrap();
+        assert_eq!(overlay.bounds.width, 40);
+        assert_eq!(overlay.bounds.height, 15);
     }
 }

--- a/modules/layout/src/layer.rs
+++ b/modules/layout/src/layer.rs
@@ -1,14 +1,14 @@
 //! Default layer implementation for the nested compositor.
 //!
 //! This module provides `DefaultLayer`, which implements `WindowLayerCompositor`
-//! for a single-layer, tiled-only compositor scenario (Phase 1).
+//! with tiled and float zones.
 //!
 //! # Architecture
 //!
 //! ```text
 //! DefaultLayer (implements WindowLayerCompositor)
-//! ├── Tiled Zone  (TilingLayout)  ← Active
-//! ├── Float Zone  (stub)          ← Phase 2
+//! ├── Tiled Zone  (TilingLayout)  ✓ Implemented
+//! ├── Float Zone  (FloatZone)     ✓ Implemented (#398)
 //! └── Overlay Zone (stub)         ← Phase 3
 //! ```
 //!
@@ -20,22 +20,21 @@
 use reovim_driver_display::{
     NavigateDirection, Rect, SplitDirection, WindowId,
     layout::{
-        LayerId, OverlayConstraints, TiledLayer, WindowLayerCompositor, WindowPlacement, ZOrder,
-        Zone,
+        FloatingLayer, LayerId, OverlayConstraints, TiledLayer, WindowLayerCompositor,
+        WindowPlacement, ZOrder, Zone,
     },
 };
 
-use crate::TilingLayout;
+use crate::{FloatZone, TilingLayout};
 
-/// Default layer implementation with tiled zone only.
+/// Default layer implementation with tiled and float zones.
 ///
-/// This is the single-layer compositor for Phase 1. It wraps a `TilingLayout`
-/// and implements `WindowLayerCompositor`, delegating tiled operations to the
-/// underlying layout while stubbing float/overlay operations.
+/// This compositor wraps both `TilingLayout` (tiled zone) and `FloatZone`
+/// (floating windows), implementing `WindowLayerCompositor`.
 ///
 /// # Thread Safety
 ///
-/// `DefaultLayer` is `Send + Sync` because `TilingLayout` is `Send + Sync`.
+/// `DefaultLayer` is `Send + Sync` because both zone managers are `Send + Sync`.
 #[derive(Debug, Clone)]
 pub struct DefaultLayer {
     /// Layer identifier.
@@ -44,6 +43,10 @@ pub struct DefaultLayer {
     label: String,
     /// Tiled zone manager.
     tiled: TilingLayout,
+    /// Float zone manager.
+    float: FloatZone,
+    /// Next float window ID (DefaultLayer generates IDs for float zone).
+    next_float_id: usize,
     /// Currently focused window.
     focused: Option<WindowId>,
     /// Cached screen bounds for navigation/cycle.
@@ -64,6 +67,8 @@ impl DefaultLayer {
             id,
             label: label.into(),
             tiled: TilingLayout::new(id, Zone::Tiled, z_base),
+            float: FloatZone::new(id, z_base),
+            next_float_id: 1000, // Start float IDs at 1000 to avoid collision with tiled
             focused: None,
             screen: Rect::new(0, 0, 80, 24), // Default screen size
         }
@@ -94,6 +99,24 @@ impl DefaultLayer {
     pub fn tiled_mut(&mut self) -> &mut TilingLayout {
         &mut self.tiled
     }
+
+    /// Get the float zone (for testing/inspection).
+    #[must_use]
+    pub fn float(&self) -> &FloatZone {
+        &self.float
+    }
+
+    /// Compute centered float window bounds (80% of screen, centered).
+    ///
+    /// Ensures minimum size of 10x5 for very small screens.
+    fn compute_centered_float_bounds(&self) -> Rect {
+        // 80% of screen, minimum 10x5
+        let width = ((self.screen.width * 80) / 100).max(crate::floatzone::MIN_FLOAT_WIDTH);
+        let height = ((self.screen.height * 80) / 100).max(crate::floatzone::MIN_FLOAT_HEIGHT);
+        let x = (self.screen.width.saturating_sub(width)) / 2;
+        let y = (self.screen.height.saturating_sub(height)) / 2;
+        Rect::new(x, y, width, height)
+    }
 }
 
 impl WindowLayerCompositor for DefaultLayer {
@@ -102,7 +125,12 @@ impl WindowLayerCompositor for DefaultLayer {
     }
 
     fn arrange(&self, bounds: Rect) -> Vec<WindowPlacement> {
-        TiledLayer::arrange(&self.tiled, bounds)
+        // Get placements from both zones
+        let mut placements = TiledLayer::arrange(&self.tiled, bounds);
+        placements.extend(FloatingLayer::arrange(&self.float));
+        // Sort by z-order for correct rendering (tiled first, then float)
+        placements.sort_by_key(|p| p.z_order);
+        placements
     }
 
     // =========================================================================
@@ -146,31 +174,78 @@ impl WindowLayerCompositor for DefaultLayer {
     }
 
     // =========================================================================
-    // Float Zone (Phase 2 stubs)
+    // Float Zone (#398)
     // =========================================================================
 
-    fn create_float(&mut self, _bounds: Rect) -> WindowId {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn create_float(&mut self, bounds: Rect) -> WindowId {
+        // Generate a new window ID (DefaultLayer owns ID allocation for floats)
+        let id = WindowId::from_raw(self.next_float_id);
+        self.next_float_id += 1;
+        FloatingLayer::create(&mut self.float, id, bounds);
+        self.focused = Some(id);
+        id
     }
 
-    fn move_float(&mut self, _window: WindowId, _x: u16, _y: u16) {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn move_float(&mut self, window: WindowId, x: u16, y: u16) {
+        FloatingLayer::move_to(&mut self.float, window, x, y);
     }
 
-    fn resize_float(&mut self, _window: WindowId, _width: u16, _height: u16) {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn resize_float(&mut self, window: WindowId, width: u16, height: u16) {
+        FloatingLayer::resize(&mut self.float, window, width, height);
     }
 
-    fn raise_float(&mut self, _window: WindowId) {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn raise_float(&mut self, window: WindowId) {
+        FloatingLayer::raise(&mut self.float, window);
     }
 
-    fn close_float(&mut self, _window: WindowId) {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn lower_float(&mut self, window: WindowId) {
+        FloatingLayer::lower(&mut self.float, window);
     }
 
-    fn toggle_float(&mut self, _window: WindowId) {
-        unimplemented!("Float zone not implemented in Phase 1")
+    fn close_float(&mut self, window: WindowId) {
+        if FloatingLayer::close(&mut self.float, window) {
+            // If we closed the focused window, move focus to another window
+            if self.focused == Some(window) {
+                // Prefer another float, else a tiled window
+                let floats = FloatingLayer::windows(&self.float);
+                let tiled = TiledLayer::windows(&self.tiled);
+                self.focused = floats.first().copied().or_else(|| tiled.first().copied());
+            }
+        }
+    }
+
+    fn toggle_float(&mut self, window: WindowId) {
+        if TiledLayer::windows(&self.tiled).contains(&window) {
+            // Tiled -> Float: Remove from tiled, create in float
+            TiledLayer::close(&mut self.tiled, window);
+            let bounds = self.compute_centered_float_bounds();
+            let new_id = self.create_float(bounds);
+            self.focused = Some(new_id);
+        } else if FloatingLayer::contains(&self.float, window) {
+            // Float -> Tiled: Remove from float, add to tiled
+            FloatingLayer::close(&mut self.float, window);
+
+            if self.tiled.is_empty() {
+                // Create first tiled window
+                let new_id = TiledLayer::add_first(&mut self.tiled);
+                self.focused = Some(new_id);
+            } else {
+                // Find a tiled window to split from
+                // If focused was the float we just closed, pick any tiled window
+                let split_target = self
+                    .focused
+                    .filter(|f| TiledLayer::windows(&self.tiled).contains(f))
+                    .or_else(|| TiledLayer::windows(&self.tiled).first().copied());
+
+                if let Some(target) = split_target
+                    && let Some(new_id) =
+                        TiledLayer::split(&mut self.tiled, target, SplitDirection::Vertical)
+                {
+                    self.focused = Some(new_id);
+                }
+            }
+        }
+        // Else: Window not in either zone, no-op
     }
 
     // =========================================================================
@@ -204,13 +279,16 @@ impl WindowLayerCompositor for DefaultLayer {
     fn windows_in_zone(&self, zone: Zone) -> Vec<WindowId> {
         match zone {
             Zone::Tiled => TiledLayer::windows(&self.tiled),
-            Zone::Float | Zone::Overlay => Vec::new(), // Not implemented in Phase 1
+            Zone::Float => FloatingLayer::windows(&self.float),
+            Zone::Overlay => Vec::new(), // Phase 3
         }
     }
 
     fn zone_of(&self, window: WindowId) -> Option<Zone> {
         if TiledLayer::windows(&self.tiled).contains(&window) {
             Some(Zone::Tiled)
+        } else if FloatingLayer::contains(&self.float, window) {
+            Some(Zone::Float)
         } else {
             None
         }
@@ -341,5 +419,304 @@ mod tests {
         assert_eq!(placements[0].window_id, id);
         assert_eq!(placements[0].bounds.width, 120);
         assert_eq!(placements[0].bounds.height, 40);
+    }
+
+    // =========================================================================
+    // Float Zone Tests (#398 Phase 2)
+    // =========================================================================
+
+    #[test]
+    fn test_default_layer_create_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let bounds = Rect::new(10, 5, 60, 20);
+        let id = layer.create_float(bounds);
+
+        assert!(layer.float().contains(id));
+        assert_eq!(layer.focused(), Some(id));
+        assert_eq!(layer.windows_in_zone(Zone::Float).len(), 1);
+    }
+
+    #[test]
+    fn test_default_layer_close_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let id = layer.create_float(Rect::new(10, 5, 60, 20));
+
+        assert!(layer.float().contains(id));
+
+        layer.close_float(id);
+
+        assert!(!layer.float().contains(id));
+        assert_eq!(layer.windows_in_zone(Zone::Float).len(), 0);
+    }
+
+    #[test]
+    fn test_default_layer_arrange_includes_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let tiled_id = layer.add_tiled();
+        let float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+
+        let placements = layer.arrange(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(placements.len(), 2);
+        // Both windows should be present
+        let window_ids: Vec<_> = placements.iter().map(|p| p.window_id).collect();
+        assert!(window_ids.contains(&tiled_id));
+        assert!(window_ids.contains(&float_id));
+    }
+
+    #[test]
+    fn test_default_layer_zone_of_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+
+        assert_eq!(layer.zone_of(float_id), Some(Zone::Float));
+    }
+
+    #[test]
+    fn test_default_layer_windows_in_zone_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let id1 = layer.create_float(Rect::new(10, 5, 60, 20));
+        let id2 = layer.create_float(Rect::new(20, 10, 50, 15));
+
+        let float_windows = layer.windows_in_zone(Zone::Float);
+        assert_eq!(float_windows.len(), 2);
+        assert!(float_windows.contains(&id1));
+        assert!(float_windows.contains(&id2));
+    }
+
+    #[test]
+    fn test_float_z_order_above_tiled() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        let _tiled_id = layer.add_tiled();
+        let _float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+
+        let placements = layer.arrange(Rect::new(0, 0, 80, 24));
+
+        // Placements are sorted by z-order
+        // Tiled zone z = 0-9, Float zone z = 10-49
+        let tiled_placement = placements.iter().find(|p| p.zone == Zone::Tiled).unwrap();
+        let float_placement = placements.iter().find(|p| p.zone == Zone::Float).unwrap();
+
+        assert!(
+            float_placement.z_order > tiled_placement.z_order,
+            "Float z-order {} should be greater than tiled z-order {}",
+            float_placement.z_order.as_u16(),
+            tiled_placement.z_order.as_u16()
+        );
+    }
+
+    #[test]
+    fn test_toggle_tiled_to_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let tiled_id = layer.add_tiled();
+
+        // Toggle to float
+        layer.toggle_float(tiled_id);
+
+        // Tiled should now be empty, float should have a window
+        assert_eq!(layer.windows_in_zone(Zone::Tiled).len(), 0);
+        assert_eq!(layer.windows_in_zone(Zone::Float).len(), 1);
+    }
+
+    #[test]
+    fn test_toggle_float_to_tiled_empty() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+
+        // Toggle to tiled (tiled zone is empty)
+        layer.toggle_float(float_id);
+
+        // Float should be empty, tiled should have a window
+        assert_eq!(layer.windows_in_zone(Zone::Float).len(), 0);
+        assert_eq!(layer.windows_in_zone(Zone::Tiled).len(), 1);
+    }
+
+    #[test]
+    fn test_toggle_float_to_tiled_split() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+
+        // Create a tiled window first
+        let tiled_id = layer.add_tiled();
+        layer.set_focus(tiled_id);
+
+        // Create and toggle a float
+        let float_id = layer.create_float(Rect::new(10, 5, 60, 20));
+        layer.toggle_float(float_id);
+
+        // Float should be empty, tiled should have 2 windows (original + split)
+        assert_eq!(layer.windows_in_zone(Zone::Float).len(), 0);
+        assert_eq!(layer.windows_in_zone(Zone::Tiled).len(), 2);
+    }
+
+    #[test]
+    fn test_toggle_nonexistent() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let tiled_id = layer.add_tiled();
+
+        // Toggle a non-existent window (should be no-op)
+        layer.toggle_float(WindowId::from_raw(9999));
+
+        // Original state should be unchanged
+        assert_eq!(layer.windows_in_zone(Zone::Tiled).len(), 1);
+        assert!(layer.windows_in_zone(Zone::Tiled).contains(&tiled_id));
+    }
+
+    #[test]
+    fn test_toggle_updates_focus() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 80, 24));
+        let tiled_id = layer.add_tiled();
+        layer.set_focus(tiled_id);
+
+        // Toggle to float
+        layer.toggle_float(tiled_id);
+
+        // Focus should be on the new float window
+        let focused = layer.focused().unwrap();
+        assert_eq!(layer.zone_of(focused), Some(Zone::Float));
+    }
+
+    #[test]
+    fn test_toggle_float_bounds() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 100, 50));
+        let tiled_id = layer.add_tiled();
+
+        // Toggle to float
+        layer.toggle_float(tiled_id);
+
+        // Check bounds are 80% centered
+        let float_windows = layer.windows_in_zone(Zone::Float);
+        let float_id = float_windows[0];
+        let bounds = layer.float().bounds(float_id).unwrap();
+
+        // 80% of 100 = 80, 80% of 50 = 40
+        assert_eq!(bounds.width, 80);
+        assert_eq!(bounds.height, 40);
+        // Centered: x = (100-80)/2 = 10, y = (50-40)/2 = 5
+        assert_eq!(bounds.x, 10);
+        assert_eq!(bounds.y, 5);
+    }
+
+    // =========================================================================
+    // Phase 5: Navigation Edge Cases (#398)
+    // =========================================================================
+
+    #[test]
+    fn test_navigate_includes_float_windows() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 100, 50));
+
+        // Create a tiled window on the left (0-50 width)
+        let tiled_id = layer.add_tiled();
+
+        // Create a float window on the right (position 60, width 30)
+        let float_id = layer.create_float(Rect::new(60, 10, 30, 30));
+
+        // Navigate right from tiled should find float
+        let placements = layer.arrange(layer.screen);
+        assert!(placements.len() >= 2, "Should have both tiled and float windows");
+
+        // Both windows should be in placements
+        let window_ids: Vec<_> = placements.iter().map(|p| p.window_id).collect();
+        assert!(window_ids.contains(&tiled_id), "Should contain tiled window");
+        assert!(window_ids.contains(&float_id), "Should contain float window");
+    }
+
+    #[test]
+    fn test_cycle_tiled_stays_in_tiled_zone() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 100, 50));
+
+        // Create two tiled windows
+        let tiled1 = layer.add_tiled();
+        let tiled2 = layer.split_tiled(tiled1, SplitDirection::Vertical).unwrap();
+
+        // Create float window (should not participate in tiled cycling)
+        let _float_id = layer.create_float(Rect::new(60, 10, 30, 30));
+
+        // Cycle from tiled1 should reach tiled2 (not float)
+        let next = layer.cycle_tiled(tiled1, true);
+        assert_eq!(next, Some(tiled2), "Cycling should stay within tiled zone");
+
+        // Cycle from tiled2 should wrap back to tiled1 (not float)
+        let next = layer.cycle_tiled(tiled2, true);
+        assert_eq!(next, Some(tiled1), "Cycling should wrap within tiled zone");
+    }
+
+    #[test]
+    fn test_close_float_focus_moves_to_tiled() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 100, 50));
+
+        // Create tiled window
+        let tiled_id = layer.add_tiled();
+
+        // Create and focus float window
+        let float_id = layer.create_float(Rect::new(60, 10, 30, 30));
+        assert_eq!(layer.focused(), Some(float_id));
+
+        // Close float window
+        layer.close_float(float_id);
+
+        // Focus should move to tiled window
+        assert_eq!(layer.focused(), Some(tiled_id));
+    }
+
+    #[test]
+    fn test_raise_and_lower_float() {
+        let mut layer = DefaultLayer::new(LayerId::new(0), "main");
+        layer.set_screen(Rect::new(0, 0, 100, 50));
+
+        // Create two float windows
+        let float1 = layer.create_float(Rect::new(10, 10, 30, 30));
+        let float2 = layer.create_float(Rect::new(20, 20, 30, 30));
+
+        // float2 is on top (created last)
+        let placements = layer.arrange(layer.screen);
+        let float_placements: Vec<_> = placements
+            .iter()
+            .filter(|p| p.zone == Zone::Float)
+            .collect();
+
+        // Sort by z-order to check stack order
+        let top_float = float_placements
+            .iter()
+            .max_by_key(|p| p.z_order)
+            .unwrap()
+            .window_id;
+        assert_eq!(top_float, float2, "float2 should be on top initially");
+
+        // Raise float1 to top
+        layer.raise_float(float1);
+        let placements = layer.arrange(layer.screen);
+        let float_placements: Vec<_> = placements
+            .iter()
+            .filter(|p| p.zone == Zone::Float)
+            .collect();
+        let top_float = float_placements
+            .iter()
+            .max_by_key(|p| p.z_order)
+            .unwrap()
+            .window_id;
+        assert_eq!(top_float, float1, "float1 should be on top after raise");
+
+        // Lower float1 to bottom
+        layer.lower_float(float1);
+        let placements = layer.arrange(layer.screen);
+        let float_placements: Vec<_> = placements
+            .iter()
+            .filter(|p| p.zone == Zone::Float)
+            .collect();
+        let top_float = float_placements
+            .iter()
+            .max_by_key(|p| p.z_order)
+            .unwrap()
+            .window_id;
+        assert_eq!(top_float, float2, "float2 should be on top after lowering float1");
     }
 }

--- a/modules/layout/src/lib.rs
+++ b/modules/layout/src/lib.rs
@@ -30,6 +30,7 @@ mod floatzone;
 mod focus;
 pub mod ids;
 mod layer;
+mod overlayzone;
 mod split;
 mod tiling;
 
@@ -39,6 +40,7 @@ pub use {
     floatzone::FloatZone,
     focus::VimFocusPolicy,
     layer::DefaultLayer,
+    overlayzone::OverlayZone,
     split::{SplitNode, SplitTree},
     tiling::TilingLayout,
 };

--- a/modules/layout/src/lib.rs
+++ b/modules/layout/src/lib.rs
@@ -26,6 +26,7 @@
 
 pub mod commands;
 mod compositor;
+mod floatzone;
 mod focus;
 pub mod ids;
 mod layer;
@@ -35,6 +36,7 @@ mod tiling;
 pub use {
     commands::all_commands,
     compositor::HybridCompositor,
+    floatzone::FloatZone,
     focus::VimFocusPolicy,
     layer::DefaultLayer,
     split::{SplitNode, SplitTree},

--- a/modules/layout/src/overlayzone.rs
+++ b/modules/layout/src/overlayzone.rs
@@ -1,0 +1,798 @@
+//! Overlay window zone implementation.
+//!
+//! This module provides `OverlayZone`, which implements the `OverlayLayer` trait
+//! from the display driver. Overlay windows are positioned using anchor constraints
+//! and rendered above all tiled and floating windows within a layer.
+//!
+//! # Architecture
+//!
+//! Following the mechanism vs policy principle:
+//! - **Mechanism** (display driver): `OverlayLayer` trait defines WHAT can be done
+//! - **Policy** (this module): `OverlayZone` decides HOW overlays are positioned
+//!
+//! # Z-Order
+//!
+//! Overlay zone uses z-order slots 50-99 within each layer (50 windows max).
+//! The `z_stack` vector maintains stacking order (index 0 = bottom, last = top).
+//!
+//! ```text
+//! Layer 0: Overlay windows at z = 50, 51, 52... (based on z_stack position)
+//! ```
+//!
+//! # Anchor Resolution
+//!
+//! Overlays are positioned using anchors that can reference:
+//! - **Cursor**: Position relative to cursor in a window
+//! - **Screen**: Absolute screen position
+//! - **Center**: Centered on screen
+//! - **Below**: Below another window
+//!
+//! Anchor resolution requires knowledge of existing window placements (from tiled
+//! and float zones), which are passed to `arrange()`.
+
+use std::collections::HashMap;
+
+use reovim_driver_display::{
+    Rect, WindowId,
+    layout::{
+        Anchor, LayerId, OverlayConstraints, OverlayLayer, OverlayWindow, WindowPlacement, ZOrder,
+        Zone,
+    },
+};
+
+/// Maximum number of overlay windows per layer.
+///
+/// Z-order slots 50-99 = 50 windows maximum.
+pub const MAX_OVERLAY_WINDOWS: usize = 50;
+
+/// Minimum overlay width in cells.
+pub const MIN_OVERLAY_WIDTH: u16 = 5;
+
+/// Minimum overlay height in cells.
+pub const MIN_OVERLAY_HEIGHT: u16 = 1;
+
+/// Overlay window zone manager.
+///
+/// Manages temporary UI elements like popups and menus within a layer's
+/// overlay zone. Overlays are positioned using anchor constraints.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_module_layout::OverlayZone;
+/// use reovim_driver_display::{Rect, WindowId, layout::{LayerId, ZOrder, OverlayConstraints, OverlayLayer}};
+///
+/// let mut zone = OverlayZone::new(LayerId::new(0), ZOrder::new(0));
+/// let id = WindowId::from_raw(1);
+/// let constraints = OverlayConstraints::centered().with_size(40, 10);
+/// zone.show(id, constraints);
+///
+/// let placements = zone.arrange(Rect::new(0, 0, 80, 24), &[]);
+/// assert_eq!(placements.len(), 1);
+/// ```
+#[derive(Debug, Clone)]
+pub struct OverlayZone {
+    /// Overlays by ID.
+    overlays: HashMap<WindowId, OverlayWindow>,
+    /// Z-stack: bottom to top (index 0 = lowest, last = highest).
+    z_stack: Vec<WindowId>,
+    /// Layer ID this zone belongs to.
+    layer_id: LayerId,
+    /// Base z-order for the layer.
+    z_base: ZOrder,
+}
+
+impl OverlayZone {
+    /// Create a new empty overlay zone.
+    ///
+    /// # Arguments
+    ///
+    /// * `layer_id` - The layer this zone belongs to
+    /// * `z_base` - Base z-order for the layer
+    #[must_use]
+    pub fn new(layer_id: LayerId, z_base: ZOrder) -> Self {
+        Self {
+            overlays: HashMap::new(),
+            z_stack: Vec::new(),
+            layer_id,
+            z_base,
+        }
+    }
+
+    /// Check if the zone is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.overlays.is_empty()
+    }
+
+    /// Get the number of overlay windows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.overlays.len()
+    }
+
+    /// Check if at capacity (50 overlays max).
+    #[must_use]
+    pub fn is_at_capacity(&self) -> bool {
+        self.overlays.len() >= MAX_OVERLAY_WINDOWS
+    }
+
+    /// Get the constraints of an overlay.
+    #[must_use]
+    pub fn constraints(&self, window: WindowId) -> Option<&OverlayConstraints> {
+        self.overlays.get(&window).map(|ow| &ow.constraints)
+    }
+
+    /// Get the z-stack position of an overlay (0 = bottom).
+    #[must_use]
+    pub fn z_position(&self, window: WindowId) -> Option<usize> {
+        self.z_stack.iter().position(|&id| id == window)
+    }
+
+    /// Resolve an anchor to screen coordinates.
+    ///
+    /// # Arguments
+    ///
+    /// * `anchor` - The anchor to resolve
+    /// * `screen` - Screen bounds for clamping
+    /// * `width` - Overlay width for clamping calculation
+    /// * `height` - Overlay height for clamping calculation
+    /// * `placements` - Existing window placements for Cursor/Below anchors
+    ///
+    /// # Returns
+    ///
+    /// `(x, y)` screen coordinates. Falls back to `(0, 0)` if anchor references
+    /// a window that doesn't exist in placements.
+    fn resolve_anchor(
+        &self,
+        anchor: &Anchor,
+        screen: Rect,
+        width: u16,
+        height: u16,
+        placements: &[WindowPlacement],
+    ) -> (u16, u16) {
+        match anchor {
+            Anchor::Cursor { window, line, col } => {
+                // Find the referenced window in placements
+                if let Some(wp) = placements.iter().find(|p| p.window_id == *window) {
+                    // Position below cursor: window bounds + cursor offset
+                    let x = wp.bounds.x.saturating_add(col.as_usize() as u16);
+                    // +1 to position below the cursor line
+                    let y = wp
+                        .bounds
+                        .y
+                        .saturating_add(line.as_usize() as u16)
+                        .saturating_add(1);
+                    self.clamp_position(x, y, width, height, screen)
+                } else {
+                    // Window not found - fall back to origin (will be clamped)
+                    (0, 0)
+                }
+            }
+            Anchor::Screen { x, y } => self.clamp_position(*x, *y, width, height, screen),
+            Anchor::Center => {
+                // Center on screen
+                let x = screen
+                    .x
+                    .saturating_add(screen.width.saturating_sub(width) / 2);
+                let y = screen
+                    .y
+                    .saturating_add(screen.height.saturating_sub(height) / 2);
+                (x, y)
+            }
+            Anchor::Below(window_id) => {
+                // Find the referenced window in placements
+                if let Some(wp) = placements.iter().find(|p| p.window_id == *window_id) {
+                    // Position directly below the window
+                    let x = wp.bounds.x;
+                    let y = wp.bounds.y.saturating_add(wp.bounds.height);
+                    self.clamp_position(x, y, width, height, screen)
+                } else {
+                    // Window not found - fall back to origin
+                    (0, 0)
+                }
+            }
+        }
+    }
+
+    /// Clamp position so overlay stays within screen bounds.
+    ///
+    /// # Arguments
+    ///
+    /// * `x`, `y` - Desired position
+    /// * `width`, `height` - Overlay dimensions
+    /// * `screen` - Screen bounds
+    ///
+    /// # Returns
+    ///
+    /// Clamped `(x, y)` ensuring overlay fits on screen.
+    fn clamp_position(&self, x: u16, y: u16, width: u16, height: u16, screen: Rect) -> (u16, u16) {
+        // Calculate maximum allowed position so overlay stays on screen
+        let max_x = screen
+            .x
+            .saturating_add(screen.width)
+            .saturating_sub(width)
+            .max(screen.x);
+        let max_y = screen
+            .y
+            .saturating_add(screen.height)
+            .saturating_sub(height)
+            .max(screen.y);
+
+        // Clamp position to valid range
+        let clamped_x = x.clamp(screen.x, max_x);
+        let clamped_y = y.clamp(screen.y, max_y);
+
+        (clamped_x, clamped_y)
+    }
+
+    /// Calculate overlay dimensions from constraints.
+    ///
+    /// Uses preferred size if specified, otherwise defaults to minimums.
+    /// Clamps to max size if specified.
+    fn calculate_size(&self, constraints: &OverlayConstraints) -> (u16, u16) {
+        let mut width = constraints.preferred_width.unwrap_or(MIN_OVERLAY_WIDTH);
+        let mut height = constraints.preferred_height.unwrap_or(MIN_OVERLAY_HEIGHT);
+
+        // Apply minimum constraints
+        width = width.max(MIN_OVERLAY_WIDTH);
+        height = height.max(MIN_OVERLAY_HEIGHT);
+
+        // Apply maximum constraints if specified
+        if let Some(max_w) = constraints.max_width {
+            width = width.min(max_w);
+        }
+        if let Some(max_h) = constraints.max_height {
+            height = height.min(max_h);
+        }
+
+        (width, height)
+    }
+}
+
+impl OverlayLayer for OverlayZone {
+    /// Get all overlays as placements, sorted by z-order.
+    ///
+    /// Windows are returned in z-stack order (lowest first), with z-order
+    /// computed as `z_base + Zone::Overlay.z_offset() + stack_index`.
+    ///
+    /// Anchor resolution uses the provided `window_placements` to find
+    /// positions for `Cursor` and `Below` anchors.
+    fn arrange(&self, screen: Rect, window_placements: &[WindowPlacement]) -> Vec<WindowPlacement> {
+        self.z_stack
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &window_id)| {
+                self.overlays.get(&window_id).map(|ow| {
+                    // Calculate size from constraints
+                    let (width, height) = self.calculate_size(&ow.constraints);
+
+                    // Resolve anchor to screen position
+                    let (x, y) = self.resolve_anchor(
+                        &ow.constraints.anchor,
+                        screen,
+                        width,
+                        height,
+                        window_placements,
+                    );
+
+                    let bounds = Rect::new(x, y, width, height);
+                    let z_order = ZOrder::for_window(self.z_base, Zone::Overlay, index as u16);
+
+                    WindowPlacement::new(window_id, self.layer_id, Zone::Overlay, bounds, z_order)
+                })
+            })
+            .collect()
+    }
+
+    /// Show an overlay with constraints.
+    ///
+    /// The overlay is added to the top of the z-stack (highest z-order).
+    /// If at capacity (50 overlays), silently ignores the request.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Window identifier (provided by caller)
+    /// * `constraints` - Positioning and size constraints
+    fn show(&mut self, id: WindowId, constraints: OverlayConstraints) {
+        // Check capacity - silently reject if at limit
+        if self.is_at_capacity() {
+            return;
+        }
+
+        // If overlay already exists, update constraints and raise to top
+        if self.overlays.contains_key(&id) {
+            if let Some(ow) = self.overlays.get_mut(&id) {
+                ow.constraints = constraints;
+            }
+            // Raise to top
+            self.z_stack.retain(|&x| x != id);
+            self.z_stack.push(id);
+            return;
+        }
+
+        let z_order = ZOrder::for_window(self.z_base, Zone::Overlay, self.z_stack.len() as u16);
+        let overlay_window = OverlayWindow {
+            id,
+            constraints,
+            computed_bounds: Rect::default(), // Will be computed in arrange()
+            z_order,
+        };
+
+        self.overlays.insert(id, overlay_window);
+        self.z_stack.push(id); // Add to top of stack
+    }
+
+    /// Hide (remove) an overlay.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the overlay existed and was hidden.
+    fn hide(&mut self, id: WindowId) -> bool {
+        if self.overlays.remove(&id).is_some() {
+            self.z_stack.retain(|&x| x != id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update overlay size (content changed).
+    ///
+    /// Updates the preferred size in constraints.
+    /// Does nothing if the overlay doesn't exist.
+    fn update_size(&mut self, id: WindowId, width: u16, height: u16) {
+        if let Some(ow) = self.overlays.get_mut(&id) {
+            ow.constraints.preferred_width = Some(width.max(MIN_OVERLAY_WIDTH));
+            ow.constraints.preferred_height = Some(height.max(MIN_OVERLAY_HEIGHT));
+        }
+    }
+
+    /// Check if overlay is visible.
+    fn is_visible(&self, id: WindowId) -> bool {
+        self.overlays.contains_key(&id)
+    }
+
+    /// Get all visible overlay IDs.
+    fn visible_overlays(&self) -> Vec<WindowId> {
+        self.z_stack.clone()
+    }
+
+    /// Hide all overlays.
+    fn hide_all(&mut self) {
+        self.overlays.clear();
+        self.z_stack.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn test_zone() -> OverlayZone {
+        OverlayZone::new(LayerId::new(0), ZOrder::new(0))
+    }
+
+    fn test_screen() -> Rect {
+        Rect::new(0, 0, 80, 24)
+    }
+
+    fn centered_constraints() -> OverlayConstraints {
+        OverlayConstraints::centered().with_size(40, 10)
+    }
+
+    #[test]
+    fn test_overlay_zone_new() {
+        let zone = test_zone();
+        assert!(zone.is_empty());
+        assert_eq!(zone.len(), 0);
+        assert!(!zone.is_at_capacity());
+    }
+
+    #[test]
+    fn test_show_overlay() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+        let constraints = centered_constraints();
+
+        zone.show(id, constraints);
+
+        assert!(zone.is_visible(id));
+        assert_eq!(zone.len(), 1);
+        assert!(zone.constraints(id).is_some());
+    }
+
+    #[test]
+    fn test_hide_overlay() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        zone.show(id, centered_constraints());
+        assert!(zone.is_visible(id));
+
+        let hidden = zone.hide(id);
+
+        assert!(hidden);
+        assert!(!zone.is_visible(id));
+        assert_eq!(zone.len(), 0);
+    }
+
+    #[test]
+    fn test_hide_nonexistent_overlay() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        let hidden = zone.hide(id);
+
+        assert!(!hidden);
+        assert!(zone.is_empty());
+    }
+
+    #[test]
+    fn test_overlay_z_order() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.show(id1, centered_constraints());
+        zone.show(id2, centered_constraints());
+        zone.show(id3, centered_constraints());
+
+        // Z-stack order: id1 (bottom), id2, id3 (top)
+        assert_eq!(zone.z_position(id1), Some(0));
+        assert_eq!(zone.z_position(id2), Some(1));
+        assert_eq!(zone.z_position(id3), Some(2));
+
+        let placements = zone.arrange(test_screen(), &[]);
+
+        // Verify z-order increases (overlay base is 50)
+        assert_eq!(placements[0].z_order.as_u16(), 50);
+        assert_eq!(placements[1].z_order.as_u16(), 51);
+        assert_eq!(placements[2].z_order.as_u16(), 52);
+    }
+
+    #[test]
+    fn test_anchor_cursor_resolution() {
+        let mut zone = test_zone();
+        let overlay_id = WindowId::from_raw(100);
+        let window_id = WindowId::from_raw(1);
+
+        // Create overlay anchored to cursor in window at line 5, col 10
+        let constraints = OverlayConstraints::at_cursor_raw(window_id, 5, 10).with_size(20, 5);
+        zone.show(overlay_id, constraints);
+
+        // Create a placement for the referenced window
+        let window_placement = WindowPlacement::new(
+            window_id,
+            LayerId::new(0),
+            Zone::Tiled,
+            Rect::new(0, 0, 40, 20), // Window at (0,0) with size 40x20
+            ZOrder::new(0),
+        );
+
+        let placements = zone.arrange(test_screen(), &[window_placement]);
+
+        assert_eq!(placements.len(), 1);
+        // Expected: x = 0 + 10 = 10, y = 0 + 5 + 1 = 6 (below cursor)
+        assert_eq!(placements[0].bounds.x, 10);
+        assert_eq!(placements[0].bounds.y, 6);
+    }
+
+    #[test]
+    fn test_anchor_screen_resolution() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        // Anchor to specific screen position
+        let constraints = OverlayConstraints::at_position(30, 10).with_size(20, 5);
+        zone.show(id, constraints);
+
+        let placements = zone.arrange(test_screen(), &[]);
+
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].bounds.x, 30);
+        assert_eq!(placements[0].bounds.y, 10);
+    }
+
+    #[test]
+    fn test_anchor_center_resolution() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        let constraints = OverlayConstraints::centered().with_size(20, 10);
+        zone.show(id, constraints);
+
+        let screen = Rect::new(0, 0, 80, 24);
+        let placements = zone.arrange(screen, &[]);
+
+        assert_eq!(placements.len(), 1);
+        // Center: x = (80 - 20) / 2 = 30, y = (24 - 10) / 2 = 7
+        assert_eq!(placements[0].bounds.x, 30);
+        assert_eq!(placements[0].bounds.y, 7);
+    }
+
+    #[test]
+    fn test_anchor_below_resolution() {
+        let mut zone = test_zone();
+        let overlay_id = WindowId::from_raw(100);
+        let window_id = WindowId::from_raw(1);
+
+        // Create overlay anchored below a window
+        let constraints = OverlayConstraints {
+            anchor: Anchor::Below(window_id),
+            preferred_width: Some(30),
+            preferred_height: Some(5),
+            max_width: None,
+            max_height: None,
+        };
+        zone.show(overlay_id, constraints);
+
+        // Create a placement for the referenced window at (10, 5) with height 10
+        let window_placement = WindowPlacement::new(
+            window_id,
+            LayerId::new(0),
+            Zone::Tiled,
+            Rect::new(10, 5, 40, 10),
+            ZOrder::new(0),
+        );
+
+        let placements = zone.arrange(test_screen(), &[window_placement]);
+
+        assert_eq!(placements.len(), 1);
+        // Expected: x = 10 (same as window), y = 5 + 10 = 15 (below window)
+        assert_eq!(placements[0].bounds.x, 10);
+        assert_eq!(placements[0].bounds.y, 15);
+    }
+
+    #[test]
+    fn test_clamp_to_screen() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        // Anchor to position that would go off screen
+        let constraints = OverlayConstraints::at_position(70, 20).with_size(20, 10);
+        zone.show(id, constraints);
+
+        let screen = Rect::new(0, 0, 80, 24);
+        let placements = zone.arrange(screen, &[]);
+
+        assert_eq!(placements.len(), 1);
+        // Should be clamped: max_x = 80 - 20 = 60, max_y = 24 - 10 = 14
+        assert_eq!(placements[0].bounds.x, 60);
+        assert_eq!(placements[0].bounds.y, 14);
+    }
+
+    #[test]
+    fn test_max_overlay_capacity() {
+        let mut zone = test_zone();
+
+        // Create MAX_OVERLAY_WINDOWS overlays
+        for i in 0..MAX_OVERLAY_WINDOWS {
+            let id = WindowId::from_raw(i);
+            zone.show(id, centered_constraints());
+        }
+
+        assert_eq!(zone.len(), MAX_OVERLAY_WINDOWS);
+        assert!(zone.is_at_capacity());
+
+        // Try to create one more - should be silently ignored
+        let extra_id = WindowId::from_raw(999);
+        zone.show(extra_id, centered_constraints());
+
+        assert_eq!(zone.len(), MAX_OVERLAY_WINDOWS);
+        assert!(!zone.is_visible(extra_id));
+    }
+
+    #[test]
+    fn test_update_size() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        zone.show(id, OverlayConstraints::centered().with_size(20, 10));
+
+        // Update size
+        zone.update_size(id, 40, 15);
+
+        let constraints = zone.constraints(id).unwrap();
+        assert_eq!(constraints.preferred_width, Some(40));
+        assert_eq!(constraints.preferred_height, Some(15));
+    }
+
+    #[test]
+    fn test_hide_all() {
+        let mut zone = test_zone();
+
+        zone.show(WindowId::from_raw(1), centered_constraints());
+        zone.show(WindowId::from_raw(2), centered_constraints());
+        zone.show(WindowId::from_raw(3), centered_constraints());
+
+        assert_eq!(zone.len(), 3);
+
+        zone.hide_all();
+
+        assert!(zone.is_empty());
+        assert_eq!(zone.len(), 0);
+    }
+
+    #[test]
+    fn test_arrange_sorted_by_z() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+        let id3 = WindowId::from_raw(3);
+
+        zone.show(id1, OverlayConstraints::at_position(0, 0).with_size(10, 5));
+        zone.show(id2, OverlayConstraints::at_position(10, 5).with_size(15, 5));
+        zone.show(id3, OverlayConstraints::at_position(20, 10).with_size(20, 5));
+
+        let placements = zone.arrange(test_screen(), &[]);
+
+        assert_eq!(placements.len(), 3);
+
+        // Verify z-order increases
+        assert!(placements[0].z_order < placements[1].z_order);
+        assert!(placements[1].z_order < placements[2].z_order);
+
+        // Verify order matches z_stack
+        assert_eq!(placements[0].window_id, id1);
+        assert_eq!(placements[1].window_id, id2);
+        assert_eq!(placements[2].window_id, id3);
+
+        // Verify zone is Overlay
+        for p in &placements {
+            assert_eq!(p.zone, Zone::Overlay);
+        }
+    }
+
+    #[test]
+    fn test_anchor_cursor_window_not_in_placements() {
+        let mut zone = test_zone();
+        let overlay_id = WindowId::from_raw(100);
+        let nonexistent_window = WindowId::from_raw(999);
+
+        // Anchor to window that doesn't exist in placements
+        let constraints =
+            OverlayConstraints::at_cursor_raw(nonexistent_window, 5, 10).with_size(20, 5);
+        zone.show(overlay_id, constraints);
+
+        // Empty placements - window won't be found
+        let placements = zone.arrange(test_screen(), &[]);
+
+        assert_eq!(placements.len(), 1);
+        // Should fall back to (0, 0)
+        assert_eq!(placements[0].bounds.x, 0);
+        assert_eq!(placements[0].bounds.y, 0);
+    }
+
+    #[test]
+    fn test_anchor_below_window_not_in_placements() {
+        let mut zone = test_zone();
+        let overlay_id = WindowId::from_raw(100);
+        let nonexistent_window = WindowId::from_raw(999);
+
+        // Anchor below window that doesn't exist
+        let constraints = OverlayConstraints {
+            anchor: Anchor::Below(nonexistent_window),
+            preferred_width: Some(20),
+            preferred_height: Some(5),
+            max_width: None,
+            max_height: None,
+        };
+        zone.show(overlay_id, constraints);
+
+        let placements = zone.arrange(test_screen(), &[]);
+
+        assert_eq!(placements.len(), 1);
+        // Should fall back to (0, 0)
+        assert_eq!(placements[0].bounds.x, 0);
+        assert_eq!(placements[0].bounds.y, 0);
+    }
+
+    #[test]
+    fn test_visible_overlays_returns_all_ids() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.show(id1, centered_constraints());
+        zone.show(id2, centered_constraints());
+
+        let visible = zone.visible_overlays();
+
+        assert_eq!(visible.len(), 2);
+        assert!(visible.contains(&id1));
+        assert!(visible.contains(&id2));
+    }
+
+    #[test]
+    fn test_is_visible() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.show(id1, centered_constraints());
+
+        assert!(zone.is_visible(id1));
+        assert!(!zone.is_visible(id2));
+    }
+
+    #[test]
+    fn test_z_order_values_are_in_overlay_zone_range() {
+        let mut zone = OverlayZone::new(LayerId::new(0), ZOrder::new(0));
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.show(id1, centered_constraints());
+        zone.show(id2, centered_constraints());
+
+        let placements = zone.arrange(test_screen(), &[]);
+
+        // Overlay zone offset is 50
+        let overlay_offset = Zone::Overlay.z_offset();
+        assert_eq!(overlay_offset, 50);
+
+        // First window: z = 0 + 50 + 0 = 50
+        assert_eq!(placements[0].z_order.as_u16(), 50);
+        // Second window: z = 0 + 50 + 1 = 51
+        assert_eq!(placements[1].z_order.as_u16(), 51);
+    }
+
+    #[test]
+    fn test_arrange_empty_zone_returns_empty() {
+        let zone = test_zone();
+        let placements = zone.arrange(test_screen(), &[]);
+        assert!(placements.is_empty());
+    }
+
+    #[test]
+    fn test_show_existing_overlay_updates_and_raises() {
+        let mut zone = test_zone();
+        let id1 = WindowId::from_raw(1);
+        let id2 = WindowId::from_raw(2);
+
+        zone.show(id1, OverlayConstraints::at_position(10, 10).with_size(20, 5));
+        zone.show(id2, centered_constraints());
+
+        // id1 is at bottom (position 0), id2 is at top (position 1)
+        assert_eq!(zone.z_position(id1), Some(0));
+        assert_eq!(zone.z_position(id2), Some(1));
+
+        // Show id1 again with different constraints - should update and raise
+        zone.show(id1, OverlayConstraints::at_position(30, 20).with_size(25, 8));
+
+        // id1 should now be at top
+        assert_eq!(zone.z_position(id2), Some(0));
+        assert_eq!(zone.z_position(id1), Some(1));
+
+        // Constraints should be updated
+        let constraints = zone.constraints(id1).unwrap();
+        assert_eq!(constraints.preferred_width, Some(25));
+        assert_eq!(constraints.preferred_height, Some(8));
+    }
+
+    #[test]
+    fn test_update_size_clamps_to_minimum() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(1);
+
+        zone.show(id, centered_constraints());
+
+        // Try to update to size smaller than minimum
+        zone.update_size(id, 2, 0);
+
+        let constraints = zone.constraints(id).unwrap();
+        assert_eq!(constraints.preferred_width, Some(MIN_OVERLAY_WIDTH));
+        assert_eq!(constraints.preferred_height, Some(MIN_OVERLAY_HEIGHT));
+    }
+
+    #[test]
+    fn test_update_size_nonexistent_is_noop() {
+        let mut zone = test_zone();
+        let id = WindowId::from_raw(999);
+
+        // Should not panic
+        zone.update_size(id, 50, 50);
+
+        assert!(!zone.is_visible(id));
+    }
+}

--- a/modules/pair/Cargo.toml
+++ b/modules/pair/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "reovim-module-pair"
+version = "0.9.2-dev"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Pair module: auto-close brackets, rainbow highlighting, matched pair indicator"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+dynamic = []  # Enable FFI entry points for standalone dynamic loading
+
+[lints]
+workspace = true
+
+[dependencies]
+# Kernel layer (for Module trait, BufferId, ServiceRegistry)
+reovim-kernel = { path = "../../lib/kernel", version = "0.9.2-dev" }
+
+# Module macros for dynamic loading
+reovim-module-macros = { path = "../../lib/module-macros" }
+
+# Driver layers
+reovim-driver-buffer = { path = "../../lib/drivers/buffer", version = "0.9.2-dev" }
+reovim-driver-display = { path = "../../lib/drivers/display", version = "0.9.2-dev" }
+
+# Platform abstraction (for RwLock, Color)
+reovim-arch = { path = "../../lib/arch", version = "0.9.2-dev" }
+
+# Logging
+tracing = { workspace = true }

--- a/modules/pair/src/auto_pair.rs
+++ b/modules/pair/src/auto_pair.rs
@@ -1,0 +1,347 @@
+//! Auto-pair bracket insertion logic.
+//!
+//! When an opening bracket is typed, this module auto-inserts the closing bracket
+//! with the cursor positioned between them.
+//!
+//! # Supported Pairs
+//!
+//! | Open | Close | Type |
+//! |------|-------|------|
+//! | `(`  | `)`   | Asymmetric |
+//! | `[`  | `]`   | Asymmetric |
+//! | `{`  | `}`   | Asymmetric |
+//! | `` ` `` | `` ` `` | Symmetric |
+//! | `'`  | `'`   | Symmetric |
+//! | `"`  | `"`   | Symmetric |
+//!
+//! # Symmetric Pair Handling
+//!
+//! Symmetric pairs (backtick, quotes) require special tracking to prevent
+//! infinite recursion. When we auto-insert a symmetric closing character,
+//! we track it so that when the `BufferModified` event fires for that
+//! insertion, we know to skip auto-pairing.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Tracks the last auto-inserted symmetric character to prevent infinite recursion.
+///
+/// Uses a simple encoding:
+/// - 0 = none
+/// - 1 = backtick
+/// - 2 = single quote
+/// - 3 = double quote
+static LAST_AUTO_INSERT: AtomicU8 = AtomicU8::new(0);
+
+/// Map a symmetric character to its tracking code.
+const fn char_to_code(c: char) -> u8 {
+    match c {
+        '`' => 1,
+        '\'' => 2,
+        '"' => 3,
+        _ => 0,
+    }
+}
+
+/// Check if the given character was just auto-inserted by us.
+///
+/// This atomically clears the tracking state, so it can only return `true` once
+/// per auto-insertion.
+pub fn is_last_auto_insert(c: char) -> bool {
+    let code = char_to_code(c);
+    code != 0 && LAST_AUTO_INSERT.swap(0, Ordering::SeqCst) == code
+}
+
+/// Mark that we're about to auto-insert a symmetric character.
+///
+/// Call this before inserting the closing bracket for symmetric pairs.
+pub fn mark_auto_insert(c: char) {
+    let code = char_to_code(c);
+    if code != 0 {
+        LAST_AUTO_INSERT.store(code, Ordering::SeqCst);
+    }
+}
+
+/// Result of checking if auto-pair should trigger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoPairResult {
+    /// Insert the closing bracket.
+    Insert {
+        /// The closing character to insert.
+        close: char,
+        /// Whether this is a symmetric pair (same open and close).
+        symmetric: bool,
+    },
+    /// Skip over an existing closing bracket (don't insert, just move cursor).
+    SkipOver,
+    /// Skip auto-pairing (not an opening bracket or was our own insertion).
+    Skip,
+}
+
+/// Check if the inserted text should trigger auto-pairing.
+///
+/// Returns `AutoPairResult::Insert` if a closing bracket should be inserted,
+/// or `AutoPairResult::Skip` if no action is needed.
+///
+/// # Arguments
+///
+/// * `text` - The text that was just inserted into the buffer.
+///
+/// # Examples
+///
+/// ```ignore
+/// use reovim_module_pair::auto_pair::{should_auto_pair, AutoPairResult};
+///
+/// assert_eq!(
+///     should_auto_pair("("),
+///     AutoPairResult::Insert { close: ')', symmetric: false }
+/// );
+/// assert_eq!(should_auto_pair("a"), AutoPairResult::Skip);
+/// ```
+#[must_use]
+pub fn should_auto_pair(text: &str) -> AutoPairResult {
+    // Only handle single-character insertions
+    let mut chars = text.chars();
+    let (Some(c), None) = (chars.next(), chars.next()) else {
+        return AutoPairResult::Skip;
+    };
+
+    // For symmetric pairs, check if this is our own auto-inserted character
+    if is_symmetric(c) && is_last_auto_insert(c) {
+        return AutoPairResult::Skip;
+    }
+
+    match c {
+        '(' => AutoPairResult::Insert {
+            close: ')',
+            symmetric: false,
+        },
+        '[' => AutoPairResult::Insert {
+            close: ']',
+            symmetric: false,
+        },
+        '{' => AutoPairResult::Insert {
+            close: '}',
+            symmetric: false,
+        },
+        '`' => AutoPairResult::Insert {
+            close: '`',
+            symmetric: true,
+        },
+        '\'' => AutoPairResult::Insert {
+            close: '\'',
+            symmetric: true,
+        },
+        '"' => AutoPairResult::Insert {
+            close: '"',
+            symmetric: true,
+        },
+        // Note: < is intentionally excluded (ambiguous with less-than operator)
+        _ => AutoPairResult::Skip,
+    }
+}
+
+/// Check if a character is a symmetric pair (same open and close).
+const fn is_symmetric(c: char) -> bool {
+    matches!(c, '`' | '\'' | '"')
+}
+
+/// Get the closing bracket for an opening bracket.
+///
+/// Returns `None` if the character is not a supported opening bracket.
+#[must_use]
+pub const fn get_closing_bracket(open: char) -> Option<char> {
+    match open {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '`' => Some('`'),
+        '\'' => Some('\''),
+        '"' => Some('"'),
+        _ => None,
+    }
+}
+
+/// Check if a character is an opening bracket.
+#[must_use]
+pub const fn is_opening_bracket(c: char) -> bool {
+    matches!(c, '(' | '[' | '{' | '`' | '\'' | '"')
+}
+
+/// Check if a character is a closing bracket.
+#[must_use]
+pub const fn is_closing_bracket(c: char) -> bool {
+    matches!(c, ')' | ']' | '}' | '`' | '\'' | '"')
+}
+
+/// Check if we should skip over a closing bracket instead of inserting.
+///
+/// Returns `true` if:
+/// - The typed character is a closing bracket
+/// - The character at the cursor position (before insert) is the same
+///
+/// # Arguments
+///
+/// * `typed` - The character that was just typed
+/// * `char_at_cursor` - The character that was at the cursor position before the insert
+#[must_use]
+pub fn should_skip_over(typed: char, char_at_cursor: Option<char>) -> bool {
+    is_closing_bracket(typed) && char_at_cursor == Some(typed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_auto_pair_parentheses() {
+        assert_eq!(
+            should_auto_pair("("),
+            AutoPairResult::Insert {
+                close: ')',
+                symmetric: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_auto_pair_brackets() {
+        assert_eq!(
+            should_auto_pair("["),
+            AutoPairResult::Insert {
+                close: ']',
+                symmetric: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_auto_pair_braces() {
+        assert_eq!(
+            should_auto_pair("{"),
+            AutoPairResult::Insert {
+                close: '}',
+                symmetric: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_auto_pair_backtick() {
+        // Reset state first
+        LAST_AUTO_INSERT.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            should_auto_pair("`"),
+            AutoPairResult::Insert {
+                close: '`',
+                symmetric: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_auto_pair_single_quote() {
+        LAST_AUTO_INSERT.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            should_auto_pair("'"),
+            AutoPairResult::Insert {
+                close: '\'',
+                symmetric: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_auto_pair_double_quote() {
+        LAST_AUTO_INSERT.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            should_auto_pair("\""),
+            AutoPairResult::Insert {
+                close: '"',
+                symmetric: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_should_skip_regular_text() {
+        assert_eq!(should_auto_pair("a"), AutoPairResult::Skip);
+        assert_eq!(should_auto_pair("hello"), AutoPairResult::Skip);
+        assert_eq!(should_auto_pair(""), AutoPairResult::Skip);
+    }
+
+    #[test]
+    fn test_should_skip_angle_brackets() {
+        // < and > are intentionally NOT auto-paired
+        assert_eq!(should_auto_pair("<"), AutoPairResult::Skip);
+        assert_eq!(should_auto_pair(">"), AutoPairResult::Skip);
+    }
+
+    #[test]
+    fn test_symmetric_pair_tracking() {
+        // Reset state
+        LAST_AUTO_INSERT.store(0, Ordering::SeqCst);
+
+        // First backtick should trigger auto-pair
+        assert_eq!(
+            should_auto_pair("`"),
+            AutoPairResult::Insert {
+                close: '`',
+                symmetric: true
+            }
+        );
+
+        // Mark that we auto-inserted a backtick
+        mark_auto_insert('`');
+
+        // Second backtick should be skipped (it's our auto-inserted one)
+        assert_eq!(should_auto_pair("`"), AutoPairResult::Skip);
+
+        // Third backtick should trigger again (tracking was cleared)
+        assert_eq!(
+            should_auto_pair("`"),
+            AutoPairResult::Insert {
+                close: '`',
+                symmetric: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_closing_bracket_lookup() {
+        assert_eq!(get_closing_bracket('('), Some(')'));
+        assert_eq!(get_closing_bracket('['), Some(']'));
+        assert_eq!(get_closing_bracket('{'), Some('}'));
+        assert_eq!(get_closing_bracket('`'), Some('`'));
+        assert_eq!(get_closing_bracket('\''), Some('\''));
+        assert_eq!(get_closing_bracket('"'), Some('"'));
+        assert_eq!(get_closing_bracket('<'), None);
+        assert_eq!(get_closing_bracket('a'), None);
+    }
+
+    #[test]
+    fn test_is_opening_bracket() {
+        assert!(is_opening_bracket('('));
+        assert!(is_opening_bracket('['));
+        assert!(is_opening_bracket('{'));
+        assert!(is_opening_bracket('`'));
+        assert!(is_opening_bracket('\''));
+        assert!(is_opening_bracket('"'));
+        assert!(!is_opening_bracket('<'));
+        assert!(!is_opening_bracket('a'));
+    }
+
+    #[test]
+    fn test_is_closing_bracket() {
+        assert!(is_closing_bracket(')'));
+        assert!(is_closing_bracket(']'));
+        assert!(is_closing_bracket('}'));
+        assert!(is_closing_bracket('`'));
+        assert!(is_closing_bracket('\''));
+        assert!(is_closing_bracket('"'));
+        assert!(!is_closing_bracket('>'));
+        assert!(!is_closing_bracket('a'));
+    }
+}

--- a/modules/pair/src/decorations.rs
+++ b/modules/pair/src/decorations.rs
@@ -1,0 +1,296 @@
+//! Decoration generation for rainbow bracket highlighting.
+//!
+//! This module provides bracket decorations for the rendering system:
+//! - Rainbow colors based on nesting depth
+//! - Bold/underline for matched pair under cursor
+//! - Red warning style for unmatched brackets
+//!
+//! # Rainbow Palette
+//!
+//! Uses a 6-color cycle that repeats for deeply nested brackets:
+//! - Depth 0: Red
+//! - Depth 1: Orange
+//! - Depth 2: Yellow
+//! - Depth 3: Green
+//! - Depth 4: Blue
+//! - Depth 5: Purple
+//! - Depth 6+: Repeats from red
+
+use {
+    reovim_arch::Color,
+    reovim_driver_display::{Decoration, DecorationGroup, Span, Style},
+};
+
+use crate::state::{BracketInfo, MatchedPair, SharedPairState};
+
+/// Rainbow bracket colors (6-color palette, cycles for deeper nesting).
+///
+/// These are vibrant, high-contrast colors for visibility in both
+/// dark and light themes. Theme integration (Phase 5) will allow
+/// customization via `rainbow.bracket.{1-6}` highlight groups.
+pub const RAINBOW_COLORS: [Color; 6] = [
+    Color::Rgb {
+        r: 229,
+        g: 57,
+        b: 53,
+    }, // Red
+    Color::Rgb {
+        r: 255,
+        g: 152,
+        b: 0,
+    }, // Orange
+    Color::Rgb {
+        r: 253,
+        g: 216,
+        b: 53,
+    }, // Yellow
+    Color::Rgb {
+        r: 76,
+        g: 175,
+        b: 80,
+    }, // Green
+    Color::Rgb {
+        r: 33,
+        g: 150,
+        b: 243,
+    }, // Blue
+    Color::Rgb {
+        r: 156,
+        g: 39,
+        b: 176,
+    }, // Purple
+];
+
+/// Warning color for unmatched brackets.
+pub const UNMATCHED_COLOR: Color = Color::Red;
+
+/// Get the rainbow color for a bracket depth.
+///
+/// Cycles through the 6-color palette for depths >= 6.
+#[must_use]
+pub const fn color_for_depth(depth: usize) -> Color {
+    RAINBOW_COLORS[depth % RAINBOW_COLORS.len()]
+}
+
+/// Generate a style for a bracket at the given depth.
+///
+/// - Normal brackets: foreground color only
+/// - Unmatched brackets (depth == `usize::MAX`): red + underline
+#[must_use]
+pub fn style_for_bracket(depth: usize) -> Style {
+    if depth == usize::MAX {
+        // Unmatched bracket: red with underline for warning
+        Style::new().fg(UNMATCHED_COLOR).underline()
+    } else {
+        // Normal bracket: rainbow color based on depth
+        Style::new().fg(color_for_depth(depth))
+    }
+}
+
+/// Generate a style for a matched pair bracket (cursor is on/between them).
+///
+/// Uses the rainbow color plus bold and underline to make them distinctive.
+#[must_use]
+pub fn style_for_matched_pair(depth: usize) -> Style {
+    if depth == usize::MAX {
+        // Edge case: unmatched bracket shouldn't be in a matched pair,
+        // but handle gracefully
+        style_for_bracket(depth)
+    } else {
+        Style::new().fg(color_for_depth(depth)).bold().underline()
+    }
+}
+
+/// Generate decorations for all brackets in a buffer.
+///
+/// Returns a vector of `Decoration::InlineStyle` items for each bracket,
+/// using rainbow colors based on depth. Matched pair brackets (if any)
+/// get additional bold + underline styling.
+///
+/// # Arguments
+///
+/// * `brackets` - Iterator of bracket info from `SharedPairState`
+/// * `matched_pair` - Optional matched pair for cursor highlighting
+///
+/// # Returns
+///
+/// Vector of decorations for `DecorationGroup::Syntax`
+#[must_use]
+pub fn generate_bracket_decorations<'a>(
+    brackets: impl Iterator<Item = &'a BracketInfo>,
+    matched_pair: Option<&MatchedPair>,
+) -> Vec<Decoration> {
+    let mut decorations = Vec::new();
+
+    // Track matched pair positions for special styling
+    let matched_positions: Option<((usize, usize), (usize, usize))> =
+        matched_pair.map(|mp| ((mp.open.line, mp.open.col), (mp.close.line, mp.close.col)));
+
+    for bracket in brackets {
+        let pos = (bracket.line, bracket.col);
+        let is_matched = matched_positions.is_some_and(|(open, close)| pos == open || pos == close);
+
+        let style = if is_matched {
+            style_for_matched_pair(bracket.depth)
+        } else {
+            style_for_bracket(bracket.depth)
+        };
+
+        // Bracket is a single character at (line, col)
+        #[allow(clippy::cast_possible_truncation)]
+        let span = Span::line(bracket.line as u32, bracket.col as u32, bracket.col as u32 + 1);
+
+        decorations.push(Decoration::inline_style(span, style));
+    }
+
+    decorations
+}
+
+/// Generate decorations from shared pair state for a specific buffer.
+///
+/// Convenience function that extracts bracket data from `SharedPairState`
+/// and generates decorations.
+///
+/// # Arguments
+///
+/// * `state` - The shared pair state service
+/// * `buffer_id` - Buffer to generate decorations for
+///
+/// # Returns
+///
+/// Vector of decorations for the buffer's brackets
+#[must_use]
+pub fn generate_decorations_for_buffer(
+    state: &SharedPairState,
+    buffer_id: reovim_kernel::api::v1::BufferId,
+) -> Vec<Decoration> {
+    // Get brackets and matched pair from state
+    let brackets = state.get_brackets(buffer_id);
+    let matched_pair = state.get_matched_pair(buffer_id);
+
+    brackets.map_or_else(Vec::new, |bracket_map| {
+        let bracket_iter = bracket_map.values();
+        generate_bracket_decorations(bracket_iter, matched_pair.as_ref())
+    })
+}
+
+/// The decoration group for bracket highlighting.
+///
+/// Uses `Syntax` group (priority 10) which is above Language (0)
+/// but below Search (20) and Visual (40).
+pub const PAIR_DECORATION_GROUP: DecorationGroup = DecorationGroup::Syntax;
+
+#[cfg(test)]
+mod tests {
+    use reovim_driver_display::Attributes;
+
+    use super::*;
+
+    #[test]
+    fn test_rainbow_colors_count() {
+        assert_eq!(RAINBOW_COLORS.len(), 6);
+    }
+
+    #[test]
+    fn test_color_for_depth_cycles() {
+        // First cycle
+        assert_eq!(color_for_depth(0), RAINBOW_COLORS[0]); // Red
+        assert_eq!(color_for_depth(1), RAINBOW_COLORS[1]); // Orange
+        assert_eq!(color_for_depth(5), RAINBOW_COLORS[5]); // Purple
+
+        // Second cycle
+        assert_eq!(color_for_depth(6), RAINBOW_COLORS[0]); // Red again
+        assert_eq!(color_for_depth(7), RAINBOW_COLORS[1]); // Orange again
+    }
+
+    #[test]
+    fn test_style_for_bracket_normal() {
+        let style = style_for_bracket(0);
+        assert_eq!(style.fg, Some(RAINBOW_COLORS[0]));
+        assert!(!style.attributes.contains(Attributes::UNDERLINE));
+    }
+
+    #[test]
+    fn test_style_for_bracket_unmatched() {
+        let style = style_for_bracket(usize::MAX);
+        assert_eq!(style.fg, Some(UNMATCHED_COLOR));
+        assert!(style.attributes.contains(Attributes::UNDERLINE));
+    }
+
+    #[test]
+    fn test_style_for_matched_pair() {
+        let style = style_for_matched_pair(2);
+        assert_eq!(style.fg, Some(RAINBOW_COLORS[2])); // Yellow
+        assert!(style.attributes.contains(Attributes::BOLD));
+        assert!(style.attributes.contains(Attributes::UNDERLINE));
+    }
+
+    #[test]
+    fn test_generate_bracket_decorations_empty() {
+        let brackets: Vec<BracketInfo> = vec![];
+        let decorations = generate_bracket_decorations(brackets.iter(), None);
+        assert!(decorations.is_empty());
+    }
+
+    #[test]
+    fn test_generate_bracket_decorations_simple() {
+        let brackets = [
+            BracketInfo {
+                line: 0,
+                col: 0,
+                depth: 0,
+                char: '(',
+            },
+            BracketInfo {
+                line: 0,
+                col: 5,
+                depth: 0,
+                char: ')',
+            },
+        ];
+
+        let decorations = generate_bracket_decorations(brackets.iter(), None);
+        assert_eq!(decorations.len(), 2);
+
+        // Both should be inline styles
+        assert!(decorations[0].is_inline_style());
+        assert!(decorations[1].is_inline_style());
+    }
+
+    #[test]
+    fn test_generate_bracket_decorations_with_matched_pair() {
+        let brackets = [
+            BracketInfo {
+                line: 0,
+                col: 0,
+                depth: 0,
+                char: '(',
+            },
+            BracketInfo {
+                line: 0,
+                col: 5,
+                depth: 0,
+                char: ')',
+            },
+        ];
+
+        let matched = MatchedPair {
+            open: brackets[0],
+            close: brackets[1],
+        };
+
+        let decorations = generate_bracket_decorations(brackets.iter(), Some(&matched));
+        assert_eq!(decorations.len(), 2);
+
+        // Both should have matched pair styling (bold + underline)
+        // We can't easily inspect the style, but we know they're generated
+        assert!(decorations[0].is_inline_style());
+        assert!(decorations[1].is_inline_style());
+    }
+
+    #[test]
+    fn test_pair_decoration_group() {
+        assert_eq!(PAIR_DECORATION_GROUP, DecorationGroup::Syntax);
+        assert_eq!(PAIR_DECORATION_GROUP.priority(), 10);
+    }
+}

--- a/modules/pair/src/lib.rs
+++ b/modules/pair/src/lib.rs
@@ -1,0 +1,466 @@
+//! Pair module: auto-close brackets, rainbow highlighting, matched pair indicator.
+//!
+//! This module provides bracket assistance features:
+//!
+//! - **Auto-close brackets**: Typing `(` inserts `()` with cursor between
+//! - **Rainbow bracket highlighting**: Nested brackets colored by depth
+//! - **Matched pair indicator**: Highlight matching bracket under cursor
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │  PAIR MODULE (this crate)                                   POLICY      │
+//! │  PairModule, SharedPairState, rainbow colors, auto-pair behavior        │
+//! │  → Decides HOW brackets behave                                          │
+//! ├─────────────────────────────────────────────────────────────────────────┤
+//! │  DISPLAY DRIVER                                             MECHANISM   │
+//! │  DecorationProvider, DecorationStore, Style, Color                      │
+//! ├─────────────────────────────────────────────────────────────────────────┤
+//! │  KERNEL                                                     MECHANISM   │
+//! │  Module trait, ServiceRegistry, EventBus, BufferManager                 │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Event Subscriptions
+//!
+//! The module subscribes to the following kernel events:
+//!
+//! - `CursorMoved` (priority 100): Update cursor position for matched pair tracking
+//! - `BufferModified` (priority 90): Auto-pair insertion for opening brackets
+//! - `BufferModified` (priority 100): Invalidate bracket cache when content changes
+//! - `BufferClosed` (priority 100): Cleanup buffer-specific state
+//!
+//! # Usage
+//!
+//! The module is automatically loaded when included in the defaults bundle.
+//! No configuration is required for basic functionality.
+//!
+//! ```ignore
+//! use reovim_module_pair::{PairModule, PAIR_MODULE};
+//!
+//! let module = PairModule::new();
+//! assert_eq!(module.id(), PAIR_MODULE);
+//! ```
+
+pub mod auto_pair;
+pub mod decorations;
+pub mod rainbow;
+pub mod state;
+pub mod styles;
+
+// Re-exports
+pub use {
+    auto_pair::AutoPairResult,
+    decorations::{
+        PAIR_DECORATION_GROUP, RAINBOW_COLORS, UNMATCHED_COLOR, color_for_depth,
+        generate_bracket_decorations, generate_decorations_for_buffer, style_for_bracket,
+        style_for_matched_pair,
+    },
+    state::{BracketInfo, MatchedPair, SharedPairState},
+};
+
+/// Decoration source key for rainbow bracket highlighting.
+///
+/// This follows the `<module>.<feature>` naming convention.
+/// Used to register in `BufferDecorationSourceRegistry`.
+pub const DECORATION_KEY_RAINBOW: &str = "pair.rainbow";
+
+use std::sync::Arc;
+
+use {
+    reovim_arch::sync::RwLock,
+    reovim_driver_buffer::{BufferManagerKey, BufferManagerRegistry},
+    reovim_kernel::api::v1::{
+        Buffer, BufferId, EventResult, Module, ModuleContext, ModuleError, ModuleId, Position,
+        ProbeResult, Subscription, Version,
+        events::kernel::{BufferClosed, BufferModified, CursorMoved, Modification, priority},
+    },
+};
+
+use {
+    crate::auto_pair::{
+        get_closing_bracket, is_closing_bracket, is_opening_bracket, mark_auto_insert,
+        should_auto_pair,
+    },
+    tracing::{debug, info, trace},
+};
+
+/// Convert event `buffer_id` (u64) to kernel `BufferId`.
+///
+/// # Note
+///
+/// Buffer IDs are monotonically increasing from 0 within a session,
+/// so they will never realistically exceed `usize::MAX` even on 32-bit systems.
+#[allow(clippy::cast_possible_truncation)]
+const fn buffer_id_from_event(event_buffer_id: u64) -> BufferId {
+    BufferId::from_raw(event_buffer_id as usize)
+}
+
+/// Handle auto-pair logic for a single character insertion.
+///
+/// This function handles:
+/// - **Skip-over**: If a closing bracket is typed and the next char is the same,
+///   delete the just-typed char and leave cursor at the original bracket.
+/// - **Auto-pair**: If an opening bracket is typed, insert the closing bracket
+///   and position cursor between them.
+fn handle_auto_pair(
+    typed_char: char,
+    start: (u32, u32),
+    text: &str,
+    buffer_lock: &Arc<RwLock<Buffer>>,
+) {
+    // Check for closing bracket skip-over (#440)
+    // If user typed a closing bracket and the next char is the same,
+    // delete the just-typed char and move cursor forward
+    if is_closing_bracket(typed_char) {
+        let mut buffer = buffer_lock.write();
+        let insert_pos = Position::new(start.0 as usize, start.1 as usize);
+
+        // Check char at position AFTER the insert (insert_pos.column + 1)
+        if let Some(line_content) = buffer.line(insert_pos.line)
+            && let Some(next_char) = line_content.chars().nth(insert_pos.column + 1)
+            && next_char == typed_char
+        {
+            // Skip over: delete the just-inserted char, move cursor AFTER the bracket
+            buffer.delete_range(insert_pos, Position::new(insert_pos.line, insert_pos.column + 1));
+            // Cursor should be AFTER the closing bracket (position + 1)
+            let after_bracket = Position::new(insert_pos.line, insert_pos.column + 1);
+            buffer.set_position(after_bracket);
+            trace!(
+                "Pair: skipped over '{}' at ({}, {}), cursor now at col {}",
+                typed_char, insert_pos.line, insert_pos.column, after_bracket.column
+            );
+            return;
+        }
+        drop(buffer);
+    }
+
+    // Check for opening bracket auto-pair
+    match should_auto_pair(text) {
+        AutoPairResult::Insert { close, symmetric } => {
+            // Calculate position after the inserted character
+            let insert_pos = Position::new(start.0 as usize, start.1 as usize + 1);
+
+            // Insert closing bracket, then restore cursor to between brackets
+            {
+                let mut buffer = buffer_lock.write();
+                buffer.insert_at(insert_pos, &close.to_string());
+                buffer.set_position(insert_pos); // Restore cursor between brackets
+            }
+
+            // Track symmetric pairs to prevent infinite recursion
+            if symmetric {
+                mark_auto_insert(close);
+            }
+
+            trace!(
+                "Pair: auto-inserted '{}' after '{}' at ({}, {})",
+                close, text, insert_pos.line, insert_pos.column
+            );
+        }
+        AutoPairResult::Skip | AutoPairResult::SkipOver => {}
+    }
+}
+
+/// Handle backspace pair deletion (#440).
+///
+/// When an opening bracket is deleted (via backspace), check if the next character
+/// is the corresponding closing bracket. If so, delete it too.
+///
+/// Example: `(|)` + backspace → empty buffer (both brackets deleted)
+fn handle_backspace_pair(start: (u32, u32), deleted_text: &str, buffer_lock: &Arc<RwLock<Buffer>>) {
+    // Only handle single-character deletions
+    let mut chars = deleted_text.chars();
+    let Some(deleted_char) = chars.next() else {
+        return;
+    };
+    if chars.next().is_some() {
+        return; // Multi-char delete, skip
+    }
+
+    // Only handle opening brackets
+    if !is_opening_bracket(deleted_char) {
+        return;
+    }
+
+    // Get the expected closing bracket
+    let Some(expected_close) = get_closing_bracket(deleted_char) else {
+        return;
+    };
+
+    let mut buffer = buffer_lock.write();
+    let delete_pos = Position::new(start.0 as usize, start.1 as usize);
+
+    // Check if the character at the delete position is the closing bracket
+    if let Some(line_content) = buffer.line(delete_pos.line)
+        && let Some(char_at_pos) = line_content.chars().nth(delete_pos.column)
+        && char_at_pos == expected_close
+    {
+        // Delete the closing bracket
+        buffer.delete_range(delete_pos, Position::new(delete_pos.line, delete_pos.column + 1));
+        drop(buffer);
+        trace!(
+            "Pair: deleted matching '{}' after backspace of '{}' at ({}, {})",
+            expected_close, deleted_char, delete_pos.line, delete_pos.column
+        );
+    }
+}
+
+/// The module identifier for the pair module.
+pub const PAIR_MODULE: ModuleId = ModuleId::new("pair");
+
+/// Pair module instance.
+///
+/// Provides bracket assistance: auto-close, rainbow highlighting, and
+/// matched pair indication.
+///
+/// # Subscription Lifetime
+///
+/// Event subscriptions are stored in the `subscriptions` field to prevent
+/// early drop. They are automatically unsubscribed when the module exits.
+pub struct PairModule {
+    /// Shared bracket state registered in `ServiceRegistry`.
+    state: Option<Arc<SharedPairState>>,
+    /// Active event subscriptions (RAII: dropped on exit).
+    subscriptions: Vec<Subscription>,
+}
+
+impl PairModule {
+    /// Create a new pair module.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: None,
+            subscriptions: Vec::new(),
+        }
+    }
+}
+
+impl Default for PairModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Module for PairModule {
+    fn id(&self) -> ModuleId {
+        PAIR_MODULE
+    }
+
+    fn name(&self) -> &'static str {
+        "Pair Module"
+    }
+
+    fn version(&self) -> Version {
+        Version::new(0, 9, 2)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+        info!("Initializing pair module");
+
+        // Create and register shared state
+        let state = Arc::new(SharedPairState::new());
+        ctx.services.register(state.clone());
+        self.state = Some(state.clone());
+
+        debug!("Pair module: SharedPairState registered in ServiceRegistry");
+
+        // Register style group defaults in StyleGroupRegistry
+        // This allows themes to optionally override rainbow bracket colors
+        {
+            use reovim_driver_display::StyleGroupRegistry;
+
+            let style_registry = ctx.services.get::<StyleGroupRegistry>().unwrap_or_else(|| {
+                let new_registry = StyleGroupRegistry::new();
+                ctx.services.register(Arc::new(new_registry));
+                ctx.services.get::<StyleGroupRegistry>().unwrap()
+            });
+
+            style_registry.register_batch(&styles::default_registrations());
+            debug!(
+                "Pair module: registered {} style groups in StyleGroupRegistry",
+                styles::groups::ALL_RAINBOW_GROUPS.len()
+            );
+        }
+
+        // Register as BufferDecorationSource in BufferDecorationSourceRegistry (#440)
+        // This allows the runner to query decorations generically without
+        // knowing about this module specifically (mechanism/policy separation)
+        {
+            use reovim_driver_display::{BufferDecorationSourceRegistry, DecorationSourceKey};
+
+            let registry = ctx
+                .services
+                .get::<BufferDecorationSourceRegistry>()
+                .unwrap_or_else(|| {
+                    let new_registry = BufferDecorationSourceRegistry::new();
+                    ctx.services.register(Arc::new(new_registry));
+                    ctx.services
+                        .get::<BufferDecorationSourceRegistry>()
+                        .unwrap()
+                });
+
+            let key = DecorationSourceKey::new(DECORATION_KEY_RAINBOW);
+            registry.register(key, state.clone());
+            debug!(
+                "Pair module: registered in BufferDecorationSourceRegistry with key '{}'",
+                DECORATION_KEY_RAINBOW
+            );
+        }
+
+        // Get event bus for subscriptions
+        let bus = Arc::clone(&ctx.kernel.event_bus);
+
+        // Subscribe to cursor movement events
+        // Priority: PLUGIN (100) - standard module priority
+        let state_cursor = state.clone();
+        let sub_cursor = bus.subscribe::<CursorMoved, _>(priority::PLUGIN, move |event| {
+            let buffer_id = buffer_id_from_event(event.buffer_id);
+            let cursor = (event.to.0 as usize, event.to.1 as usize);
+
+            trace!(
+                "Pair: cursor moved in buffer {} to ({}, {})",
+                event.buffer_id, cursor.0, cursor.1
+            );
+
+            state_cursor.update_cursor(buffer_id, cursor);
+            EventResult::Handled
+        });
+        self.subscriptions.push(sub_cursor);
+
+        // Subscribe to buffer modifications for auto-pair insertion
+        // Priority: 90 - process before cache invalidation at 100
+        //
+        // NOTE (#440): We capture `services` instead of `ctx.kernel.buffers` because
+        // the buffer manager is registered AFTER this module's init() by another module.
+        // At init time, ctx.kernel.buffers is a stub. We must query ServiceRegistry
+        // at handler invocation time to get the real buffer manager.
+        let services_for_auto_pair = Arc::clone(&ctx.services);
+        let sub_auto_pair = bus.subscribe::<BufferModified, _>(90, move |event| {
+            let buffer_id = buffer_id_from_event(event.buffer_id);
+
+            // Query buffer manager from ServiceRegistry (late binding)
+            let buffer_lock = services_for_auto_pair
+                .get::<BufferManagerRegistry>()
+                .and_then(|registry| registry.get(&BufferManagerKey::Simple))
+                .and_then(|mgr| mgr.get(buffer_id));
+
+            let Some(buffer_lock) = buffer_lock else {
+                trace!("Pair: buffer {} not found, skipping", event.buffer_id);
+                return EventResult::Handled;
+            };
+
+            match &event.modification {
+                // Handle Insert: auto-pair or skip-over
+                Modification::Insert { start, text } => {
+                    // Only handle single-character insertions
+                    let mut chars = text.chars();
+                    let Some(typed_char) = chars.next() else {
+                        return EventResult::Handled;
+                    };
+                    if chars.next().is_some() {
+                        return EventResult::Handled; // Multi-char insert, skip
+                    }
+
+                    handle_auto_pair(typed_char, *start, text, &buffer_lock);
+                }
+
+                // Handle Delete: backspace pair deletion (#440)
+                Modification::Delete { start, text, .. } => {
+                    handle_backspace_pair(*start, text, &buffer_lock);
+                }
+
+                // Replace, FullReplace: no special handling needed
+                Modification::Replace { .. } | Modification::FullReplace => {}
+            }
+
+            EventResult::Handled
+        });
+        self.subscriptions.push(sub_auto_pair);
+
+        // Subscribe to buffer modification events
+        // Priority: PLUGIN (100) - invalidate cache when content changes
+        let state_modified = state.clone();
+        let sub_modified = bus.subscribe::<BufferModified, _>(priority::PLUGIN, move |event| {
+            let buffer_id = buffer_id_from_event(event.buffer_id);
+
+            trace!("Pair: buffer {} modified, invalidating bracket cache", event.buffer_id);
+
+            state_modified.invalidate_buffer(buffer_id);
+            EventResult::Handled
+        });
+        self.subscriptions.push(sub_modified);
+
+        // Subscribe to buffer close events
+        // Priority: PLUGIN (100) - cleanup buffer state
+        let state_closed = state;
+        let sub_closed = bus.subscribe::<BufferClosed, _>(priority::PLUGIN, move |event| {
+            let buffer_id = buffer_id_from_event(event.buffer_id);
+
+            trace!("Pair: buffer {} closed, removing state", event.buffer_id);
+
+            state_closed.remove_buffer(buffer_id);
+            EventResult::Handled
+        });
+        self.subscriptions.push(sub_closed);
+
+        info!("Pair module initialized with {} event subscriptions", self.subscriptions.len());
+        ProbeResult::Success
+    }
+
+    fn exit(&mut self) -> Result<(), ModuleError> {
+        info!("Shutting down pair module");
+
+        // Clear subscriptions (auto-unsubscribe via RAII)
+        let count = self.subscriptions.len();
+        self.subscriptions.clear();
+        debug!("Pair module: cleared {} subscriptions", count);
+
+        self.state = None;
+        Ok(())
+    }
+}
+
+// Generate FFI entry points for dynamic loading (only when building standalone cdylib)
+#[cfg(feature = "dynamic")]
+reovim_module_macros::declare_module!(PairModule);
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use reovim_kernel::api::v1::Module;
+
+    use super::*;
+
+    #[test]
+    fn test_pair_module_id() {
+        assert_eq!(PAIR_MODULE.as_str(), "pair");
+    }
+
+    #[test]
+    fn test_pair_module_identity() {
+        let module = PairModule::new();
+        assert_eq!(module.id(), PAIR_MODULE);
+        assert_eq!(module.name(), "Pair Module");
+        assert_eq!(module.version(), Version::new(0, 9, 2));
+    }
+
+    #[test]
+    fn test_pair_module_default() {
+        let module = PairModule::default();
+        assert!(module.state.is_none());
+        assert!(module.subscriptions.is_empty());
+    }
+
+    #[test]
+    fn test_pair_module_subscription_count() {
+        // Verify module struct can hold subscriptions
+        let module = PairModule::new();
+        assert_eq!(module.subscriptions.len(), 0);
+    }
+}

--- a/modules/pair/src/rainbow.rs
+++ b/modules/pair/src/rainbow.rs
@@ -1,0 +1,226 @@
+//! Rainbow bracket depth calculation.
+//!
+//! This module provides a simple stack-based algorithm to compute
+//! bracket nesting depths. The algorithm is language-agnostic and
+//! operates directly on text content.
+//!
+//! # Algorithm
+//!
+//! For each bracket type, we maintain a stack of opening bracket positions.
+//! When we encounter an opening bracket, we push its position and assign
+//! the current stack depth. When we encounter a closing bracket, we pop
+//! the stack and assign the same depth as the matching opening bracket.
+//!
+//! Unmatched brackets (both opening and closing) are marked with
+//! `depth = usize::MAX` as a sentinel value.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_module_pair::rainbow::compute_bracket_depths;
+//!
+//! let content = "((a + b))";
+//! let brackets = compute_bracket_depths(content);
+//!
+//! // Outer brackets have depth 0
+//! assert_eq!(brackets.get(&(0, 0)).unwrap().depth, 0);
+//! assert_eq!(brackets.get(&(0, 8)).unwrap().depth, 0);
+//!
+//! // Inner brackets have depth 1
+//! assert_eq!(brackets.get(&(0, 1)).unwrap().depth, 1);
+//! assert_eq!(brackets.get(&(0, 7)).unwrap().depth, 1);
+//! ```
+
+use std::collections::HashMap;
+
+use crate::state::BracketInfo;
+
+/// Bracket pair definition.
+///
+/// Note: `<` and `>` are intentionally excluded as they're commonly used in
+/// operators (`->`, `=>`, `<=`, `>=`, `<<`, `>>`) rather than as brackets.
+const BRACKET_PAIRS: [(char, char); 3] = [('(', ')'), ('[', ']'), ('{', '}')];
+
+/// Compute bracket depths for all brackets in content.
+///
+/// Returns a map from (line, col) to `BracketInfo` containing depth information.
+///
+/// # Algorithm
+///
+/// For each bracket type, we maintain a stack of opening bracket positions.
+/// When we encounter an opening bracket, we push its position and assign
+/// the current stack depth. When we encounter a closing bracket, we pop
+/// the stack and assign the same depth as the matching opening bracket.
+///
+/// Unmatched brackets are marked with `depth = usize::MAX`.
+#[must_use]
+pub fn compute_bracket_depths(content: &str) -> HashMap<(usize, usize), BracketInfo> {
+    let mut result = HashMap::new();
+
+    // Stacks for each bracket type, storing (line, col, depth)
+    let mut stacks: [Vec<(usize, usize, usize)>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+
+    for (line_idx, line) in content.lines().enumerate() {
+        for (col_idx, ch) in line.chars().enumerate() {
+            // Check each bracket type
+            for (pair_idx, (open, close)) in BRACKET_PAIRS.iter().enumerate() {
+                if ch == *open {
+                    // Opening bracket: push to stack with current depth
+                    let depth = stacks[pair_idx].len();
+                    stacks[pair_idx].push((line_idx, col_idx, depth));
+
+                    result.insert(
+                        (line_idx, col_idx),
+                        BracketInfo {
+                            line: line_idx,
+                            col: col_idx,
+                            depth,
+                            char: ch,
+                        },
+                    );
+                } else if ch == *close {
+                    // Closing bracket: pop from stack and use same depth
+                    if let Some((_open_line, _open_col, depth)) = stacks[pair_idx].pop() {
+                        result.insert(
+                            (line_idx, col_idx),
+                            BracketInfo {
+                                line: line_idx,
+                                col: col_idx,
+                                depth,
+                                char: ch,
+                            },
+                        );
+                    } else {
+                        // Unmatched closing bracket - mark with special depth
+                        result.insert(
+                            (line_idx, col_idx),
+                            BracketInfo {
+                                line: line_idx,
+                                col: col_idx,
+                                depth: usize::MAX, // Marks unmatched
+                                char: ch,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Mark remaining unmatched opening brackets
+    for stack in &stacks {
+        for (line, col, _depth) in stack {
+            if let Some(info) = result.get_mut(&(*line, *col)) {
+                info.depth = usize::MAX; // Marks unmatched
+            }
+        }
+    }
+
+    result
+}
+
+/// Simple content hash for cache invalidation.
+///
+/// Uses FNV-1a hash algorithm for fast, reasonable distribution.
+#[must_use]
+pub fn content_hash(content: &str) -> u64 {
+    // Use FNV-1a hash
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in content.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_brackets() {
+        let content = "(a + b)";
+        let brackets = compute_bracket_depths(content);
+
+        assert_eq!(brackets.len(), 2);
+        assert_eq!(brackets.get(&(0, 0)).unwrap().depth, 0);
+        assert_eq!(brackets.get(&(0, 6)).unwrap().depth, 0);
+    }
+
+    #[test]
+    fn test_nested_brackets() {
+        let content = "((a))";
+        let brackets = compute_bracket_depths(content);
+
+        assert_eq!(brackets.len(), 4);
+        assert_eq!(brackets.get(&(0, 0)).unwrap().depth, 0); // outer (
+        assert_eq!(brackets.get(&(0, 1)).unwrap().depth, 1); // inner (
+        assert_eq!(brackets.get(&(0, 3)).unwrap().depth, 1); // inner )
+        assert_eq!(brackets.get(&(0, 4)).unwrap().depth, 0); // outer )
+    }
+
+    #[test]
+    fn test_multiline() {
+        let content = "{\n  (a)\n}";
+        let brackets = compute_bracket_depths(content);
+
+        assert_eq!(brackets.len(), 4);
+        assert_eq!(brackets.get(&(0, 0)).unwrap().depth, 0); // {
+        assert_eq!(brackets.get(&(1, 2)).unwrap().depth, 0); // (
+        assert_eq!(brackets.get(&(1, 4)).unwrap().depth, 0); // )
+        assert_eq!(brackets.get(&(2, 0)).unwrap().depth, 0); // }
+    }
+
+    #[test]
+    fn test_unmatched_closing() {
+        let content = "a)";
+        let brackets = compute_bracket_depths(content);
+
+        assert_eq!(brackets.len(), 1);
+        assert_eq!(brackets.get(&(0, 1)).unwrap().depth, usize::MAX);
+    }
+
+    #[test]
+    fn test_unmatched_opening() {
+        let content = "(a";
+        let brackets = compute_bracket_depths(content);
+
+        assert_eq!(brackets.len(), 1);
+        assert_eq!(brackets.get(&(0, 0)).unwrap().depth, usize::MAX);
+    }
+
+    #[test]
+    fn test_angle_brackets_excluded() {
+        // `<` and `>` are intentionally NOT treated as brackets
+        // because they're commonly used in operators
+        let content = "Vec<T>";
+        let brackets = compute_bracket_depths(content);
+
+        // No brackets should be detected (< and > are excluded)
+        assert_eq!(brackets.len(), 0);
+    }
+
+    #[test]
+    fn test_arrow_with_parens() {
+        // `->` doesn't interfere with actual brackets
+        let content = "fn foo() -> u32";
+        let brackets = compute_bracket_depths(content);
+
+        // Only ( and ) should be detected
+        assert_eq!(brackets.len(), 2);
+        assert!(brackets.contains_key(&(0, 6))); // (
+        assert!(brackets.contains_key(&(0, 7))); // )
+    }
+
+    #[test]
+    fn test_match_with_braces() {
+        // `=>` doesn't interfere with actual brackets
+        let content = "match x { a => b }";
+        let brackets = compute_bracket_depths(content);
+
+        // Only { and } should be detected
+        assert_eq!(brackets.len(), 2);
+        assert!(brackets.contains_key(&(0, 8))); // {
+        assert!(brackets.contains_key(&(0, 17))); // }
+    }
+}

--- a/modules/pair/src/state.rs
+++ b/modules/pair/src/state.rs
@@ -1,0 +1,473 @@
+//! Pair state management - tracks bracket positions and matches.
+//!
+//! This module provides per-buffer bracket tracking with:
+//! - Bracket position and depth information
+//! - Matched pair detection for cursor highlighting
+//! - Content hash-based cache invalidation
+//!
+//! # Thread Safety
+//!
+//! `SharedPairState` provides thread-safe access via `RwLock` and can be
+//! registered in `ServiceRegistry` for cross-module access.
+
+use std::collections::HashMap;
+
+use {reovim_arch::sync::RwLock, reovim_kernel::api::v1::BufferId};
+
+use crate::rainbow::compute_bracket_depths;
+
+/// Information about a single bracket.
+#[derive(Debug, Clone, Copy)]
+pub struct BracketInfo {
+    /// Line number (0-indexed).
+    pub line: usize,
+    /// Column number (0-indexed).
+    pub col: usize,
+    /// Nesting depth (0 = outermost, `usize::MAX` = unmatched).
+    pub depth: usize,
+    /// The bracket character.
+    pub char: char,
+}
+
+/// A matched bracket pair.
+#[derive(Debug, Clone, Copy)]
+pub struct MatchedPair {
+    /// The opening bracket.
+    pub open: BracketInfo,
+    /// The closing bracket.
+    pub close: BracketInfo,
+}
+
+/// Bracket state for a single buffer.
+#[derive(Debug, Default)]
+pub struct BufferPairState {
+    /// Bracket positions and depths: (line, col) -> `BracketInfo`.
+    pub brackets: HashMap<(usize, usize), BracketInfo>,
+    /// Current matched pair (if cursor is on/between brackets).
+    pub matched_pair: Option<MatchedPair>,
+    /// Current cursor position.
+    pub cursor: (usize, usize),
+    /// Content hash for cache invalidation.
+    content_hash: u64,
+}
+
+impl BufferPairState {
+    /// Check if cache is valid for given content hash.
+    #[must_use]
+    pub const fn is_valid(&self, content_hash: u64) -> bool {
+        self.content_hash == content_hash
+    }
+
+    /// Update brackets from content.
+    pub fn update_from_content(&mut self, content: &str, content_hash: u64) {
+        self.brackets = compute_bracket_depths(content);
+        self.content_hash = content_hash;
+    }
+
+    /// Get bracket at position.
+    #[must_use]
+    pub fn get_bracket(&self, line: usize, col: usize) -> Option<&BracketInfo> {
+        self.brackets.get(&(line, col))
+    }
+}
+
+/// Bracket state manager for all buffers.
+#[derive(Debug, Default)]
+pub struct PairState {
+    buffers: HashMap<usize, BufferPairState>,
+}
+
+impl PairState {
+    /// Create new bracket state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            buffers: HashMap::new(),
+        }
+    }
+
+    /// Get or create buffer state.
+    pub fn get_or_create(&mut self, buffer_id: BufferId) -> &mut BufferPairState {
+        self.buffers.entry(buffer_id.as_usize()).or_default()
+    }
+
+    /// Get buffer state (immutable).
+    #[must_use]
+    pub fn get(&self, buffer_id: BufferId) -> Option<&BufferPairState> {
+        self.buffers.get(&buffer_id.as_usize())
+    }
+
+    /// Remove buffer state.
+    pub fn remove(&mut self, buffer_id: BufferId) {
+        self.buffers.remove(&buffer_id.as_usize());
+    }
+
+    /// Update cursor position.
+    pub fn update_cursor(&mut self, buffer_id: BufferId, cursor: (usize, usize)) {
+        let state = self.get_or_create(buffer_id);
+        state.cursor = cursor;
+        // Clear matched_pair - will be recomputed when needed
+        state.matched_pair = None;
+    }
+
+    /// Compute matched pair for current cursor position.
+    pub fn compute_matched_pair(&mut self, buffer_id: BufferId) {
+        let cursor = self.get(buffer_id).map(|s| s.cursor);
+        if let Some(cursor) = cursor {
+            let matched = self.find_matched_pair(buffer_id, cursor);
+            if let Some(state) = self.buffers.get_mut(&buffer_id.as_usize()) {
+                state.matched_pair = matched;
+            }
+        }
+    }
+
+    /// Compute matched pair with explicit cursor position.
+    pub fn compute_matched_pair_with_cursor(
+        &mut self,
+        buffer_id: BufferId,
+        cursor: (usize, usize),
+    ) {
+        let matched = self.find_matched_pair(buffer_id, cursor);
+        if let Some(state) = self.buffers.get_mut(&buffer_id.as_usize()) {
+            state.matched_pair = matched;
+        }
+    }
+
+    /// Find the innermost matched bracket pair that contains the cursor position.
+    ///
+    /// This finds brackets where: `open_pos` <= cursor <= `close_pos`
+    /// and returns the pair with the smallest range (innermost).
+    fn find_matched_pair(
+        &self,
+        buffer_id: BufferId,
+        cursor: (usize, usize),
+    ) -> Option<MatchedPair> {
+        let state = self.buffers.get(&buffer_id.as_usize())?;
+
+        // Build all matched pairs first
+        let mut pairs: Vec<MatchedPair> = Vec::new();
+
+        // Find all opening brackets and their matches
+        for bracket in state.brackets.values() {
+            // Only process opening brackets to avoid duplicates
+            let close_char = match bracket.char {
+                '(' => ')',
+                '[' => ']',
+                '{' => '}',
+                _ => continue, // Skip closing brackets
+            };
+
+            // Skip unmatched brackets
+            if bracket.depth == usize::MAX {
+                continue;
+            }
+
+            // Find the matching closing bracket (the NEAREST one with same depth)
+            let matching = state
+                .brackets
+                .values()
+                .filter(|b| {
+                    b.depth == bracket.depth
+                        && b.char == close_char
+                        && (b.line, b.col) > (bracket.line, bracket.col)
+                })
+                .min_by_key(|b| (b.line, b.col));
+
+            if let Some(close) = matching {
+                pairs.push(MatchedPair {
+                    open: *bracket,
+                    close: *close,
+                });
+            }
+        }
+
+        // Find the innermost pair that contains the cursor
+        pairs
+            .into_iter()
+            .filter(|pair| {
+                let open_pos = (pair.open.line, pair.open.col);
+                let close_pos = (pair.close.line, pair.close.col);
+                cursor >= open_pos && cursor <= close_pos
+            })
+            .min_by(|a, b| {
+                // Compare by range size: line difference first, then column difference
+                let a_range = (
+                    a.close.line.saturating_sub(a.open.line),
+                    a.close.col.saturating_sub(a.open.col),
+                );
+                let b_range = (
+                    b.close.line.saturating_sub(b.open.line),
+                    b.close.col.saturating_sub(b.open.col),
+                );
+                a_range.cmp(&b_range)
+            })
+    }
+}
+
+/// Thread-safe shared bracket state.
+///
+/// This can be registered in `ServiceRegistry` for cross-module access.
+///
+/// # Example
+///
+/// ```ignore
+/// use reovim_module_pair::state::SharedPairState;
+///
+/// let state = SharedPairState::new();
+///
+/// // Update cursor
+/// state.update_cursor(buffer_id, (10, 5));
+///
+/// // Ensure brackets are computed
+/// state.ensure_computed(buffer_id, &content, hash);
+///
+/// // Get matched pair
+/// let pair = state.get_matched_pair(buffer_id);
+/// ```
+pub struct SharedPairState {
+    inner: RwLock<PairState>,
+}
+
+impl std::fmt::Debug for SharedPairState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedPairState").finish()
+    }
+}
+
+impl Default for SharedPairState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedPairState {
+    /// Create new shared bracket state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(PairState::new()),
+        }
+    }
+
+    /// Update cursor position.
+    pub fn update_cursor(&self, buffer_id: BufferId, cursor: (usize, usize)) {
+        self.inner.write().update_cursor(buffer_id, cursor);
+    }
+
+    /// Invalidate buffer cache.
+    pub fn invalidate_buffer(&self, buffer_id: BufferId) {
+        let mut state = self.inner.write();
+        if let Some(buffer_state) = state.buffers.get_mut(&buffer_id.as_usize()) {
+            buffer_state.content_hash = 0; // Force recomputation
+        }
+    }
+
+    /// Remove buffer state.
+    pub fn remove_buffer(&self, buffer_id: BufferId) {
+        self.inner.write().remove(buffer_id);
+    }
+
+    /// Execute a function with read access to the state.
+    pub fn with_read<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&PairState) -> R,
+    {
+        f(&self.inner.read())
+    }
+
+    /// Execute a function with write access to the state.
+    pub fn with_write<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut PairState) -> R,
+    {
+        f(&mut self.inner.write())
+    }
+
+    /// Get matched pair for a buffer.
+    #[must_use]
+    pub fn get_matched_pair(&self, buffer_id: BufferId) -> Option<MatchedPair> {
+        self.inner
+            .read()
+            .get(buffer_id)
+            .and_then(|bs| bs.matched_pair)
+    }
+
+    /// Get cursor position for a buffer.
+    #[must_use]
+    pub fn get_cursor(&self, buffer_id: BufferId) -> Option<(usize, usize)> {
+        self.inner.read().get(buffer_id).map(|bs| bs.cursor)
+    }
+
+    /// Get all brackets for a buffer (for rainbow rendering).
+    #[must_use]
+    pub fn get_brackets(
+        &self,
+        buffer_id: BufferId,
+    ) -> Option<HashMap<(usize, usize), BracketInfo>> {
+        self.inner
+            .read()
+            .get(buffer_id)
+            .map(|bs| bs.brackets.clone())
+    }
+
+    /// Ensure brackets are computed for buffer content.
+    #[allow(clippy::significant_drop_tightening)]
+    pub fn ensure_computed(&self, buffer_id: BufferId, content: &str, content_hash: u64) {
+        let mut state = self.inner.write();
+        let buffer_state = state.get_or_create(buffer_id);
+        if !buffer_state.is_valid(content_hash) {
+            buffer_state.update_from_content(content, content_hash);
+        }
+    }
+
+    /// Compute matched pair for current cursor position.
+    /// Must be called after `ensure_computed`.
+    pub fn compute_matched_pair(&self, buffer_id: BufferId) {
+        self.inner.write().compute_matched_pair(buffer_id);
+    }
+
+    /// Compute matched pair with explicit cursor position.
+    pub fn compute_matched_pair_with_cursor(&self, buffer_id: BufferId, cursor: (usize, usize)) {
+        self.inner
+            .write()
+            .compute_matched_pair_with_cursor(buffer_id, cursor);
+    }
+}
+
+// Implement Service marker trait for ServiceRegistry integration
+impl reovim_kernel::api::v1::Service for SharedPairState {}
+
+// Implement BufferDecorationSource for generic decoration registry integration (#440)
+impl reovim_driver_display::BufferDecorationSource for SharedPairState {
+    fn name(&self) -> &'static str {
+        "rainbow-brackets"
+    }
+
+    fn group(&self) -> reovim_driver_display::DecorationGroup {
+        reovim_driver_display::DecorationGroup::Syntax
+    }
+
+    fn decorations_for_buffer(
+        &self,
+        buffer_id: BufferId,
+        content: &str,
+        cursor: (usize, usize),
+    ) -> Vec<reovim_driver_display::Decoration> {
+        // Compute content hash for cache
+        let content_hash = crate::rainbow::content_hash(content);
+
+        // Ensure brackets are computed for current content
+        self.ensure_computed(buffer_id, content, content_hash);
+
+        // Compute matched pair for cursor position
+        self.compute_matched_pair_with_cursor(buffer_id, cursor);
+
+        // Generate decorations
+        crate::decorations::generate_decorations_for_buffer(self, buffer_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_pair_state_creation() {
+        let state = BufferPairState::default();
+        assert!(state.brackets.is_empty());
+        assert!(state.matched_pair.is_none());
+        assert_eq!(state.cursor, (0, 0));
+    }
+
+    #[test]
+    fn test_buffer_pair_state_update() {
+        let mut state = BufferPairState::default();
+        let content = "(a + b)";
+        let hash = crate::rainbow::content_hash(content);
+
+        state.update_from_content(content, hash);
+
+        assert_eq!(state.brackets.len(), 2);
+        assert!(state.is_valid(hash));
+        assert!(!state.is_valid(hash + 1));
+    }
+
+    #[test]
+    fn test_pair_state_buffer_isolation() {
+        let mut state = PairState::new();
+        let buf1 = BufferId::from_raw(1);
+        let buf2 = BufferId::from_raw(2);
+
+        state.update_cursor(buf1, (10, 5));
+        state.update_cursor(buf2, (20, 10));
+
+        assert_eq!(state.get(buf1).unwrap().cursor, (10, 5));
+        assert_eq!(state.get(buf2).unwrap().cursor, (20, 10));
+    }
+
+    #[test]
+    fn test_pair_state_remove_buffer() {
+        let mut state = PairState::new();
+        let buf = BufferId::from_raw(1);
+
+        state.update_cursor(buf, (10, 5));
+        assert!(state.get(buf).is_some());
+
+        state.remove(buf);
+        assert!(state.get(buf).is_none());
+    }
+
+    #[test]
+    fn test_shared_pair_state_thread_safety() {
+        let state = SharedPairState::new();
+        let buf = BufferId::from_raw(1);
+
+        state.update_cursor(buf, (10, 5));
+        assert_eq!(state.get_cursor(buf), Some((10, 5)));
+
+        state.invalidate_buffer(buf);
+        state.remove_buffer(buf);
+        assert_eq!(state.get_cursor(buf), None);
+    }
+
+    #[test]
+    fn test_matched_pair_finding() {
+        let mut state = PairState::new();
+        let buf = BufferId::from_raw(1);
+        let content = "(a + b)";
+        let hash = crate::rainbow::content_hash(content);
+
+        let buffer_state = state.get_or_create(buf);
+        buffer_state.update_from_content(content, hash);
+        buffer_state.cursor = (0, 3); // Cursor on 'a'
+
+        state.compute_matched_pair(buf);
+
+        let matched = state.get(buf).unwrap().matched_pair;
+        assert!(matched.is_some());
+        let pair = matched.unwrap();
+        assert_eq!(pair.open.col, 0);
+        assert_eq!(pair.close.col, 6);
+    }
+
+    #[test]
+    fn test_innermost_matched_pair() {
+        let mut state = PairState::new();
+        let buf = BufferId::from_raw(1);
+        let content = "((a))";
+        let hash = crate::rainbow::content_hash(content);
+
+        let buffer_state = state.get_or_create(buf);
+        buffer_state.update_from_content(content, hash);
+        buffer_state.cursor = (0, 2); // Cursor on 'a'
+
+        state.compute_matched_pair(buf);
+
+        let matched = state.get(buf).unwrap().matched_pair;
+        assert!(matched.is_some());
+        let pair = matched.unwrap();
+        // Should get the inner pair, not the outer
+        assert_eq!(pair.open.col, 1);
+        assert_eq!(pair.close.col, 3);
+    }
+}

--- a/modules/pair/src/styles.rs
+++ b/modules/pair/src/styles.rs
@@ -1,0 +1,198 @@
+//! Style group definitions for the pair module.
+//!
+//! This module defines the style group constants and default styles for
+//! rainbow bracket highlighting. These are registered with `StyleGroupRegistry`
+//! during module init, allowing themes to optionally override them.
+//!
+//! # Architecture
+//!
+//! This follows mechanism vs policy separation:
+//!
+//! - **Mechanism** (`StyleGroupRegistry` in driver): Generic registry for style groups
+//! - **Policy** (this module): Specific group names and default colors for rainbow brackets
+//!
+//! # Groups
+//!
+//! - `rainbow.bracket.{1-6}`: Bracket colors by depth (cycles for deeper nesting)
+//! - `bracket.unmatched`: Warning style for unmatched brackets
+//!
+//! # Example
+//!
+//! ```ignore
+//! use reovim_module_pair::styles;
+//!
+//! // Get group name for depth 2 bracket
+//! let group = styles::groups::RAINBOW_BRACKET_3;  // "rainbow.bracket.3"
+//!
+//! // Register defaults with StyleGroupRegistry
+//! for (group, style) in styles::default_registrations() {
+//!     registry.register(group, style);
+//! }
+//! ```
+
+use {reovim_arch::Color, reovim_driver_display::Style};
+
+/// Style group name constants for rainbow brackets.
+///
+/// These group names follow the `<feature>.<subtype>.<variant>` convention.
+pub mod groups {
+    /// Rainbow bracket depth 1 (red)
+    pub const RAINBOW_BRACKET_1: &str = "rainbow.bracket.1";
+
+    /// Rainbow bracket depth 2 (orange)
+    pub const RAINBOW_BRACKET_2: &str = "rainbow.bracket.2";
+
+    /// Rainbow bracket depth 3 (yellow)
+    pub const RAINBOW_BRACKET_3: &str = "rainbow.bracket.3";
+
+    /// Rainbow bracket depth 4 (green)
+    pub const RAINBOW_BRACKET_4: &str = "rainbow.bracket.4";
+
+    /// Rainbow bracket depth 5 (blue)
+    pub const RAINBOW_BRACKET_5: &str = "rainbow.bracket.5";
+
+    /// Rainbow bracket depth 6 (purple)
+    pub const RAINBOW_BRACKET_6: &str = "rainbow.bracket.6";
+
+    /// Unmatched bracket (red + underline warning)
+    pub const BRACKET_UNMATCHED: &str = "bracket.unmatched";
+
+    /// All rainbow bracket groups (for iteration).
+    pub const ALL_RAINBOW_GROUPS: &[&str] = &[
+        RAINBOW_BRACKET_1,
+        RAINBOW_BRACKET_2,
+        RAINBOW_BRACKET_3,
+        RAINBOW_BRACKET_4,
+        RAINBOW_BRACKET_5,
+        RAINBOW_BRACKET_6,
+        BRACKET_UNMATCHED,
+    ];
+}
+
+/// Get the style group name for a bracket depth.
+///
+/// Returns the appropriate `rainbow.bracket.N` group name, cycling for depths >= 6.
+#[must_use]
+pub const fn group_for_depth(depth: usize) -> &'static str {
+    match depth % 6 {
+        0 => groups::RAINBOW_BRACKET_1,
+        1 => groups::RAINBOW_BRACKET_2,
+        2 => groups::RAINBOW_BRACKET_3,
+        3 => groups::RAINBOW_BRACKET_4,
+        4 => groups::RAINBOW_BRACKET_5,
+        5 => groups::RAINBOW_BRACKET_6,
+        _ => unreachable!(),
+    }
+}
+
+/// Generate the default style registrations for rainbow brackets.
+///
+/// These are the default colors used when the theme doesn't define
+/// custom colors for rainbow brackets. The pair module registers
+/// these in `StyleGroupRegistry` during init.
+///
+/// # Colors
+///
+/// Uses a vibrant 6-color palette designed for visibility:
+/// - Depth 1: Red (#e53935)
+/// - Depth 2: Orange (#ff9800)
+/// - Depth 3: Yellow (#fdd835)
+/// - Depth 4: Green (#4caf50)
+/// - Depth 5: Blue (#2196f3)
+/// - Depth 6: Purple (#9c27b0)
+/// - Unmatched: Red with underline
+#[must_use]
+pub fn default_registrations() -> Vec<(&'static str, Style)> {
+    vec![
+        (
+            groups::RAINBOW_BRACKET_1,
+            Style::new().fg(Color::Rgb {
+                r: 229,
+                g: 57,
+                b: 53,
+            }), // Red
+        ),
+        (
+            groups::RAINBOW_BRACKET_2,
+            Style::new().fg(Color::Rgb {
+                r: 255,
+                g: 152,
+                b: 0,
+            }), // Orange
+        ),
+        (
+            groups::RAINBOW_BRACKET_3,
+            Style::new().fg(Color::Rgb {
+                r: 253,
+                g: 216,
+                b: 53,
+            }), // Yellow
+        ),
+        (
+            groups::RAINBOW_BRACKET_4,
+            Style::new().fg(Color::Rgb {
+                r: 76,
+                g: 175,
+                b: 80,
+            }), // Green
+        ),
+        (
+            groups::RAINBOW_BRACKET_5,
+            Style::new().fg(Color::Rgb {
+                r: 33,
+                g: 150,
+                b: 243,
+            }), // Blue
+        ),
+        (
+            groups::RAINBOW_BRACKET_6,
+            Style::new().fg(Color::Rgb {
+                r: 156,
+                g: 39,
+                b: 176,
+            }), // Purple
+        ),
+        (
+            groups::BRACKET_UNMATCHED,
+            Style::new()
+                .fg(Color::Rgb {
+                    r: 224,
+                    g: 108,
+                    b: 117,
+                }) // Red (like error)
+                .underline(),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_group_for_depth_cycles() {
+        assert_eq!(group_for_depth(0), groups::RAINBOW_BRACKET_1);
+        assert_eq!(group_for_depth(1), groups::RAINBOW_BRACKET_2);
+        assert_eq!(group_for_depth(5), groups::RAINBOW_BRACKET_6);
+        // Cycles
+        assert_eq!(group_for_depth(6), groups::RAINBOW_BRACKET_1);
+        assert_eq!(group_for_depth(7), groups::RAINBOW_BRACKET_2);
+    }
+
+    #[test]
+    fn test_default_registrations_count() {
+        let registrations = default_registrations();
+        assert_eq!(registrations.len(), 7); // 6 rainbow + 1 unmatched
+    }
+
+    #[test]
+    fn test_all_rainbow_groups_covered() {
+        let registrations = default_registrations();
+        for group in groups::ALL_RAINBOW_GROUPS {
+            assert!(
+                registrations.iter().any(|(g, _)| g == group),
+                "Missing registration for group: {group}"
+            );
+        }
+    }
+}

--- a/modules/vim/src/bindings/window.rs
+++ b/modules/vim/src/bindings/window.rs
@@ -33,6 +33,12 @@
 //! - `>` - Increase window width
 //! - `<` - Decrease window width
 //! - `=` - Equalize all window sizes
+//!
+//! # Float Zone (f/]/[)
+//!
+//! - `f` - Toggle between tiled and floating
+//! - `]` - Raise float to front
+//! - `[` - Lower float to back
 
 use {reovim_kernel::api::v1::KeybindingRegistration, reovim_module_layout::ids as layout};
 
@@ -149,6 +155,21 @@ pub fn bindings() -> Vec<KeybindingRegistration> {
             .with_modes(&["vim:window"])
             .with_category("window")
             .with_description("Equalize all window sizes"),
+        // ====================================================================
+        // Float Zone (#398)
+        // ====================================================================
+        KeybindingRegistration::new("f", layout::TOGGLE_FLOAT)
+            .with_modes(&["vim:window"])
+            .with_category("window")
+            .with_description("Toggle between tiled and floating"),
+        KeybindingRegistration::new("]", layout::RAISE_FLOAT)
+            .with_modes(&["vim:window"])
+            .with_category("window")
+            .with_description("Raise float to front"),
+        KeybindingRegistration::new("[", layout::LOWER_FLOAT)
+            .with_modes(&["vim:window"])
+            .with_category("window")
+            .with_description("Lower float to back"),
         // ====================================================================
         // Escape back to normal mode
         // ====================================================================

--- a/runner/src/client/tui/app.rs
+++ b/runner/src/client/tui/app.rs
@@ -43,7 +43,7 @@ use super::{
     log_buffer::{DEFAULT_TUI_LOG_CAPACITY, TuiLogBuffer},
     log_panel::LogPanelState,
     log_render::render_panel as render_log_panel,
-    render::Renderer,
+    render::{CursorStyleKind, Renderer},
     render_core::{self, RenderState},
 };
 
@@ -902,6 +902,17 @@ impl TuiApp {
                     let new_mode = payload.mode.display.clone();
                     self.state.mode_display = Some(payload.mode.display);
                     self.state.needs_redraw = true;
+
+                    // Update cursor style based on edit mode (#440)
+                    let cursor_style = match payload.mode.edit_mode.as_str() {
+                        "Insert" => CursorStyleKind::Bar,
+                        "Replace" => CursorStyleKind::Underline,
+                        _ => CursorStyleKind::Block, // Normal, Visual, etc.
+                    };
+                    if let Err(e) = self.renderer.set_cursor_style(cursor_style) {
+                        tracing::warn!("Failed to set cursor style: {e}");
+                    }
+
                     tracing::debug!("Mode changed to: {:?}", self.state.mode_display);
                     self.debug_log(&format!("Mode changed: {new_mode}"));
                 }
@@ -1061,15 +1072,7 @@ impl TuiApp {
 
     /// Render the current screen state.
     async fn render(&mut self) -> Result<(), TuiError> {
-        // Request screen content from server
-        let _ = self
-            .rpc_writer
-            .send_request("state/screen_content", json!({ "format": "raw_ansi" }))
-            .await;
-
-        // Wait a bit for the response and read it
-        // In a fully async model, we'd handle this via the message channel
-        // For now, we do a simple refresh
+        // Refresh screen using cell_grid format which includes decoration colors (#440)
         self.refresh_screen().await?;
         Ok(())
     }
@@ -1091,10 +1094,10 @@ impl TuiApp {
         // Clear back buffer
         self.frame_renderer.buffer_mut().clear();
 
-        // Request screen content from server
+        // Request screen content from server with cell_grid format for decoration colors (#440)
         let _ = self
             .rpc_writer
-            .send_request("state/screen_content", json!({ "format": "plain_text" }))
+            .send_request("state/screen_content", json!({ "format": "cell_grid" }))
             .await;
 
         // Read response and write to frame buffer
@@ -1105,15 +1108,8 @@ impl TuiApp {
         .await
         {
             Ok(Ok(content)) => {
-                // Write server content to frame buffer (line by line)
-                let default_style = Style::default();
-                for (y, line) in content.lines().enumerate().take(height as usize) {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let y_u16 = y as u16;
-                    self.frame_renderer
-                        .buffer_mut()
-                        .write_str(0, y_u16, line, &default_style);
-                }
+                // Parse cell_grid JSON and write with decoration styles (#440)
+                self.write_cell_grid_to_buffer(&content, width, height);
             }
             Ok(Err(e)) => return Err(e),
             Err(_) => {
@@ -1465,6 +1461,49 @@ impl TuiApp {
             .await
             .map_err(TuiError::Rpc)?;
         Ok(())
+    }
+
+    /// Write `cell_grid` content to frame buffer with decoration colors (#440).
+    ///
+    /// Parses the JSON cell grid format and applies per-cell styles for
+    /// rainbow brackets and other decorations.
+    fn write_cell_grid_to_buffer(&mut self, content: &str, width: u16, height: u16) {
+        // Try to parse as JSON cell grid
+        let cells: Result<Vec<Vec<serde_json::Value>>, _> = serde_json::from_str(content);
+
+        if let Ok(rows) = cells {
+            // Write each cell with its decoration style
+            for (y, row) in rows.iter().enumerate().take(height as usize) {
+                #[allow(clippy::cast_possible_truncation)]
+                let y_u16 = y as u16;
+
+                for (x, cell) in row.iter().enumerate().take(width as usize) {
+                    let ch = cell
+                        .get("char")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| s.chars().next())
+                        .unwrap_or(' ');
+
+                    let style = render_core::parse_cell_style(cell);
+
+                    #[allow(clippy::cast_possible_truncation)]
+                    let x_u16 = x as u16;
+                    self.frame_renderer
+                        .buffer_mut()
+                        .put_char(x_u16, y_u16, ch, &style);
+                }
+            }
+        } else {
+            // Fallback to plain text if JSON parsing fails
+            let default_style = Style::default();
+            for (y, line) in content.lines().enumerate().take(height as usize) {
+                #[allow(clippy::cast_possible_truncation)]
+                let y_u16 = y as u16;
+                self.frame_renderer
+                    .buffer_mut()
+                    .write_str(0, y_u16, line, &default_style);
+            }
+        }
     }
 
     /// Quit the application.

--- a/runner/src/client/tui/headless.rs
+++ b/runner/src/client/tui/headless.rs
@@ -5,7 +5,7 @@
 //! enabling the CLI → Server → TUI → Server → CLI frame capture flow.
 
 use {
-    reovim_driver_display::{FrameBuffer, Style},
+    reovim_driver_display::FrameBuffer,
     reovim_protocol::v1::{
         RpcNotification, RpcResponse, ScreenContentResult,
         notifications::{
@@ -23,7 +23,7 @@ use crate::client::common::{
     ConnectionConfig, ConnectionReader, RpcClient, RpcClientError, RpcWriter, ServerMessage,
 };
 
-use super::render_core::{RenderState, build_frame_content};
+use super::render_core::{RenderState, build_frame_content, write_cell_grid_to_buffer};
 
 /// Default terminal size for headless mode.
 const DEFAULT_WIDTH: u16 = 80;
@@ -389,14 +389,15 @@ impl HeadlessClient {
     ///
     /// This makes the headless TUI behave like the interactive TUI by fetching
     /// actual buffer content from the server before building capture responses.
+    /// Uses `cell_grid` format to preserve decoration colors (#440).
     async fn refresh_frame_buffer(&mut self) -> Result<(), HeadlessError> {
         // Clear frame buffer
         self.frame_buffer.clear();
 
-        // Request screen content from server
+        // Request screen content from server with cell_grid format for decoration colors (#440)
         let request_id = self
             .rpc_writer
-            .send_request("state/screen_content", json!({ "format": "plain_text" }))
+            .send_request("state/screen_content", json!({ "format": "cell_grid" }))
             .await
             .map_err(HeadlessError::Rpc)?;
 
@@ -409,19 +410,15 @@ impl HeadlessClient {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        // Write content to frame buffer (line by line, like interactive TUI)
-        let default_style = Style::default();
-        for (y, line) in content
-            .lines()
-            .enumerate()
-            .take(self.render_state.height as usize)
-        {
-            #[allow(clippy::cast_possible_truncation)]
-            self.frame_buffer
-                .write_str(0, y as u16, line, &default_style);
-        }
+        // Write cell_grid content to frame buffer with decoration styles (#440)
+        write_cell_grid_to_buffer(
+            &mut self.frame_buffer,
+            content,
+            self.render_state.width,
+            self.render_state.height,
+        );
 
-        tracing::debug!("Refreshed frame buffer with {} lines", content.lines().count());
+        tracing::debug!("Refreshed frame buffer from cell_grid");
         Ok(())
     }
 

--- a/runner/src/client/tui/render.rs
+++ b/runner/src/client/tui/render.rs
@@ -5,11 +5,23 @@
 use std::io::{self, Stdout, Write};
 
 use crossterm::{
-    cursor,
+    cursor::{self, SetCursorStyle},
     event::DisableMouseCapture,
     execute,
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
 };
+
+/// Cursor style kind for terminal rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorStyleKind {
+    /// Block cursor (default for normal mode).
+    #[default]
+    Block,
+    /// Vertical bar cursor (for insert mode).
+    Bar,
+    /// Underline cursor (for replace mode).
+    Underline,
+}
 
 /// Terminal renderer.
 pub struct Renderer {
@@ -124,6 +136,20 @@ impl Renderer {
     /// Returns error if hide fails.
     pub fn hide_cursor(&mut self) -> io::Result<()> {
         execute!(self.stdout, cursor::Hide)
+    }
+
+    /// Set cursor style (block, bar, underline).
+    ///
+    /// # Errors
+    ///
+    /// Returns error if style change fails.
+    pub fn set_cursor_style(&mut self, style: CursorStyleKind) -> io::Result<()> {
+        let crossterm_style = match style {
+            CursorStyleKind::Block => SetCursorStyle::SteadyBlock,
+            CursorStyleKind::Bar => SetCursorStyle::SteadyBar,
+            CursorStyleKind::Underline => SetCursorStyle::SteadyUnderScore,
+        };
+        execute!(self.stdout, crossterm_style)
     }
 
     /// Flush output buffer.

--- a/runner/src/client/tui/render_core.rs
+++ b/runner/src/client/tui/render_core.rs
@@ -190,6 +190,65 @@ fn write_plain_content(output: &mut String, buffer: &FrameBuffer, buf_height: u1
     }
 }
 
+// ============================================================================
+// Cell Grid Parsing (shared by TuiApp and HeadlessClient) - #440
+// ============================================================================
+
+/// Parse cell style from JSON cell object.
+///
+/// Converts JSON fg/bg/attrs to `Style` for rainbow bracket colors.
+/// Parse cell style from JSON cell object.
+///
+/// Delegates to `Style::from_wire()` for parsing colors and attributes.
+/// This is the single source of truth for wire format parsing.
+#[must_use]
+pub fn parse_cell_style(cell: &serde_json::Value) -> Style {
+    Style::from_wire(
+        cell.get("fg").and_then(|v| v.as_str()),
+        cell.get("bg").and_then(|v| v.as_str()),
+        cell.get("attrs").and_then(|v| v.as_str()),
+    )
+}
+
+/// Write `cell_grid` content to frame buffer with decoration colors.
+///
+/// Parses the JSON cell grid format and applies per-cell styles for
+/// rainbow brackets and other decorations.
+pub fn write_cell_grid_to_buffer(buffer: &mut FrameBuffer, content: &str, width: u16, height: u16) {
+    // Try to parse as JSON cell grid
+    let cells: Result<Vec<Vec<serde_json::Value>>, _> = serde_json::from_str(content);
+
+    if let Ok(rows) = cells {
+        // Write each cell with its decoration style
+        for (y, row) in rows.iter().enumerate().take(height as usize) {
+            #[allow(clippy::cast_possible_truncation)]
+            let y_u16 = y as u16;
+
+            for (x, cell) in row.iter().enumerate().take(width as usize) {
+                let ch = cell
+                    .get("char")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.chars().next())
+                    .unwrap_or(' ');
+
+                let style = parse_cell_style(cell);
+
+                #[allow(clippy::cast_possible_truncation)]
+                let x_u16 = x as u16;
+                buffer.put_char(x_u16, y_u16, ch, &style);
+            }
+        }
+    } else {
+        // Fallback to plain text if JSON parsing fails
+        let default_style = Style::default();
+        for (y, line) in content.lines().enumerate().take(height as usize) {
+            #[allow(clippy::cast_possible_truncation)]
+            let y_u16 = y as u16;
+            buffer.write_str(0, y_u16, line, &default_style);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runner/src/server/bootstrap/kernel.rs
+++ b/runner/src/server/bootstrap/kernel.rs
@@ -26,7 +26,29 @@ use {
 /// # Panics
 ///
 /// Panics if no `BufferManager` is registered in `ServiceRegistry`.
+#[allow(dead_code)] // Used in test utilities
 pub fn real_kernel_context(services: Arc<ServiceRegistry>) -> KernelContext {
+    real_kernel_context_with_event_bus(services, Arc::new(EventBus::new()))
+}
+
+/// Create a real `KernelContext` with a pre-existing event bus.
+///
+/// This variant allows sharing an event bus between modules and the session (#440).
+/// Modules subscribe to the event bus during init, and the session uses
+/// the same bus to emit events.
+///
+/// # Arguments
+///
+/// * `services` - `ServiceRegistry` to query `BufferManager` from
+/// * `event_bus` - Shared event bus for module subscriptions
+///
+/// # Panics
+///
+/// Panics if no `BufferManager` is registered in `ServiceRegistry`.
+pub fn real_kernel_context_with_event_bus(
+    services: Arc<ServiceRegistry>,
+    event_bus: Arc<EventBus>,
+) -> KernelContext {
     let option_registry = Arc::new(OptionRegistry::new());
     register_default_options(&option_registry);
 
@@ -38,7 +60,7 @@ pub fn real_kernel_context(services: Arc<ServiceRegistry>) -> KernelContext {
         .expect("BufferManager must be registered by buffer-simple module");
 
     KernelContext::new(
-        Arc::new(EventBus::new()),
+        event_bus,
         buffer_manager,
         Arc::new(MotionEngine),
         Arc::new(TextObjectEngine),

--- a/runner/src/server/bootstrap/mod.rs
+++ b/runner/src/server/bootstrap/mod.rs
@@ -13,7 +13,7 @@ mod kernel;
 mod registries;
 mod session;
 
-pub use kernel::real_kernel_context;
+pub use kernel::real_kernel_context_with_event_bus;
 // register_default_options is internal to kernel.rs
 pub use {
     registries::{build_default_registries, build_empty_session_registry, handle_empty_session},

--- a/runner/src/server/bootstrap/registries.rs
+++ b/runner/src/server/bootstrap/registries.rs
@@ -15,8 +15,23 @@ use {
     reovim_driver_search::{SearchKey, SearchProviderRegistry},
     reovim_driver_session::{EmptySessionContext, SessionHandlerKey, SessionHandlerRegistry},
     reovim_driver_undo::{UndoKey, UndoProviderRegistry},
-    reovim_kernel::api::v1::{KernelContext, ModuleContext, ServiceRegistry},
+    reovim_kernel::api::v1::{
+        EventBus, KernelContext, Module, ModuleContext, Service, ServiceRegistry,
+    },
 };
+
+/// Holder for defaults bundle modules (#440).
+///
+/// Modules that register event subscriptions must be kept alive for the
+/// subscriptions to remain active (RAII pattern). This holder stores
+/// initialized modules and is registered in `ServiceRegistry`.
+struct DefaultsModuleHolder {
+    /// Modules kept alive for their event subscriptions. Never read, only held.
+    #[allow(dead_code)]
+    modules: Vec<Box<dyn Module>>,
+}
+
+impl Service for DefaultsModuleHolder {}
 
 use crate::server::capture::CaptureTracker;
 
@@ -99,7 +114,8 @@ pub fn handle_empty_session(kernel: &KernelContext, registry: &EmptySessionHandl
 /// 1. Dynamic modules from XDG paths (`~/.local/share/reovim/modules/`)
 /// 2. Static fallback for modules not found in paths
 ///
-/// Returns the registries plus resolver registry, compositor, and provider registries.
+/// Returns the registries plus resolver registry, compositor, provider registries,
+/// and kernel context (for sharing event bus with session).
 ///
 /// # Panics
 ///
@@ -116,6 +132,7 @@ pub fn build_default_registries() -> (
     Option<Box<dyn RootCompositor>>,
     registry::DefaultModeProviderRegistry,
     Arc<ServiceRegistry>,
+    KernelContext,
 ) {
     let mut mode_registry = ModeRegistry::new();
     let mut command_registry = CommandRegistry::new();
@@ -139,14 +156,31 @@ pub fn build_default_registries() -> (
         tracing::debug!("registered SharedThemeManager in ServiceRegistry (#439)");
     }
 
+    // Create shared EventBus FIRST - before any module initialization (#440)
+    // This bus will be used by both modules (for subscriptions) and session (for emitting)
+    let shared_event_bus = Arc::new(EventBus::new());
+
+    // Create minimal kernel context for module initialization
+    // Uses the shared event bus so modules can subscribe to events
+    // Note: Uses default() for other fields since modules mainly need event_bus and services
+    let module_init_kernel = KernelContext::with_event_bus_and_services(
+        Arc::clone(&shared_event_bus),
+        Arc::clone(&services),
+    );
+
     // Initialize defaults bundle modules (Epic #417 Phase 5)
     // Modules register their services (undo, buffer, search, scratch-buffer) during init()
+    // Use the shared event bus so modules can subscribe to events (#440)
     let defaults_init_ctx = ModuleContext::new(
-        KernelContext::default(),
+        module_init_kernel,
         services.clone(),
         PathBuf::from("/tmp/reovim-init/defaults/data"),
         PathBuf::from("/tmp/reovim-init/defaults/cache"),
     );
+
+    // CRITICAL (#440): Collect and store modules to keep event subscriptions alive.
+    // Modules use RAII for subscriptions - when the module drops, subscriptions are canceled.
+    let mut defaults_modules: Vec<Box<dyn Module>> = Vec::new();
     for mut module in reovim_module_defaults::DefaultsModule::create_modules() {
         let module_id = module.id();
         match module.init(&defaults_init_ctx) {
@@ -157,7 +191,20 @@ pub fn build_default_registries() -> (
                 tracing::warn!(module = %module_id, ?result, "defaults module init returned non-success");
             }
         }
+        defaults_modules.push(module);
     }
+
+    // Store modules in ServiceRegistry to keep them alive for session lifetime (#440)
+    let module_count = defaults_modules.len();
+    services.register(Arc::new(DefaultsModuleHolder {
+        modules: defaults_modules,
+    }));
+    tracing::info!(count = module_count, "stored defaults modules in ServiceRegistry (#440)");
+
+    // Create real kernel context AFTER modules are initialized (#440)
+    // BufferManager is now available in ServiceRegistry
+    // Uses the same event bus that modules subscribed to
+    let kernel = super::real_kernel_context_with_event_bus(Arc::clone(&services), shared_event_bus);
 
     // VFS provider now comes from vfs-local module via ServiceRegistry (Epic #417)
 
@@ -358,5 +405,6 @@ pub fn build_default_registries() -> (
         compositor,
         mode_providers,
         services,
+        kernel,
     )
 }

--- a/runner/src/server/bootstrap/registries.rs
+++ b/runner/src/server/bootstrap/registries.rs
@@ -130,6 +130,15 @@ pub fn build_default_registries() -> (
     services.register(Arc::new(CaptureTracker::new()));
     tracing::debug!("registered CaptureTracker in ServiceRegistry (#447)");
 
+    // Register SharedThemeManager with default Dark theme (#439)
+    // Theme is server-specific (policy), ThemeManager is driver mechanism.
+    {
+        use reovim_driver_display::style::{BuiltinTheme, SharedThemeManager};
+        let theme_manager = SharedThemeManager::new(BuiltinTheme::Dark.load());
+        services.register(Arc::new(theme_manager));
+        tracing::debug!("registered SharedThemeManager in ServiceRegistry (#439)");
+    }
+
     // Initialize defaults bundle modules (Epic #417 Phase 5)
     // Modules register their services (undo, buffer, search, scratch-buffer) during init()
     let defaults_init_ctx = ModuleContext::new(

--- a/runner/src/server/bootstrap/session.rs
+++ b/runner/src/server/bootstrap/session.rs
@@ -26,6 +26,7 @@ pub fn create_session_with_defaults(id: SessionId) -> Arc<Session> {
         compositor,
         _mode_providers, // TODO(Epic #417 Part 3): Remove when build_default_registries() is simplified
         services,
+        kernel, // Shared kernel context for event bus (#440)
     ) = super::build_default_registries();
 
     // Query mode provider from ServiceRegistry using typed key (Epic #417)
@@ -45,9 +46,8 @@ pub fn create_session_with_defaults(id: SessionId) -> Arc<Session> {
         .and_then(|registry| registry.get(&VfsScheme::File))
         .expect("VFS provider must be registered by vfs-local module");
 
-    // Create kernel context (Epic #417 Part 2: queries BufferManager from ServiceRegistry)
-    // Pass services Arc so kernel has access to ClipboardProvider and other services
-    let kernel = super::real_kernel_context(Arc::clone(&services));
+    // Kernel context is shared from build_default_registries (#440)
+    // This ensures modules and session use the same event bus
 
     // Handle empty session: create buffer if handlers indicate so
     let empty_session_registry = super::build_empty_session_registry(&services);

--- a/runner/src/server/rpc/handlers/screen.rs
+++ b/runner/src/server/rpc/handlers/screen.rs
@@ -21,8 +21,10 @@
 //! bounds from the compositor's layout. Currently all windows share the active
 //! buffer (vim-like behavior where splits show the same content initially).
 
+use std::collections::HashMap;
+
 use {
-    reovim_driver_display::{LineNumberMode, Rect},
+    reovim_driver_display::{BufferDecorationSourceRegistry, Decoration, LineNumberMode, Rect},
     reovim_kernel::api::v1::{BufferId, OptionRegistry, OptionScopeId, OptionValue},
     reovim_protocol::v1::{RpcError, ScreenContentResult, ScreenFormat, StateScreenContentParams},
 };
@@ -94,6 +96,197 @@ fn format_line_number(
             }
         }
     }
+}
+
+/// Create the selection style (REVERSE for visibility).
+fn selection_style() -> reovim_driver_display::Style {
+    use reovim_driver_display::{Attributes, Style};
+    let mut attrs = Attributes::new();
+    attrs.set(Attributes::REVERSE);
+    Style {
+        fg: None,
+        bg: None,
+        underline_color: None,
+        attributes: attrs,
+    }
+}
+
+/// Generate character-wise selection decorations.
+#[allow(clippy::cast_possible_truncation)]
+fn char_selection_decorations(
+    start: reovim_kernel::api::v1::Position,
+    end: reovim_kernel::api::v1::Position,
+    style: reovim_driver_display::Style,
+) -> Vec<Decoration> {
+    use reovim_driver_display::Span;
+    let mut decorations = Vec::new();
+
+    if start.line == end.line {
+        // Single line selection
+        let span = Span::line(start.line as u32, start.column as u32, (end.column + 1) as u32);
+        decorations.push(Decoration::InlineStyle { span, style });
+    } else {
+        // Multi-line: first line
+        let first = Span::new(start.line as u32, start.column as u32, start.line as u32, u32::MAX);
+        decorations.push(Decoration::InlineStyle {
+            span: first,
+            style: style.clone(),
+        });
+        // Middle lines
+        for line in (start.line + 1)..end.line {
+            let mid = Span::new(line as u32, 0, line as u32, u32::MAX);
+            decorations.push(Decoration::InlineStyle {
+                span: mid,
+                style: style.clone(),
+            });
+        }
+        // Last line
+        let last = Span::line(end.line as u32, 0, (end.column + 1) as u32);
+        decorations.push(Decoration::InlineStyle { span: last, style });
+    }
+    decorations
+}
+
+/// Generate visual selection decorations (#440).
+///
+/// Creates decorations for the currently selected text range in visual mode.
+/// Uses REVERSE attribute for visibility (inverts fg/bg colors).
+fn generate_selection_decorations(
+    state: &crate::session::SessionState,
+    buffer_id: BufferId,
+    cursor: (usize, usize),
+) -> Vec<Decoration> {
+    use reovim_kernel::api::v1::{Position, Selection, SelectionMode};
+
+    // Get selection state from buffer (read lock released immediately)
+    let selection: Selection = {
+        let Some(buffer_arc) = state.app.kernel.buffers.get(buffer_id) else {
+            return Vec::new();
+        };
+        buffer_arc.read().selection()
+    };
+
+    if !selection.is_active() {
+        return Vec::new();
+    }
+
+    let cursor_pos = Position::new(cursor.0, cursor.1);
+    let style = selection_style();
+    let mut decorations = Vec::new();
+
+    match selection.mode() {
+        SelectionMode::Character => {
+            if let Some((start, end)) = selection.bounds(cursor_pos) {
+                decorations = char_selection_decorations(start, end, style);
+            }
+        }
+        SelectionMode::Line => {
+            if let Some((start_line, end_line)) = selection.line_bounds(cursor_pos) {
+                for line in start_line..=end_line {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let span =
+                        reovim_driver_display::Span::new(line as u32, 0, line as u32, u32::MAX);
+                    decorations.push(Decoration::InlineStyle {
+                        span,
+                        style: style.clone(),
+                    });
+                }
+            }
+        }
+        SelectionMode::Block => {
+            if let Some((top_left, bottom_right)) = selection.block_bounds(cursor_pos) {
+                for line in top_left.line..=bottom_right.line {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let span = reovim_driver_display::Span::line(
+                        line as u32,
+                        top_left.column as u32,
+                        (bottom_right.column + 1) as u32,
+                    );
+                    decorations.push(Decoration::InlineStyle {
+                        span,
+                        style: style.clone(),
+                    });
+                }
+            }
+        }
+    }
+    decorations
+}
+
+/// Generate decorations for a buffer from all registered decoration sources (#440).
+///
+/// Queries `BufferDecorationSourceRegistry` from `ServiceRegistry` and collects
+/// decorations from all registered sources (e.g., rainbow brackets, search highlights).
+/// Also generates visual selection decorations directly from buffer state.
+/// This provides generic decoration support without depending on specific modules.
+fn generate_buffer_decorations(
+    state: &crate::session::SessionState,
+    buffer_id: BufferId,
+    content: &str,
+    cursor: (usize, usize),
+) -> Vec<Decoration> {
+    let mut decorations = Vec::new();
+
+    // Generate visual selection decorations first (lower priority - can be overridden)
+    decorations.extend(generate_selection_decorations(state, buffer_id, cursor));
+
+    // Query BufferDecorationSourceRegistry from ServiceRegistry
+    let Some(registry) = state
+        .app
+        .kernel
+        .services
+        .get::<BufferDecorationSourceRegistry>()
+    else {
+        return decorations;
+    };
+
+    // Iterate ALL registered decoration sources generically
+    // This follows mechanism/policy separation: the runner has no knowledge
+    // of which specific modules registered which sources (pair, search, etc.)
+    for key in registry.keys() {
+        if let Some(source) = registry.get(&key) {
+            decorations.extend(source.decorations_for_buffer(buffer_id, content, cursor));
+        }
+    }
+
+    decorations
+}
+
+/// Build a decoration lookup map: (line, col) -> Style.
+///
+/// Used for efficient lookup when building cell grid.
+/// Handles both single-line and multi-line spans (for visual selection).
+fn build_decoration_map(
+    decorations: &[Decoration],
+) -> HashMap<(usize, usize), reovim_driver_display::Style> {
+    let mut map = HashMap::new();
+    for decoration in decorations {
+        if let Decoration::InlineStyle { span, style } = decoration {
+            let start_line = span.start_line as usize;
+            let end_line = span.end_line as usize;
+
+            for line in start_line..=end_line {
+                // Determine column range for this line
+                let start_col = if line == start_line {
+                    span.start_col as usize
+                } else {
+                    0
+                };
+                let end_col = if line == end_line {
+                    span.end_col as usize
+                } else {
+                    // For lines before the last, extend to a reasonable max
+                    // (actual line length will clip this in rendering)
+                    256
+                };
+
+                for col in start_col..end_col {
+                    map.insert((line, col), style.clone());
+                }
+            }
+        }
+    }
+    map
 }
 
 /// Handler for `state/screen_content` method.
@@ -176,18 +369,24 @@ fn render_multi_window(
     let line_mode = line_number_mode_from_options(&state.app.kernel.options);
 
     // Get the active buffer content (shared by all windows for now)
-    let (content, cursor_line) = state
+    let (buffer_id, content, cursor_line, cursor_col) = state
         .session_active_buffer()
-        .and_then(|id: BufferId| state.app.kernel.buffers.get(id))
-        .map(|arc| {
-            let buf = arc.read();
-            (buf.content(), buf.position().line)
+        .and_then(|id: BufferId| {
+            state.app.kernel.buffers.get(id).map(|arc| {
+                let buf = arc.read();
+                (id, buf.content(), buf.position().line, buf.position().column)
+            })
         })
         .unwrap_or_default();
 
     let lines: Vec<&str> = content.lines().collect();
     let total_lines = lines.len();
     let gutter_width = calculate_gutter_width(line_mode, total_lines);
+
+    // Generate rainbow bracket decorations (#440)
+    let decorations =
+        generate_buffer_decorations(state, buffer_id, &content, (cursor_line, cursor_col));
+    let decoration_map = build_decoration_map(&decorations);
 
     // Create a 2D screen buffer
     let mut screen: Vec<Vec<char>> = vec![vec![' '; width as usize]; height as usize];
@@ -219,7 +418,7 @@ fn render_multi_window(
         .collect::<Vec<_>>()
         .join("\n");
 
-    format_content(&screen_content, format, width, height)
+    format_content(&screen_content, format, width, height, &decoration_map, gutter_width)
 }
 
 /// Render a single window's content within its bounds on the screen buffer.
@@ -329,12 +528,13 @@ fn render_single_window(
     let line_mode = line_number_mode_from_options(&state.app.kernel.options);
 
     // Use driver_session SSOT for active_buffer
-    let (content, cursor_line) = state
+    let (buffer_id, content, cursor_line, cursor_col) = state
         .session_active_buffer()
-        .and_then(|id: BufferId| state.app.kernel.buffers.get(id))
-        .map(|arc| {
-            let buf = arc.read();
-            (buf.content(), buf.position().line)
+        .and_then(|id: BufferId| {
+            state.app.kernel.buffers.get(id).map(|arc| {
+                let buf = arc.read();
+                (id, buf.content(), buf.position().line, buf.position().column)
+            })
         })
         .unwrap_or_default();
 
@@ -342,6 +542,11 @@ fn render_single_window(
     let lines: Vec<&str> = content.lines().collect();
     let total_lines = lines.len();
     let gutter_width = calculate_gutter_width(line_mode, total_lines);
+
+    // Generate rainbow bracket decorations (#440)
+    let decorations =
+        generate_buffer_decorations(state, buffer_id, &content, (cursor_line, cursor_col));
+    let decoration_map = build_decoration_map(&decorations);
 
     // Build content with line numbers (#445)
     let rendered_content: String = if line_mode == LineNumberMode::None {
@@ -365,18 +570,36 @@ fn render_single_window(
     let content_width = (lines.iter().map(|l| l.len()).max().unwrap_or(80) + gutter_width)
         .min(usize::from(u16::MAX)) as u16;
 
-    format_content(&rendered_content, format, content_width.max(1), content_height.max(1))
+    format_content(
+        &rendered_content,
+        format,
+        content_width.max(1),
+        content_height.max(1),
+        &decoration_map,
+        gutter_width,
+    )
 }
 
 // Multi-window rendering will be implemented in Phase 2 using Session.compositor.
 // The compositor provides CompositeResult with all window placements in z-order.
 
 /// Format content according to the requested screen format.
+///
+/// # Arguments
+///
+/// * `content` - The text content to format
+/// * `format` - The output format (`PlainText`, `RawAnsi`, `CellGrid`)
+/// * `width` - Screen width
+/// * `height` - Screen height
+/// * `decoration_map` - Style decorations by position (line, col) for rainbow brackets (#440)
+/// * `gutter_width` - Width of line number gutter (for column offset in decorations)
 fn format_content(
     content: &str,
     format: ScreenFormat,
     width: u16,
     height: u16,
+    decoration_map: &HashMap<(usize, usize), reovim_driver_display::Style>,
+    gutter_width: usize,
 ) -> ScreenContentResult {
     let formatted_content = match format {
         ScreenFormat::PlainText => content.to_string(),
@@ -386,18 +609,45 @@ fn format_content(
             content.to_string()
         }
         ScreenFormat::CellGrid => {
-            // Return JSON cell grid representation
+            // Return JSON cell grid representation with rainbow bracket colors (#440)
             let lines: Vec<&str> = content.lines().collect();
             let cells: Vec<Vec<serde_json::Value>> = lines
                 .iter()
-                .map(|line| {
+                .enumerate()
+                .map(|(line_idx, line)| {
                     line.chars()
-                        .map(|c| {
-                            serde_json::json!({
-                                "char": c.to_string(),
-                                "fg": "default",
-                                "bg": "default"
-                            })
+                        .enumerate()
+                        .map(|(col_idx, c)| {
+                            // Check for decoration at this position
+                            // Account for gutter width when looking up decorations
+                            let content_col = col_idx.saturating_sub(gutter_width);
+                            let style = decoration_map.get(&(line_idx, content_col));
+
+                            let (fg, bg, attrs) = style.map_or_else(
+                                || ("default".to_string(), "default".to_string(), String::new()),
+                                |s| {
+                                    (
+                                        color_to_string(s.fg),
+                                        color_to_string(s.bg),
+                                        attributes_to_string(s.attributes),
+                                    )
+                                },
+                            );
+
+                            if attrs.is_empty() {
+                                serde_json::json!({
+                                    "char": c.to_string(),
+                                    "fg": fg,
+                                    "bg": bg
+                                })
+                            } else {
+                                serde_json::json!({
+                                    "char": c.to_string(),
+                                    "fg": fg,
+                                    "bg": bg,
+                                    "attrs": attrs
+                                })
+                            }
                         })
                         .collect()
                 })
@@ -412,6 +662,52 @@ fn format_content(
         format,
         content: formatted_content,
     }
+}
+
+/// Convert a Color to a string representation for JSON output.
+fn color_to_string(color: Option<reovim_arch::Color>) -> String {
+    match color {
+        None | Some(reovim_arch::Color::Reset) => "default".to_string(),
+        Some(reovim_arch::Color::Black) => "black".to_string(),
+        Some(reovim_arch::Color::DarkGrey) => "#555555".to_string(),
+        Some(reovim_arch::Color::Red) => "red".to_string(),
+        Some(reovim_arch::Color::DarkRed) => "#aa0000".to_string(),
+        Some(reovim_arch::Color::Green) => "green".to_string(),
+        Some(reovim_arch::Color::DarkGreen) => "#00aa00".to_string(),
+        Some(reovim_arch::Color::Yellow) => "yellow".to_string(),
+        Some(reovim_arch::Color::DarkYellow) => "#aaaa00".to_string(),
+        Some(reovim_arch::Color::Blue) => "blue".to_string(),
+        Some(reovim_arch::Color::DarkBlue) => "#0000aa".to_string(),
+        Some(reovim_arch::Color::Magenta) => "magenta".to_string(),
+        Some(reovim_arch::Color::DarkMagenta) => "#aa00aa".to_string(),
+        Some(reovim_arch::Color::Cyan) => "cyan".to_string(),
+        Some(reovim_arch::Color::DarkCyan) => "#00aaaa".to_string(),
+        Some(reovim_arch::Color::White) => "white".to_string(),
+        Some(reovim_arch::Color::Grey) => "#aaaaaa".to_string(),
+        Some(reovim_arch::Color::Rgb { r, g, b }) => format!("#{r:02x}{g:02x}{b:02x}"),
+        Some(reovim_arch::Color::AnsiValue(n)) => format!("ansi:{n}"),
+    }
+}
+
+/// Convert Attributes to a string representation for JSON output.
+fn attributes_to_string(attrs: reovim_driver_display::Attributes) -> String {
+    let mut parts = Vec::new();
+    if attrs.contains(reovim_driver_display::Attributes::BOLD) {
+        parts.push("bold");
+    }
+    if attrs.contains(reovim_driver_display::Attributes::ITALIC) {
+        parts.push("italic");
+    }
+    if attrs.contains(reovim_driver_display::Attributes::UNDERLINE) {
+        parts.push("underline");
+    }
+    if attrs.contains(reovim_driver_display::Attributes::REVERSE) {
+        parts.push("reverse");
+    }
+    if attrs.contains(reovim_driver_display::Attributes::STRIKETHROUGH) {
+        parts.push("strikethrough");
+    }
+    parts.join(",")
 }
 
 #[cfg(test)]
@@ -723,7 +1019,9 @@ mod tests {
     #[test]
     fn test_format_content_plain_text() {
         let content = "Hello\nWorld";
-        let result = super::format_content(content, ScreenFormat::PlainText, 10, 5);
+        let decoration_map = HashMap::new();
+        let result =
+            super::format_content(content, ScreenFormat::PlainText, 10, 5, &decoration_map, 0);
 
         assert_eq!(result.content, "Hello\nWorld");
         assert_eq!(result.width, 10);
@@ -734,7 +1032,9 @@ mod tests {
     #[test]
     fn test_format_content_cell_grid() {
         let content = "AB";
-        let result = super::format_content(content, ScreenFormat::CellGrid, 10, 5);
+        let decoration_map = HashMap::new();
+        let result =
+            super::format_content(content, ScreenFormat::CellGrid, 10, 5, &decoration_map, 0);
 
         // Should be valid JSON
         let cells: Vec<Vec<serde_json::Value>> =
@@ -743,6 +1043,47 @@ mod tests {
         assert_eq!(cells[0].len(), 2);
         assert_eq!(cells[0][0].get("char").unwrap().as_str().unwrap(), "A");
         assert_eq!(cells[0][1].get("char").unwrap().as_str().unwrap(), "B");
+    }
+
+    #[test]
+    fn test_format_content_cell_grid_with_decorations() {
+        use reovim_driver_display::{Color, Style};
+
+        // Create content with a bracket
+        let content = "(A)";
+
+        // Create a decoration map with color at position (0, 0) for the '('
+        let mut decoration_map = HashMap::new();
+        let style = Style {
+            fg: Some(Color::Red),
+            bg: None,
+            underline_color: None,
+            attributes: reovim_driver_display::Attributes::default(),
+        };
+        decoration_map.insert((0, 0), style);
+
+        let result =
+            super::format_content(content, ScreenFormat::CellGrid, 10, 5, &decoration_map, 0);
+
+        // Parse the JSON
+        let cells: Vec<Vec<serde_json::Value>> =
+            serde_json::from_str(&result.content).expect("Should be valid JSON");
+
+        // First character '(' should have red foreground
+        let first_cell = &cells[0][0];
+        assert_eq!(first_cell.get("char").unwrap().as_str().unwrap(), "(");
+        assert_eq!(first_cell.get("fg").unwrap().as_str().unwrap(), "red");
+        assert_eq!(first_cell.get("bg").unwrap().as_str().unwrap(), "default");
+
+        // Second character 'A' should have default colors
+        let second_cell = &cells[0][1];
+        assert_eq!(second_cell.get("char").unwrap().as_str().unwrap(), "A");
+        assert_eq!(second_cell.get("fg").unwrap().as_str().unwrap(), "default");
+
+        // Third character ')' should have default colors
+        let third_cell = &cells[0][2];
+        assert_eq!(third_cell.get("char").unwrap().as_str().unwrap(), ")");
+        assert_eq!(third_cell.get("fg").unwrap().as_str().unwrap(), "default");
     }
 
     // === Line number rendering tests (#445) ===

--- a/runner/src/server/session/session.rs
+++ b/runner/src/server/session/session.rs
@@ -12,7 +12,10 @@ use {
     reovim_driver_display::layout::RootCompositor,
     reovim_driver_input::{KeySequence, ResolverRegistry},
     reovim_driver_vfs::VfsDriver,
-    reovim_kernel::api::v1::{CommandId, KernelContext, ModeId},
+    reovim_kernel::api::v1::{
+        CommandId, KernelContext, ModeId,
+        events::kernel::{BufferModified, Modification},
+    },
 };
 
 use {
@@ -612,6 +615,7 @@ impl Session {
     /// was inserted, `false` if not (no active buffer, mode doesn't accept input).
     ///
     /// Acquires a write lock on the session state.
+    /// Emits `BufferModified` event for auto-pair and other modules.
     pub async fn insert_char(&self, ch: char) -> bool {
         use reovim_driver_input::FallbackContext;
 
@@ -641,6 +645,25 @@ impl Session {
             state
                 .app
                 .accumulate_edit(buffer_id, edit, cursor_before, cursor_after);
+
+            // Emit BufferModified event for auto-pair and other modules (#440)
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                let handler_count = state.app.kernel.event_bus.handler_count::<BufferModified>();
+                let result = state.app.kernel.event_bus.emit(BufferModified {
+                    buffer_id: buffer_id.as_usize() as u64,
+                    modification: Modification::Insert {
+                        start: (cursor_before.line as u32, cursor_before.column as u32),
+                        text: ch.to_string(),
+                    },
+                });
+                tracing::trace!(
+                    char = %ch,
+                    handlers = handler_count,
+                    result = ?result,
+                    "BufferModified event emitted for insert_char"
+                );
+            }
 
             true
         })


### PR DESCRIPTION
## Summary

Phase 8 implementation adding four major features:

- **Floating window layer** (#398): Windows can toggle between tiled and floating with `<C-w>f`. Float windows render above tiled, reorder with `<C-w>]`/`<C-w>[`
- **Overlay/popup layer** (#399): Anchor-based positioning for temporary UI (popups, menus, tooltips). Supports Cursor, Screen, Center, Below anchors
- **Color and theme system** (#439): 3 built-in themes (dark, light, tokyo-night-orange), 41 highlight groups, runtime switching via `:colorscheme`
- **Pair module** (#440): Auto-close brackets, rainbow bracket highlighting (6 colors by depth), matched pair indicator

Display driver refactored for mechanism/policy separation:
- String-based `DecorationSourceKey` instead of enum variants
- `StyleGroupRegistry` for module-provided style defaults
- `FromStr`/`Display` traits for `Color` and `Attributes`
- `Style::from_wire()` for unified RPC deserialization

## Test plan

- [x] `./scripts/check.sh` passes
- [x] Rainbow brackets render correctly with `[{()}]`
- [x] Auto-pair insertion works for `(`, `[`, `{`, quotes
- [x] Float windows toggle and render above tiled
- [x] Theme switching via `:colorscheme dark/light/tokyo-night-orange`

Closes #398, Closes #399, Closes #439, Closes #440