### PR TITLE
docs: fix documentation drift and add module/driver docs (#489, #490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ## [Unreleased] - v0.9.3-dev
 
+### Documentation
+
+- **Documentation drift fixes (#489)**: Fixed CLAUDE.md outdated counts (13->14 drivers,
+  17->19 modules), added missing crate names (reovim-testing, reovim-log, etc.), added
+  web client to clients list, added syntax-treesitter driver. Added "Plan Files" section
+  with naming convention. Simplified Build Commands section with reference to new
+  CLI Reference document. Fixed broken links in docs/architecture/overview.md (module-mode
+  -> modules/mode-inheritance, kernel.md -> kernel/overview.md, etc.). Fixed server-mode.md
+  to use gRPC instead of JSON-RPC. Fixed testing.md fabricated APIs (ServerTest ->
+  IntegrationTest, with_content -> with_buffer, with_keys -> send_keys). Removed
+  fabricated Visual Testing section with more accurate StepTest and frame assertions docs.
+
+- **New module documentation (#490)**: Created 7 module docs in docs/architecture/modules/builtin/:
+  buffer-ops.md (buffer lifecycle events), commands.md (ex-commands), defaults.md (meta-module
+  aggregating 13 modules), mode-manager.md (mode transition tracker), options.md (editor settings),
+  buffer-simple.md (SimpleBufferManager), scratch-buffer.md (empty buffer on startup).
+
+- **New driver documentation (#490)**: Created 8 driver docs in docs/architecture/drivers/:
+  buffer/overview.md (BufferManager registry), clipboard/overview.md (ClipboardProvider trait),
+  command-types/overview.md (CommandContext, CommandResult shared types), ffi/overview.md
+  (C FFI interface + ABI versioning), ffi-python/overview.md (Python bindings via PyO3),
+  search/overview.md (SearchProvider trait), syntax-treesitter/overview.md (TreeSitterDriver),
+  undo/overview.md (UndoProvider trait + persistence).
+
+- **Debug infrastructure documentation**: Created docs/architecture/kernel/panic/overview.md
+  documenting panic handling (install_panic_handler, recovery, crash reports) and
+  docs/architecture/server/debug/overview.md documenting server ring buffer (64KB server +
+  8KB per-client), CompositeLogger, CLI log-tail command, and gRPC DebugService.
+
+- **CLI reference guide**: Created docs/user-guide/cli-reference.md with complete command
+  reference for server, CLI client, and TUI client commands extracted from CLAUDE.md.
+
+- **Updated index files**: Updated docs/architecture/modules/builtin/README.md with all 19
+  modules. Updated docs/architecture/drivers/overview.md with all 14 drivers.
+
 ### Added
 
 - **Server debug ring buffer with panic integration (#478)**: Added comprehensive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,12 @@ reovim/
 ├── server/                # Server-side components
 │   ├── lib/kernel/        # Core mechanisms (mm/, ipc/, core/, block/, sched/, api/)
 │   ├── lib/server/        # Server runtime (gRPC handlers, session management)
-│   └── lib/drivers/       # Server drivers (13 crates)
+│   └── lib/drivers/       # Server drivers (14 crates)
 │       ├── command/       # Command trait and registry
 │       ├── command-types/ # Command type definitions
 │       ├── input/         # Key events and input parsing
-│       ├── syntax/        # Tree-sitter integration
+│       ├── syntax/        # Syntax highlighting abstraction
+│       ├── syntax-treesitter/ # Tree-sitter implementation
 │       ├── lsp/           # Language server protocol client
 │       ├── vfs/           # Virtual filesystem operations
 │       ├── session/       # Session management traits
@@ -90,19 +91,31 @@ reovim/
 │       ├── clipboard/     # Clipboard operations
 │       ├── ffi/           # Foreign function interface
 │       └── ffi-python/    # Python FFI bindings
-├── server/modules/        # Policy modules (17 loadable modules)
+├── server/modules/        # Policy modules (19 loadable modules)
 │   ├── vim/               # Core Vim-like behavior
 │   ├── editor/            # Editor core operations
 │   ├── motions/           # Movement commands
 │   ├── textobjects/       # Text object definitions
-│   ├── commands/          # Command implementations
+│   ├── commands/          # Ex-commands (:w, :q, :e, :wq)
 │   ├── keymap/            # Keymap definitions
-│   ├── mode-manager/      # Mode system
-│   └── ...                # (options, buffer-ops, clipboard, search, undo, etc.)
+│   ├── mode-manager/      # Mode state management
+│   ├── options/           # Editor settings (virtualedit)
+│   ├── buffer-ops/        # Buffer lifecycle events
+│   ├── buffer-simple/     # SimpleBufferManager implementation
+│   ├── scratch-buffer/    # Empty buffer on session start
+│   ├── defaults/          # Meta-module aggregating 13 modules
+│   ├── clipboard/         # Clipboard operations
+│   ├── search/            # Search provider
+│   ├── undo/              # Undo provider
+│   ├── vfs-local/         # Local filesystem VFS
+│   ├── window-ops/        # Window operations (<C-w> commands)
+│   ├── treesitter-rust/   # Rust syntax highlighting
+│   └── treesitter-markdown/ # Markdown syntax highlighting
 ├── clients/               # Client applications
 │   ├── cli/               # CLI client (gRPC v2)
-│   └── tui/               # TUI client (gRPC v2)
-│       └── lib/drivers/   # TUI-specific drivers (tui, display)
+│   ├── tui/               # TUI client (gRPC v2)
+│   │   └── lib/drivers/   # TUI-specific drivers (tui, display)
+│   └── web/               # Web client (gRPC-Web, WASM)
 ├── shared/                # Shared libraries
 │   ├── protocol/          # gRPC v2 protocol definitions (.proto files)
 │   ├── arch/              # Platform abstraction (unix/, windows/)
@@ -127,8 +140,14 @@ reovim/
 - `reovim-module-*` → `server/modules/*/`
 - `reovim-client-tui` → `clients/tui/`
 - `reovim-client-cli` → `clients/cli/`
+- `reovim-client-web` → `clients/web/`
 - `reovim-protocol` → `shared/protocol/`
 - `reovim-arch` → `shared/arch/`
+- `reovim-testing` → `shared/testing/`
+- `reovim-log` → `shared/log/`
+- `reovim-net` → `shared/net/`
+- `reovim-trace` → `shared/trace/`
+- `reovim-module-macros` → `shared/module-macros/`
 
 ### Key Dependencies
 
@@ -235,93 +254,71 @@ nursery = "deny"
 - Any command that terminates reovim processes you didn't start
 
 **Safe workflow for testing:**
-1. **Before starting a server**: Run `reovim cli list` to see existing servers
-2. **Start your server**: Note the PID/port from stderr output or `reovim cli list`
-3. **Track your servers**: Keep a list of PIDs you started in this session
-4. **After testing**: Only kill the specific server(s) YOU started: `reovim cli --tcp 127.0.0.1:<PORT> kill`
-5. **Never assume**: Don't kill servers just because they exist - they might be from another session
+1. **Before starting**: Check existing servers with `ps aux | grep reovim`
+2. **Start your server**: Note the PID from output
+3. **Track PIDs**: Keep a list of PIDs you started in this session
+4. **After testing**: Kill only YOUR server with `kill <PID>` or Ctrl+C in its terminal
+5. **Never assume**: Servers from other sessions may be running
+
+## Plan Files
+
+**IMPORTANT**: Claude Code does NOT automatically enforce plan file naming. You MUST manually ensure plans follow this convention.
+
+**Plan File Convention:**
+```
+~/.claude/plans/reovim/{ISSUE_NUMBER}-{Version/Phase}-{SUBJECT}.md
+```
+
+**Examples:**
+- `489-490-v1-documentation-drift.md` - Issues #489 and #490, version 1
+- `465-phase-12-syntax-drivers.md` - Issue #465, phase 12
+- `417-part3-true-clean-architecture.md` - Issue #417, part 3
+
+**Naming Components:**
+- `{ISSUE_NUMBER}` - GitHub issue number(s), use hyphen for multiple (e.g., `489-490`)
+- `{Version/Phase}` - Version (`v1`, `v2`) or phase identifier (`phase-10`, `part-2`)
+- `{SUBJECT}` - Brief kebab-case description of the work
+
+**Plan Requirements:**
+- Plans must be **self-contained** (works after context compact/clear)
+- Include all information needed for implementation:
+  - Architecture diagrams, file locations, type definitions
+  - Reference to related issues and dependencies
+  - Acceptance criteria and test targets
+- Add to every plan: **"Never stop until ALL phases are FULLY FINISHED."**
+- Include a **Final Procedure** section referencing Final Approach
+
+**Known Limitation:**
+Claude Code generates random plan filenames (e.g., `groovy-popping-kahn.md`) by default. After creating a plan, verify and rename to follow the convention above.
+
+**Workaround:**
+1. When plan mode creates a file, note the random filename
+2. After exiting plan mode, move to correct path:
+   ```bash
+   mv ~/.claude/plans/{random-name}.md ~/.claude/plans/reovim/{ISSUE}-{VERSION}-{SUBJECT}.md
+   ```
+3. Continue with countdown/implementation using the correctly named file
 
 ## Build Commands
 
 ```bash
-# Build all crates
-cargo build
-
-# Build release
-cargo build --release
-
-# Run the main binary (default-members set to apps/bin/)
-cargo run
-
-# Run tests
-cargo test
+# Essential commands
+cargo build              # Build all crates
+cargo build --release    # Build release
+cargo run                # Run (starts server + TUI)
+cargo test               # Run tests
+cargo check              # Check without building
+cargo fmt                # Format code
+cargo clippy             # Run linter
 
 # Run tests for a specific crate
 cargo test -p reovim-kernel
 
-# Run integration tests (currently ignored, pending module loading)
-cargo test --test operators --ignored
-cargo test --test cursor_movement --ignored
-
-# Run all ignored integration tests
-cargo test --ignored
-
-# Check code without building
-cargo check
-
-# Format code
-cargo fmt
-
-# Run clippy
-cargo clippy
-
 # Generate performance report
 cargo run -p perf-report -- bench -v X.Y.Z
-
-# Default: Start server + TUI in one command (tmux-like)
-cargo run
-# Server spawns in background, TUI attaches automatically
-# TUI exit doesn't kill server (graceful detach)
-
-# Start server in detached/daemon mode (no TUI)
-cargo run -- -d
-cargo run -- --detach
-
-# Attach TUI to existing server
-cargo run -- attach
-cargo run -- attach --tcp 127.0.0.1:12521
-
-# Explicit server mode (TCP on 127.0.0.1:12521, or next available port)
-cargo run -- server
-# Server prints "Listening on 127.0.0.1:<PORT>" to stderr
-
-# Run server with stdio transport
-cargo run -- server --stdio
-
-# Run server on Unix socket
-cargo run -- server --socket /tmp/reovim.sock
-
-# Run server on custom TCP port
-cargo run -- server --tcp 9000
-
-# Run CLI client
-cargo run -- cli list                     # List running servers
-cargo run -- cli keys 'iHello<Esc>'       # Inject keys
-cargo run -- cli --tcp 127.0.0.1:12522 keys 'j'  # Connect to specific server
-cargo run -- cli mode                     # Get current mode
-cargo run -- cli cursor                   # Get cursor position
-cargo run -- cli --format json mode       # JSON output format
-cargo run -- cli -i                       # Interactive REPL mode
-
-# TUI frame capture (#447) - requires connected TUI
-cargo run -- cli capture                  # Capture with raw_ansi (ANSI colors)
-cargo run -- cli capture --format plain_text  # Plain text without colors
-
-# Explicit TUI client (connects to running server)
-cargo run -- tui                          # Auto-discover server
-cargo run -- tui --tcp 127.0.0.1:12521    # Connect to specific server
-cargo run -- tui --headless               # Headless mode (no TTY, for CI/scripting)
 ```
+
+For detailed server, CLI, and TUI commands, see [Server Mode](docs/user-guide/server-mode.md) and [CLI Reference](docs/user-guide/cli-reference.md).
 
 ## Git Commits
 
@@ -471,12 +468,8 @@ When creating PRs with `gh pr create`, do NOT add promotional footers like "Gene
 
 3. **Plan File Setup** (for implementation tasks):
    - Launch `oracle` agent for complex planning (uses Opus)
-   - Create/update plan file at `~/.claude/plans/reovim/{ISSUE_NUMBER}-{SUBJECT}.md`
+   - Create/update plan file following [Plan Files](#plan-files) naming convention
    - Plan must be **self-contained** (works after context compact/clear)
-   - Include all information needed for implementation:
-     - Architecture diagrams, file locations, type definitions
-     - Reference to related issues and dependencies
-     - Acceptance criteria and test targets
 
 4. **Countdown - Go Poll Round 1**:
    - Launch review agents (mission-control, telemetry, flight-director) in `countdown` mode with `model: {model}`
@@ -684,12 +677,6 @@ The logging system is partially implemented. The driver infrastructure exists in
 Query and control logging on a running server via CLI:
 
 ```bash
-# Get current log level
-reovim cli log-level
-
-# Set log level dynamically (trace, debug, info, warn, error, off)
-reovim cli log-level debug
-
 # Get recent log entries (default: 50)
 reovim cli log-tail
 reovim cli log-tail --count 100
@@ -705,46 +692,24 @@ reovim cli log-tail --grep "connection"
 
 # Combine filters
 reovim cli log-tail --level info --target runner --grep error
-
-# Follow mode - stream logs in real-time (Ctrl+C to stop)
-reovim cli log-tail --follow
-reovim cli log-tail --follow --level warn
 ```
 
 Output is color-coded when stdout is a TTY:
 - ERROR (red), WARN (yellow), INFO (green), DEBUG (cyan), TRACE (gray)
 
-### TUI Debug Mode
+### Frame Capture
 
-Enable debug mode for TUI diagnostics:
+Capture TUI screen for debugging (requires connected TUI):
 
 ```bash
-# Enable debug statusline and frame capture
-reovim tui --debug
+# Capture with ANSI colors
+reovim cli --grpc 127.0.0.1:PORT capture
 
-# Custom log directory
-reovim tui --debug --debug-dir /tmp/reovim-debug
-
-# Custom session name
-reovim tui --debug --debug-name mysession
+# Plain text (good for logs/LLMs)
+reovim cli --grpc 127.0.0.1:PORT capture --format plain_text
 ```
 
-**Output files:**
-- `~/.local/share/reovim/logs/tui/{name}_{start_time}.log` - Session log
-- `~/.local/share/reovim/logs/tui/frame-buffer/{name}-{timestamp}.frame` - Frame captures (every 5 seconds)
-
-**Statusline format:**
-```
-[YY-MM-DD HH:MM:SS TZ] [server: ADDR] [mode: MODE] [modules: N]
-```
-
-The statusline is rendered at the bottom of the screen with inverse colors.
-
-**Session log events:**
-- Session start/end
-- Mode changes
-- Terminal resize
-- Frame captures
+See [Frame Capture Guide](docs/user-guide/frame-capture.md) for details.
 
 ### Debugging Flaky Tests
 
@@ -791,13 +756,13 @@ The statusline is rendered at the bottom of the screen with inverse colors.
 
 ```bash
 # Start server
-./target/release/reovim server --tcp 13000 &
+./target/release/reovim server --grpc 13000 &
 
 # Test via CLI (Pull - always fresh)
-./target/release/reovim cli --tcp 127.0.0.1:13000 --format json layout
+./target/release/reovim cli --grpc 127.0.0.1:13000 capture --format plain_text
 
 # Test via TUI (Push - depends on notifications)
-./target/release/reovim tui --tcp 127.0.0.1:13000 --debug
+./target/release/reovim tui --grpc 127.0.0.1:13000
 ```
 
 **Key files for layout/notification debugging:**

--- a/docs/architecture/drivers/buffer/overview.md
+++ b/docs/architecture/drivers/buffer/overview.md
@@ -1,0 +1,66 @@
+# buffer/ - Buffer Manager Driver
+
+Typed key and registry for buffer manager lookup.
+
+## Source Location
+
+`server/lib/drivers/buffer/src/`
+
+## Purpose
+
+Defines the typed key and registry for buffer manager implementations. The
+`BufferManager` trait itself is defined in the kernel; this driver provides
+the registration mechanism.
+
+Following the mechanism/policy separation:
+- **Mechanism** (kernel): `BufferManager` trait
+- **Mechanism** (this driver): `BufferManagerKey`, `BufferManagerRegistry`
+- **Policy** (modules): Implementations like `SimpleBufferManager`
+
+## Architecture
+
+```
+lib/kernel/           -> BufferManager trait (MECHANISM)
+lib/drivers/buffer/   -> Key + Registry (MECHANISM)
+modules/buffer-simple/-> SimpleBufferManager implementation (POLICY)
+```
+
+## Key Types
+
+```rust
+/// Typed key for buffer manager lookup
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BufferManagerKey {
+    Simple,
+    // Future: Rope, Gap, etc.
+}
+
+/// Registry for buffer manager implementations
+pub struct BufferManagerRegistry {
+    managers: RwLock<HashMap<BufferManagerKey, Arc<dyn BufferManager>>>,
+}
+
+impl BufferManagerRegistry {
+    pub fn register(&self, key: BufferManagerKey, manager: Arc<dyn BufferManager>);
+    pub fn get(&self, key: &BufferManagerKey) -> Option<Arc<dyn BufferManager>>;
+}
+```
+
+## Test Utilities
+
+```rust
+/// Test buffer manager for unit testing
+pub struct TestBufferManager {
+    // Simplified implementation for tests
+}
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1::BufferManager` - The trait being registered
+- `reovim_arch::sync::RwLock` - Thread-safe locking
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [buffer-simple Module](../../modules/builtin/buffer-simple.md)

--- a/docs/architecture/drivers/clipboard/overview.md
+++ b/docs/architecture/drivers/clipboard/overview.md
@@ -1,0 +1,101 @@
+# clipboard/ - Clipboard Provider Driver
+
+System clipboard access and yank history interface.
+
+## Source Location
+
+`server/lib/drivers/clipboard/src/`
+
+## Purpose
+
+Defines the interface for system clipboard access and yank history. Complements
+the kernel's `RegisterBank` with system integration.
+
+Following the mechanism/policy separation:
+- **Mechanism** (this driver): `ClipboardProvider` trait, `ClipboardKey`, registry
+- **Policy** (modules): Implementations with actual OS clipboard integration
+
+## Architecture
+
+```
++-------------------------------------------------------------+
+|  Kernel RegisterBank                                         |
+|  - Unnamed register ("")                                     |
+|  - Named registers (a-z)                                     |
++-------------------------------------------------------------+
+|  Clipboard Driver (this crate)                               |
+|  - System clipboard (+)                                      |
+|  - Selection clipboard (*)                                   |
+|  - History registers (0-9)                                   |
++-------------------------------------------------------------+
+```
+
+## Usage Flow
+
+**Yank/Delete Operation:**
+1. Check register name
+2. If `+`/`*` -> `ClipboardProvider.copy_to_clipboard/selection()`
+3. If a-z/unnamed -> `RegisterBank.set_by_name()`
+4. Always -> `ClipboardProvider.push_history()` (for 0-9 access)
+
+**Paste Operation:**
+1. Check register name
+2. If `+`/`*` -> `ClipboardProvider.paste_from_clipboard/selection()`
+3. If 0-9 -> `ClipboardProvider.history_entry()`
+4. If a-z/unnamed -> `RegisterBank.get_by_name()`
+
+## Key Types
+
+```rust
+/// Error type for clipboard operations
+pub enum ClipboardError {
+    NotAvailable,
+    AccessDenied,
+    InvalidData,
+}
+
+/// Typed key for clipboard provider lookup
+pub enum ClipboardKey {
+    Default,
+    // Future: X11, Wayland, macOS, etc.
+}
+
+/// Clipboard provider trait
+pub trait ClipboardProvider: Send + Sync {
+    fn copy_to_clipboard(&self, content: &str) -> Result<(), ClipboardError>;
+    fn paste_from_clipboard(&self) -> Result<String, ClipboardError>;
+    fn copy_to_selection(&self, content: &str) -> Result<(), ClipboardError>;
+    fn paste_from_selection(&self) -> Result<String, ClipboardError>;
+    fn push_history(&self, content: RegisterContent);
+    fn history_entry(&self, index: usize) -> Option<RegisterContent>;
+}
+
+/// Registry for clipboard providers
+pub struct ClipboardProviderRegistry { /* ... */ }
+```
+
+## Example Usage
+
+```rust
+use reovim_driver_clipboard::{ClipboardKey, ClipboardProviderRegistry};
+
+// In module init():
+let clipboard = Arc::new(MyClipboardService::new());
+let registry = ctx.services.get_or_create::<ClipboardProviderRegistry>();
+registry.register(ClipboardKey::Default, clipboard);
+
+// In operator execute():
+if let Some(registry) = ctx.services.get::<ClipboardProviderRegistry>() {
+    if let Some(provider) = registry.get(&ClipboardKey::Default) {
+        provider.push_history(content.clone());
+        if register == Some('+') {
+            let _ = provider.copy_to_clipboard(&content.text);
+        }
+    }
+}
+```
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [Kernel RegisterBank](../../kernel/core/overview.md)

--- a/docs/architecture/drivers/command-types/overview.md
+++ b/docs/architecture/drivers/command-types/overview.md
@@ -1,0 +1,95 @@
+# command-types/ - Command Types Driver
+
+Shared types for the command system.
+
+## Source Location
+
+`server/lib/drivers/command-types/src/`
+
+## Purpose
+
+Provides the fundamental types for the command system. These types are extracted
+to a separate crate to break the circular dependency between `reovim-driver-command`
+and `reovim-driver-session`. Both drivers can depend on this crate without creating
+a cycle.
+
+## Key Types
+
+### CommandContext
+
+Carries all inputs for command execution:
+
+```rust
+pub struct CommandContext {
+    pub buffer_id: Option<BufferId>,
+    pub cursor: Position,
+    pub count: Option<usize>,
+    pub register: Option<char>,
+    pub motion: Option<Motion>,
+    pub text_object: Option<TextObject>,
+    // ...
+}
+```
+
+### CommandResult
+
+Result of command execution:
+
+```rust
+pub struct CommandResult {
+    pub success: bool,
+    pub message: Option<String>,
+    pub cursor_moved: bool,
+    pub buffer_modified: bool,
+    // ...
+}
+```
+
+### MotionType
+
+Motion classification for operator-pending mode:
+
+```rust
+pub enum MotionType {
+    Characterwise,
+    Linewise,
+    Blockwise,
+}
+```
+
+### Argument Specifications
+
+For command argument handling:
+
+```rust
+pub enum ArgKind {
+    String,
+    Number,
+    Boolean,
+    Path,
+    // ...
+}
+
+pub struct ArgSpec {
+    pub name: String,
+    pub kind: ArgKind,
+    pub required: bool,
+    pub default: Option<ArgValue>,
+}
+
+pub enum ArgValue {
+    String(String),
+    Number(i64),
+    Boolean(bool),
+    // ...
+}
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Position, BufferId, Motion, TextObject
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [command Driver](../command/overview.md)

--- a/docs/architecture/drivers/ffi-python/overview.md
+++ b/docs/architecture/drivers/ffi-python/overview.md
@@ -1,0 +1,129 @@
+# ffi-python/ - Python FFI Bindings Driver
+
+Python bindings via PyO3 for writing reovim modules in Python.
+
+## Source Location
+
+`server/lib/drivers/ffi-python/src/`
+
+## Purpose
+
+Provides Python bindings that allow writing reovim modules in Python. Wraps kernel
+types (`ModuleId`, `Version`, `ProbeResult`) and provides a `PythonModule` wrapper
+that implements the `Module` trait.
+
+## Architecture
+
+```
+Python Module (my_module.py)
+        |
+        v
++-------------------------+
+|  ffi-python crate       |
+|  PythonModule wrapper   |
+|  impl Module trait      |
++-------------------------+
+        |
+        v
++-------------------------+
+|  ModuleLoader           |
+|  .py detection          |
++-------------------------+
+```
+
+## Python Usage
+
+```python
+from reovim import Module, ModuleId, Version, ProbeResult
+
+class MyModule(Module):
+    def id(self) -> ModuleId:
+        return ModuleId("my-python-module")
+
+    def name(self) -> str:
+        return "My Python Module"
+
+    def version(self) -> tuple[int, int, int]:
+        return (1, 0, 0)
+
+    def init(self, ctx) -> ProbeResult:
+        return ProbeResult.Success
+
+    def exit(self):
+        pass
+```
+
+## Key Types
+
+### PyModuleBase
+
+Base class for Python modules:
+
+```rust
+#[pyclass(name = "Module", module = "reovim", subclass)]
+pub struct PyModuleBase;
+
+#[pymethods]
+impl PyModuleBase {
+    fn id(&self) -> PyModuleId;
+    fn name(&self) -> &'static str;
+    fn version(&self) -> (u32, u32, u32);
+    fn api_version(&self) -> PyVersion;
+    fn dependencies(&self) -> Vec<PyModuleId>;
+    fn init(&mut self, ctx: &Bound<'_, PyAny>) -> PyProbeResult;
+    fn exit(&mut self);
+    fn supports_hot_reload(&self) -> bool;
+    fn commands(&self) -> Vec<PyCommandRegistration>;
+    fn keybindings(&self) -> Vec<PyKeybindingRegistration>;
+    fn event_handlers(&self) -> Vec<PyEventHandlerRegistration>;
+}
+```
+
+### PythonModule Wrapper
+
+Rust wrapper that implements `Module` trait:
+
+```rust
+pub struct PythonModule {
+    py_instance: Py<PyAny>,
+}
+
+impl Module for PythonModule {
+    // Delegates all calls to Python instance
+}
+```
+
+### Python Types
+
+| Python Type | Rust Type | Purpose |
+|-------------|-----------|---------|
+| `ModuleId` | `PyModuleId` | Module identifier |
+| `Version` | `PyVersion` | Semantic version |
+| `ProbeResult` | `PyProbeResult` | Init result |
+| `ModuleContext` | `PyModuleContext` | Init context |
+| `CommandRegistration` | `PyCommandRegistration` | Command registration |
+| `KeybindingRegistration` | `PyKeybindingRegistration` | Keybinding registration |
+| `EventHandlerRegistration` | `PyEventHandlerRegistration` | Event handler registration |
+
+## Initialization
+
+```rust
+use reovim_driver_ffi_python::init_python;
+
+// Initialize Python with reovim module
+// MUST be called before any other Python operations
+init_python();
+
+// Now Python code can: from reovim import Module
+```
+
+## Dependencies
+
+- `pyo3` - Python bindings for Rust
+- `reovim_kernel::api::v1` - Module trait, Version, etc.
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [ffi Driver](../ffi/overview.md)
+- [Module System](../../modules/overview.md)

--- a/docs/architecture/drivers/ffi/overview.md
+++ b/docs/architecture/drivers/ffi/overview.md
@@ -1,0 +1,123 @@
+# ffi/ - Foreign Function Interface Driver
+
+C-compatible interfaces for external module development.
+
+## Source Location
+
+`server/lib/drivers/ffi/src/`
+
+## Purpose
+
+Provides C-compatible interfaces for external module development. Generates a C
+header file (`reovim.h`) and provides FFI-safe service wrappers that external
+modules can use to interact with the kernel.
+
+Following Linux kernel design (mechanism vs policy):
+- **Kernel provides mechanism**: `#[repr(C)]` types, FFI-safe Module trait
+- **This driver provides policy**: C header generation, FFI wrappers, ABI versioning
+
+## Architecture
+
+```
++-------------------------------------------------------------+
+|             External Modules (C, Haskell, etc.)              |
+|   #include <reovim.h>                                        |
+|   reovim_log_info("Module loaded");                          |
++-------------------------------------------------------------+
+                              |
+                              v
++-------------------------------------------------------------+
+|                 Driver (drivers/ffi/)                        |
+|   reovim.h | reovim_log_* | reovim_abi_version               |
++-------------------------------------------------------------+
+                              |
+                              v
++-------------------------------------------------------------+
+|                     Kernel (api/v1)                          |
+|   Version | ModuleProbe | Module trait | tracing             |
++-------------------------------------------------------------+
+```
+
+## Module Entry Points
+
+External modules must export these symbols (matching `declare_module!` output):
+
+| Symbol | Type | Purpose |
+|--------|------|---------|
+| `REOVIM_MODULE_API_VERSION` | `Version` | Pre-load version check |
+| `reovim_module_probe()` | `fn() -> ModuleProbe` | Metadata query |
+| `reovim_module_entry()` | `fn() -> *mut c_void` | Instance creation |
+| `reovim_module_init()` | `fn(*mut c_void, *const c_void) -> i32` | Init trampoline |
+| `reovim_module_exit()` | `fn(*mut c_void) -> i32` | Exit trampoline |
+| `reovim_module_destroy()` | `fn(*mut c_void)` | Cleanup trampoline |
+
+## Key Exports
+
+### Logging Functions
+
+```rust
+pub extern "C" fn reovim_log_info(msg: *const c_char);
+pub extern "C" fn reovim_log_warn(msg: *const c_char);
+pub extern "C" fn reovim_log_error(msg: *const c_char);
+pub extern "C" fn reovim_log_debug(msg: *const c_char);
+```
+
+### Version Checking
+
+```rust
+pub const ABI_VERSION: Version;
+pub extern "C" fn reovim_abi_version() -> Version;
+pub extern "C" fn reovim_abi_is_compatible(version: Version) -> bool;
+```
+
+### Timer Wheel
+
+```rust
+pub type ReovimTimerCallback = extern "C" fn(*mut c_void);
+pub type ReovimTimerHandle = u64;
+
+pub extern "C" fn reovim_schedule_delayed(
+    delay_ms: u64,
+    callback: ReovimTimerCallback,
+    user_data: *mut c_void,
+) -> ReovimTimerHandle;
+
+pub extern "C" fn reovim_schedule_periodic(
+    interval_ms: u64,
+    callback: ReovimTimerCallback,
+    user_data: *mut c_void,
+) -> ReovimTimerHandle;
+
+pub extern "C" fn reovim_cancel_timer(handle: ReovimTimerHandle) -> bool;
+```
+
+## ABI vs API Versioning
+
+The ABI version is separate from the API version:
+
+- **ABI version**: Binary compatibility (struct layouts, calling conventions)
+- **API version**: Semantic compatibility (trait methods, behavior)
+
+ABI version bumps when:
+- Struct sizes change (e.g., `ModuleProbe` 216 -> 1308 bytes)
+- Struct field layouts change
+- Function signatures change
+
+API version bumps when:
+- New methods are added to traits
+- Method semantics change
+- New types are added (backwards compatible)
+
+## Generated C Header
+
+The `build.rs` generates `include/reovim.h` with:
+- ABI version constants (`REOVIM_ABI_VERSION_*`)
+- API version constants (`REOVIM_API_VERSION_*`)
+- Type definitions (`ReovimVersion`, `ReovimModuleProbe`)
+- Service function declarations
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [ffi-python Driver](../ffi-python/overview.md)
+- [Module System](../../modules/overview.md)

--- a/docs/architecture/drivers/overview.md
+++ b/docs/architecture/drivers/overview.md
@@ -6,15 +6,23 @@ Drivers (`server/lib/drivers/*`) implement traits defined by the kernel. Each dr
 
 | Driver | Crate | Purpose | Documentation |
 |--------|-------|---------|---------------|
+| `buffer/` | `reovim-driver-buffer` | Buffer manager registry | [buffer/overview.md](./buffer/overview.md) |
+| `clipboard/` | `reovim-driver-clipboard` | System clipboard interface | [clipboard/overview.md](./clipboard/overview.md) |
 | `command/` | `reovim-driver-command` | Command traits and execution | [command/overview.md](./command/overview.md) |
-| `syntax/` | `reovim-driver-syntax` | Syntax highlighting abstraction | [syntax/overview.md](./syntax/overview.md) |
-| `input/` | `reovim-driver-input` | Keyboard, mouse, clipboard | [input/overview.md](./input/overview.md) |
+| `command-types/` | `reovim-driver-command-types` | CommandContext, CommandResult | [command-types/overview.md](./command-types/overview.md) |
 | `display/` | `reovim-driver-display` | Frame buffer, compositor | [display/overview.md](./display/overview.md) |
+| `ffi/` | `reovim-driver-ffi` | C FFI interface + ABI versioning | [ffi/overview.md](./ffi/overview.md) |
+| `ffi-python/` | `reovim-driver-ffi-python` | Python bindings via PyO3 | [ffi-python/overview.md](./ffi-python/overview.md) |
+| `input/` | `reovim-driver-input` | Keyboard, mouse input | [input/overview.md](./input/overview.md) |
+| `log/` | `reovim-driver-log` | Logger implementation (tracing) | [log/overview.md](./log/overview.md) |
 | `lsp/` | `reovim-driver-lsp` | LSP client infrastructure | [lsp/overview.md](./lsp/overview.md) |
 | `net/` | `reovim-driver-net` | RPC server, transports | [net/overview.md](./net/overview.md) |
-| `vfs/` | `reovim-driver-vfs` | Virtual filesystem | [vfs/overview.md](./vfs/overview.md) |
+| `search/` | `reovim-driver-search` | Search provider interface | [search/overview.md](./search/overview.md) |
 | `session/` | `reovim-driver-session` | Session management traits | [session/overview.md](./session/overview.md) |
-| `log/` | `reovim-driver-log` | Logger implementation (tracing) | [log/overview.md](./log/overview.md) |
+| `syntax/` | `reovim-driver-syntax` | Syntax highlighting abstraction | [syntax/overview.md](./syntax/overview.md) |
+| `syntax-treesitter/` | `reovim-driver-syntax-treesitter` | Tree-sitter implementation | [syntax-treesitter/overview.md](./syntax-treesitter/overview.md) |
+| `undo/` | `reovim-driver-undo` | Undo provider interface | [undo/overview.md](./undo/overview.md) |
+| `vfs/` | `reovim-driver-vfs` | Virtual filesystem | [vfs/overview.md](./vfs/overview.md) |
 
 ## Layer Position
 

--- a/docs/architecture/drivers/search/overview.md
+++ b/docs/architecture/drivers/search/overview.md
@@ -1,0 +1,106 @@
+# search/ - Search Provider Driver
+
+Pattern matching interface for buffer searching.
+
+## Source Location
+
+`server/lib/drivers/search/src/`
+
+## Purpose
+
+Defines the interface for pattern matching in buffers. Provides the trait and
+types for search functionality.
+
+Following the mechanism/policy separation:
+- **Mechanism** (this driver): `SearchProvider` trait, types, registry
+- **Policy** (modules): Implementations like regex-based `SearchEngine`
+
+## Architecture
+
+```
+lib/drivers/search/   -> Trait + Types + Key + Registry (MECHANISM)
+modules/search/       -> SearchEngine implementation (POLICY)
+```
+
+## Key Types
+
+### SearchProvider Trait
+
+```rust
+pub trait SearchProvider: Send + Sync {
+    /// Search for pattern in buffer
+    fn search(
+        &self,
+        buffer: &Buffer,
+        pattern: &str,
+        from: Position,
+        direction: Direction,
+    ) -> Result<Option<SearchMatch>, SearchError>;
+
+    /// Find all matches in buffer
+    fn find_all(
+        &self,
+        buffer: &Buffer,
+        pattern: &str,
+    ) -> Result<Vec<SearchMatch>, SearchError>;
+
+    /// Replace matches
+    fn replace(
+        &self,
+        buffer: &mut Buffer,
+        pattern: &str,
+        replacement: &str,
+        range: Option<Range>,
+    ) -> Result<usize, SearchError>;
+}
+```
+
+### Direction
+
+```rust
+pub enum Direction {
+    Forward,
+    Backward,
+}
+```
+
+### SearchMatch
+
+```rust
+pub struct SearchMatch {
+    pub start: Position,
+    pub end: Position,
+    pub text: String,
+}
+```
+
+### SearchError
+
+```rust
+pub enum SearchError {
+    InvalidPattern(String),
+    NotFound,
+    RegexError(String),
+}
+```
+
+### Registry
+
+```rust
+pub enum SearchKey {
+    Default,
+    // Future: Fuzzy, Aho-Corasick, etc.
+}
+
+pub struct SearchProviderRegistry {
+    providers: RwLock<HashMap<SearchKey, Arc<dyn SearchProvider>>>,
+}
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Buffer, Position
+
+## Related Documents
+
+- [Driver Overview](../overview.md)

--- a/docs/architecture/drivers/syntax-treesitter/overview.md
+++ b/docs/architecture/drivers/syntax-treesitter/overview.md
@@ -1,0 +1,151 @@
+# syntax-treesitter/ - Tree-sitter Syntax Driver
+
+Generic tree-sitter implementation of the SyntaxDriver trait.
+
+## Source Location
+
+`server/lib/drivers/syntax-treesitter/src/`
+
+## Purpose
+
+Provides a tree-sitter based implementation of the `SyntaxDriver` trait from
+`reovim-driver-syntax`. Handles the generic tree-sitter parsing and highlighting
+logic, but does NOT include any language grammars.
+
+## Architecture
+
+Three-layer design:
+
+```
+Language Modules                  This Crate                   Trait Crate
+================                  ==========                   ===========
+treesitter-rust     ---------->  TreeSitterDriver  --impl-->  SyntaxDriver
+treesitter-markdown              CaptureMapper
+treesitter-python
+```
+
+1. **`reovim-driver-syntax`** (trait crate): Defines `SyntaxDriver`, `HighlightGroup`
+2. **`reovim-driver-syntax-treesitter`** (this crate): Generic tree-sitter implementation
+3. **Language modules** (e.g., `treesitter-rust`): Provide grammars and queries
+
+This separation keeps language-specific dependencies (tree-sitter-rust, etc.)
+in their own modules rather than bundled into the driver.
+
+## Key Types
+
+### TreeSitterDriver
+
+```rust
+pub struct TreeSitterDriver {
+    language_id: String,
+    parser: Mutex<Parser>,
+    tree: RwLock<Option<Tree>>,
+    highlights_query: Arc<Query>,
+    folds_query: Option<Arc<Query>>,
+    indents_query: Option<Arc<Query>>,
+    injection_manager: Option<InjectionManager>,
+    capture_mapper: Arc<CaptureMapper>,
+    // ...
+}
+
+impl TreeSitterDriver {
+    pub fn new(
+        language_id: &str,
+        language: &Language,
+        highlights_query: Arc<Query>,
+        capture_mapper: Arc<CaptureMapper>,
+    ) -> Result<Self, SyntaxError>;
+
+    pub fn with_queries(
+        self,
+        folds_query: Option<Query>,
+        indents_query: Option<Query>,
+        injections_query: Option<Query>,
+    ) -> Self;
+
+    pub fn parse(&mut self, content: &str);
+    pub fn highlights(&self, range: Range<usize>) -> Vec<HighlightSpan>;
+    pub fn folds(&self) -> Vec<FoldRange>;
+    pub fn indent_for(&self, line: usize) -> usize;
+}
+```
+
+### CaptureMapper
+
+Maps tree-sitter capture names to highlight groups:
+
+```rust
+pub struct CaptureMapper {
+    mappings: HashMap<String, HighlightGroup>,
+}
+
+impl CaptureMapper {
+    pub fn new() -> Self;
+    pub fn with_mapping(mut self, capture: &str, group: HighlightGroup) -> Self;
+    pub fn map(&self, capture: &str) -> Option<HighlightGroup>;
+}
+```
+
+### Injection Support
+
+For embedded language highlighting (e.g., Markdown in doc comments):
+
+```rust
+pub trait InjectionLayerFactory: Send + Sync {
+    fn language_id(&self) -> &str;
+    fn create(&self) -> Box<dyn SyntaxDriver>;
+}
+
+pub struct InjectionManager {
+    layers: Vec<InjectionLayer>,
+}
+
+pub struct InjectionLayerStore {
+    factories: RwLock<HashMap<String, Arc<dyn InjectionLayerFactory>>>,
+}
+```
+
+## Thread Safety
+
+`TreeSitterDriver` is `Send + Sync` through interior mutability:
+- `Parser` and `QueryCursor` use `Mutex` (exclusive access needed)
+- `Tree` and content use `RwLock` (read-heavy access pattern)
+
+## Example Usage
+
+```rust
+use std::sync::Arc;
+use reovim_driver_syntax_treesitter::{TreeSitterDriver, CaptureMapper};
+use tree_sitter::Query;
+
+// Language module provides grammar and query
+let language = tree_sitter_rust::LANGUAGE;
+let query = Query::new(&language.into(), RUST_HIGHLIGHTS_QUERY).unwrap();
+
+// Create driver
+let mapper = Arc::new(CaptureMapper::new()
+    .with_mapping("keyword", HighlightGroup::Keyword)
+    .with_mapping("function", HighlightGroup::Function));
+let mut driver = TreeSitterDriver::new(
+    "rust",
+    &language.into(),
+    Arc::new(query),
+    mapper,
+).unwrap();
+
+// Parse and highlight
+driver.parse("fn main() {}");
+let highlights = driver.highlights(0..12);
+```
+
+## Re-exports
+
+```rust
+// Re-export tree_sitter types that language modules need
+pub use tree_sitter::{Language, Query};
+```
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [syntax Driver](../syntax/overview.md)

--- a/docs/architecture/drivers/undo/overview.md
+++ b/docs/architecture/drivers/undo/overview.md
@@ -1,0 +1,107 @@
+# undo/ - Undo Provider Driver
+
+Per-buffer undo/redo operations interface.
+
+## Source Location
+
+`server/lib/drivers/undo/src/`
+
+## Purpose
+
+Defines the interface for per-buffer undo/redo operations. Provides the trait
+and types for undo functionality with optional persistence.
+
+Following the mechanism/policy separation:
+- **Mechanism** (this driver): `UndoProvider` trait, registry, error types
+- **Policy** (modules): Implementations like `UndoRegistry` with persistence
+
+## Architecture
+
+```
+lib/drivers/undo/     -> Trait + Key + Registry + Error (MECHANISM)
+modules/undo/         -> UndoRegistry implementation (POLICY)
+```
+
+## Key Types
+
+### UndoProvider Trait
+
+```rust
+pub trait UndoProvider: Send + Sync {
+    /// Record an edit for a buffer
+    fn record(&self, buffer_id: BufferId, edit: Edit);
+
+    /// Undo the last edit for a buffer
+    fn undo(&self, buffer_id: BufferId) -> Option<Edit>;
+
+    /// Redo the last undone edit for a buffer
+    fn redo(&self, buffer_id: BufferId) -> Option<Edit>;
+
+    /// Check if undo is available
+    fn can_undo(&self, buffer_id: BufferId) -> bool;
+
+    /// Check if redo is available
+    fn can_redo(&self, buffer_id: BufferId) -> bool;
+
+    /// Clear undo history for a buffer
+    fn clear(&self, buffer_id: BufferId);
+
+    /// Save undo history to disk (optional)
+    fn persist(&self, buffer_id: BufferId, path: &Path) -> Result<(), UndoPersistError>;
+
+    /// Load undo history from disk (optional)
+    fn restore(&self, buffer_id: BufferId, path: &Path) -> Result<(), UndoPersistError>;
+}
+```
+
+### UndoKey
+
+```rust
+pub enum UndoKey {
+    Default,
+    // Future: Branching, DAG, etc.
+}
+```
+
+### UndoProviderRegistry
+
+```rust
+pub struct UndoProviderRegistry {
+    providers: RwLock<HashMap<UndoKey, Arc<dyn UndoProvider>>>,
+}
+
+impl UndoProviderRegistry {
+    pub fn register(&self, key: UndoKey, provider: Arc<dyn UndoProvider>);
+    pub fn get(&self, key: &UndoKey) -> Option<Arc<dyn UndoProvider>>;
+}
+```
+
+### UndoPersistError
+
+```rust
+pub enum UndoPersistError {
+    IoError(std::io::Error),
+    SerializationError(String),
+    VersionMismatch { expected: u32, found: u32 },
+    CorruptedData,
+}
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - BufferId, Edit
+
+## Persistence
+
+Undo history can optionally be persisted to disk alongside buffer files.
+The persistence format and location are determined by the implementing module.
+
+Typical persistence location:
+```
+~/.local/share/reovim/undo/{buffer_hash}.undo
+```
+
+## Related Documents
+
+- [Driver Overview](../overview.md)
+- [Kernel Block Operations](../../kernel/block/overview.md)

--- a/docs/architecture/kernel/panic/overview.md
+++ b/docs/architecture/kernel/panic/overview.md
@@ -1,0 +1,146 @@
+# panic/ - Panic Handling Subsystem
+
+Custom panic handlers, crash recovery, and state dumping.
+
+Linux equivalent: `kernel/panic.c`
+
+## Source Location
+
+`server/lib/kernel/src/panic/`
+
+## Architecture
+
+```
++---------------------------------------------------------+
+|                     Panic Subsystem                      |
+|                                                          |
+|  +------------------+  +------------------+               |
+|  |    Handler       |  |    Recovery      |               |
+|  | (panic hook,     |  | (buffer save,    |               |
+|  |  recovery cb)    |  |  file mgmt)      |               |
+|  +------------------+  +------------------+               |
+|                                                          |
+|  +------------------+                                     |
+|  |    Report        |                                     |
+|  | (crash report    |                                     |
+|  |  generation)     |                                     |
+|  +------------------+                                     |
+|                                                          |
++---------------------------------------------------------+
+```
+
+## Components
+
+### handler.rs - Panic Handler Installation
+
+Installs a custom panic handler that:
+1. Calls recovery callback to save unsaved buffers
+2. Generates a crash report with debug context
+3. Writes crash report to file
+
+**Key exports:**
+- `install_panic_handler()` - Install the custom panic handler
+- `is_handler_installed()` - Check if handler is installed
+- `set_recovery_callback()` - Set callback for buffer recovery
+- `set_debug_context_callback()` - Set callback for debug context
+
+### recovery.rs - Buffer Recovery
+
+Provides utilities for saving buffer state during panic:
+
+**Key exports:**
+- `RecoverySnapshot` - State snapshot for crash recovery
+- `UnsavedBuffer` - Buffer data for recovery
+- `save_buffer_for_recovery()` - Save buffer to recovery file
+- `list_recovery_files()` - List available recovery files
+- `cleanup_old_recovery_files()` - Remove old recovery data
+- `recovery_dir()` - Get recovery directory path
+
+Recovery files are stored at:
+```
+~/.local/share/reovim/recovery/
+```
+
+### report.rs - Crash Report Generation
+
+Generates human-readable crash reports:
+
+**Key exports:**
+- `CrashReport` - Crash report structure
+- `generate_crash_report()` - Create report from panic info
+
+**Report format:**
+```
+========================================
+REOVIM CRASH REPORT
+========================================
+Timestamp: 2026-02-04 12:34:56 UTC
+Version: 0.9.3-dev
+...
+
+PANIC INFO
+----------
+Message: ...
+Location: file.rs:123
+
+DEBUG CONTEXT
+-------------
+Server logs: ...
+Client dump paths: ...
+
+RECOVERY INFO
+-------------
+Unsaved buffers: ...
+Recovery files: ...
+```
+
+Crash reports are written to:
+```
+~/.local/share/reovim/crash/crash-{date}_{time}-{nanos}.txt
+```
+
+## Usage Example
+
+```rust
+use reovim_kernel::panic::{
+    install_panic_handler,
+    set_recovery_callback,
+    save_buffer_for_recovery,
+};
+
+// Set up recovery callback
+set_recovery_callback(Box::new(|_info| {
+    // Save unsaved buffers
+    for buffer in get_unsaved_buffers() {
+        save_buffer_for_recovery(
+            buffer.id,
+            buffer.path.as_deref(),
+            &buffer.content,
+        ).ok();
+    }
+}));
+
+// Install the panic handler
+install_panic_handler();
+```
+
+## Debug Context Integration
+
+The panic handler integrates with the server's debug ring buffer (#478, #481):
+
+```rust
+use reovim_kernel::panic::{set_debug_context_callback, DebugContext};
+
+// Set debug context callback for crash reports
+set_debug_context_callback(Box::new(|| {
+    DebugContext {
+        server_logs: dump_server_ring_buffer(),
+        client_dump_paths: list_client_dumps(),
+    }
+}));
+```
+
+## Related Documents
+
+- [Server Debug Infrastructure](../../server/debug/overview.md) - Ring buffer and logging
+- [Kernel Overview](../overview.md) - Kernel architecture

--- a/docs/architecture/modules/builtin/README.md
+++ b/docs/architecture/modules/builtin/README.md
@@ -9,13 +9,23 @@ This directory contains documentation for reovim's built-in policy modules.
 | [editor](./editor.md) | `reovim-module-editor` | Core editing fallback handler | Documented |
 | [keymap](./keymap.md) | `reovim-module-keymap` | Key sequence mapping | Documented |
 | [operators](./operators.md) | `reovim-module-operators` | Vim operators (d, y, c) | Documented |
-| buffer-ops | `reovim-module-buffer-ops` | Buffer operations | TODO |
-| commands | `reovim-module-commands` | Ex commands (:w, :q) | TODO |
-| defaults | `reovim-module-defaults` | Default keybindings | TODO |
-| layout | — | Window layout policy | Archived (client-side in Phase 10) |
-| mode-manager | `reovim-module-mode-manager` | Mode state management | TODO |
-| options | `reovim-module-options` | Editor options (:set) | TODO |
-| window-ops | `reovim-module-window-ops` | Window operations (`<C-w>` commands) | ✅ Implemented (Phase 11) |
+| [buffer-ops](./buffer-ops.md) | `reovim-module-buffer-ops` | Buffer lifecycle events | Documented |
+| [buffer-simple](./buffer-simple.md) | `reovim-module-buffer-simple` | SimpleBufferManager | Documented |
+| [commands](./commands.md) | `reovim-module-commands` | Ex commands (:w, :q, :e) | Documented |
+| [defaults](./defaults.md) | `reovim-module-defaults` | Default modules bundle | Documented |
+| [mode-manager](./mode-manager.md) | `reovim-module-mode-manager` | Mode state management | Documented |
+| [options](./options.md) | `reovim-module-options` | Editor options (virtualedit) | Documented |
+| [scratch-buffer](./scratch-buffer.md) | `reovim-module-scratch-buffer` | Empty buffer on startup | Documented |
+| window-ops | `reovim-module-window-ops` | Window operations (`<C-w>` commands) | Implemented |
+| vim | `reovim-module-vim` | Core Vim-like behavior | Implemented |
+| motions | `reovim-module-motions` | Movement commands | Implemented |
+| textobjects | `reovim-module-textobjects` | Text object definitions | Implemented |
+| clipboard | `reovim-module-clipboard` | Clipboard operations | Implemented |
+| search | `reovim-module-search` | Search provider | Implemented |
+| undo | `reovim-module-undo` | Undo provider | Implemented |
+| vfs-local | `reovim-module-vfs-local` | Local filesystem VFS | Implemented |
+| treesitter-rust | `reovim-module-treesitter-rust` | Rust syntax | Implemented |
+| treesitter-markdown | `reovim-module-treesitter-markdown` | Markdown syntax | Implemented |
 
 ## Example Modules
 

--- a/docs/architecture/modules/builtin/buffer-ops.md
+++ b/docs/architecture/modules/builtin/buffer-ops.md
@@ -1,0 +1,60 @@
+# buffer-ops Module
+
+Buffer lifecycle event subscriber for the kernel EventBus.
+
+## Source Location
+
+`server/modules/buffer-ops/src/`
+
+## Purpose
+
+Handles buffer lifecycle events from the kernel `EventBus`. Subscribes to
+`BufferCreated`, `BufferModified`, `BufferClosed`, and `BufferSwitched` events
+and provides coordinated buffer state management.
+
+Following the kernel's "mechanism vs policy" principle:
+- Kernel provides the buffer events (mechanism)
+- This module decides how to react (policy)
+
+## Key Types
+
+```rust
+pub struct BufferOps {
+    /// Active subscriptions - stored to keep handlers active (RAII pattern)
+    subscriptions: Vec<Subscription>,
+}
+
+impl Module for BufferOps {
+    fn id(&self) -> ModuleId { ModuleId::new("buffer-ops") }
+    fn name(&self) -> &'static str { "Buffer Operations" }
+    fn version(&self) -> Version { Version::new(0, 1, 0) }
+}
+```
+
+## Event Subscriptions
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `BufferCreated` | CORE (10) | Initialize buffer-specific state |
+| `BufferModified` | NORMAL (50) | Track dirty state, schedule reparse |
+| `BufferClosed` | LOW (200) | Cleanup buffer-specific resources |
+| `BufferSwitched` | CORE (10) | Update active buffer tracking |
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait, EventBus, events
+
+## Example Usage
+
+```rust
+use reovim_module_buffer_ops::BufferOps;
+
+// Module is typically loaded via defaults bundle
+let module = BufferOps::new();
+registry.load(Box::new(module))?;
+```
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [EventBus Documentation](../../kernel/ipc/overview.md)

--- a/docs/architecture/modules/builtin/buffer-simple.md
+++ b/docs/architecture/modules/builtin/buffer-simple.md
@@ -1,0 +1,100 @@
+# buffer-simple Module
+
+SimpleBufferManager implementation of the BufferManager trait.
+
+## Source Location
+
+`server/modules/buffer-simple/src/`
+
+## Purpose
+
+Provides the `SimpleBufferManager` implementation of the `BufferManager` trait
+from the kernel. Manages buffer storage with thread-safe access.
+
+Following the mechanism/policy separation:
+- **Mechanism**: `BufferManager` trait (in kernel)
+- **Policy**: `SimpleBufferManager` (this module) provides implementation
+
+## Design Philosophy
+
+- **No I/O operations**: File loading/saving is VFS driver's job
+- **No syntax attachment**: Syntax is handled by modules (policy)
+- **Thread-safe**: All operations are safe for concurrent access
+- **Simple**: Just manages buffer storage, nothing more
+
+## Key Types
+
+```rust
+/// Simple buffer manager implementation
+pub struct SimpleBufferManager {
+    /// Buffer storage with outer RwLock protecting the HashMap
+    /// Inner Arc<RwLock<Buffer>> allows multiple references
+    buffers: RwLock<HashMap<BufferId, Arc<RwLock<Buffer>>>>,
+}
+
+impl BufferManager for SimpleBufferManager {
+    fn get(&self, id: BufferId) -> Option<Arc<RwLock<Buffer>>>;
+    fn create(&self) -> BufferId;
+    fn register(&self, buffer: Buffer) -> BufferId;
+    fn unregister(&self, id: BufferId) -> Result<Buffer, BufferError>;
+    fn list(&self) -> Vec<BufferId>;
+    fn count(&self) -> usize;
+}
+
+/// Module instance
+pub struct BufferSimpleModule;
+
+impl Module for BufferSimpleModule {
+    fn id(&self) -> ModuleId { ModuleId::new("buffer-simple") }
+    fn name(&self) -> &'static str { "Simple Buffer Manager" }
+}
+```
+
+## Registration
+
+During `init()`, the module registers itself with the `BufferManagerRegistry`:
+
+```rust
+fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+    let buffer_registry = ctx.services.get_or_create::<BufferManagerRegistry>();
+    buffer_registry.register(
+        BufferManagerKey::Simple,
+        Arc::new(SimpleBufferManager::new())
+    );
+    ProbeResult::Success
+}
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait, Buffer, BufferId, BufferManager
+- `reovim_driver_buffer` - BufferManagerKey, BufferManagerRegistry
+- `reovim_arch::sync::RwLock` - Thread-safe locking
+
+## Example Usage
+
+```rust
+let mgr = SimpleBufferManager::new();
+
+// Create a buffer
+let id = mgr.create();
+
+// Get the buffer
+if let Some(buffer) = mgr.get(id) {
+    let content = buffer.read().to_string();
+}
+
+// Register an existing buffer
+let buffer = Buffer::from_string("hello");
+let id = mgr.register(buffer);
+
+// List all buffers
+for id in mgr.list() {
+    println!("Buffer: {:?}", id);
+}
+```
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [buffer Driver](../../drivers/buffer/overview.md)

--- a/docs/architecture/modules/builtin/commands.md
+++ b/docs/architecture/modules/builtin/commands.md
@@ -1,0 +1,85 @@
+# commands Module
+
+Ex-commands implementation (:w, :q, :e, :wq, :colorscheme, session commands).
+
+## Source Location
+
+`server/modules/commands/src/`
+
+## Purpose
+
+Implements the standard ex-commands (colon commands) for the editor:
+- `:q` / `:quit` - Quit the editor
+- `:w` / `:write` - Write the buffer to disk
+- `:wq` - Write and quit
+- `:e` / `:edit` - Edit a file
+- `:colorscheme` - Change theme
+- `:detach` - Detach client from session
+- `:servers` - List running servers
+- `:kill-server` - Terminate server
+
+Following mechanism vs policy:
+- **Mechanism (Kernel)**: Buffer management, position types
+- **Policy (This Module)**: `ExCommandHandler` trait, what commands do
+
+## Key Types
+
+```rust
+/// Trait for implementing ex-commands
+pub trait ExCommandHandler: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn names(&self) -> Vec<&'static str>;
+    fn execute(&self, ctx: &ExCommandContext) -> Result<(), CommandError>;
+}
+
+/// Context passed to command execution
+pub struct ExCommandContext {
+    pub range: Option<Range>,
+    pub args: Vec<String>,
+    pub bang: bool,
+    // ...
+}
+
+/// Commands module instance
+pub struct CommandsModule;
+
+impl Module for CommandsModule {
+    fn id(&self) -> ModuleId { ModuleId::new("commands") }
+    fn name(&self) -> &'static str { "Ex-Commands" }
+}
+```
+
+## Available Commands
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| `edit` | `e` | Open file for editing |
+| `quit` | `q` | Quit editor |
+| `write` | `w` | Write buffer to disk |
+| `write-quit` | `wq` | Write and quit |
+| `colorscheme` | - | Change color theme |
+| `detach` | - | Detach client from session |
+| `servers` | - | List running servers |
+| `kill-server` | - | Terminate server |
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait
+- `reovim_driver_command::ExCommandHandlerStore` - Command registration
+
+## Example Usage
+
+```rust
+use reovim_module_commands::{commands, ExCommandHandler};
+
+// Get all registered commands
+let cmds = commands();
+for cmd in &cmds {
+    println!("{}: {:?}", cmd.id(), cmd.names());
+}
+```
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [User Commands Guide](../../../user-guide/commands.md)

--- a/docs/architecture/modules/builtin/defaults.md
+++ b/docs/architecture/modules/builtin/defaults.md
@@ -1,0 +1,107 @@
+# defaults Module
+
+Meta-module that aggregates 13 default modules for standard editor functionality.
+
+## Source Location
+
+`server/modules/defaults/src/`
+
+## Purpose
+
+Provides a single entry point to load all default server-side modules. The runner
+can load this bundle to get core vim-like editor functionality.
+
+This module aggregates:
+
+**Service modules (6):**
+- `undo` - Undo/redo provider
+- `buffer-simple` - Buffer manager implementation
+- `search` - Search provider
+- `scratch-buffer` - Empty buffer on startup
+- `vfs-local` - Local filesystem VFS
+- `clipboard` - Clipboard operations
+
+**Utility modules (2):**
+- `keymap` - Keymap utilities
+- `commands` - Ex-commands
+
+**Policy modules (3):**
+- `editor` - Core editing operations
+- `motions` - Movement commands
+- `vim` - Vim-like behavior
+
+**Syntax modules (2):**
+- `treesitter-rust` - Rust syntax highlighting
+- `treesitter-markdown` - Markdown syntax highlighting
+
+## Key Types
+
+```rust
+pub struct DefaultsModule;
+
+impl DefaultsModule {
+    /// Create instances of all default server-side modules
+    pub fn create_modules() -> Vec<Box<dyn Module>> {
+        vec![
+            // Service modules
+            Box::new(undo::UndoModule::new()),
+            Box::new(buffer_simple::BufferSimpleModule::new()),
+            // ... 11 more modules
+        ]
+    }
+}
+
+impl Module for DefaultsModule {
+    fn id(&self) -> ModuleId { ModuleId::new("defaults") }
+    fn name(&self) -> &'static str { "Default Modules Bundle" }
+
+    fn dependencies(&self) -> Vec<ModuleId> {
+        // Returns all 13 module IDs
+    }
+}
+```
+
+## Helper Functions
+
+```rust
+/// Get all default operators (from vim module)
+pub fn operators() -> Vec<Box<dyn Operator>>;
+
+/// Get all default commands (from commands module)
+pub fn commands() -> Vec<Box<dyn ExCommandHandler>>;
+
+/// Get all default keybindings (from vim module)
+pub fn keybindings() -> Vec<KeybindingRegistration>;
+```
+
+## Dependencies
+
+All 13 sub-modules plus:
+- `reovim_kernel::api::v1` - Module trait
+
+## Example Usage
+
+```rust
+use reovim_module_defaults::DefaultsModule;
+
+// Load all default modules
+let modules = DefaultsModule::create_modules();
+for module in modules {
+    registry.load(module)?;
+}
+
+// Or just the bundle (declares dependencies)
+let defaults = DefaultsModule::new();
+registry.load(Box::new(defaults))?;
+```
+
+## Note on Client-Side Modules
+
+Client-side modules (layout, pair, cmdline, statusline, which-key, undotree)
+were removed in Epic #465 Phase 11. These will be reimplemented as client-side
+plugins.
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [vim Module](./vim.md)

--- a/docs/architecture/modules/builtin/mode-manager.md
+++ b/docs/architecture/modules/builtin/mode-manager.md
@@ -1,0 +1,72 @@
+# mode-manager Module
+
+Mode transition tracker that handles ModeChanged events.
+
+## Source Location
+
+`server/modules/mode-manager/src/`
+
+## Purpose
+
+Handles mode change events from the kernel `EventBus`. Subscribes to
+`ModeChanged` events and coordinates mode-related state across the editor.
+
+Following the kernel's "mechanism vs policy" principle:
+- Kernel provides the mode change events (mechanism)
+- This module decides how to react (policy)
+
+The kernel uses string-based modes (from/to) intentionally to keep mode policy
+in modules. The mode strings are opaque to the kernel. Examples: "Normal",
+"Insert", "Visual", "Command", etc.
+
+## Key Types
+
+```rust
+pub struct ModeManager {
+    /// Active subscriptions - stored to keep handlers active (RAII pattern)
+    subscriptions: Vec<Subscription>,
+}
+
+impl Module for ModeManager {
+    fn id(&self) -> ModuleId { ModuleId::new("mode-manager") }
+    fn name(&self) -> &'static str { "Mode State Manager" }
+    fn version(&self) -> Version { Version::new(0, 1, 0) }
+}
+```
+
+## Event Subscriptions
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `ModeChanged` | CORE (10) | Track mode transitions, update UI state |
+
+## Mode Semantics
+
+Mode strings are policy-defined by modules:
+
+| Mode | Description |
+|------|-------------|
+| `"Normal"` | Normal mode (default) |
+| `"Insert"` | Insert mode for text input |
+| `"Visual"` | Visual selection mode |
+| `"VisualLine"` | Line-wise visual selection |
+| `"VisualBlock"` | Block visual selection |
+| `"Command"` | Command-line mode |
+| `"Replace"` | Replace mode |
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait, EventBus, ModeChanged event
+
+## Future Enhancements
+
+When mode changes occur, this module can:
+- Update cursor style (block vs line)
+- Update status line display
+- Update available keybindings
+- Request render updates via `ctx.request_render()`
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [Mode Inheritance](../mode-inheritance.md)

--- a/docs/architecture/modules/builtin/options.md
+++ b/docs/architecture/modules/builtin/options.md
@@ -1,0 +1,95 @@
+# options Module
+
+Editor settings and configuration (virtualedit, etc.).
+
+## Source Location
+
+`server/modules/options/src/`
+
+## Purpose
+
+Provides configurable editor settings following vim's `:set` option pattern.
+Options are POLICY - they define how the editor behaves based on user preferences.
+The kernel provides mechanisms; this module provides configuration policy.
+
+## Key Types
+
+```rust
+/// When virtual edit is allowed
+pub enum VirtualEditMode {
+    None,      // Never (default)
+    All,       // Always allow
+    Block,     // Only in visual block mode (Ctrl-V)
+    Insert,    // Only in insert mode
+    OneMore,   // Cursor can be one past line end
+}
+
+/// Configuration for virtual edit behavior
+pub struct VirtualEditConfig {
+    modes: Vec<VirtualEditMode>,
+}
+
+impl VirtualEditConfig {
+    pub fn new() -> Self;
+    pub fn all() -> Self;
+    pub fn block_only() -> Self;
+    pub fn add_mode(&mut self, mode: VirtualEditMode);
+    pub fn remove_mode(&mut self, mode: VirtualEditMode);
+    pub fn allows_mode(&self, mode: VirtualEditMode) -> bool;
+    pub fn is_enabled(&self) -> bool;
+}
+
+/// Editor-wide settings container
+pub struct EditorSettings {
+    pub virtual_edit: VirtualEditConfig,
+}
+
+/// Options module
+pub struct OptionsModule {
+    settings: EditorSettings,
+}
+
+impl Module for OptionsModule {
+    fn id(&self) -> ModuleId { ModuleId::new("options") }
+    fn name(&self) -> &'static str { "Editor Options" }
+}
+```
+
+## Virtual Edit
+
+Virtual edit allows the cursor to move beyond the end of a line, into "virtual"
+space. This is useful for block selections and certain editing operations.
+
+Corresponds to vim's `virtualedit` option.
+
+## Example Usage
+
+```rust
+use reovim_module_options::{EditorSettings, VirtualEditMode};
+
+let mut settings = EditorSettings::default();
+
+// Allow virtual edit in block mode only
+settings.virtual_edit.add_mode(VirtualEditMode::Block);
+
+// Check if virtual edit is allowed for a specific mode
+assert!(!settings.virtual_edit.allows_mode(VirtualEditMode::Insert));
+assert!(settings.virtual_edit.allows_mode(VirtualEditMode::Block));
+```
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait
+
+## Future Enhancements
+
+Additional options to implement:
+- `number` / `relativenumber` - Line number display
+- `wrap` / `nowrap` - Line wrapping
+- `tabstop` / `shiftwidth` - Indentation settings
+- `ignorecase` / `smartcase` - Search case sensitivity
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [User Configuration](../../../user-guide/configuration.md)

--- a/docs/architecture/modules/builtin/scratch-buffer.md
+++ b/docs/architecture/modules/builtin/scratch-buffer.md
@@ -1,0 +1,93 @@
+# scratch-buffer Module
+
+Creates an empty buffer when a session starts with no buffers.
+
+## Source Location
+
+`server/modules/scratch-buffer/src/`
+
+## Purpose
+
+Provides `ScratchBufferHandler` which creates an empty buffer when a session
+starts with no buffers. Like a Linux driver's `probe()` function that initializes
+hardware, this handler initializes the editor with a usable state when no files
+are specified.
+
+Following the mechanism/policy separation:
+- **Mechanism**: `EmptySessionHandler` trait (in `reovim-driver-session`)
+- **Policy**: `ScratchBufferHandler` (this module) decides to create a buffer
+
+## Key Types
+
+```rust
+/// Handler that creates an empty scratch buffer
+pub struct ScratchBufferHandler;
+
+impl EmptySessionHandler for ScratchBufferHandler {
+    fn handle(&self, ctx: &EmptySessionContext) -> EmptySessionAction {
+        // If files were specified on command line, don't create scratch buffer
+        if !ctx.file_args.is_empty() {
+            return EmptySessionAction::None;
+        }
+
+        // Create an empty scratch buffer
+        EmptySessionAction::CreateBuffer {
+            name: None,  // Unnamed scratch buffer
+            content: String::new(),
+        }
+    }
+
+    fn priority(&self) -> u32 {
+        100  // Default module priority
+    }
+
+    fn id(&self) -> &'static str {
+        "scratch-buffer:handler"
+    }
+}
+
+/// Module instance
+pub struct ScratchBufferModule;
+
+impl Module for ScratchBufferModule {
+    fn id(&self) -> ModuleId { ModuleId::new("scratch-buffer") }
+    fn name(&self) -> &'static str { "Scratch Buffer" }
+}
+```
+
+## Behavior
+
+| Scenario | Action |
+|----------|--------|
+| No files specified | Creates empty scratch buffer |
+| Files on command line | Returns `None` (lets file opener handle them) |
+
+## Registration
+
+During `init()`, the module registers itself with the `SessionHandlerRegistry`:
+
+```rust
+fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+    let handler_registry = ctx.services.get_or_create::<SessionHandlerRegistry>();
+    handler_registry.register(
+        SessionHandlerKey::Empty,
+        Arc::new(ScratchBufferHandler)
+    );
+    ProbeResult::Success
+}
+```
+
+## Priority
+
+Uses the default priority (100), allowing core handlers (0-50) to take precedence
+if needed.
+
+## Dependencies
+
+- `reovim_kernel::api::v1` - Module trait
+- `reovim_driver_session` - EmptySessionHandler trait, registry types
+
+## Related Documents
+
+- [Module System Overview](../overview.md)
+- [session Driver](../../drivers/session/overview.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -217,7 +217,7 @@ shared/
 
 - [Session Model](./session-model.md) - tmux-like multi-client architecture
 - [Mechanism vs Policy](./mechanism-vs-policy.md) - Core principle
-- [Module-Mode Inheritance](./module-mode-inheritance.md) - Mode system
-- [Kernel Subsystems](./kernel.md) - Kernel internals
-- [Driver Layer](./drivers.md) - Driver implementations
-- [Module System](./modules.md) - Dynamic modules
+- [Module-Mode Inheritance](./modules/mode-inheritance.md) - Mode system
+- [Kernel Subsystems](./kernel/overview.md) - Kernel internals
+- [Driver Layer](./drivers/overview.md) - Driver implementations
+- [Module System](./modules/overview.md) - Dynamic modules

--- a/docs/architecture/server/debug/overview.md
+++ b/docs/architecture/server/debug/overview.md
@@ -1,0 +1,213 @@
+# debug/ - Server Debug Infrastructure
+
+Post-mortem analysis and debugging infrastructure for server-side crash reporting.
+
+## Source Location
+
+`server/lib/server/src/debug/`
+
+## Architecture
+
+```
++------------------------------------------------------------------+
+|                      Debug Infrastructure                          |
+|                                                                    |
+|  Server Ring Buffer (64 KB)                                        |
+|  +-----------------------------------------------------------+    |
+|  | Captures: pr_err!, pr_info!, pr_warn!, pr_debug!          |    |
+|  | Thread-safe: parking_lot::RwLock                          |    |
+|  | Non-blocking: try_dump() for panic safety                 |    |
+|  +-----------------------------------------------------------+    |
+|                           |                                        |
+|         +-----------------+------------------+                     |
+|         |                                    |                     |
+|  Per-Client Buffers (8 KB each)     CompositeLogger               |
+|  +------------------------+         +------------------------+     |
+|  | Keys, commands, mode   |         | Forwards to:           |     |
+|  | Dump on disconnect to  |         | - Ring buffer          |     |
+|  | crash/ directory       |         | - tracing subscriber   |     |
+|  +------------------------+         +------------------------+     |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Components
+
+### ring_buffer.rs - Debug Ring Buffer
+
+A lock-free ring buffer for capturing events for crash analysis:
+
+```rust
+pub struct DebugRingBuffer {
+    // 64 KB server-wide buffer
+    // 8 KB per-client buffers
+}
+
+impl DebugRingBuffer {
+    pub fn push(&self, entry: LogEntry);
+    pub fn dump(&self) -> Vec<LogEntry>;
+    pub fn try_dump(&self) -> Option<Vec<LogEntry>>; // Non-blocking
+    pub fn stats(&self) -> BufferStats;
+}
+```
+
+**Key exports:**
+- `DebugRingBuffer` - The ring buffer implementation
+- `LogEntry` - Log entry with timestamp, level, target, message
+- `LogEntryView` - View into entry without allocation
+- `BufferStats` - Buffer statistics
+- `init_debug_ring()` - Initialize global ring buffer
+- `debug_ring()` - Get reference to global buffer
+- `try_debug_ring()` - Non-blocking access for panic handler
+
+**Constants:**
+- `DEFAULT_CAPACITY` - 64 KB (server), 8 KB (per-client)
+- `MAX_MESSAGE_LEN` - Maximum message length before truncation
+
+### composite_logger.rs - Dual Output Logger
+
+Forwards log messages to both ring buffer and tracing:
+
+```rust
+pub struct CompositeLogger {
+    ring_buffer: Arc<DebugRingBuffer>,
+    tracing_subscriber: TracingSubscriber,
+}
+
+impl Logger for CompositeLogger {
+    fn log(&self, entry: LogEntry) {
+        self.ring_buffer.push(entry.clone());
+        self.tracing_subscriber.emit(entry);
+    }
+}
+```
+
+**Key exports:**
+- `CompositeLogger` - The dual-output logger
+- `COMPOSITE_LOGGER` - Global singleton
+
+## Integration Points
+
+### Kernel Logger Trait
+
+The ring buffer implements the kernel's `Logger` trait:
+
+```rust
+// server/lib/kernel/src/api/logger.rs
+pub trait Logger: Send + Sync {
+    fn log(&self, level: Level, target: &str, message: &str);
+}
+```
+
+This enables kernel code to log via `pr_err!`, `pr_info!`, etc.
+
+### Panic Handler Integration
+
+The debug ring buffer integrates with the panic subsystem:
+
+```rust
+use reovim_kernel::panic::set_debug_context_callback;
+
+set_debug_context_callback(Box::new(|| {
+    DebugContext {
+        server_logs: try_debug_ring()
+            .map(|rb| rb.try_dump())
+            .flatten()
+            .unwrap_or_default(),
+        client_dump_paths: /* ... */,
+    }
+}));
+```
+
+### Client Disconnect Dumps
+
+When a client disconnects, their ring buffer is dumped:
+
+```rust
+// Session::remove_client()
+fn remove_client(&self, client_id: ClientId) {
+    // Dump client ring buffer to file
+    let path = format!(
+        "~/.local/share/reovim/crash/client-{}-{}.log",
+        client_id, timestamp
+    );
+    client.ring_buffer.dump_to_file(&path);
+
+    // Log disconnect to server ring buffer
+    self.ring_buffer.push(LogEntry::new(
+        Level::Info,
+        "session",
+        format!("CLIENT_DISCONNECT: {}", client_id),
+    ));
+}
+```
+
+## CLI Access
+
+Query the ring buffer via the CLI:
+
+```bash
+# Get recent log entries
+reovim cli log-tail
+
+# Filter by count
+reovim cli log-tail --count 100
+
+# Filter by level (trace, debug, info, warn, error)
+reovim cli log-tail --level warn
+
+# Filter by target module
+reovim cli log-tail --target runner::server
+
+# Search messages
+reovim cli log-tail --grep "connection"
+
+# Stream logs (like tail -f)
+reovim cli log-tail --follow
+
+# JSON output
+reovim cli --format json log-tail
+```
+
+**Color coding (TTY output):**
+- ERROR: Red
+- WARN: Yellow
+- INFO: Green
+- DEBUG: Cyan
+- TRACE: Gray
+
+## gRPC Protocol
+
+The `DebugService` provides access via gRPC:
+
+```protobuf
+// shared/protocol/proto/reovim/v2/debug.proto
+service DebugService {
+    rpc LogTail(LogTailRequest) returns (LogTailResponse);
+    rpc LogLevel(LogLevelRequest) returns (LogLevelResponse);
+}
+
+message LogTailRequest {
+    optional uint32 count = 1;
+    optional string level = 2;
+    optional string target = 3;
+    optional string grep = 4;
+}
+
+message LogTailResponse {
+    repeated LogEntry entries = 1;
+}
+```
+
+## File Locations
+
+| Type | Path |
+|------|------|
+| Crash reports | `~/.local/share/reovim/crash/crash-{date}_{time}-{nanos}.txt` |
+| Client dumps | `~/.local/share/reovim/crash/client-{id}-{timestamp}.log` |
+| Recovery files | `~/.local/share/reovim/recovery/` |
+
+## Related Documents
+
+- [Kernel Panic Handling](../../kernel/panic/overview.md) - Panic subsystem
+- [Server Mode](../../../user-guide/server-mode.md) - CLI usage

--- a/docs/contributing/guides/testing.md
+++ b/docs/contributing/guides/testing.md
@@ -49,14 +49,14 @@ Reovim includes an end-to-end integration test system that uses server mode to v
 ### Architecture
 
 ```
-ServerTestHarness
+TestServerHarness
 ├── Spawns: reovim server --tcp <port>
-├── TestClient (TCP connection via JSON-RPC)
+├── GrpcClient (TCP connection via gRPC)
 └── Auto-cleanup on Drop
 
 Test Flow:
-┌─────────────┐     JSON-RPC      ┌─────────────────────────┐
-│ TestClient  │ ────────────────→ │    reovim server        │
+┌─────────────┐      gRPC         ┌─────────────────────────┐
+│ GrpcClient  │ ────────────────→ │    reovim server        │
 │             │                   │                         │
 │ keys()      │  input/keys       │  ChannelKeySource       │
 │ mode()      │  state/mode       │  Runtime                │
@@ -88,18 +88,18 @@ cargo test -p reovim-module-vim test_visual_mode
 
 ```rust
 mod common;
-use common::*;
+use common::IntegrationTest;
 
 #[tokio::test]
 async fn test_example() {
-    let result = ServerTest::new()
+    let result = IntegrationTest::new()
         .await
-        .with_content("hello\nworld")  // Initial buffer content
-        .with_keys("jj")               // Key sequence (vim notation)
+        .with_buffer("hello\nworld")   // Initial buffer content
+        .send_keys("jj")               // Key sequence (vim notation)
         .run()
         .await;
 
-    result.assert_cursor(0, 2);
+    result.assert_cursor(2, 0);
     result.assert_normal_mode();
 }
 ```
@@ -122,14 +122,14 @@ async fn test_example() {
 
 **Examples:**
 ```rust
-.with_keys("ihello<Esc>")    // Enter insert, type "hello", escape
-.with_keys(":wq<CR>")        // Command mode, type "wq", enter
-.with_keys("<C-d>")          // Ctrl+D
-.with_keys("5j")             // Move down 5 lines
-.with_keys("daw")            // Delete a word
+.send_keys("ihello<Esc>")    // Enter insert, type "hello", escape
+.send_keys(":wq<CR>")        // Command mode, type "wq", enter
+.send_keys("<C-d>")          // Ctrl+D
+.send_keys("5j")             // Move down 5 lines
+.send_keys("daw")            // Delete a word
 ```
 
-#### ServerTestResult Assertions
+#### TestResult Assertions
 
 | Method | Description |
 |--------|-------------|
@@ -141,19 +141,19 @@ async fn test_example() {
 | `assert_buffer_contains("text")` | Buffer contains substring |
 | `assert_buffer_eq("text")` | Buffer equals exactly |
 
-#### Accessing ServerTestResult Fields
+#### Accessing TestResult Fields
 
 ```rust
-let result = ServerTest::new()
+let result = IntegrationTest::new()
     .await
-    .with_keys("ihello<Esc>")
+    .send_keys("ihello<Esc>")
     .run()
     .await;
 
 // Direct field access
-println!("Mode: {:?}", result.mode);
+println!("Mode: {:?}", result.edit_mode);
 println!("Buffer: {}", result.buffer_content);
-println!("Cursor: {:?}", result.cursor);
+println!("Cursor: line={}, col={}", result.cursor_line, result.cursor_column);
 ```
 
 ### Integration Test Organization
@@ -218,217 +218,44 @@ IntegrationTest::new()
     .await
 ```
 
-### Visual Testing
+### Step-by-Step Testing
 
-Reovim includes visual debugging infrastructure for testing TUI output. This enables:
-- ASCII art snapshots for human-readable debugging
-- Structured visual snapshots (JSON) for programmatic assertions
-- Layer visibility testing
-- Cell-level content verification
-
-#### Screen Size Configuration
-
-Set explicit screen dimensions for deterministic visual tests:
+For tests that need to verify state at each keystroke, use `StepTest`:
 
 ```rust
-let mut result = ServerTest::new()
-    .await
-    .with_size(80, 24)  // Width x Height
-    .with_content("Hello World")
-    .run()
-    .await;
+use shared::testing::StepTest;
 
-let snap = result.visual_snapshot().await;
-assert_eq!(snap.width, 80);
-assert_eq!(snap.height, 24);
-```
+#[tokio::test]
+async fn test_delete_word_step_by_step() {
+    let trace = StepTest::new()
+        .await
+        .with_buffer("hello world")
+        .step("d")
+            .expect_mode_contains("DELETE")
+        .step("w")
+            .expect_buffer("world")
+        .run()
+        .await;
 
-#### Visual Snapshot Methods
-
-| Method | Description |
-|--------|-------------|
-| `visual_snapshot()` | Get structured snapshot with cells, cursor, layers |
-| `ascii_art(false)` | Get plain ASCII representation |
-| `ascii_art(true)` | Get annotated ASCII with borders and line numbers |
-| `layer_info()` | Get layer visibility and bounds |
-
-**Example: Visual Snapshot**
-
-```rust
-let mut result = ServerTest::new()
-    .await
-    .with_size(40, 10)
-    .with_content("Hello World")
-    .run()
-    .await;
-
-let snap = result.visual_snapshot().await;
-
-// Check dimensions
-assert_eq!(snap.cells.len(), 10);  // 10 rows
-assert_eq!(snap.cells[0].len(), 40);  // 40 columns each
-
-// Check cursor
-if let Some(cursor) = &snap.cursor {
-    println!("Cursor at ({}, {})", cursor.x, cursor.y);
-}
-
-// Check plain text content
-assert!(snap.plain_text.contains("Hello World"));
-```
-
-**Example: ASCII Art Debugging**
-
-```rust
-let mut result = ServerTest::new()
-    .await
-    .with_size(40, 10)
-    .with_content("fn main() {\n    println!(\"Hello\");\n}")
-    .run()
-    .await;
-
-// Plain ASCII
-let plain = result.ascii_art(false).await;
-println!("{}", plain);
-// Output:
-//   1 fn main() {
-//   2     println!("Hello");
-//   3 }
-// ~
-// ...
-
-// Annotated ASCII (with borders and column numbers)
-let annotated = result.ascii_art(true).await;
-println!("{}", annotated);
-// Output:
-//    0123456789...
-//   +----------------------------------------+
-//  0|  1 fn main() {                         |
-//  1|  2     println!("Hello");              |
-//  2|  3 }                                   |
-//   +----------------------------------------+
-```
-
-**Example: Layer Visibility Testing**
-
-```rust
-// Test that which-key layer appears after timeout
-let mut result = ServerTest::new()
-    .await
-    .with_size(80, 24)
-    .with_keys("g")
-    .with_delay(600)  // Wait for which-key popup
-    .run()
-    .await;
-
-let layers = result.layer_info().await;
-assert!(layers.iter().any(|l| l.name == "which_key" && l.visible));
-
-// Test microscope layer
-let mut result = ServerTest::new()
-    .await
-    .with_size(80, 24)
-    .with_keys(" ff")  // Open microscope
-    .with_delay(100)
-    .run()
-    .await;
-
-let layers = result.layer_info().await;
-assert!(layers.iter().any(|l| l.name == "microscope" && l.visible));
-```
-
-#### Visual Assertions Trait
-
-The `VisualAssertions` trait provides assertion methods on `VisualSnapshot`:
-
-```rust
-use reovim_core::testing::VisualAssertions;
-
-let snap = result.visual_snapshot().await;
-
-// Assert specific cell character
-snap.assert_cell_char(0, 0, 'H');
-
-// Assert row content (trimmed)
-snap.assert_row_content(0, "  1 Hello World");
-
-// Assert row starts with prefix
-snap.assert_row_starts_with(0, "  1");
-
-// Assert screen contains text
-snap.assert_contains("Hello World");
-
-// Assert region contains text
-snap.assert_region_contains(0, 0, 20, 5, "Hello");
-```
-
-#### Full Screen Cell Verification
-
-Verify that the screen has the expected dimensions:
-
-```rust
-let mut result = ServerTest::new()
-    .await
-    .with_size(40, 10)
-    .run()
-    .await;
-
-let snap = result.visual_snapshot().await;
-
-// Verify exact row count
-assert_eq!(snap.cells.len(), 10, "Should have 10 rows");
-
-// Verify each row has correct width
-for (y, row) in snap.cells.iter().enumerate() {
-    assert_eq!(row.len(), 40, "Row {} should have 40 cells", y);
+    trace.assert_ok();
 }
 ```
 
-#### VisualSnapshot Structure
+### Frame Assertions
+
+For tests that need to verify TUI output:
 
 ```rust
-pub struct VisualSnapshot {
-    pub width: u16,
-    pub height: u16,
-    pub cells: Vec<Vec<CellSnapshot>>,  // cells[y][x]
-    pub cursor: Option<CursorInfo>,
-    pub layers: Vec<LayerInfo>,
-    pub plain_text: String,
-}
+use shared::testing::frame::{assert_frame_contains, assert_statusline_mode};
 
-pub struct CellSnapshot {
-    pub char: char,
-    pub fg: Option<String>,   // "#RRGGBB"
-    pub bg: Option<String>,
-    pub bold: bool,
-    pub italic: bool,
-    pub underline: bool,
-}
+// Assert frame contains text
+assert_frame_contains(&frame, "Hello");
 
-pub struct CursorInfo {
-    pub x: u16,
-    pub y: u16,
-    pub layer: String,  // "editor", "microscope", etc.
-}
+// Assert statusline shows mode
+assert_statusline_mode(&frame, "NORMAL");
 
-pub struct LayerInfo {
-    pub name: String,
-    pub z_order: u8,
-    pub visible: bool,
-    pub bounds: BoundsInfo,  // x, y, width, height
-}
-```
-
-#### Visual Test Organization
-
-```
-lib/core/tests/
-├── visual_snapshot.rs      # Visual testing tests
-│   ├── Screen size tests   # Explicit dimensions, full screen cells
-│   ├── Basic snapshot      # Content verification, ASCII art
-│   ├── Layer tests         # Editor, microscope, which-key
-│   └── Visual assertions   # Cell/row/content checks
-└── ...
+// Assert specific line content
+assert_frame_line_contains(&frame, 0, "fn main");
 ```
 
 ### Best Practices
@@ -436,7 +263,7 @@ lib/core/tests/
 1. **Build release first** - Tests spawn `./target/release/reovim`
 2. **Keep key sequences short** - Long sequences are harder to debug
 3. **Test one behavior per test** - Makes failures easier to diagnose
-4. **Use `with_content()` for cursor tests** - Need text to move through
+4. **Use `with_buffer()` for cursor tests** - Need text to move through
 5. **Tests run in parallel** - Each spawns its own server on an OS-assigned port
 
 ## Phase 7+ Integration Tests
@@ -451,11 +278,11 @@ IntegrationTest (Builder)
 │   ├── Spawns: reovim server --tcp 0 (OS-assigned port)
 │   ├── Parses port from stderr
 │   └── kill_on_drop(true) for cleanup
-├── RpcClient (TCP JSON-RPC connection)
+├── GrpcClient (TCP gRPC connection)
 └── TestResult (captures final state)
 
 Test Flow:
-┌──────────────────┐     JSON-RPC      ┌─────────────────────────┐
+┌──────────────────┐       gRPC        ┌─────────────────────────┐
 │ IntegrationTest  │ ────────────────→ │    reovim server        │
 │                  │                   │                         │
 │ with_buffer()    │  buffer/set       │  Buffer state           │
@@ -613,13 +440,12 @@ This approach ensures:
 
 ### How It Works
 
-1. `ServerTest::new()` spawns `reovim server --tcp <port>`
-2. Server binds to specified port (tests use atomic counter for unique ports)
-3. Server prints `Listening on 127.0.0.1:<port>` to stderr
-4. Test harness reads stderr to discover the actual port
-5. `TestClient` connects via TCP and sends commands
-6. Keys are injected with 1ms delay between each (for mode propagation)
-7. After keys, 50ms delay allows processing before querying state
+1. `IntegrationTest::new()` spawns `reovim server --tcp 0` (OS-assigned port)
+2. Server binds to an ephemeral port and prints `Listening on 127.0.0.1:<port>` to stderr
+3. Test harness reads stderr to discover the actual port
+4. `GrpcClient` connects via gRPC and sends commands
+5. Keys are injected with delays between each (for mode propagation)
+6. After keys, delay allows processing before querying state
 8. Test cleans up server via kill command
 
 ## Current Test Coverage

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -1,0 +1,218 @@
+# CLI Reference
+
+Complete command reference for reovim server, CLI client, and TUI client.
+
+## Server Commands
+
+### Starting the Server
+
+```bash
+# Default: Start server + TUI in one command (tmux-like)
+cargo run
+# Server spawns in background, TUI attaches automatically
+# TUI exit doesn't kill server (graceful detach)
+
+# Start server in detached/daemon mode (no TUI)
+cargo run -- -d
+cargo run -- --detach
+
+# Explicit server mode (TCP on 127.0.0.1:12521, or next available port)
+cargo run -- server
+# Server prints "Listening on 127.0.0.1:<PORT>" to stderr
+
+# Run server with stdio transport
+cargo run -- server --stdio
+
+# Run server on Unix socket
+cargo run -- server --socket /tmp/reovim.sock
+
+# Run server on custom TCP port
+cargo run -- server --tcp 9000
+```
+
+### Server Options
+
+| Flag | Description |
+|------|-------------|
+| `-d`, `--detach` | Start server in daemon mode (no TUI) |
+| `--tcp <PORT>` | Listen on custom TCP port (default: 12521) |
+| `--socket <PATH>` | Listen on Unix socket |
+| `--stdio` | Use stdio transport (always one-shot) |
+
+## CLI Client Commands
+
+The CLI client provides command-line access to running reovim servers.
+
+### Connection Options
+
+```bash
+# Auto-discover and connect to available server
+reovim cli <command>
+
+# Connect to specific server via TCP
+reovim cli --tcp 127.0.0.1:12521 <command>
+
+# Connect to specific server via Unix socket
+reovim cli --socket /tmp/reovim.sock <command>
+
+# JSON output format
+reovim cli --format json <command>
+```
+
+### Server Management
+
+```bash
+# List running servers
+reovim cli list
+
+# Kill server
+reovim cli kill
+```
+
+### Key Input
+
+```bash
+# Inject key sequence (vim notation)
+reovim cli keys 'iHello<Esc>'
+
+# Examples
+reovim cli keys '100gg'              # Go to line 100
+reovim cli keys ':%s/foo/bar/g<CR>'  # Search and replace
+reovim cli keys ':wq<CR>'            # Save and quit
+```
+
+### State Queries
+
+```bash
+# Get current mode
+reovim cli mode
+
+# Get cursor position
+reovim cli cursor
+
+# Get layout information
+reovim cli layout
+```
+
+### Debug Commands
+
+```bash
+# Get/set log level dynamically
+reovim cli log-level                 # Get current level
+reovim cli log-level debug           # Set to debug
+
+# View recent log entries
+reovim cli log-tail                  # Last 50 entries
+reovim cli log-tail --count 100      # Last 100 entries
+
+# Filter logs
+reovim cli log-tail --level warn     # WARN and above
+reovim cli log-tail --target runner  # Filter by module
+reovim cli log-tail --grep "error"   # Search messages
+
+# Stream logs in real-time (like tail -f)
+reovim cli log-tail --follow
+reovim cli log-tail --follow --level warn
+```
+
+### Frame Capture
+
+```bash
+# Capture TUI frame (requires connected TUI)
+reovim cli capture                        # With ANSI colors
+reovim cli capture --format plain_text    # Plain text without colors
+```
+
+### Interactive REPL
+
+```bash
+reovim cli -i                        # Enter interactive mode
+
+# REPL commands
+reovim> keys iHello<Esc>
+ok: true
+reovim> mode
+Mode: NORMAL
+reovim> cursor
+Cursor: line 0, column 5
+reovim> quit
+```
+
+## TUI Client Commands
+
+The TUI client provides a full terminal user interface.
+
+### Starting the TUI
+
+```bash
+# Auto-discover and connect to server
+reovim tui
+
+# Connect to specific server
+reovim tui --tcp 127.0.0.1:12521
+reovim tui --socket /tmp/reovim.sock
+
+# Attach to existing server
+cargo run -- attach
+cargo run -- attach --tcp 127.0.0.1:12521
+```
+
+### TUI Debug Mode
+
+```bash
+# Enable debug statusline and frame capture
+reovim tui --debug
+
+# Custom log directory
+reovim tui --debug --debug-dir /tmp/reovim-debug
+
+# Custom session name
+reovim tui --debug --debug-name mysession
+
+# Headless mode (no TTY, for CI/scripting)
+reovim tui --headless
+```
+
+### TUI Options
+
+| Flag | Description |
+|------|-------------|
+| `--tcp <ADDR>` | Connect to server via TCP |
+| `--socket <PATH>` | Connect to server via Unix socket |
+| `--debug` | Enable debug mode (statusline + frame capture) |
+| `--debug-dir <DIR>` | Custom log directory |
+| `--debug-name <NAME>` | Session name for filenames |
+| `--headless` | Headless mode for CI/scripting |
+
+### Debug Output Files
+
+When debug mode is enabled:
+
+- **Session log**: `~/.local/share/reovim/logs/tui/{name}_{start_time}.log`
+- **Frame captures**: `~/.local/share/reovim/logs/tui/frame-buffer/{name}-{timestamp}.frame`
+
+**Statusline format:**
+```
+[YY-MM-DD HH:MM:SS TZ] [server: ADDR] [mode: MODE] [modules: N]
+```
+
+## Key Notation
+
+| Notation | Key Event |
+|----------|-----------|
+| `a`-`z`, `0`-`9` | Character keys |
+| `<Esc>` | Escape key |
+| `<CR>` or `<Enter>` | Enter key |
+| `<BS>` | Backspace |
+| `<Tab>` | Tab |
+| `<Space>` | Space |
+| `<C-x>` | Ctrl+X |
+| `<S-x>` | Shift+X |
+| `<Up>`, `<Down>`, `<Left>`, `<Right>` | Arrow keys |
+| `<Home>`, `<End>` | Navigation keys |
+| `<PageUp>`, `<PageDown>` | Page keys |
+
+## Related Documents
+
+- [Server Mode](./server-mode.md) - Server architecture and RPC protocol
+- [Commands](./commands.md) - Ex-commands reference

--- a/docs/user-guide/server-mode.md
+++ b/docs/user-guide/server-mode.md
@@ -1,6 +1,6 @@
 # Server Mode
 
-Reovim can run as a JSON-RPC 2.0 server for programmatic control, enabling integration with external tools, IDEs, and automation scripts.
+Reovim can run as a gRPC server for programmatic control, enabling integration with external tools, IDEs, and automation scripts.
 
 ## Quick Start
 
@@ -229,58 +229,49 @@ reovim tui --debug --debug-name mysession
 | `--debug-dir <DIR>` | Custom log directory (default: `~/.local/share/reovim/logs/tui/`) |
 | `--debug-name <NAME>` | Session name for filenames (default: `default`) |
 
-## JSON-RPC Protocol
+## gRPC Protocol
 
-### Request Format
+Reovim uses gRPC v2 protocol for client-server communication. The protocol definitions are in `shared/protocol/proto/reovim/v2/`.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "keys",
-  "params": { "keys": "iHello<Esc>" }
-}
+### Available Services
+
+| Service | Purpose |
+|---------|---------|
+| `InputService` | Key injection (SendKeys) |
+| `StateService` | Query mode, cursor, layout, selection |
+| `BufferService` | Buffer content access |
+| `NotificationService` | Server-to-client streaming |
+| `PresenceService` | Multi-client collaboration |
+| `SyntaxService` | Syntax token queries |
+| `DebugService` | Log level and log tail access |
+| `ServerService` | Ping, info, kill |
+
+### Key Methods
+
+| Method | Service | Description |
+|--------|---------|-------------|
+| `SendKeys` | InputService | Inject key sequence |
+| `GetMode` | StateService | Get current mode |
+| `GetCursor` | StateService | Get cursor position |
+| `GetLayout` | StateService | Get window layout |
+| `GetSelection` | StateService | Get visual selection |
+| `GetRawContent` | BufferService | Get buffer content |
+| `SubscribeNotifications` | NotificationService | Stream notifications |
+| `LogTail` | DebugService | Get log entries |
+| `Kill` | ServerService | Terminate server |
+
+### Protocol Files
+
 ```
-
-### Response Format
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "mode": "Normal",
-    "cursor": { "line": 0, "column": 5 }
-  }
-}
-```
-
-### Available Methods
-
-| Method | Params | Description |
-|--------|--------|-------------|
-| `keys` | `{ keys: string }` | Inject key sequence |
-| `screen` | `{ format?: string }` | Get screen content |
-| `screen_size` | - | Get terminal dimensions |
-| `cursor` | - | Get cursor position |
-| `mode` | - | Get current mode |
-| `kill` | - | Terminate server |
-| `debug/log_level` | `{ level?: string }` | Get/set log level |
-| `debug/log_tail` | `{ count?, level?, target?, grep? }` | Get filtered log entries |
-| `debug/log_subscribe` | `{ level?: string }` | Subscribe to log stream |
-| `debug/log_unsubscribe` | `{ subscription_id: number }` | Unsubscribe from log stream |
-
-### Screen Formats
-
-```json
-// Plain text (default)
-{ "method": "screen", "params": { "format": "plain" } }
-
-// Raw ANSI escape sequences
-{ "method": "screen", "params": { "format": "ansi" } }
-
-// Cell grid (structured)
-{ "method": "screen", "params": { "format": "cells" } }
+shared/protocol/proto/reovim/v2/
+├── input.proto          # InputService
+├── state.proto          # StateService
+├── buffer.proto         # BufferService
+├── notification.proto   # NotificationService, payloads
+├── presence.proto       # PresenceService
+├── syntax.proto         # SyntaxService
+├── debug.proto          # DebugService
+└── server.proto         # ServerService
 ```
 
 ## Use Cases
@@ -370,7 +361,7 @@ The default port `12521` is derived from ASCII: `'r'×100 + 'e'×10 + 'o' = 114�
 
 ### Architecture
 
-- `RpcServer` coordinates JSON-RPC 2.0 request handling
+- gRPC services handle client requests
 - `TransportConfig` selects transport: Stdio, UnixSocket, Tcp
 - `TransportReader`/`TransportWriter` provide async I/O abstraction
 - `TransportListener` accepts connections for socket/TCP


### PR DESCRIPTION
- Fix CLAUDE.md
- Add missing crate names (reovim-testing, reovim-log, etc.)
- Add Plan Files section with naming convention
- Simplify Build Commands section
- Fix 4 broken links in docs/architecture/overview.md
- Migrate server-mode.md from JSON-RPC to gRPC
- Fix fabricated APIs in testing.md (ServerTest, with_keys, with_content)
- Document kernel panic subsystem
- Document server debug ring buffer infrastructure
- Create CLI reference guide
- buffer-ops, commands, defaults, mode-manager
- options, buffer-simple, scratch-buffer
- buffer, clipboard, command-types, ffi
- ffi-python, search, syntax-treesitter, undo
- Update modules/builtin/README.md
- Update drivers/overview.md
- Update CHANGELOG.md

Closes #489, Closes #490