### PR TITLE
feat(undo): OT-lite conflict resolution for multi-client undo (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- **OT-lite conflict resolution for multi-client undo (#495)**: When multiple
+  clients edit a shared buffer, each client's undo now correctly adjusts
+  positions through intervening edits from other clients. Kernel provides
+  general-purpose `transform_position()` (inclusion transformation),
+  `TextDimensions`, `delete_end()`, `Edit::transform()`, and
+  `UndoTree::edits_since()`. The undo module's `undo_for_client()` uses these
+  to transform inverse edits and cursor positions through all edits that
+  occurred after the target node. Without this, Client 0 undoing after Client 1
+  inserted text before Client 0's edit would incorrectly remove Client 1's text.
+
 - **Code coverage infrastructure**: Added `scripts/coverage.sh` for local
   coverage with four modes (`line`, `branch`, `mcdc`, `server`) using
   `cargo-llvm-cov`. CI generates MC/DC coverage for non-server crates and

--- a/server/lib/kernel/src/api/v1.rs
+++ b/server/lib/kernel/src/api/v1.rs
@@ -43,7 +43,10 @@ pub use super::context::{KernelContext, ModuleContext};
 // Memory Management (mm/)
 // ============================================================================
 
-pub use crate::mm::{Buffer, BufferId, Cursor, Edit, Position, WindowId};
+pub use crate::mm::{
+    Buffer, BufferId, Cursor, Edit, Position, TextDimensions, WindowId, delete_end,
+    text_dimensions, transform_position,
+};
 
 // Selection types
 pub use crate::mm::{Selection, SelectionMode};

--- a/server/lib/kernel/src/block/tests.rs
+++ b/server/lib/kernel/src/block/tests.rs
@@ -805,6 +805,240 @@ mod undo_tree_tests {
     }
 }
 
+// === edits_since Tests (#495) ===
+
+mod edits_since_tests {
+    use {super::*, crate::block::EditOrigin};
+
+    #[test]
+    fn test_edits_since_same_as_current() {
+        let mut tree = UndoTree::new();
+
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "AAA")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+            EditOrigin::Client(0),
+        );
+
+        // from_idx == current → empty vec
+        let edits = tree.edits_since(tree.current_index()).unwrap();
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn test_edits_since_one_step() {
+        let mut tree = UndoTree::new();
+
+        // Node 1: Client A inserts "AAA"
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "AAA")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+            EditOrigin::Client(0),
+        );
+
+        // Node 2: Client B inserts "BBB"
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 3), "BBB")],
+            Position::new(0, 3),
+            Position::new(0, 6),
+            EditOrigin::Client(1),
+        );
+
+        // Edits since node 1 (current is node 2)
+        let edits = tree.edits_since(1).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].text(), "BBB");
+        assert!(edits[0].is_insert());
+    }
+
+    #[test]
+    fn test_edits_since_multiple_steps() {
+        let mut tree = UndoTree::new();
+
+        // Node 1: Client A
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "A1")],
+            Position::new(0, 0),
+            Position::new(0, 2),
+            EditOrigin::Client(0),
+        );
+
+        // Node 2: Client B
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 2), "B1")],
+            Position::new(0, 2),
+            Position::new(0, 4),
+            EditOrigin::Client(1),
+        );
+
+        // Node 3: Client C
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 4), "C1")],
+            Position::new(0, 4),
+            Position::new(0, 6),
+            EditOrigin::Client(2),
+        );
+
+        // Edits since node 1 → should include nodes 2 and 3 in order
+        let edits = tree.edits_since(1).unwrap();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].text(), "B1"); // forward order: B first
+        assert_eq!(edits[1].text(), "C1"); // then C
+    }
+
+    #[test]
+    fn test_edits_since_not_ancestor() {
+        let mut tree = UndoTree::new();
+
+        // Create branching: root → A → B
+        //                          ↘ C (current)
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+            EditOrigin::Client(0),
+        );
+
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+            EditOrigin::Client(1),
+        );
+
+        // B is node 2, undo back to A
+        tree.undo();
+
+        // Push C (creates branch)
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 1), "C")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+            EditOrigin::Client(2),
+        );
+
+        // Current is C (node 3). B (node 2) is NOT an ancestor of C.
+        assert!(tree.edits_since(2).is_none());
+    }
+
+    #[test]
+    fn test_edits_since_with_branches() {
+        let mut tree = UndoTree::new();
+
+        // root → A → B → C
+        //           ↘ D (branch)
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+            EditOrigin::Client(0),
+        );
+
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 1), "B")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+            EditOrigin::Client(1),
+        );
+
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 2), "C")],
+            Position::new(0, 2),
+            Position::new(0, 3),
+            EditOrigin::Client(2),
+        );
+
+        // Now undo to A and create branch D
+        tree.undo(); // at B
+        tree.undo(); // at A
+
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 1), "D")],
+            Position::new(0, 1),
+            Position::new(0, 2),
+            EditOrigin::Client(3),
+        );
+
+        // Current is D. edits_since(A) should be just D's edits.
+        // A is node 1.
+        let edits = tree.edits_since(1).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].text(), "D");
+
+        // edits_since(root) should be A + D in order
+        let edits = tree.edits_since(0).unwrap();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].text(), "A");
+        assert_eq!(edits[1].text(), "D");
+    }
+
+    #[test]
+    fn test_edits_since_out_of_bounds() {
+        let tree = UndoTree::new();
+        assert!(tree.edits_since(999).is_none());
+    }
+
+    #[test]
+    fn test_edits_since_batched_node() {
+        let mut tree = UndoTree::new();
+
+        // Node 1: Client A
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "X")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+            EditOrigin::Client(0),
+        );
+
+        // Node 2: Client B with BATCHED edits (2 edits in one node)
+        tree.push_with_origin(
+            vec![
+                Edit::insert(Position::new(0, 1), "AA"),
+                Edit::insert(Position::new(0, 3), "BB"),
+            ],
+            Position::new(0, 1),
+            Position::new(0, 5),
+            EditOrigin::Client(1),
+        );
+
+        // Edits since node 1 should include BOTH of node 2's edits
+        let edits = tree.edits_since(1).unwrap();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].text(), "AA");
+        assert_eq!(edits[1].text(), "BB");
+    }
+
+    #[test]
+    fn test_edits_since_skips_empty() {
+        let mut tree = UndoTree::new();
+
+        // Node 1
+        tree.push_with_origin(
+            vec![Edit::insert(Position::new(0, 0), "A")],
+            Position::new(0, 0),
+            Position::new(0, 1),
+            EditOrigin::Client(0),
+        );
+
+        // Node 2 with an empty edit mixed in
+        tree.push_with_origin(
+            vec![
+                Edit::insert(Position::new(0, 1), ""),
+                Edit::insert(Position::new(0, 1), "B"),
+            ],
+            Position::new(0, 1),
+            Position::new(0, 2),
+            EditOrigin::Client(1),
+        );
+
+        let edits = tree.edits_since(1).unwrap();
+        assert_eq!(edits.len(), 1); // empty edit skipped
+        assert_eq!(edits[0].text(), "B");
+    }
+}
+
 // === History Tests ===
 
 mod history_tests {

--- a/server/lib/kernel/src/block/undo.rs
+++ b/server/lib/kernel/src/block/undo.rs
@@ -455,6 +455,57 @@ impl UndoTree {
         self.seq_counter
     }
 
+    /// Collect all edits applied between a node and the current head.
+    ///
+    /// Walks from the current position back to `from_idx` via parent links,
+    /// collecting all edits from intermediate nodes in forward (application)
+    /// order. The edits from the `from_idx` node itself are NOT included.
+    ///
+    /// Returns `Some(empty_vec)` if `from_idx` is the current position.
+    /// Returns `None` if `from_idx` is not an ancestor of the current position
+    /// or is out of bounds.
+    #[must_use]
+    pub fn edits_since(&self, from_idx: usize) -> Option<Vec<&Edit>> {
+        if from_idx >= self.nodes.len() {
+            return None;
+        }
+
+        if from_idx == self.current {
+            return Some(Vec::new());
+        }
+
+        // Walk from current back to from_idx via parent links.
+        let mut path_indices = Vec::new();
+        let mut idx = self.current;
+
+        loop {
+            if idx == from_idx {
+                break;
+            }
+            path_indices.push(idx);
+            match self.nodes[idx].parent {
+                Some(parent) => idx = parent,
+                None => return None, // Reached root without finding from_idx
+            }
+        }
+
+        // path_indices is in reverse order (current -> ... -> from_idx+1).
+        // Reverse to get forward order (from_idx+1 -> ... -> current).
+        path_indices.reverse();
+
+        // Collect non-empty edits from each node in forward order.
+        let mut edits = Vec::new();
+        for node_idx in path_indices {
+            for edit in &self.nodes[node_idx].edits {
+                if !edit.is_empty() {
+                    edits.push(edit);
+                }
+            }
+        }
+
+        Some(edits)
+    }
+
     /// Prune old nodes if over the limit.
     ///
     /// This is a simple pruning strategy that removes the oldest

--- a/server/lib/kernel/src/mm/edit.rs
+++ b/server/lib/kernel/src/mm/edit.rs
@@ -118,4 +118,200 @@ impl Edit {
     pub fn is_empty(&self) -> bool {
         self.text().is_empty()
     }
+
+    /// Transform this edit's position through another edit.
+    ///
+    /// Returns a new edit with the same text but a position adjusted
+    /// to account for the effect of `against`. This is the OT inclusion
+    /// transformation (IT) applied at the edit level.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reovim_kernel::api::v1::*;
+    ///
+    /// // An insert at (0,5) transformed through an earlier insert of "abc" at (0,2)
+    /// let edit = Edit::insert(Position::new(0, 5), "hello");
+    /// let against = Edit::insert(Position::new(0, 2), "abc");
+    /// let transformed = edit.transform(&against);
+    /// assert_eq!(transformed.position(), Position::new(0, 8)); // 5 + 3
+    /// assert_eq!(transformed.text(), "hello"); // text unchanged
+    /// ```
+    #[must_use]
+    pub fn transform(&self, against: &Self) -> Self {
+        match self {
+            Self::Insert { position, text } => Self::Insert {
+                position: transform_position(*position, against),
+                text: text.clone(),
+            },
+            Self::Delete { position, text } => Self::Delete {
+                position: transform_position(*position, against),
+                text: text.clone(),
+            },
+        }
+    }
+}
+
+/// Dimensions of text for OT position transformation.
+///
+/// Describes the shape of a text string in terms of line count and
+/// the length of the last line. Used by [`transform_position`] to
+/// compute how an edit shifts positions in a 2D text buffer.
+///
+/// All lengths are in Unicode scalar values (chars), consistent with
+/// [`Position::column`] semantics throughout reovim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextDimensions {
+    /// Number of newline characters in the text.
+    pub line_count: usize,
+    /// Character count of text after the last newline,
+    /// or the full character count if there are no newlines.
+    pub last_line_len: usize,
+}
+
+/// Compute the dimensions of a text string.
+///
+/// Returns the number of newlines and the character length of the
+/// text after the last newline.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::text_dimensions;
+///
+/// let dims = text_dimensions("hello");
+/// assert_eq!(dims.line_count, 0);
+/// assert_eq!(dims.last_line_len, 5);
+///
+/// let dims = text_dimensions("ab\ncd\ne");
+/// assert_eq!(dims.line_count, 2);
+/// assert_eq!(dims.last_line_len, 1);
+/// ```
+#[must_use]
+pub fn text_dimensions(text: &str) -> TextDimensions {
+    let line_count = text.chars().filter(|&c| c == '\n').count();
+    let last_line_len = text.rsplit('\n').next().map_or(0, |s| s.chars().count());
+    TextDimensions {
+        line_count,
+        last_line_len,
+    }
+}
+
+/// Compute the end position of deleted text in the pre-delete buffer state.
+///
+/// Given a deletion starting at `pos` with the specified `text`, returns
+/// the position just past the end of the deleted region.
+#[must_use]
+pub fn delete_end(pos: Position, text: &str) -> Position {
+    let dims = text_dimensions(text);
+    if dims.line_count == 0 {
+        Position::new(pos.line, pos.column + dims.last_line_len)
+    } else {
+        Position::new(pos.line + dims.line_count, dims.last_line_len)
+    }
+}
+
+/// Transform a position through the effect of an edit.
+///
+/// This is the OT inclusion transformation (IT): given a position `pos`
+/// in the buffer state *before* `against` was applied, returns the
+/// equivalent position in the buffer state *after* `against`.
+///
+/// # Tie-breaking (same-position edits)
+///
+/// Uses left-bias convention: when `pos` equals the edit position,
+/// an Insert shifts `pos` right (the insert "happened before" our position),
+/// while a Delete leaves `pos` unchanged (`pos <= del_pos` → no shift).
+///
+/// # Character counting
+///
+/// All column arithmetic uses Unicode scalar values (`.chars().count()`),
+/// consistent with [`Position::column`] semantics.
+///
+/// # Example
+///
+/// ```
+/// use reovim_kernel::api::v1::*;
+///
+/// // Insert "abc" at (0,2) shifts position (0,5) to (0,8)
+/// let pos = transform_position(
+///     Position::new(0, 5),
+///     &Edit::insert(Position::new(0, 2), "abc"),
+/// );
+/// assert_eq!(pos, Position::new(0, 8));
+/// ```
+#[must_use]
+pub fn transform_position(pos: Position, against: &Edit) -> Position {
+    if against.is_empty() {
+        return pos;
+    }
+
+    match against {
+        Edit::Insert {
+            position: ins_pos,
+            text,
+        } => transform_position_against_insert(pos, *ins_pos, text),
+        Edit::Delete {
+            position: del_pos,
+            text,
+        } => transform_position_against_delete(pos, *del_pos, text),
+    }
+}
+
+/// Transform a position through an insert edit.
+fn transform_position_against_insert(pos: Position, ins_pos: Position, text: &str) -> Position {
+    // Position strictly before the insert is unaffected.
+    if pos < ins_pos {
+        return pos;
+    }
+
+    let dims = text_dimensions(text);
+
+    if pos.line == ins_pos.line {
+        // Same line as insert. Column >= ins_pos.column (due to pos >= ins_pos).
+        if dims.line_count == 0 {
+            // Single-line insert: shift column right.
+            Position::new(pos.line, pos.column + dims.last_line_len)
+        } else {
+            // Multi-line insert: position moves down and column resets
+            // relative to the end of the inserted text.
+            Position::new(
+                pos.line + dims.line_count,
+                pos.column - ins_pos.column + dims.last_line_len,
+            )
+        }
+    } else {
+        // Position is on a line after the insert line: shift line down.
+        Position::new(pos.line + dims.line_count, pos.column)
+    }
+}
+
+/// Transform a position through a delete edit.
+fn transform_position_against_delete(pos: Position, del_pos: Position, text: &str) -> Position {
+    // Position at or before the delete start is unaffected.
+    if pos <= del_pos {
+        return pos;
+    }
+
+    let del_end = delete_end(del_pos, text);
+    let dims = text_dimensions(text);
+
+    // Position within the deleted region collapses to the delete start.
+    if pos <= del_end {
+        return del_pos;
+    }
+
+    if pos.line == del_end.line {
+        // Position is on the last line of the deletion but after it.
+        if dims.line_count == 0 {
+            // Single-line delete: shift column left.
+            Position::new(pos.line, pos.column - dims.last_line_len)
+        } else {
+            // Multi-line delete: column merges onto the delete-start line.
+            Position::new(del_pos.line, del_pos.column + pos.column - del_end.column)
+        }
+    } else {
+        // Position is on a line after the deletion: shift line up.
+        Position::new(pos.line - dims.line_count, pos.column)
+    }
 }

--- a/server/lib/kernel/src/mm/mod.rs
+++ b/server/lib/kernel/src/mm/mod.rs
@@ -65,7 +65,7 @@ pub use {
     buffer_id::BufferId,
     cache::LineCache,
     delimiter::{find_delimiter_pair, find_matching_delimiter},
-    edit::Edit,
+    edit::{Edit, TextDimensions, delete_end, text_dimensions, transform_position},
     position::{Cursor, Position},
     saturator::{
         RequestPriority, SaturationRequest, SaturatorConfig, SaturatorHandle, spawn_saturator,

--- a/server/lib/kernel/src/mm/tests.rs
+++ b/server/lib/kernel/src/mm/tests.rs
@@ -529,3 +529,239 @@ mod buffer_tests {
     // Note: test_cursor_accessors removed.
     // Buffer no longer has cursor/selection state - these are per-window (#471).
 }
+
+// === OT-Lite Position Transformation Tests (#495) ===
+
+mod transform_tests {
+    use super::*;
+
+    // --- text_dimensions ---
+
+    #[test]
+    fn test_text_dimensions_single_line() {
+        let dims = text_dimensions("hello");
+        assert_eq!(dims.line_count, 0);
+        assert_eq!(dims.last_line_len, 5);
+    }
+
+    #[test]
+    fn test_text_dimensions_multi_line() {
+        let dims = text_dimensions("ab\ncd\ne");
+        assert_eq!(dims.line_count, 2);
+        assert_eq!(dims.last_line_len, 1);
+    }
+
+    #[test]
+    fn test_text_dimensions_trailing_newline() {
+        let dims = text_dimensions("hello\n");
+        assert_eq!(dims.line_count, 1);
+        assert_eq!(dims.last_line_len, 0);
+    }
+
+    #[test]
+    fn test_text_dimensions_empty() {
+        let dims = text_dimensions("");
+        assert_eq!(dims.line_count, 0);
+        assert_eq!(dims.last_line_len, 0);
+    }
+
+    // --- transform_position against Insert ---
+
+    #[test]
+    fn test_transform_position_insert_before() {
+        // Position is before the insert: unchanged.
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(0, 10), "abc")),
+            Position::new(0, 5)
+        );
+        // Different line, before.
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(1, 0), "abc")),
+            Position::new(0, 5)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_insert_after_same_line() {
+        // Insert "abc" at (0,2), position (0,5) shifts to (0,8).
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(0, 2), "abc")),
+            Position::new(0, 8)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_insert_after_different_line() {
+        // Insert two lines at (1,0), position (3,5) shifts to (5,5).
+        assert_eq!(
+            transform_position(Position::new(3, 5), &Edit::insert(Position::new(1, 0), "aa\nbb\n")),
+            Position::new(5, 5) // 3 + 2 newlines = 5
+        );
+    }
+
+    #[test]
+    fn test_transform_position_insert_multiline() {
+        // Insert "ab\nc" at (0,2), position (0,5) moves to (1, 5-2+1 = 4).
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(0, 2), "ab\nc")),
+            Position::new(1, 4)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_same_position_insert() {
+        // Tie-breaking: insert at same position shifts right (left-bias).
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(0, 5), "abc")),
+            Position::new(0, 8) // 5 + 3
+        );
+    }
+
+    // --- transform_position against Delete ---
+
+    #[test]
+    fn test_transform_position_delete_before() {
+        // Position is before the delete: unchanged.
+        assert_eq!(
+            transform_position(Position::new(0, 1), &Edit::delete(Position::new(0, 5), "abc")),
+            Position::new(0, 1)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_delete_within() {
+        // Position is within deleted range: collapses to delete start.
+        assert_eq!(
+            transform_position(Position::new(0, 3), &Edit::delete(Position::new(0, 2), "abcde")),
+            Position::new(0, 2)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_delete_after_same_line() {
+        // Delete "abc" at (0,2), position (0,5) shifts to (0,2).
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::delete(Position::new(0, 2), "abc")),
+            Position::new(0, 2)
+        );
+        // Position further after the deleted range.
+        assert_eq!(
+            transform_position(Position::new(0, 8), &Edit::delete(Position::new(0, 2), "abc")),
+            Position::new(0, 5) // 8 - 3 = 5
+        );
+    }
+
+    #[test]
+    fn test_transform_position_delete_after_different_line() {
+        // Delete two lines starting at (1,0), position (5,3) shifts to (3,3).
+        assert_eq!(
+            transform_position(
+                Position::new(5, 3),
+                &Edit::delete(Position::new(1, 0), "hello\nworld\n")
+            ),
+            Position::new(3, 3) // 5 - 2 newlines = 3
+        );
+    }
+
+    #[test]
+    fn test_transform_position_delete_multiline() {
+        // Multiline delete: position on last line of deletion but after it.
+        // Delete "hello\nworld" at (0,3), del_end=(1,5).
+        // Position (1,8) is on the last line, after del_end.
+        assert_eq!(
+            transform_position(
+                Position::new(1, 8),
+                &Edit::delete(Position::new(0, 3), "hello\nworld")
+            ),
+            Position::new(0, 3 + 8 - 5) // del_pos.col + pos.col - del_end.col = 3+8-5 = 6
+        );
+    }
+
+    #[test]
+    fn test_transform_position_delete_multiline_within() {
+        // Position within multiline delete: collapses to delete start.
+        assert_eq!(
+            transform_position(
+                Position::new(1, 5),
+                &Edit::delete(Position::new(0, 3), "hello\nworld")
+            ),
+            Position::new(0, 3)
+        );
+    }
+
+    #[test]
+    fn test_transform_position_same_position_delete() {
+        // Tie-breaking: delete at same position leaves pos unchanged.
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::delete(Position::new(0, 5), "abc")),
+            Position::new(0, 5) // pos <= del_pos, unchanged
+        );
+    }
+
+    // --- Empty edit ---
+
+    #[test]
+    fn test_transform_position_empty_edit() {
+        // Empty insert and delete are no-ops.
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::insert(Position::new(0, 2), "")),
+            Position::new(0, 5)
+        );
+        assert_eq!(
+            transform_position(Position::new(0, 5), &Edit::delete(Position::new(0, 2), "")),
+            Position::new(0, 5)
+        );
+    }
+
+    // --- Edit::transform ---
+
+    #[test]
+    fn test_transform_edit_preserves_text() {
+        let edit = Edit::insert(Position::new(0, 5), "hello");
+        let against = Edit::insert(Position::new(0, 2), "abc");
+        let transformed = edit.transform(&against);
+
+        assert_eq!(transformed.position(), Position::new(0, 8));
+        assert_eq!(transformed.text(), "hello"); // text unchanged
+        assert!(transformed.is_insert());
+    }
+
+    #[test]
+    fn test_transform_edit_delete() {
+        let edit = Edit::delete(Position::new(0, 5), "xyz");
+        let against = Edit::insert(Position::new(0, 0), "abc");
+        let transformed = edit.transform(&against);
+
+        assert_eq!(transformed.position(), Position::new(0, 8)); // 5 + 3
+        assert_eq!(transformed.text(), "xyz"); // text unchanged
+        assert!(transformed.is_delete());
+    }
+
+    #[test]
+    fn test_transform_identity_no_shift() {
+        // Position before the intervening edit: no shift.
+        let edit = Edit::insert(Position::new(0, 0), "hello");
+        let against = Edit::insert(Position::new(0, 10), "abc");
+        let transformed = edit.transform(&against);
+
+        assert_eq!(transformed.position(), Position::new(0, 0));
+        assert_eq!(transformed.text(), "hello");
+    }
+
+    // --- delete_end ---
+
+    #[test]
+    fn test_delete_end_single_line() {
+        assert_eq!(delete_end(Position::new(0, 3), "abc"), Position::new(0, 6));
+    }
+
+    #[test]
+    fn test_delete_end_multi_line() {
+        assert_eq!(delete_end(Position::new(0, 3), "hello\nworld"), Position::new(1, 5));
+    }
+
+    #[test]
+    fn test_delete_end_trailing_newline() {
+        assert_eq!(delete_end(Position::new(2, 0), "hello\n"), Position::new(3, 0));
+    }
+}

--- a/server/lib/server/tests/multi_client_isolation.rs
+++ b/server/lib/server/tests/multi_client_isolation.rs
@@ -200,6 +200,63 @@ async fn test_independent_editing() {
         .await;
 }
 
+/// Test that undo correctly adjusts positions when edits are position-dependent (#495).
+///
+/// This verifies the OT-lite transformation: when Client 0 makes an edit and
+/// Client 1 then inserts text BEFORE Client 0's edit position, Client 0's undo
+/// must transform inverse edit positions to account for Client 1's text shift,
+/// removing only Client 0's text.
+///
+/// Without OT-lite, the inverse Delete would use the original position (0,0),
+/// deleting Client 1's "BBBB" instead of Client 0's "AAAA".
+#[tokio::test]
+async fn test_undo_with_dependent_edits() {
+    MultiClientPresenceTest::with_clients(2)
+        .await
+        .run(|mut clients| async move {
+            // Client 0 types "AAAA" at position (0,0)
+            clients[0]
+                .send_keys("iAAAA<Esc>")
+                .await
+                .expect("client 0 types AAAA");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Client 1 inserts "BBBB" at position 0 (before Client 0's text)
+            // Use 0i to explicitly go to column 0 before entering insert mode
+            clients[1]
+                .send_keys("0iBBBB<Esc>")
+                .await
+                .expect("client 1 types BBBB");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Buffer should contain both BBBB and AAAA
+            let content_before = clients[0]
+                .get_buffer()
+                .await
+                .expect("get buffer before undo");
+            assert!(
+                content_before.contains("BBBB") && content_before.contains("AAAA"),
+                "Buffer should contain both BBBB and AAAA, got: '{content_before}'"
+            );
+
+            // Client 0 undoes — OT-lite transforms the inverse position
+            // from (0,0) to (0,4), correctly targeting "AAAA" not "BBBB"
+            clients[0].send_keys("u").await.expect("client 0 undo");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Buffer should contain only "BBBB" (Client 0's AAAA was removed)
+            let content_after = clients[0]
+                .get_buffer()
+                .await
+                .expect("get buffer after undo");
+            assert!(
+                content_after.contains("BBBB") && !content_after.contains("AAAA"),
+                "After OT-lite undo: should contain 'BBBB' but not 'AAAA', got: '{content_after}'"
+            );
+        })
+        .await;
+}
+
 /// Test that undo is isolated per-client (#471).
 ///
 /// When Client 0 makes edits and Client 1 makes edits, then Client 0

--- a/server/modules/undo/src/registry.rs
+++ b/server/modules/undo/src/registry.rs
@@ -16,7 +16,9 @@ use {
     reovim_arch::sync::RwLock,
     reovim_driver_undo::{UndoPersistError, UndoProvider},
     reovim_driver_vfs::VfsDriver,
-    reovim_kernel::api::v1::{BufferId, Edit, EditOrigin, Position, UndoResult, UndoTree},
+    reovim_kernel::api::v1::{
+        BufferId, Edit, EditOrigin, Position, UndoResult, UndoTree, transform_position,
+    },
     reovim_protocol::v1::undo::{UndoFileError, UndoFileFormat, from_undo_tree, to_undo_tree},
     std::collections::HashMap,
 };
@@ -378,11 +380,30 @@ impl UndoProvider for UndoRegistry {
 
             // Check if this node was made by the client
             if node.origin() == target_origin {
-                // Found a node to undo - compute inverse edits
-                let result = UndoResult {
-                    edits: node.edits().iter().rev().map(Edit::inverse).collect(),
-                    cursor: node.cursor_before(),
+                // Found target node — compute raw inverse edits
+                let inverse_edits: Vec<Edit> =
+                    node.edits().iter().rev().map(Edit::inverse).collect();
+                let cursor = node.cursor_before();
+
+                // Transform through intervening edits (OT-lite, #495)
+                let (edits, cursor) = match tree.edits_since(cursor_pos) {
+                    Some(intervening) if !intervening.is_empty() => {
+                        transform_through_intervening(&intervening, inverse_edits, cursor)
+                    }
+                    Some(_) => (inverse_edits, cursor),
+                    None => {
+                        // Target is not ancestor of current (pruned tree?)
+                        // Graceful degradation: use raw inverse
+                        tracing::warn!(
+                            "edits_since({}) returned None for buffer {:?}, using raw inverse",
+                            cursor_pos,
+                            buffer_id,
+                        );
+                        (inverse_edits, cursor)
+                    }
                 };
+
+                let result = UndoResult { edits, cursor };
 
                 // Update client's cursor to parent
                 drop(trees);
@@ -484,6 +505,23 @@ impl UndoProvider for UndoRegistry {
         let key = (buffer_id, client_id);
         self.client_cursors.write().remove(&key);
     }
+}
+
+/// Transform inverse edits and cursor through intervening edits.
+///
+/// This is the core OT-lite algorithm (#495): given raw inverse edits from
+/// an undo target and the edits that happened since that target, produce
+/// adjusted inverse edits that apply correctly to the current buffer state.
+fn transform_through_intervening(
+    intervening: &[&Edit],
+    mut inverse_edits: Vec<Edit>,
+    mut cursor: Position,
+) -> (Vec<Edit>, Position) {
+    for ie in intervening {
+        inverse_edits = inverse_edits.iter().map(|inv| inv.transform(ie)).collect();
+        cursor = transform_position(cursor, ie);
+    }
+    (inverse_edits, cursor)
 }
 
 /// Find the next node to redo for a specific client.
@@ -953,6 +991,306 @@ mod tests {
                 .client_cursors
                 .read()
                 .contains_key(&(buffer_id, client_id))
+        );
+    }
+
+    // ========================================================================
+    // OT-Lite Transformation Tests (#495)
+    // ========================================================================
+
+    #[test]
+    fn test_undo_for_client_transforms_same_line_insert() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+
+        // Client A inserts "AAA" at (0,5)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 5), "AAA")],
+            Position::new(0, 5),
+            Position::new(0, 8),
+        );
+
+        // Client B inserts "BBB" at (0,0) — shifts A's text right by 3
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![Edit::insert(Position::new(0, 0), "BBB")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+        );
+
+        // Client A undoes — inverse Delete "AAA" should be at (0,8), not (0,5)
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits.len(), 1);
+        assert!(result.edits[0].is_delete());
+        assert_eq!(result.edits[0].text(), "AAA");
+        assert_eq!(result.edits[0].position(), Position::new(0, 8));
+    }
+
+    #[test]
+    fn test_undo_for_client_transforms_multiline_insert() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+
+        // Client A inserts "AAA" at (0,0)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 0), "AAA")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+        );
+
+        // Client B inserts a multiline text "BB\nCC" at (0,3)
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![Edit::insert(Position::new(0, 3), "BB\nCC")],
+            Position::new(0, 3),
+            Position::new(1, 2),
+        );
+
+        // Client A undoes — inverse Delete "AAA" at (0,0) is before B's insert (0,3),
+        // so no shift needed. Position stays (0,0).
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits[0].position(), Position::new(0, 0));
+        assert_eq!(result.edits[0].text(), "AAA");
+    }
+
+    #[test]
+    fn test_undo_for_client_no_intervening_edits() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+
+        // Client A makes a single edit — no other clients
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 0), "AAA")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+        );
+
+        // Undo with no intervening edits — should work exactly like Phase 2
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits.len(), 1);
+        assert!(result.edits[0].is_delete());
+        assert_eq!(result.edits[0].text(), "AAA");
+        assert_eq!(result.edits[0].position(), Position::new(0, 0));
+        assert_eq!(result.cursor, Position::new(0, 0));
+    }
+
+    #[test]
+    fn test_undo_for_client_transforms_delete() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+
+        // Client A inserts "AAA" at (0,5)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 5), "AAA")],
+            Position::new(0, 5),
+            Position::new(0, 8),
+        );
+
+        // Client B deletes "XX" at (0,0) — shifts A's text left by 2
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![Edit::delete(Position::new(0, 0), "XX")],
+            Position::new(0, 0),
+            Position::new(0, 0),
+        );
+
+        // Client A undoes — inverse Delete "AAA" should be at (0,3), not (0,5)
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits[0].position(), Position::new(0, 3));
+        assert_eq!(result.edits[0].text(), "AAA");
+    }
+
+    #[test]
+    fn test_undo_for_client_multiple_intervening_edits() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+        let client_c = 3_usize;
+
+        // Client A inserts "AAA" at (0,0)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 0), "AAA")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+        );
+
+        // Client B inserts "B1" at (0,0) — shifts A's text right by 2
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![Edit::insert(Position::new(0, 0), "B1")],
+            Position::new(0, 0),
+            Position::new(0, 2),
+        );
+
+        // Client C inserts "C1" at (0,0) — shifts A's text right by another 2
+        registry.record_for_client(
+            buffer_id,
+            client_c,
+            vec![Edit::insert(Position::new(0, 0), "C1")],
+            Position::new(0, 0),
+            Position::new(0, 2),
+        );
+
+        // Client A undoes — inverse Delete "AAA" at (0,0) → (0,4) after two shifts
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits[0].position(), Position::new(0, 4));
+        assert_eq!(result.edits[0].text(), "AAA");
+    }
+
+    #[test]
+    fn test_undo_for_client_cursor_position_transformed() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+
+        // Client A inserts "AAA" at (0,5), cursor_before=(0,5)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 5), "AAA")],
+            Position::new(0, 5),
+            Position::new(0, 8),
+        );
+
+        // Client B inserts "BBB" at (0,0) — shifts cursor right by 3
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![Edit::insert(Position::new(0, 0), "BBB")],
+            Position::new(0, 0),
+            Position::new(0, 3),
+        );
+
+        // Client A undoes — cursor should be transformed from (0,5) to (0,8)
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.cursor, Position::new(0, 8));
+    }
+
+    #[test]
+    fn test_undo_for_client_batch_edits_in_intervening_node() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+        let client_a = 1_usize;
+        let client_b = 2_usize;
+
+        // Client A inserts "X" at (0,5)
+        registry.record_for_client(
+            buffer_id,
+            client_a,
+            vec![Edit::insert(Position::new(0, 5), "X")],
+            Position::new(0, 5),
+            Position::new(0, 6),
+        );
+
+        // Client B batches two edits at (0,0) and (0,2):
+        // First "AA" at (0,0), then "BB" at (0,2)
+        // Total shift: +4
+        registry.record_for_client(
+            buffer_id,
+            client_b,
+            vec![
+                Edit::insert(Position::new(0, 0), "AA"),
+                Edit::insert(Position::new(0, 2), "BB"),
+            ],
+            Position::new(0, 0),
+            Position::new(0, 4),
+        );
+
+        // Client A undoes — inverse Delete "X" at (0,5) → (0,9) after both batch shifts
+        let result = registry.undo_for_client(buffer_id, client_a).unwrap();
+        assert_eq!(result.edits[0].position(), Position::new(0, 9));
+        assert_eq!(result.edits[0].text(), "X");
+    }
+
+    /// Simulate the exact insert-mode batching scenario from the integration test.
+    ///
+    /// Client 0 types "iAAAA<Esc>" → batch of 4 char inserts at (0,0)-(0,3)
+    /// Client 1 types "0iBBBB<Esc>" → batch of 4 char inserts at (0,0)-(0,3)
+    /// Client 0 undoes → should remove AAAA (now at col 4-7), not BBBB (at col 0-3)
+    #[test]
+    fn test_undo_for_client_batched_insert_mode_scenario() {
+        let registry = UndoRegistry::new();
+        let buffer_id = BufferId::from_raw(1);
+
+        // Client 0 enters insert mode: begin_batch
+        registry.begin_batch(buffer_id, Position::new(0, 0));
+
+        // Client 0 types 'A' 4 times
+        for col in 0..4_usize {
+            registry.record_for_client(
+                buffer_id,
+                0,
+                vec![Edit::insert(Position::new(0, col), "A")],
+                Position::new(0, col),
+                Position::new(0, col + 1),
+            );
+        }
+
+        // Client 0 exits insert mode: end_batch
+        registry.end_batch(buffer_id, Position::new(0, 4));
+
+        // Client 1 enters insert mode: begin_batch
+        registry.begin_batch(buffer_id, Position::new(0, 0));
+
+        // Client 1 types 'B' 4 times (at position 0, before AAAA)
+        for col in 0..4_usize {
+            registry.record_for_client(
+                buffer_id,
+                1,
+                vec![Edit::insert(Position::new(0, col), "B")],
+                Position::new(0, col),
+                Position::new(0, col + 1),
+            );
+        }
+
+        // Client 1 exits insert mode: end_batch
+        registry.end_batch(buffer_id, Position::new(0, 4));
+
+        // Client 0 undoes — OT-lite should transform the inverse edits
+        // from col 0-3 to col 4-7 (shifted by Client 1's 4 char inserts)
+        let result = registry.undo_for_client(buffer_id, 0);
+        assert!(result.is_some(), "undo_for_client should return Some");
+
+        let result = result.unwrap();
+
+        // All inverse edits should be Delete operations targeting the shifted positions
+        assert_eq!(result.edits.len(), 4, "Should have 4 inverse edits");
+        for edit in &result.edits {
+            assert!(edit.is_delete(), "Each inverse edit should be Delete: {edit:?}");
+            assert_eq!(edit.text(), "A", "Each delete should remove 'A': {edit:?}");
+        }
+
+        // After OT transformation, the positions should be shifted right by 4
+        // Original inverse: Delete at (0,3), (0,2), (0,1), (0,0)
+        // After transforming through 4 inserts at (0,0)-(0,3):
+        // Should be Delete at (0,7), (0,6), (0,5), (0,4)
+        let positions: Vec<usize> = result.edits.iter().map(|e| e.position().column).collect();
+        assert!(
+            positions.iter().all(|&col| col >= 4),
+            "All delete positions should be >= 4 (shifted past BBBB), got: {positions:?}"
         );
     }
 


### PR DESCRIPTION
Implement Operational Transformation (lite) so that per-client undo correctly adjusts edit positions through intervening edits from other clients. Without this, Client 0 undoing after Client 1 inserted text before Client 0's edit would remove Client 1's text instead.

Kernel (mechanism):
- transform_position(): inclusion transformation through insert/delete
- TextDimensions, text_dimensions(), delete_end(): text shape helpers
- Edit::transform(): transform edit position through another edit
- UndoTree::edits_since(): collect edits between ancestor and current

Module (policy):
- transform_through_intervening(): OT pipeline assembly
- undo_for_client(): integrates OT-lite transformation

Tests: 41 new (23 transform + 8 edits_since + 9 OT-lite + 1 integration)

Refs #495
