### PR TITLE
feat(presence): render remote client cursors and selections (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   TUI simplified: removed deprecated v1 args (`--tcp`, `--socket-path`, `--instance`),
   now uses only `--grpc` for gRPC v2 connections. Part of Epic #465. (#465)
 
+### Added
+
+- **Remote client cursor and selection rendering (Phase 18)**: Implemented
+  client-side rendering of other connected clients' cursors and selections.
+  Server PresenceService (Phase 14) provides the mechanism; this adds client
+  policy. Protocol extended with `selection` and `visual_mode` fields in
+  `ClientPresence` and `UpdatePresenceRequest`. TUI: Added 8-color deterministic
+  palette for remote clients (`REMOTE_CLIENT_COLORS`), extended `RemoteClient`
+  with selection state, `render_remote_cursors()` uses client-specific colors,
+  new `render_remote_selections()` method. Web: Added `remoteClients` Map to
+  EditorState, presence notification handlers, CSS for `.remote-cursor` and
+  `.remote-selection` with 8-color scheme, rendering in BufferRenderer. Server:
+  Input handler now auto-updates presence when selection changes via new
+  `update_presence_selection()` function. Includes 10+ unit tests for color
+  palette and selection handling. Part of Epic #465. (#474)
+
 ### Fixed
 
 - **Visual selection not visible in TUI (Phase 17)**: Fixed bug where entering

--- a/clients/cli/src/client.rs
+++ b/clients/cli/src/client.rs
@@ -357,6 +357,9 @@ impl GrpcClient {
             cursor,
             visible_lines: None,
             mode,
+            // Phase 18 (#474): Selection fields (optional)
+            selection: None,
+            visual_mode: None,
         };
         let response = self.presence.update_presence(request).await?;
         Ok(response.into_inner())

--- a/clients/tui/src/app_v2.rs
+++ b/clients/tui/src/app_v2.rs
@@ -134,9 +134,42 @@ impl ClientRole {
     }
 }
 
-/// Presence information for a remote client (Phase 11.2).
+// ─────────────────────────────────────────────────────────────────────────────
+// Remote Client Colors (Phase 18 #474)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Deterministic color palette for remote clients.
 ///
-/// Tracks other clients' cursor positions for awareness rendering.
+/// 8 distinct colors that work on both dark and light backgrounds.
+/// Each client gets a consistent color based on `client_id % 8`.
+const REMOTE_CLIENT_COLORS: [(Color, Color); 8] = [
+    (Color::Red, Color::DarkRed),         // Client 0
+    (Color::Green, Color::DarkGreen),     // Client 1
+    (Color::Yellow, Color::DarkYellow),   // Client 2
+    (Color::Blue, Color::DarkBlue),       // Client 3
+    (Color::Magenta, Color::DarkMagenta), // Client 4
+    (Color::Cyan, Color::DarkCyan),       // Client 5
+    (Color::White, Color::Grey),          // Client 6
+    (Color::DarkGrey, Color::Black),      // Client 7
+];
+
+/// Get deterministic colors for a remote client.
+///
+/// Returns `(foreground, background)` colors based on client ID.
+/// The same `client_id` always returns the same color pair.
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+const fn get_client_color(client_id: u64) -> (Color, Color) {
+    REMOTE_CLIENT_COLORS[(client_id as usize) % REMOTE_CLIENT_COLORS.len()]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Remote Client State
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Presence information for a remote client (Phase 11.2, enhanced Phase 18 #474).
+///
+/// Tracks other clients' cursor positions and selections for awareness rendering.
 #[derive(Debug, Clone)]
 struct RemoteClient {
     /// Client's unique ID.
@@ -157,6 +190,9 @@ struct RemoteClient {
     /// Reserved for future use (showing mode indicator next to cursor).
     #[allow(dead_code)]
     mode: String,
+    /// Selection state (Phase 18 #474).
+    /// Present when client is in visual mode with an active selection.
+    selection: Option<SelectionState>,
 }
 
 /// Cursor position for per-window tracking (Phase 8 #465).
@@ -896,6 +932,8 @@ impl TuiAppV2 {
                         // Skip self
                         if Some(client.client_id) != self.state.my_client_id {
                             let cursor = client.cursor.as_ref();
+                            // Phase 18 (#474): Parse selection from presence
+                            let selection = Self::parse_presence_selection(&client);
                             self.state.other_clients.insert(
                                 client.client_id,
                                 RemoteClient {
@@ -905,6 +943,7 @@ impl TuiAppV2 {
                                     cursor_col: cursor.map_or(0, |c| c.column),
                                     buffer_id: client.buffer_id,
                                     mode: client.mode,
+                                    selection,
                                 },
                             );
                             self.state.needs_redraw = true;
@@ -913,10 +952,12 @@ impl TuiAppV2 {
                 }
                 Payload::PresenceUpdated(p) => {
                     // Phase 11.2: Update remote client's position
+                    // Phase 18 (#474): Also update selection
                     if let Some(client) = p.client
                         && Some(client.client_id) != self.state.my_client_id
                     {
                         let cursor = client.cursor.as_ref();
+                        let selection = Self::parse_presence_selection(&client);
                         self.state.other_clients.insert(
                             client.client_id,
                             RemoteClient {
@@ -926,6 +967,7 @@ impl TuiAppV2 {
                                 cursor_col: cursor.map_or(0, |c| c.column),
                                 buffer_id: client.buffer_id,
                                 mode: client.mode,
+                                selection,
                             },
                         );
                         self.state.needs_redraw = true;
@@ -1096,6 +1138,30 @@ impl TuiAppV2 {
         }
 
         tui_style
+    }
+
+    /// Parse selection state from `ClientPresence` (Phase 18 #474).
+    ///
+    /// Returns `Some(SelectionState)` if the client has an active selection,
+    /// `None` otherwise.
+    fn parse_presence_selection(
+        client: &reovim_protocol::v2::ClientPresence,
+    ) -> Option<SelectionState> {
+        let sel = client.selection.as_ref()?;
+        let start = sel.start.as_ref()?;
+        let end = sel.end.as_ref()?;
+
+        Some(SelectionState {
+            start: CursorPosition {
+                line: start.line,
+                column: start.column,
+            },
+            end: CursorPosition {
+                line: end.line,
+                column: end.column,
+            },
+            mode: client.visual_mode.clone().unwrap_or_default(),
+        })
     }
 
     /// Check if a character at (line, col) is within the selection.
@@ -1309,12 +1375,18 @@ impl TuiAppV2 {
 
             // Phase 11.2: Render other clients' cursors for awareness
             self.render_remote_cursors(placement, gutter_width);
+
+            // Phase 18 (#474): Render other clients' selections
+            if let Some(lines) = buffer_cache.get(&placement.buffer_id) {
+                self.render_remote_selections(placement, gutter_width, lines);
+            }
         }
     }
 
-    /// Render other clients' cursors within a window (Phase 11.2).
+    /// Render other clients' cursors within a window (Phase 11.2, enhanced Phase 18 #474).
     ///
-    /// Shows each remote client's cursor as a colored marker with their name.
+    /// Shows each remote client's cursor as a colored marker. Each client gets a
+    /// deterministic color based on their `client_id` for consistent identification.
     fn render_remote_cursors(
         &mut self,
         placement: &crate::layout_mirror::WindowPlacement,
@@ -1324,17 +1396,16 @@ impl TuiAppV2 {
         let remotes: Vec<_> = self
             .state
             .other_clients
-            .values()
-            .filter(|r| r.buffer_id == placement.buffer_id)
-            .cloned()
+            .iter()
+            .filter(|(_, r)| r.buffer_id == placement.buffer_id)
+            .map(|(id, r)| (*id, r.clone()))
             .collect();
 
-        // Style for remote cursors (distinct color)
-        let cursor_style = Style::default()
-            .with_fg(Color::Cyan)
-            .with_bg(Color::DarkCyan);
+        for (client_id, remote) in remotes {
+            // Phase 18 (#474): Get deterministic color for this client
+            let (fg, bg) = get_client_color(client_id);
+            let cursor_style = Style::default().with_fg(fg).with_bg(bg);
 
-        for remote in remotes {
             // Check if cursor is within the visible window area
             #[allow(clippy::cast_possible_truncation)]
             let cursor_row = remote.cursor_line as u16;
@@ -1351,6 +1422,87 @@ impl TuiAppV2 {
                 {
                     // Use a thin vertical bar to indicate remote cursor
                     self.screen.put_char(screen_x, screen_y, '▎', &cursor_style);
+                }
+            }
+        }
+    }
+
+    /// Render other clients' selections within a window (Phase 18 #474).
+    ///
+    /// Shows each remote client's visual selection with their color as background.
+    /// Renders AFTER line content so selection indicators appear on top.
+    #[allow(clippy::cast_possible_truncation)]
+    fn render_remote_selections(
+        &mut self,
+        placement: &crate::layout_mirror::WindowPlacement,
+        gutter_width: u16,
+        buffer_content: &[String],
+    ) {
+        // Collect remote clients with selections viewing this buffer
+        let remotes: Vec<_> = self
+            .state
+            .other_clients
+            .iter()
+            .filter(|(_, r)| r.buffer_id == placement.buffer_id && r.selection.is_some())
+            .map(|(id, r)| (*id, r.clone()))
+            .collect();
+
+        for (client_id, remote) in remotes {
+            let Some(selection) = &remote.selection else {
+                continue;
+            };
+
+            // Get deterministic color for this client (use darker bg for selection)
+            let (_, bg) = get_client_color(client_id);
+            let selection_style = Style::default().with_fg(Color::Black).with_bg(bg);
+
+            // Render selection markers for each affected line
+            let start_line = selection.start.line;
+            let end_line = selection.end.line;
+
+            for line_num in start_line..end_line {
+                #[allow(clippy::cast_possible_truncation)]
+                let screen_row = line_num as u16;
+
+                // Skip if line is outside visible area
+                if screen_row >= placement.height {
+                    continue;
+                }
+
+                let screen_y = placement.y + screen_row;
+
+                // Get line content length
+                let line_len = buffer_content
+                    .get(line_num as usize)
+                    .map_or(0, |l| l.chars().count());
+
+                // Calculate selection bounds for this line
+                let (start_col, end_col) = match selection.mode.as_str() {
+                    "line" => (0_u64, line_len as u64),
+                    "block" => (selection.start.column, selection.end.column),
+                    _ => {
+                        // Character mode
+                        if line_num == start_line {
+                            (selection.start.column, line_len as u64)
+                        } else if line_num == end_line.saturating_sub(1) {
+                            (0, selection.end.column)
+                        } else {
+                            (0, line_len as u64)
+                        }
+                    }
+                };
+
+                // Render selection indicator at the start of the selected region
+                // Using a thin left border character to indicate selection
+                #[allow(clippy::cast_possible_truncation)]
+                let screen_x = placement.x + gutter_width + start_col as u16;
+                if screen_x < placement.x + placement.width
+                    && end_col > start_col
+                    && screen_y < placement.y + placement.height
+                {
+                    // Mark the selection start with a colored indicator
+                    self.screen
+                        .put_char(screen_x, screen_y, '┃', &selection_style);
                 }
             }
         }
@@ -1508,5 +1660,83 @@ mod tests {
         let _ = LineNumberMode::Absolute;
         let _ = LineNumberMode::Relative;
         let _ = LineNumberMode::Hybrid;
+    }
+
+    // ============ Phase 18 (#474): Remote Presence Tests ============
+
+    #[test]
+    fn test_get_client_color_deterministic() {
+        // Same client_id always returns the same color
+        let (fg1, bg1) = get_client_color(42);
+        let (fg2, bg2) = get_client_color(42);
+        assert_eq!(fg1, fg2);
+        assert_eq!(bg1, bg2);
+
+        // Different calls with same ID
+        let (fg3, bg3) = get_client_color(42);
+        assert_eq!(fg1, fg3);
+        assert_eq!(bg1, bg3);
+    }
+
+    #[test]
+    fn test_get_client_color_distribution() {
+        // First 8 clients get different colors
+        use std::collections::HashSet;
+
+        let colors: HashSet<_> = (0..8).map(get_client_color).collect();
+
+        // All 8 colors should be distinct
+        assert_eq!(colors.len(), 8);
+    }
+
+    #[test]
+    fn test_get_client_color_wraps_at_8() {
+        // Client ID 8 should get same color as client ID 0
+        let color_0 = get_client_color(0);
+        let color_8 = get_client_color(8);
+        let color_16 = get_client_color(16);
+
+        assert_eq!(color_0, color_8);
+        assert_eq!(color_0, color_16);
+    }
+
+    #[test]
+    fn test_remote_client_default() {
+        let remote = RemoteClient {
+            client_id: 1,
+            display_name: "test".to_string(),
+            cursor_line: 0,
+            cursor_col: 0,
+            buffer_id: 0,
+            mode: "NORMAL".to_string(),
+            selection: None,
+        };
+        assert_eq!(remote.client_id, 1);
+        assert!(remote.selection.is_none());
+    }
+
+    #[test]
+    fn test_remote_client_with_selection() {
+        let remote = RemoteClient {
+            client_id: 1,
+            display_name: "test".to_string(),
+            cursor_line: 5,
+            cursor_col: 10,
+            buffer_id: 1,
+            mode: "VISUAL".to_string(),
+            selection: Some(SelectionState {
+                start: CursorPosition { line: 5, column: 0 },
+                end: CursorPosition {
+                    line: 5,
+                    column: 10,
+                },
+                mode: "char".to_string(),
+            }),
+        };
+        assert!(remote.selection.is_some());
+        let sel = remote.selection.unwrap();
+        assert_eq!(sel.start.line, 5);
+        assert_eq!(sel.end.column, 10);
+        assert_eq!(sel.mode, "char");
     }
 }

--- a/clients/web/src/editor.ts
+++ b/clients/web/src/editor.ts
@@ -23,7 +23,7 @@ import {
 
 // Rendering layer
 import { LayoutRenderer } from "./render/layout.js";
-import { BufferRenderer, type SelectionRange } from "./render/buffer.js";
+import { BufferRenderer, type SelectionRange, type RemoteClientRenderData } from "./render/buffer.js";
 
 // Caching layer (Phase 11.1)
 import { ViewportCache, BufferCache } from "./cache/index.js";
@@ -52,6 +52,49 @@ interface WindowState {
   selection: SelectionRange | null;
 }
 
+// ============ Phase 18 (#474): Remote Client Presence ============
+
+/**
+ * Remote client presence state.
+ *
+ * Tracks cursor, selection, and buffer for other connected clients.
+ */
+interface RemoteClient {
+  clientId: bigint;
+  displayName: string;
+  cursorLine: number;
+  cursorCol: number;
+  bufferId: number;
+  mode: string;
+  /** Selection state (Phase 18 #474). */
+  selection: SelectionRange | null;
+}
+
+/**
+ * Deterministic color palette for remote clients.
+ *
+ * 8 distinct colors that work on both dark and light backgrounds.
+ * Client color is determined by `clientId % 8`.
+ */
+const REMOTE_CLIENT_COLORS = [
+  "#e06c75", // 0: Red
+  "#98c379", // 1: Green
+  "#e5c07b", // 2: Yellow
+  "#61afef", // 3: Blue
+  "#c678dd", // 4: Magenta
+  "#56b6c2", // 5: Cyan
+  "#abb2bf", // 6: White/Gray
+  "#be5046", // 7: Dark Red
+] as const;
+
+/**
+ * Get deterministic color for a remote client.
+ */
+function getClientColor(clientId: bigint): string {
+  // Index is guaranteed to be 0-7 due to modulo 8
+  return REMOTE_CLIENT_COLORS[Number(clientId % 8n)] as string;
+}
+
 interface EditorState {
   mode: string;
   modeDisplay: string;
@@ -72,6 +115,9 @@ interface EditorState {
 
   // Flag to enable multi-window rendering
   useMultiWindow: boolean;
+
+  // Remote client presence (Phase 18 #474)
+  remoteClients: Map<bigint, RemoteClient>;
 }
 
 /**
@@ -132,6 +178,8 @@ export class Editor {
       focusedWindowId: 0,
       windowStates: new Map(),
       useMultiWindow: false,
+      // Remote client presence (Phase 18 #474)
+      remoteClients: new Map(),
     };
 
     // Initialize renderers
@@ -529,6 +577,49 @@ export class Editor {
         break;
       }
 
+      // ============ Phase 18 (#474): Presence Notifications ============
+
+      case "presenceJoined": {
+        const { client } = payload.value;
+        if (client && BigInt(client.clientId) !== this.myClientId) {
+          this.state.remoteClients.set(BigInt(client.clientId), {
+            clientId: BigInt(client.clientId),
+            displayName: client.displayName,
+            cursorLine: Number(client.cursor?.line ?? 0n),
+            cursorCol: Number(client.cursor?.column ?? 0n),
+            bufferId: Number(client.bufferId ?? 0n),
+            mode: client.mode ?? "NORMAL",
+            selection: this.parsePresenceSelection(client),
+          });
+          this.scheduleRender();
+        }
+        break;
+      }
+
+      case "presenceUpdated": {
+        const { client } = payload.value;
+        if (client && BigInt(client.clientId) !== this.myClientId) {
+          this.state.remoteClients.set(BigInt(client.clientId), {
+            clientId: BigInt(client.clientId),
+            displayName: client.displayName,
+            cursorLine: Number(client.cursor?.line ?? 0n),
+            cursorCol: Number(client.cursor?.column ?? 0n),
+            bufferId: Number(client.bufferId ?? 0n),
+            mode: client.mode ?? "NORMAL",
+            selection: this.parsePresenceSelection(client),
+          });
+          this.scheduleRender();
+        }
+        break;
+      }
+
+      case "presenceLeft": {
+        const { clientId } = payload.value;
+        this.state.remoteClients.delete(BigInt(clientId));
+        this.scheduleRender();
+        break;
+      }
+
       default:
         break;
     }
@@ -727,12 +818,16 @@ export class Editor {
         y: windowState.cursorLine,
       };
 
+      // Get remote clients for this buffer (Phase 18 #474)
+      const remoteClients = this.getRemoteClientsForRender(window.buffer_id);
+
       this.bufferRenderer.render(
         windowState.lines,
         windowEl,
         windowState.selection,
         cursor,
-        windowState.topLine
+        windowState.topLine,
+        remoteClients
       );
     }
 
@@ -1042,5 +1137,92 @@ export class Editor {
       cmdline.textContent = "";
       cmdline.classList.remove("leader-pending");
     }
+  // ============ Phase 18 (#474): Remote Presence Helpers ============
+
+  /** Pending render frame ID for debouncing. */
+  private pendingRenderFrame: number | null = null;
+
+  /**
+   * Schedule a render on next animation frame (debounced).
+   */
+  private scheduleRender(): void {
+    if (this.pendingRenderFrame !== null) return;
+    this.pendingRenderFrame = requestAnimationFrame(() => {
+      this.pendingRenderFrame = null;
+      if (this.state.useMultiWindow && this.state.layout) {
+        this.renderMultiWindow();
+      } else {
+        this.renderSingleWindow();
+      }
+    });
+  }
+
+  /**
+   * Parse selection from presence client data.
+   */
+  private parsePresenceSelection(client: {
+    selection?: { start?: { line?: bigint; column?: bigint }; end?: { line?: bigint; column?: bigint } };
+    visualMode?: string;
+  }): SelectionRange | null {
+    if (!client.selection) return null;
+
+    const start = client.selection.start;
+    const end = client.selection.end;
+    if (!start || !end) return null;
+
+    const mode = (client.visualMode ?? "char") as "char" | "line" | "block";
+
+    return {
+      anchor: {
+        x: Number(start.column ?? 0n),
+        y: Number(start.line ?? 0n),
+      },
+      cursor: {
+        x: Number(end.column ?? 0n),
+        y: Number(end.line ?? 0n),
+      },
+      mode,
+    };
+  }
+
+  /**
+   * Get remote clients for a specific buffer.
+   */
+  getRemoteClientsForBuffer(bufferId: number): RemoteClient[] {
+    const result: RemoteClient[] = [];
+    for (const client of this.state.remoteClients.values()) {
+      if (client.bufferId === bufferId) {
+        result.push(client);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get remote clients for rendering in a specific buffer.
+   *
+   * Converts RemoteClient to RemoteClientRenderData.
+   */
+  private getRemoteClientsForRender(bufferId: number): RemoteClientRenderData[] {
+    const result: RemoteClientRenderData[] = [];
+    for (const client of this.state.remoteClients.values()) {
+      if (client.bufferId === bufferId) {
+        result.push({
+          clientId: client.clientId,
+          displayName: client.displayName,
+          cursorLine: client.cursorLine,
+          cursorCol: client.cursorCol,
+          selection: client.selection,
+        });
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get color for a remote client.
+   */
+  getRemoteClientColor(clientId: bigint): string {
+    return getClientColor(clientId);
   }
 }

--- a/clients/web/src/render/buffer.ts
+++ b/clients/web/src/render/buffer.ts
@@ -20,6 +20,19 @@ export interface SelectionRange {
   mode: "char" | "line" | "block";
 }
 
+// ============ Phase 18 (#474): Remote Client Types ============
+
+/**
+ * Remote client presence data for rendering.
+ */
+export interface RemoteClientRenderData {
+  clientId: bigint;
+  displayName: string;
+  cursorLine: number;
+  cursorCol: number;
+  selection: SelectionRange | null;
+}
+
 /**
  * Options for the buffer renderer.
  */
@@ -82,13 +95,15 @@ export class BufferRenderer {
    * @param selection - Current selection, if any
    * @param cursor - Current cursor position
    * @param topLine - First visible line index (for scrolling)
+   * @param remoteClients - Remote clients to render (Phase 18 #474)
    */
   render(
     lines: string[],
     windowEl: HTMLElement,
     selection: SelectionRange | null,
     cursor: ScreenPosition,
-    topLine: number = 0
+    topLine: number = 0,
+    remoteClients: RemoteClientRenderData[] = []
   ): void {
     const bufferEl = windowEl.querySelector(".window-buffer");
     if (!bufferEl) return;
@@ -114,6 +129,10 @@ export class BufferRenderer {
 
     // Update cursor position
     this.updateCursor(windowEl, cursor, topLine);
+
+    // Render remote clients (Phase 18 #474)
+    this.renderRemoteCursors(windowEl, remoteClients, topLine);
+    this.renderRemoteSelections(windowEl, remoteClients, topLine, lines.length);
   }
 
   private createLineElement(
@@ -366,6 +385,132 @@ export class BufferRenderer {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
+  }
+
+  // ============ Phase 18 (#474): Remote Client Rendering ============
+
+  /**
+   * Render remote client cursors.
+   */
+  private renderRemoteCursors(
+    windowEl: HTMLElement,
+    remoteClients: RemoteClientRenderData[],
+    topLine: number
+  ): void {
+    // Remove existing remote cursors
+    windowEl.querySelectorAll('.remote-cursor').forEach(el => el.remove());
+
+    if (remoteClients.length === 0) return;
+
+    const lineNumberOffset = this.options.showLineNumbers
+      ? this.options.lineNumberWidth + 1
+      : 0;
+    const charWidth = 8.4;
+    const lineHeight = 21;
+
+    for (const client of remoteClients) {
+      const screenY = client.cursorLine - topLine;
+      if (screenY < 0) continue; // Cursor above viewport
+
+      const el = document.createElement('div');
+      el.className = 'remote-cursor';
+      el.dataset.color = String(Number(client.clientId % 8n));
+      el.dataset.name = client.displayName;
+
+      el.style.left = `${(client.cursorCol + lineNumberOffset) * charWidth}px`;
+      el.style.top = `${screenY * lineHeight}px`;
+
+      windowEl.appendChild(el);
+    }
+  }
+
+  /**
+   * Render remote client selections.
+   */
+  private renderRemoteSelections(
+    windowEl: HTMLElement,
+    remoteClients: RemoteClientRenderData[],
+    topLine: number,
+    totalLines: number
+  ): void {
+    // Remove existing remote selections
+    windowEl.querySelectorAll('.remote-selection').forEach(el => el.remove());
+
+    if (remoteClients.length === 0) return;
+
+    const lineNumberOffset = this.options.showLineNumbers
+      ? this.options.lineNumberWidth + 1
+      : 0;
+    const charWidth = 8.4;
+    const lineHeight = 21;
+
+    // Calculate visible range
+    const windowHeight = parseInt(windowEl.style.height) || 0;
+    const visibleLines = Math.ceil(windowHeight / lineHeight);
+    const endLine = Math.min(topLine + visibleLines, totalLines);
+
+    for (const client of remoteClients) {
+      if (!client.selection) continue;
+
+      const { anchor, cursor, mode } = client.selection;
+      const startLine = Math.min(anchor.y, cursor.y);
+      const endSelLine = Math.max(anchor.y, cursor.y);
+      const colorIdx = String(Number(client.clientId % 8n));
+
+      // Only render visible portion
+      const renderStart = Math.max(startLine, topLine);
+      const renderEnd = Math.min(endSelLine, endLine - 1);
+
+      for (let line = renderStart; line <= renderEnd; line++) {
+        const screenY = line - topLine;
+        if (screenY < 0) continue;
+
+        const el = document.createElement('div');
+        el.className = 'remote-selection';
+        el.dataset.color = colorIdx;
+
+        // Calculate selection span for this line
+        let startCol = 0;
+        let endCol = 80; // Default to wide selection for line mode
+
+        switch (mode) {
+          case "line":
+            // Full line - use default wide selection
+            break;
+
+          case "char": {
+            if (startLine === endSelLine) {
+              // Single line selection
+              startCol = Math.min(anchor.x, cursor.x);
+              endCol = Math.max(anchor.x, cursor.x) + 1;
+            } else if (line === startLine) {
+              // First line
+              startCol = anchor.y <= cursor.y ? anchor.x : cursor.x;
+              endCol = 200; // To end of line
+            } else if (line === endSelLine) {
+              // Last line
+              startCol = 0;
+              endCol = (anchor.y <= cursor.y ? cursor.x : anchor.x) + 1;
+            }
+            // Middle lines use default full width
+            break;
+          }
+
+          case "block": {
+            startCol = Math.min(anchor.x, cursor.x);
+            endCol = Math.max(anchor.x, cursor.x) + 1;
+            break;
+          }
+        }
+
+        el.style.left = `${(startCol + lineNumberOffset) * charWidth}px`;
+        el.style.top = `${screenY * lineHeight}px`;
+        el.style.width = `${(endCol - startCol) * charWidth}px`;
+        el.style.height = `${lineHeight}px`;
+
+        windowEl.appendChild(el);
+      }
+    }
   }
 }
 

--- a/clients/web/styles/layout.css
+++ b/clients/web/styles/layout.css
@@ -217,3 +217,74 @@
 .window.focused::before {
   background: var(--theme-accent);
 }
+
+/* ============ Remote Presence (Phase 18 #474) ============ */
+
+/* Remote cursor - thin bar indicating other client's position */
+.remote-cursor {
+  position: absolute;
+  width: 2px;
+  height: 21px; /* Match line height */
+  pointer-events: none;
+  z-index: 5; /* Below local cursor (z-index: 10) */
+  opacity: 0.8;
+  transition: left 0.1s, top 0.1s;
+}
+
+/* Deterministic colors by client ID mod 8 */
+.remote-cursor[data-color="0"] { background: #e06c75; } /* Red */
+.remote-cursor[data-color="1"] { background: #98c379; } /* Green */
+.remote-cursor[data-color="2"] { background: #e5c07b; } /* Yellow */
+.remote-cursor[data-color="3"] { background: #61afef; } /* Blue */
+.remote-cursor[data-color="4"] { background: #c678dd; } /* Magenta */
+.remote-cursor[data-color="5"] { background: #56b6c2; } /* Cyan */
+.remote-cursor[data-color="6"] { background: #abb2bf; } /* White/Gray */
+.remote-cursor[data-color="7"] { background: #be5046; } /* Dark Red */
+
+/* Name label - shows on hover */
+.remote-cursor::after {
+  content: attr(data-name);
+  position: absolute;
+  top: -18px;
+  left: 0;
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+
+/* Color-matched labels */
+.remote-cursor[data-color="0"]::after { background: #e06c75; color: #1e2127; }
+.remote-cursor[data-color="1"]::after { background: #98c379; color: #1e2127; }
+.remote-cursor[data-color="2"]::after { background: #e5c07b; color: #1e2127; }
+.remote-cursor[data-color="3"]::after { background: #61afef; color: #1e2127; }
+.remote-cursor[data-color="4"]::after { background: #c678dd; color: #1e2127; }
+.remote-cursor[data-color="5"]::after { background: #56b6c2; color: #1e2127; }
+.remote-cursor[data-color="6"]::after { background: #abb2bf; color: #1e2127; }
+.remote-cursor[data-color="7"]::after { background: #be5046; color: #1e2127; }
+
+.remote-cursor:hover::after,
+.remote-cursor[data-show-label]::after {
+  opacity: 1;
+}
+
+/* Remote selection - translucent background for other client's selection */
+.remote-selection {
+  position: absolute;
+  pointer-events: none;
+  z-index: 1; /* Below text, cursors */
+  opacity: 0.25;
+}
+
+/* Selection colors match cursor colors */
+.remote-selection[data-color="0"] { background: #e06c75; }
+.remote-selection[data-color="1"] { background: #98c379; }
+.remote-selection[data-color="2"] { background: #e5c07b; }
+.remote-selection[data-color="3"] { background: #61afef; }
+.remote-selection[data-color="4"] { background: #c678dd; }
+.remote-selection[data-color="5"] { background: #56b6c2; }
+.remote-selection[data-color="6"] { background: #abb2bf; }
+.remote-selection[data-color="7"] { background: #be5046; }

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -212,7 +212,7 @@ impl InputService for InputServiceImpl {
 
         // Emit notifications for accumulated state changes
         if accumulated_changes.has_changes() {
-            Self::emit_notifications(&session, &accumulated_changes).await;
+            Self::emit_notifications(&session, &accumulated_changes, client_id).await;
         }
 
         // Return result
@@ -228,7 +228,11 @@ impl InputServiceImpl {
     ///
     /// Converts accumulated `StateChanges` to gRPC notifications and emits them
     /// to all subscribed clients.
-    async fn emit_notifications(session: &Session, changes: &StateChanges) {
+    ///
+    /// Phase 18 (#474): When selection changes, also updates the client's presence
+    /// in the `PresenceMap` and emits a `presence_updated` notification so that
+    /// other clients can render the remote selection.
+    async fn emit_notifications(session: &Session, changes: &StateChanges, client_id: ClientId) {
         let notifications = session
             .with_state(|state| notification_builder::build_notifications(changes, state))
             .await;
@@ -236,6 +240,12 @@ impl InputServiceImpl {
         let notification_count = notifications.len();
         for notification in notifications {
             session.emit_notification(notification);
+        }
+
+        // Phase 18 (#474): Update presence when selection changes.
+        // This allows other clients to see this client's visual selection.
+        if changes.selection_changed {
+            Self::update_presence_selection(session, client_id).await;
         }
 
         if notification_count > 0 {
@@ -246,6 +256,55 @@ impl InputServiceImpl {
                 buffer_modified = changes.buffer_modified,
                 selection_changed = changes.selection_changed,
                 "Emitted notifications"
+            );
+        }
+    }
+
+    /// Update client's presence with current selection state (Phase 18 #474).
+    ///
+    /// Reads selection from the active window and updates the presence map.
+    /// Emits a `presence_updated` notification so other clients can render
+    /// the remote selection.
+    async fn update_presence_selection(session: &Session, client_id: ClientId) {
+        use crate::grpc::presence::build_presence_updated_notification;
+
+        // Extract selection from active window
+        let selection = session
+            .with_state(|state| {
+                state
+                    .driver_session
+                    .windows
+                    .active()
+                    .and_then(|w| w.selection.clone())
+            })
+            .await;
+
+        // Convert internal selection to presence format
+        let presence_selection = selection.map(|sel| {
+            let mode_str = match sel.mode {
+                reovim_driver_session::SelectionMode::Character => "char",
+                reovim_driver_session::SelectionMode::Line => "line",
+                reovim_driver_session::SelectionMode::Block => "block",
+            };
+            (
+                (sel.start.line, sel.start.column),
+                (sel.end.line, sel.end.column),
+                mode_str.to_string(),
+            )
+        });
+
+        // Update presence map
+        let updated = session.presence().update(client_id, |presence| {
+            presence.selection = presence_selection;
+        });
+
+        // Emit presence_updated notification if client exists in presence map
+        if let Some(presence) = updated {
+            session.emit_notification(build_presence_updated_notification(&presence));
+            tracing::trace!(
+                client_id = client_id.as_usize(),
+                has_selection = presence.selection.is_some(),
+                "Updated presence with selection"
             );
         }
     }

--- a/server/lib/server/src/grpc/presence.rs
+++ b/server/lib/server/src/grpc/presence.rs
@@ -31,7 +31,7 @@ use {
     reovim_protocol::v2::{
         ClientPresence as ProtoClientPresence, ClientRole as ProtoRole, JoinRequest, JoinResponse,
         LeaveRequest, LeaveResponse, LineRange, ListClientsRequest, ListClientsResponse,
-        Notification, Position, PresenceUpdate, SetRoleRequest, SetRoleResponse,
+        Notification, Position, PresenceUpdate, Selection, SetRoleRequest, SetRoleResponse,
         SetSyncModeRequest, SetSyncModeResponse, StreamPresenceRequest, SyncMode as ProtoSyncMode,
         UpdatePresenceRequest, UpdatePresenceResponse, notification::Payload,
         presence_service_server::PresenceService, presence_update::Update,
@@ -59,6 +59,27 @@ fn to_proto_presence(presence: &ClientPresence) -> ProtoClientPresence {
         SyncMode::Present => (ProtoSyncMode::Present as i32, None),
     };
 
+    // Phase 18 (#474): Convert selection to proto format
+    let (selection, visual_mode) =
+        presence
+            .selection
+            .as_ref()
+            .map_or((None, None), |(start, end, mode)| {
+                (
+                    Some(Selection {
+                        start: Some(Position {
+                            line: start.0 as u64,
+                            column: start.1 as u64,
+                        }),
+                        end: Some(Position {
+                            line: end.0 as u64,
+                            column: end.1 as u64,
+                        }),
+                    }),
+                    Some(mode.clone()),
+                )
+            });
+
     ProtoClientPresence {
         client_id: presence.client_id.as_usize() as u64,
         client_type: presence.client_type.clone(),
@@ -76,6 +97,9 @@ fn to_proto_presence(presence: &ClientPresence) -> ProtoClientPresence {
         sync_mode,
         follow_target,
         joined_at_ms: presence.joined_at_ms(),
+        // Phase 18 (#474): Selection state
+        selection,
+        visual_mode,
     }
 }
 
@@ -107,7 +131,9 @@ fn build_presence_left_notification(client_id: ClientId, display_name: &str) -> 
 }
 
 /// Build `presence_updated` notification.
-fn build_presence_updated_notification(presence: &ClientPresence) -> Notification {
+///
+/// Public for use by input handler's selection-to-presence update (Phase 18 #474).
+pub fn build_presence_updated_notification(presence: &ClientPresence) -> Notification {
     use reovim_protocol::v2::PresenceUpdatedPayload;
 
     Notification {
@@ -559,6 +585,8 @@ mod tests {
             }),
             visible_lines: Some(LineRange { start: 5, end: 30 }),
             mode: Some("INSERT".to_string()),
+            selection: None,
+            visual_mode: None,
         });
         let response = service.update_presence(update_req).await;
 
@@ -577,6 +605,8 @@ mod tests {
             cursor: None,
             visible_lines: None,
             mode: None,
+            selection: None,
+            visual_mode: None,
         });
         let response = service.update_presence(request).await;
 
@@ -762,5 +792,145 @@ mod tests {
 
         // Should successfully return a stream
         assert!(response.is_ok());
+    }
+
+    // ============ Phase 18 (#474): Selection Tests ============
+
+    #[tokio::test]
+    async fn test_update_presence_with_selection() {
+        let registry = test_registry();
+        let service = PresenceServiceImpl::new(registry, SessionId::new("test"));
+
+        // Join first
+        let join_req = Request::new(JoinRequest {
+            client_type: "tui".to_string(),
+            display_name: "laptop".to_string(),
+        });
+        let join_resp = service.join(join_req).await.unwrap().into_inner();
+        let client_id = join_resp.client_id;
+
+        // Update presence with selection
+        let update_req = Request::new(UpdatePresenceRequest {
+            client_id,
+            buffer_id: Some(1),
+            cursor: Some(Position {
+                line: 5,
+                column: 10,
+            }),
+            visible_lines: None,
+            mode: Some("VISUAL".to_string()),
+            selection: Some(Selection {
+                start: Some(Position { line: 5, column: 0 }),
+                end: Some(Position {
+                    line: 5,
+                    column: 10,
+                }),
+            }),
+            visual_mode: Some("char".to_string()),
+        });
+        let response = service.update_presence(update_req).await;
+
+        assert!(response.is_ok());
+        assert!(response.unwrap().into_inner().ok);
+    }
+
+    #[tokio::test]
+    async fn test_update_presence_clear_selection() {
+        let registry = test_registry();
+        let service = PresenceServiceImpl::new(registry, SessionId::new("test"));
+
+        // Join first
+        let join_req = Request::new(JoinRequest {
+            client_type: "tui".to_string(),
+            display_name: "laptop".to_string(),
+        });
+        let join_resp = service.join(join_req).await.unwrap().into_inner();
+        let client_id = join_resp.client_id;
+
+        // Set selection
+        let update_req = Request::new(UpdatePresenceRequest {
+            client_id,
+            buffer_id: None,
+            cursor: None,
+            visible_lines: None,
+            mode: None,
+            selection: Some(Selection {
+                start: Some(Position { line: 5, column: 0 }),
+                end: Some(Position {
+                    line: 5,
+                    column: 10,
+                }),
+            }),
+            visual_mode: Some("char".to_string()),
+        });
+        service.update_presence(update_req).await.unwrap();
+
+        // Clear selection (by not providing selection in update)
+        let clear_req = Request::new(UpdatePresenceRequest {
+            client_id,
+            buffer_id: None,
+            cursor: None,
+            visible_lines: None,
+            mode: Some("NORMAL".to_string()),
+            selection: None,
+            visual_mode: None,
+        });
+        let response = service.update_presence(clear_req).await;
+
+        assert!(response.is_ok());
+        assert!(response.unwrap().into_inner().ok);
+    }
+
+    #[test]
+    fn test_to_proto_presence_with_selection() {
+        use super::ClientPresence;
+
+        let presence = ClientPresence {
+            client_id: ClientId::new(1),
+            client_type: "tui".to_string(),
+            display_name: "laptop".to_string(),
+            buffer_id: Some(1),
+            cursor: (5, 10),
+            visible_lines: (0, 24),
+            mode: "VISUAL".to_string(),
+            sync_mode: SyncMode::Independent,
+            joined_at: std::time::SystemTime::now(),
+            selection: Some(((5, 0), (5, 10), "char".to_string())),
+        };
+
+        let proto = to_proto_presence(&presence);
+
+        assert!(proto.selection.is_some());
+        let sel = proto.selection.unwrap();
+        assert_eq!(sel.start.as_ref().unwrap().line, 5);
+        assert_eq!(sel.start.as_ref().unwrap().column, 0);
+        assert_eq!(sel.end.as_ref().unwrap().line, 5);
+        assert_eq!(sel.end.as_ref().unwrap().column, 10);
+
+        assert!(proto.visual_mode.is_some());
+        assert_eq!(proto.visual_mode.unwrap(), "char");
+    }
+
+    #[test]
+    fn test_to_proto_presence_without_selection() {
+        use super::ClientPresence;
+
+        let presence = ClientPresence {
+            client_id: ClientId::new(1),
+            client_type: "tui".to_string(),
+            display_name: "laptop".to_string(),
+            buffer_id: Some(1),
+            cursor: (0, 0),
+            visible_lines: (0, 24),
+            mode: "NORMAL".to_string(),
+            sync_mode: SyncMode::Independent,
+            joined_at: std::time::SystemTime::now(),
+            selection: None,
+        };
+
+        let proto = to_proto_presence(&presence);
+
+        assert!(proto.selection.is_none());
+        assert!(proto.visual_mode.is_none());
     }
 }

--- a/server/lib/server/src/session/presence.rs
+++ b/server/lib/server/src/session/presence.rs
@@ -86,6 +86,12 @@ pub struct ClientPresence {
 
     /// When the client joined.
     pub joined_at: SystemTime,
+
+    /// Selection state (Phase 18 #474).
+    /// Format: `((start_line, start_col), (end_line, end_col), visual_mode)`
+    /// Present only when client is in visual mode with an active selection.
+    #[allow(clippy::type_complexity)]
+    pub selection: Option<((usize, usize), (usize, usize), String)>,
 }
 
 impl ClientPresence {
@@ -106,6 +112,7 @@ impl ClientPresence {
             mode: "NORMAL".to_string(),
             sync_mode: SyncMode::default(),
             joined_at: SystemTime::now(),
+            selection: None,
         }
     }
 
@@ -480,5 +487,86 @@ mod tests {
 
         // All clients should have left
         assert!(map.is_empty());
+    }
+
+    // ============ Phase 18 (#474): Selection Tests ============
+
+    #[test]
+    fn test_client_presence_selection_default_none() {
+        let presence = make_presence(1, "laptop");
+        assert!(presence.selection.is_none());
+    }
+
+    #[test]
+    fn test_update_with_selection() {
+        let map = PresenceMap::new();
+        let client_id = ClientId::new(1);
+
+        map.join(make_presence(1, "laptop"));
+
+        // Update with selection
+        let updated = map.update(client_id, |p| {
+            p.selection = Some(((0, 5), (0, 10), "char".to_string()));
+        });
+
+        assert!(updated.is_some());
+        let presence = updated.unwrap();
+        assert!(presence.selection.is_some());
+
+        let sel = presence.selection.unwrap();
+        assert_eq!(sel.0, (0, 5)); // start
+        assert_eq!(sel.1, (0, 10)); // end
+        assert_eq!(sel.2, "char"); // mode
+    }
+
+    #[test]
+    fn test_clear_selection() {
+        let map = PresenceMap::new();
+        let client_id = ClientId::new(1);
+
+        map.join(make_presence(1, "laptop"));
+
+        // Set selection
+        map.update(client_id, |p| {
+            p.selection = Some(((0, 5), (0, 10), "char".to_string()));
+        });
+
+        // Clear selection
+        let updated = map.update(client_id, |p| {
+            p.selection = None;
+        });
+
+        assert!(updated.is_some());
+        let presence = updated.unwrap();
+        assert!(presence.selection.is_none());
+    }
+
+    #[test]
+    fn test_selection_modes() {
+        let map = PresenceMap::new();
+        let client_id = ClientId::new(1);
+
+        map.join(make_presence(1, "laptop"));
+
+        // Test character mode
+        map.update(client_id, |p| {
+            p.selection = Some(((0, 0), (0, 5), "char".to_string()));
+        });
+        let presence = map.get(client_id).unwrap();
+        assert_eq!(presence.selection.as_ref().unwrap().2, "char");
+
+        // Test line mode
+        map.update(client_id, |p| {
+            p.selection = Some(((0, 0), (2, 0), "line".to_string()));
+        });
+        let presence = map.get(client_id).unwrap();
+        assert_eq!(presence.selection.as_ref().unwrap().2, "line");
+
+        // Test block mode
+        map.update(client_id, |p| {
+            p.selection = Some(((0, 5), (2, 10), "block".to_string()));
+        });
+        let presence = map.get(client_id).unwrap();
+        assert_eq!(presence.selection.as_ref().unwrap().2, "block");
     }
 }

--- a/shared/protocol/proto/reovim/v2/presence.proto
+++ b/shared/protocol/proto/reovim/v2/presence.proto
@@ -78,6 +78,14 @@ message ClientPresence {
 
   // Timestamp when client joined (Unix ms).
   uint64 joined_at_ms = 10;
+
+  // Phase 18 (#474): Selection state for visual mode rendering.
+  // Present only when client is in visual mode with an active selection.
+  optional Selection selection = 11;
+
+  // Visual mode type ("char", "line", "block").
+  // Present only when selection is set.
+  optional string visual_mode = 12;
 }
 
 // Visible line range for viewport tracking.
@@ -182,6 +190,12 @@ message UpdatePresenceRequest {
 
   // New mode name (optional, only if changed).
   optional string mode = 5;
+
+  // Phase 18 (#474): Selection state for visual mode.
+  optional Selection selection = 6;
+
+  // Visual mode type ("char", "line", "block").
+  optional string visual_mode = 7;
 }
 
 // Update presence response.


### PR DESCRIPTION
Implement client-side rendering of other connected clients' cursors and selections. The PresenceService (Phase 14) provides the mechanism; this adds client-side rendering policy.

Protocol:
- Extended ClientPresence with optional `selection` and `visual_mode` fields
- Extended UpdatePresenceRequest with same fields for updates

TUI:
- Added 8-color deterministic palette (REMOTE_CLIENT_COLORS)
- Extended RemoteClient struct with selection state
- Updated render_remote_cursors() to use client-specific colors
- Added render_remote_selections() for remote visual selections

Web:
- Added RemoteClient type and remoteClients Map to EditorState
- Added presenceJoined/Updated/Left notification handlers
- Added CSS for .remote-cursor and .remote-selection with 8-color scheme
- Added remote cursor/selection rendering in BufferRenderer

Server:
- Input handler auto-updates presence when selection changes
- New update_presence_selection() function in emit_notifications flow
- Made build_presence_updated_notification() public for cross-module use

Tests:
- 5 TUI tests for color palette and remote client selection
- 5 server tests for presence selection functionality

Refs #474, Parts of #465