### PR TITLE
feat(web): add leader key for browser-reserved shortcuts (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ## [Unreleased] - v0.9.3-dev
 
+### Added
+
+- **Web client leader key for browser-reserved shortcuts**: Browsers reserve
+  Ctrl+W, Ctrl+T, Ctrl+N, etc. for security and these cannot be captured by
+  JavaScript. Added `WebKeymapper` class with leader key (`\`) support that
+  translates sequences like `\w` → `<C-w>`, `\t` → `<C-t>`, etc. This is a
+  web-only translation layer - the server receives standard vim notation and
+  doesn't know about the leader key. TUI clients still capture Ctrl+W natively.
+  Also added `beforeunload` exit protection to warn users about unsaved changes
+  if they accidentally press Ctrl+W. Includes visual leader indicator in
+  command line when leader is pending. (#473)
+
 ### Changed
 
 - **Directory restructure**: Major codebase restructure to clarify

--- a/clients/web/src/editor.ts
+++ b/clients/web/src/editor.ts
@@ -994,4 +994,53 @@ export class Editor {
       windowStates: this.state.windowStates,
     };
   }
+
+  // ==========================================================================
+  // Buffer State (Phase: Browser Keyboard Policy)
+  // ==========================================================================
+
+  /**
+   * Check if any buffer has unsaved changes.
+   *
+   * Used by exit protection to warn users before closing the tab.
+   * Currently returns true if any content exists (simple heuristic).
+   *
+   * TODO: Implement proper dirty tracking via server notifications.
+   */
+  hasUnsavedChanges(): boolean {
+    // Simple heuristic: if there's any content, assume it might be unsaved
+    // A proper implementation would track buffer dirty state from server
+    return this.state.lines.length > 0 && this.state.lines.some((line) => line.length > 0);
+  }
+
+  // ==========================================================================
+  // Leader Key Indicator (Phase: Browser Keyboard Policy)
+  // ==========================================================================
+
+  /**
+   * Show leader key indicator in command line.
+   *
+   * Called when user presses the leader key (\) to indicate
+   * that we're waiting for the next key in the sequence.
+   */
+  showLeaderIndicator(): void {
+    const cmdline = document.getElementById("commandline");
+    if (cmdline) {
+      cmdline.textContent = "\\";
+      cmdline.classList.add("leader-pending");
+    }
+  }
+
+  /**
+   * Hide leader key indicator.
+   *
+   * Called when leader sequence completes, times out, or is cancelled.
+   */
+  hideLeaderIndicator(): void {
+    const cmdline = document.getElementById("commandline");
+    if (cmdline) {
+      cmdline.textContent = "";
+      cmdline.classList.remove("leader-pending");
+    }
+  }
 }

--- a/clients/web/src/input.ts
+++ b/clients/web/src/input.ts
@@ -2,36 +2,56 @@
  * Keyboard Input Handler
  *
  * Captures keyboard events and sends them to the server via gRPC-Web.
+ *
+ * ## Browser Keyboard Policy
+ *
+ * Browsers reserve Ctrl+W, Ctrl+T, Ctrl+N, etc. for security.
+ * We use a leader key (\) to access these combinations:
+ *   - `\w` → `<C-w>` (window commands)
+ *   - `\t` → `<C-t>` (tag jump)
+ *   - etc.
+ *
+ * The server receives standard vim notation and doesn't know
+ * about the web leader key.
  */
 
 import type { ReovimClient } from "./client.js";
 import type { Editor } from "./editor.js";
-import { browserKeyToVim, shouldPreventDefault } from "./keymapper.js";
+import { WebKeymapper } from "./keymapper.js";
 
 /**
  * Setup keyboard event handler for the editor.
  *
- * Captures keydown events on the document and sends them to the server.
+ * Uses WebKeymapper to handle browser-reserved keys via leader sequences.
  *
  * @param client - gRPC client for server communication
- * @param _editor - Editor instance (unused - state updates via notifications)
+ * @param editor - Editor instance (used for leader indicator)
  * @param myClientId - This client's unique ID (Phase 11.2)
  */
 export function setupKeyboardHandler(
   client: ReovimClient,
-  _editor: Editor,
+  editor: Editor,
   myClientId: bigint
 ): void {
-  document.addEventListener("keydown", async (event: KeyboardEvent) => {
-    // Check if we should prevent browser default behavior
-    if (shouldPreventDefault(event)) {
-      event.preventDefault();
-    }
+  // Create stateful keymapper with leader key support
+  const keymapper = new WebKeymapper({
+    onLeaderStart: () => {
+      // Show leader indicator in command line
+      editor.showLeaderIndicator?.();
+    },
+    onLeaderEnd: () => {
+      // Hide leader indicator
+      editor.hideLeaderIndicator?.();
+    },
+  });
 
-    // Convert to vim notation
-    const vimKey = browserKeyToVim(event);
+  document.addEventListener("keydown", async (event: KeyboardEvent) => {
+    // Use WebKeymapper - it handles preventDefault internally
+    const vimKey = keymapper.handleKeyEvent(event);
+
     if (!vimKey) {
-      return; // Ignore modifier-only or unknown keys
+      // Leader pending, modifier-only press, or cancelled
+      return;
     }
 
     try {
@@ -48,7 +68,7 @@ export function setupKeyboardHandler(
         console.warn(`Key not handled: ${vimKey}`, response.status);
       }
 
-      // NOTE: We now rely on notifications for state updates instead of
+      // NOTE: We rely on notifications for state updates instead of
       // calling editor.refresh() after every key. This prevents state
       // overwrites and reduces unnecessary round-trips.
     } catch (error) {
@@ -61,5 +81,5 @@ export function setupKeyboardHandler(
     event.preventDefault();
   });
 
-  console.log("Keyboard handler initialized");
+  console.log("Keyboard handler initialized (with leader key support: \\ for Ctrl+)");
 }

--- a/clients/web/src/keymapper.ts
+++ b/clients/web/src/keymapper.ts
@@ -3,8 +3,24 @@
  *
  * Converts browser KeyboardEvent to vim-style key notation.
  *
- * KNOWN LIMITATIONS:
- * - Ctrl+W, Ctrl+T, Ctrl+N may be intercepted by browser (cannot reliably capture)
+ * ## Browser Keyboard Policy
+ *
+ * Browsers reserve certain shortcuts (Ctrl+W, Ctrl+T, Ctrl+N) for security.
+ * Web apps CANNOT capture these keys - this is intentional browser policy.
+ *
+ * ### Solution: Web-Only Leader Key
+ *
+ * Use `\` (backslash) as a leader key to access Ctrl combinations:
+ *   - `\w` → `<C-w>` (window commands)
+ *   - `\t` → `<C-t>` (tag jump)
+ *   - `\n` → `<C-n>` (next completion)
+ *   - etc.
+ *
+ * The server receives standard vim notation - it doesn't know about
+ * the web leader key. TUI clients capture Ctrl+W natively.
+ *
+ * ## Other Limitations
+ *
  * - Meta key (Cmd on Mac) behavior varies by browser
  * - Dead keys (accents) may not map correctly
  * - Some international keyboard layouts may have edge cases
@@ -194,13 +210,237 @@ export function shouldPreventDefault(event: KeyboardEvent): boolean {
 
 /**
  * List of keys that browsers typically intercept and cannot be captured.
- * Documented for user awareness.
+ * Use the leader key (\) as an alternative. See WebKeymapper.
  */
 export const UNCAPTURABLE_KEYS = [
-  "Ctrl+W (closes tab)",
-  "Ctrl+T (new tab)",
-  "Ctrl+N (new window)",
+  "Ctrl+W (closes tab) - use \\w instead",
+  "Ctrl+T (new tab) - use \\t instead",
+  "Ctrl+N (new window) - use \\n instead",
   "Ctrl+Shift+T (reopen tab)",
+  "Ctrl+Shift+I (dev tools)",
   "F11 (fullscreen)",
   "Alt+F4 (close window on Windows)",
 ];
+
+// ============================================================================
+// Web-Only Leader Key System
+// ============================================================================
+
+/** Leader key state */
+export type KeymapperState = "normal" | "leader_pending";
+
+/** Default leader key (backslash) */
+const LEADER_KEY = "\\";
+
+/** Leader timeout in milliseconds */
+const LEADER_TIMEOUT_MS = 1000;
+
+/**
+ * Mapping from leader+key to Ctrl combinations.
+ *
+ * These are browser-reserved keys that we translate via leader key.
+ */
+const LEADER_TO_CTRL: Record<string, string> = {
+  // Window/tab management (browser reserves Ctrl+W/T/N)
+  w: "<C-w>", // Window commands
+  t: "<C-t>", // Tag jump
+  n: "<C-n>", // Next completion / down
+
+  // Navigation (browser may reserve some)
+  p: "<C-p>", // Prev completion / up
+  o: "<C-o>", // Jump back in jumplist
+  i: "<C-i>", // Jump forward (same as Tab)
+  "]": "<C-]>", // Jump to definition
+  "[": "<C-[>", // Same as Escape
+
+  // Scrolling
+  d: "<C-d>", // Half page down
+  u: "<C-u>", // Half page up
+  f: "<C-f>", // Page forward (down)
+  b: "<C-b>", // Page back (up)
+  e: "<C-e>", // Scroll down one line
+  y: "<C-y>", // Scroll up one line
+
+  // Editing
+  r: "<C-r>", // Redo / insert register
+  a: "<C-a>", // Increment number
+  x: "<C-x>", // Decrement number
+  v: "<C-v>", // Visual block mode
+
+  // Other
+  g: "<C-g>", // File info
+  l: "<C-l>", // Redraw screen
+  z: "<C-z>", // Suspend (no-op in web)
+};
+
+/** Options for WebKeymapper constructor */
+export interface WebKeymapperOptions {
+  /** Called when leader key is pressed (to show indicator) */
+  onLeaderStart?: () => void;
+  /** Called when leader sequence completes or times out */
+  onLeaderEnd?: () => void;
+}
+
+/**
+ * Stateful keyboard mapper with leader key support.
+ *
+ * Handles browser-reserved keys by translating leader sequences:
+ *   `\w` → `<C-w>`
+ *   `\t` → `<C-t>`
+ *   etc.
+ *
+ * The server receives standard vim notation and doesn't know
+ * about the leader key - this is a web-only translation layer.
+ *
+ * @example
+ * ```typescript
+ * const keymapper = new WebKeymapper({
+ *   onLeaderStart: () => showIndicator('\\'),
+ *   onLeaderEnd: () => hideIndicator(),
+ * });
+ *
+ * document.addEventListener('keydown', (event) => {
+ *   const vimKey = keymapper.handleKeyEvent(event);
+ *   if (vimKey) {
+ *     sendToServer(vimKey);
+ *   }
+ * });
+ * ```
+ */
+export class WebKeymapper {
+  private state: KeymapperState = "normal";
+  private leaderTimeout: number | null = null;
+  private onLeaderStart?: () => void;
+  private onLeaderEnd?: () => void;
+
+  constructor(options?: WebKeymapperOptions) {
+    this.onLeaderStart = options?.onLeaderStart;
+    this.onLeaderEnd = options?.onLeaderEnd;
+  }
+
+  /**
+   * Handle a keyboard event and return vim notation.
+   *
+   * @param event - Browser keyboard event
+   * @returns Vim notation string, or null if no key should be sent
+   *          (e.g., leader pending, modifier-only press, cancelled)
+   */
+  handleKeyEvent(event: KeyboardEvent): string | null {
+    const { key } = event;
+
+    // Ignore modifier-only presses
+    if (["Control", "Alt", "Shift", "Meta"].includes(key)) {
+      return null;
+    }
+
+    // Handle based on current state
+    if (this.state === "normal") {
+      return this.handleNormalState(event);
+    }
+
+    // Leader pending state
+    return this.handleLeaderPendingState(event);
+  }
+
+  /**
+   * Handle key in normal state.
+   */
+  private handleNormalState(event: KeyboardEvent): string | null {
+    const { key, ctrlKey, altKey, metaKey } = event;
+
+    // Check for leader key (\ without modifiers)
+    if (key === LEADER_KEY && !ctrlKey && !altKey && !metaKey) {
+      // Prevent browser default (\ might do something)
+      event.preventDefault();
+
+      this.state = "leader_pending";
+      this.startTimeout();
+      this.onLeaderStart?.();
+      return null; // Wait for next key
+    }
+
+    // Normal key handling with preventDefault
+    if (shouldPreventDefault(event)) {
+      event.preventDefault();
+    }
+
+    return browserKeyToVim(event);
+  }
+
+  /**
+   * Handle key in leader pending state.
+   */
+  private handleLeaderPendingState(event: KeyboardEvent): string | null {
+    const { key } = event;
+
+    // Always prevent default in leader state
+    event.preventDefault();
+
+    // Clear timeout and reset state
+    this.clearTimeout();
+    this.state = "normal";
+    this.onLeaderEnd?.();
+
+    // Escape cancels leader
+    if (key === "Escape") {
+      return null;
+    }
+
+    // Check leader mappings (case-insensitive for letters)
+    const lookupKey = key.length === 1 ? key.toLowerCase() : key;
+    const mapped = LEADER_TO_CTRL[lookupKey];
+
+    if (mapped) {
+      return mapped;
+    }
+
+    // Unknown leader combo - send the key after leader as-is
+    // This allows \ followed by unmapped keys to work normally
+    return browserKeyToVim(event);
+  }
+
+  /**
+   * Start the leader timeout.
+   * If timeout expires, leader is cancelled.
+   */
+  private startTimeout(): void {
+    // Use globalThis for Node.js test compatibility
+    this.leaderTimeout = globalThis.setTimeout(() => {
+      this.state = "normal";
+      this.leaderTimeout = null;
+      this.onLeaderEnd?.();
+    }, LEADER_TIMEOUT_MS) as unknown as number;
+  }
+
+  /**
+   * Clear the leader timeout.
+   */
+  private clearTimeout(): void {
+    if (this.leaderTimeout !== null) {
+      globalThis.clearTimeout(this.leaderTimeout);
+      this.leaderTimeout = null;
+    }
+  }
+
+  /**
+   * Get current keymapper state.
+   */
+  getState(): KeymapperState {
+    return this.state;
+  }
+
+  /**
+   * Check if leader key is currently pending.
+   */
+  isLeaderPending(): boolean {
+    return this.state === "leader_pending";
+  }
+
+  /**
+   * Reset state (useful for testing or error recovery).
+   */
+  reset(): void {
+    this.clearTimeout();
+    this.state = "normal";
+  }
+}

--- a/clients/web/src/main.ts
+++ b/clients/web/src/main.ts
@@ -7,6 +7,7 @@
 import { createClient } from "./client.js";
 import { setupKeyboardHandler } from "./input.js";
 import { Editor } from "./editor.js";
+import { setupExitProtection } from "./protection.js";
 
 async function main() {
   const app = document.getElementById("app");
@@ -43,8 +44,11 @@ async function main() {
     // Initialize WASM module for multi-window support
     await editor.init();
 
-    // Setup keyboard input with client ID
+    // Setup keyboard input with client ID (includes leader key for browser-reserved shortcuts)
     setupKeyboardHandler(client, editor, myClientId);
+
+    // Setup exit protection (beforeunload warning for unsaved changes)
+    setupExitProtection(editor);
 
     // Initial state fetch
     await editor.refresh();

--- a/clients/web/src/protection.ts
+++ b/clients/web/src/protection.ts
@@ -1,0 +1,39 @@
+/**
+ * Exit Protection
+ *
+ * Provides a safety net for accidental tab closure (Ctrl+W, etc.)
+ * by warning users about unsaved changes.
+ *
+ * ## Browser Keyboard Policy
+ *
+ * Since browsers reserve Ctrl+W for tab closing and we cannot prevent it,
+ * we use beforeunload as a last-resort warning for unsaved work.
+ *
+ * Note: This doesn't capture Ctrl+W - it just warns the user if they
+ * have unsaved changes before the tab closes.
+ */
+
+import type { Editor } from "./editor.js";
+
+/**
+ * Setup exit protection with beforeunload warning.
+ *
+ * When the user tries to close the tab (Ctrl+W, close button, etc.)
+ * and there are unsaved changes, shows a browser confirmation dialog.
+ *
+ * @param editor - Editor instance to check for unsaved changes
+ */
+export function setupExitProtection(editor: Editor): void {
+  window.addEventListener("beforeunload", (event: BeforeUnloadEvent) => {
+    // Check if editor has unsaved changes
+    // Note: Editor.hasUnsavedChanges() may not be implemented yet
+    if (editor.hasUnsavedChanges?.()) {
+      // Trigger browser's "Leave site?" dialog
+      event.preventDefault();
+      // Modern browsers ignore custom messages but this is still required
+      event.returnValue = "";
+    }
+  });
+
+  console.log("Exit protection initialized (beforeunload warning for unsaved changes)");
+}

--- a/clients/web/styles/main.css
+++ b/clients/web/styles/main.css
@@ -158,6 +158,12 @@ body {
   min-height: 1.5rem;
 }
 
+/* Leader key indicator (Browser Keyboard Policy) */
+#commandline.leader-pending {
+  color: var(--theme-mode-command, #e5c07b);
+  font-weight: bold;
+}
+
 /* Connection status indicator */
 #app.disconnected #statusline::after {
   content: "DISCONNECTED";

--- a/clients/web/tests/keymapper.test.ts
+++ b/clients/web/tests/keymapper.test.ts
@@ -309,3 +309,255 @@ describe("shouldPreventDefault", () => {
     );
   });
 });
+
+// ============================================================================
+// WebKeymapper Tests (Browser Keyboard Policy)
+// ============================================================================
+
+import { WebKeymapper } from "../src/keymapper.js";
+
+/**
+ * Helper to create a mock KeyboardEvent with preventDefault.
+ */
+function mockKeyEventWithPreventDefault(
+  key: string,
+  modifiers: {
+    ctrlKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+    metaKey?: boolean;
+  } = {}
+): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: modifiers.ctrlKey ?? false,
+    altKey: modifiers.altKey ?? false,
+    shiftKey: modifiers.shiftKey ?? false,
+    metaKey: modifiers.metaKey ?? false,
+    preventDefault: () => {},
+  } as KeyboardEvent;
+}
+
+describe("WebKeymapper", () => {
+  describe("leader key sequences", () => {
+    it("translates \\w to <C-w>", () => {
+      const keymapper = new WebKeymapper();
+
+      // Press backslash - should return null (waiting for next key)
+      const leaderResult = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("\\")
+      );
+      expect(leaderResult).toBeNull();
+      expect(keymapper.isLeaderPending()).toBe(true);
+
+      // Press w - should return <C-w>
+      const wResult = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("w")
+      );
+      expect(wResult).toBe("<C-w>");
+      expect(keymapper.isLeaderPending()).toBe(false);
+    });
+
+    it("translates \\t to <C-t>", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("t")
+      );
+
+      expect(result).toBe("<C-t>");
+    });
+
+    it("translates \\n to <C-n>", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("n")
+      );
+
+      expect(result).toBe("<C-n>");
+    });
+
+    it("translates \\d to <C-d> (half page down)", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("d")
+      );
+
+      expect(result).toBe("<C-d>");
+    });
+
+    it("translates \\u to <C-u> (half page up)", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("u")
+      );
+
+      expect(result).toBe("<C-u>");
+    });
+
+    it("translates \\r to <C-r> (redo)", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("r")
+      );
+
+      expect(result).toBe("<C-r>");
+    });
+
+    it("is case-insensitive for leader mappings", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("W")
+      );
+
+      expect(result).toBe("<C-w>");
+    });
+  });
+
+  describe("leader cancellation", () => {
+    it("cancels leader on Escape", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      expect(keymapper.isLeaderPending()).toBe(true);
+
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("Escape")
+      );
+
+      expect(result).toBeNull();
+      expect(keymapper.isLeaderPending()).toBe(false);
+    });
+
+    it("passes through unmapped keys after leader", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      // 'q' is not in the leader map
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("q")
+      );
+
+      // Should pass through the key normally
+      expect(result).toBe("q");
+      expect(keymapper.isLeaderPending()).toBe(false);
+    });
+  });
+
+  describe("normal mode behavior", () => {
+    it("passes through regular keys", () => {
+      const keymapper = new WebKeymapper();
+
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("j")
+      );
+
+      expect(result).toBe("j");
+      expect(keymapper.isLeaderPending()).toBe(false);
+    });
+
+    it("passes through Ctrl+key combinations", () => {
+      const keymapper = new WebKeymapper();
+
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("a", { ctrlKey: true })
+      );
+
+      expect(result).toBe("<C-a>");
+    });
+
+    it("ignores modifier-only presses", () => {
+      const keymapper = new WebKeymapper();
+
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("Control")
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("does not trigger leader with Ctrl+backslash", () => {
+      const keymapper = new WebKeymapper();
+
+      const result = keymapper.handleKeyEvent(
+        mockKeyEventWithPreventDefault("\\", { ctrlKey: true })
+      );
+
+      // Should be treated as Ctrl+\ not leader
+      expect(result).toBe("<C-Bslash>");
+      expect(keymapper.isLeaderPending()).toBe(false);
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onLeaderStart when leader pressed", () => {
+      let called = false;
+      const keymapper = new WebKeymapper({
+        onLeaderStart: () => {
+          called = true;
+        },
+      });
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+
+      expect(called).toBe(true);
+    });
+
+    it("calls onLeaderEnd when sequence completes", () => {
+      let called = false;
+      const keymapper = new WebKeymapper({
+        onLeaderEnd: () => {
+          called = true;
+        },
+      });
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("w"));
+
+      expect(called).toBe(true);
+    });
+
+    it("calls onLeaderEnd when leader cancelled", () => {
+      let called = false;
+      const keymapper = new WebKeymapper({
+        onLeaderEnd: () => {
+          called = true;
+        },
+      });
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("Escape"));
+
+      expect(called).toBe(true);
+    });
+  });
+
+  describe("state management", () => {
+    it("starts in normal state", () => {
+      const keymapper = new WebKeymapper();
+      expect(keymapper.getState()).toBe("normal");
+    });
+
+    it("reset() returns to normal state", () => {
+      const keymapper = new WebKeymapper();
+
+      keymapper.handleKeyEvent(mockKeyEventWithPreventDefault("\\"));
+      expect(keymapper.isLeaderPending()).toBe(true);
+
+      keymapper.reset();
+      expect(keymapper.isLeaderPending()).toBe(false);
+      expect(keymapper.getState()).toBe("normal");
+    });
+  });
+});


### PR DESCRIPTION
Browsers reserve Ctrl+W, Ctrl+T, Ctrl+N, etc. for security - these cannot be captured by JavaScript. This adds a web-only leader key system that translates sequences to standard vim notation:

  \w → <C-w>  (window commands)
  \t → <C-t>  (tag jump)
  \n → <C-n>  (next completion)
  \d → <C-d>  (half page down)
  \u → <C-u>  (half page up)
  ... and more

The server receives standard vim notation and doesn't know about the leader key - this is purely a web client translation layer. TUI clients still capture Ctrl+W natively via crossterm.

Changes:
- Add WebKeymapper class with leader key state machine
- Add leader indicator UI in command line when pending
- Add beforeunload exit protection for unsaved changes
- Add 13 unit tests for WebKeymapper

Closes #473
