### PR TITLE
feat(session): per-client compositor for multi-client rendering (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Added
 
+- **Per-client compositor refactor (#474)**: Each client now owns an independent
+  compositor clone, eliminating the cross-namespace window ID mismatch between
+  shared compositor IDs and per-client WindowLayout IDs. The compositor moves
+  from `SessionShared` into per-client `EditingState` at join time via
+  `boxed_clone()`. `SessionRuntime` accepts the per-client compositor as a
+  parameter, and all `CompositorApi` methods operate on it. Notification builder
+  reads per-client compositor for layout notifications. This is foundational
+  for multi-client TUI rendering where each client has independent viewports.
+
 - **Comprehensive unit test suite (#497)**: Added ~4500 unit tests across the
   entire workspace, bringing the total from ~3250 to 7752 passing tests (0
   failures). Coverage spans all layers: kernel (mm, ipc, core, block, sched,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,7 @@ name = "reovim-module-motions"
 version = "0.9.4-dev"
 dependencies = [
  "reovim-driver-command",
+ "reovim-driver-display",
  "reovim-driver-search",
  "reovim-driver-session",
  "reovim-kernel",
@@ -2186,6 +2187,7 @@ name = "reovim-module-textobjects"
 version = "0.9.4-dev"
 dependencies = [
  "reovim-driver-command",
+ "reovim-driver-display",
  "reovim-driver-session",
  "reovim-kernel",
  "reovim-module-macros",

--- a/clients/tui/lib/drivers/display/src/compositor/mod.rs
+++ b/clients/tui/lib/drivers/display/src/compositor/mod.rs
@@ -209,8 +209,6 @@ mod tests {
         let _compositor: Box<dyn Compositor> = Box::new(LayerCompositor::new());
     }
 
-    /// Verify `ZGroup` values match the specification.
-
     // =========================================================================
     // Compositor trait impl delegation tests (cover all delegating methods)
     // =========================================================================

--- a/clients/tui/lib/drivers/tui/src/cursor.rs
+++ b/clients/tui/lib/drivers/tui/src/cursor.rs
@@ -227,6 +227,14 @@ impl Cursor {
         Ok(())
     }
 
+    /// Force position update on next apply.
+    ///
+    /// Call after operations that move the terminal cursor unpredictably
+    /// (e.g., `Screen::render()` leaves cursor at last updated cell).
+    pub const fn invalidate_position(&mut self) {
+        self.position_dirty = true;
+    }
+
     /// Force full update on next apply.
     pub const fn invalidate(&mut self) {
         self.position_dirty = true;

--- a/clients/tui/src/adapter/layout.rs
+++ b/clients/tui/src/adapter/layout.rs
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_layout_adapter_focus_returns_true() {
         let compositor = Arc::new(Mutex::new(MockCompositor::new()));
-        let mut adapter = TuiLayoutAdapter::new(compositor.clone(), LayerId::new(0));
+        let mut adapter = TuiLayoutAdapter::new(compositor, LayerId::new(0));
 
         // Focus should always return true
         assert!(adapter.focus(99));

--- a/clients/tui/src/app.rs
+++ b/clients/tui/src/app.rs
@@ -906,16 +906,17 @@ async fn connect_common(
     // Connect gRPC client
     let mut client = TuiGrpcClient::connect(addr).await?;
 
-    // Subscribe to all notifications
-    let notification_stream = client.subscribe_all().await?;
-
-    // Join presence session first to get session token.
-    // Resize must come AFTER join so the token is attached to the request
-    // and the server can set target_client_id in the resize notification.
+    // Join presence session FIRST to get session token.
+    // subscribe_all() and resize() must come AFTER join so the token is
+    // attached to requests. Without the token, the notification stream
+    // won't be wrapped in CleanupStream and disconnect cleanup won't run.
     let display_name = std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))
         .map_or_else(|_| "TUI Client".to_string(), |user| format!("TUI@{user}"));
     let join_resp = client.presence_join("tui", &display_name).await?;
+
+    // Subscribe to all notifications (token now set by presence_join)
+    let notification_stream = client.subscribe_all().await?;
 
     // Notify server of viewport size (token now attached via make_request)
     client.resize(u64::from(width), u64::from(height)).await?;

--- a/clients/tui/src/core_state.rs
+++ b/clients/tui/src/core_state.rs
@@ -604,6 +604,6 @@ mod tests {
             .buffer_cache
             .insert(100, vec!["line 1".to_string(), "line 2".to_string()]);
         assert_eq!(state.buffer_cache.get(&100).unwrap().len(), 2);
-        assert!(state.buffer_cache.get(&999).is_none());
+        assert!(!state.buffer_cache.contains_key(&999));
     }
 }

--- a/clients/tui/src/layout_mirror.rs
+++ b/clients/tui/src/layout_mirror.rs
@@ -447,7 +447,7 @@ mod tests {
             height: 24,
             focused: true,
         };
-        let cloned = placement.clone();
+        let cloned = placement;
         assert_eq!(cloned.window_id, 1);
         assert_eq!(cloned.buffer_id, Some(42));
         assert_eq!(cloned.x, 10);

--- a/clients/tui/src/notification_handler.rs
+++ b/clients/tui/src/notification_handler.rs
@@ -152,7 +152,12 @@ pub async fn handle_notification<C: NotificationContext>(
 
             if let Some(pos) = cursor.position {
                 if is_local {
-                    state.update_local_cursor(cursor.window_id, pos.line, pos.column);
+                    // Use focused_window_id as storage key: when per-client compositor
+                    // is active (#474) the IDs match, but this also handles edge cases
+                    // where cursor.window_id differs from focused_window_id (e.g., when
+                    // no compositor is loaded).
+                    let key = state.focused_window_id;
+                    state.update_local_cursor(key, pos.line, pos.column);
                 } else {
                     state.update_remote_cursor(cursor.client_id, pos.line, pos.column);
                 }
@@ -188,7 +193,20 @@ pub async fn handle_notification<C: NotificationContext>(
 
         Payload::LayoutChanged(layout) => {
             let state = ctx.state_mut();
-            apply_layout_notification(state, layout.focused_window_id, layout.windows);
+            let is_local = layout.client_id == 0 || layout.client_id == state.my_client_id;
+
+            if is_local {
+                // Local client: apply full layout update (windows + focus)
+                apply_layout_notification(state, layout.focused_window_id, layout.windows);
+            } else {
+                // Remote client changed layout: update window list but keep our focus
+                let our_focus = state.focused_window_id;
+                apply_layout_notification(state, layout.focused_window_id, layout.windows);
+                state.focused_window_id = our_focus;
+                for w in &mut state.windows {
+                    w.focused = w.window_id == our_focus;
+                }
+            }
             Ok(NotificationResult::Redraw)
         }
 
@@ -209,7 +227,7 @@ pub async fn handle_notification<C: NotificationContext>(
             if let Some(client) = p.client {
                 let state = ctx.state_mut();
                 if client.client_id != state.my_client_id {
-                    tracing::info!(
+                    tracing::debug!(
                         client_id = client.client_id,
                         display_name = %client.display_name,
                         buffer_id = ?client.buffer_id,
@@ -683,6 +701,7 @@ mod tests {
                     focused: false,
                 },
             ],
+            client_id: 1,
         }));
 
         let result = handle_notification(&mut ctx, notif).await.unwrap();

--- a/clients/tui/src/output/terminal.rs
+++ b/clients/tui/src/output/terminal.rs
@@ -90,7 +90,13 @@ impl TuiOutput for TerminalOutput {
         }
 
         // Render to terminal with diff optimization
-        self.screen.render(&mut self.terminal)
+        self.screen.render(&mut self.terminal)?;
+
+        // screen.render() leaves the terminal cursor at the last updated cell,
+        // so force re-positioning on the next apply() call.
+        self.cursor.invalidate_position();
+
+        Ok(())
     }
 
     fn position_cursor(&mut self, x: u16, y: u16) {

--- a/clients/tui/src/render_backend.rs
+++ b/clients/tui/src/render_backend.rs
@@ -544,9 +544,11 @@ mod tests {
 
     #[test]
     fn test_to_tui_style_colors() {
-        let mut style = Style::default();
-        style.fg = Some(reovim_arch::Color::Red);
-        style.bg = Some(reovim_arch::Color::Blue);
+        let style = Style {
+            fg: Some(reovim_arch::Color::Red),
+            bg: Some(reovim_arch::Color::Blue),
+            ..Style::default()
+        };
 
         let tui_style = to_tui_style(&style);
         assert_eq!(tui_style.fg, Some(reovim_arch::Color::Red));

--- a/clients/tui/src/render_engine.rs
+++ b/clients/tui/src/render_engine.rs
@@ -432,21 +432,42 @@ fn render_remote_cursors<B: RenderBackend>(
 /// Maximum display width for cursor label names.
 const MAX_LABEL_WIDTH: usize = 16;
 
-/// Prepare label text from a display name.
+/// Prepare label text from a display name and mode.
 ///
-/// Returns a padded, truncated label string. Empty names show `" ? "`.
-fn label_text(display_name: &str) -> String {
-    if display_name.is_empty() {
-        return " ? ".to_string();
-    }
-    format!(" {} ", truncate_end(display_name, MAX_LABEL_WIDTH))
+/// Returns a padded, truncated label string with mode indicator.
+/// Empty names show `" ? "`, mode is abbreviated (e.g., `[N]`, `[I]`).
+fn label_text(display_name: &str, mode: &str) -> String {
+    let name = if display_name.is_empty() {
+        "?"
+    } else {
+        display_name
+    };
+    let mode_abbrev = mode_abbreviation(mode);
+    let name = truncate_end(name, MAX_LABEL_WIDTH);
+    format!(" {name} {mode_abbrev} ")
 }
 
-/// Render floating name labels for remote cursors.
+/// Abbreviate a mode name for compact display in cursor labels.
+fn mode_abbreviation(mode: &str) -> &'static str {
+    let lower = mode.to_lowercase();
+    if lower.contains("insert") {
+        "[I]"
+    } else if lower.contains("visual") {
+        "[V]"
+    } else if lower.contains("command") || lower.contains("cmdline") {
+        "[C]"
+    } else if lower.contains("replace") {
+        "[R]"
+    } else {
+        "[N]"
+    }
+}
+
+/// Render name labels for remote cursors after line content.
 ///
-/// Shows a colored tag with the client's display name near each remote
-/// cursor. Labels appear one line above the cursor, or one line below
-/// if the cursor is at line 0. Skipped if neither position is in viewport.
+/// Shows a colored, underlined tag with the client's display name and mode
+/// on the same line as the remote cursor, positioned after the end of the
+/// line text. Skipped if the label doesn't fit within the terminal width.
 #[allow(clippy::cast_possible_truncation)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn render_remote_cursor_labels<B: RenderBackend>(
@@ -459,50 +480,42 @@ fn render_remote_cursor_labels<B: RenderBackend>(
 
     let current_buffer_id = state.windows.first().and_then(|w| w.buffer_id);
 
+    let lines = current_buffer_id.and_then(|id| state.buffer_cache.get(&id));
+
     for remote in state.other_clients.values() {
         if remote.buffer_id != current_buffer_id {
             continue;
         }
 
         let cursor_line = remote.cursor_line;
-
-        // Determine label y position: prefer above, fallback below
-        let label_y = if cursor_line > 0 {
-            (cursor_line - 1) as u16
-        } else if cursor_line + 1 < u64::from(content_height) {
-            (cursor_line + 1) as u16
-        } else {
-            continue; // No room (single-line viewport)
-        };
-
-        if label_y >= content_height {
+        if cursor_line >= u64::from(content_height) {
             continue;
         }
+        let screen_y = cursor_line as u16;
 
-        let label = label_text(&remote.display_name);
+        // Calculate end-of-line position from buffer cache
+        let eol_col = lines
+            .and_then(|l| l.get(cursor_line as usize))
+            .map_or(0, |line| display_width(line) as u16);
+
+        // Place label after line content with 1-col gap
+        let label_x = gutter_width + eol_col + 1;
+
+        let label = label_text(&remote.display_name, &remote.mode);
         let label_width = display_width(&label) as u16;
 
-        // Skip if terminal is too narrow for the label
-        if label_width + gutter_width > width {
+        // Skip if label doesn't fit on screen
+        if label_x + label_width > width {
             continue;
         }
 
-        // Clamp x position: start at cursor column, keep label within screen
-        let label_x = (remote.cursor_col as u16 + gutter_width)
-            .min(width.saturating_sub(label_width))
-            .max(gutter_width);
-
         let label_color = client_color(remote.client_id);
-        let label_style = Style::default().bg(label_color).fg(Color::White);
+        let label_style = Style::default()
+            .fg(label_color)
+            .underline()
+            .underline_color(label_color);
 
-        // Use apply_style to overlay colored background without hiding buffer text.
-        // Characters underneath remain visible (white on colored bg).
-        for i in 0..label_width {
-            let x = label_x + i;
-            if x < width {
-                backend.apply_style(x, label_y, &label_style);
-            }
-        }
+        backend.write_str(label_x, screen_y, &label, &label_style);
     }
 }
 
@@ -692,6 +705,11 @@ mod tests {
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
 
+        // Provide buffer content so label renders after EOL, not over selection
+        state
+            .buffer_cache
+            .insert(100, vec!["0123456789".to_string()]);
+
         // Add remote client in same buffer with a char selection
         let remote = RemoteClient {
             client_id: 2,
@@ -745,7 +763,7 @@ mod tests {
 
         // Entire line 1 and 2 should be highlighted (col 0..40).
         // Cursor is at (2, 0), so skip that exact cell.
-        // Label " Remote " (8 chars) renders on row 1 at col 0, overwriting selection bg.
+        // Label renders on row 2 after EOL (col 1 if no content), safely past checked col.
         for row in 1..=2u16 {
             // Use col 20 (safely past label region) to check selection bg
             let cell_mid = fb.get(20, row).unwrap();
@@ -768,6 +786,16 @@ mod tests {
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
 
+        // Provide buffer content so label renders after EOL, not over selection
+        state.buffer_cache.insert(
+            100,
+            vec![
+                "0123456789".to_string(),
+                "0123456789".to_string(),
+                "0123456789".to_string(),
+            ],
+        );
+
         state.add_remote_client(RemoteClient {
             client_id: 4,
             display_name: "Remote".to_string(),
@@ -785,14 +813,10 @@ mod tests {
 
         // Columns 3..=7 on rows 0..=2 should be highlighted.
         // Cursor is at (2, 7), so skip that cell.
-        // Label " Remote " (8 chars) renders on row 1 at col 7, overwriting selection bg there.
         for row in 0..=2u16 {
             for col in 3..=7u16 {
                 if row == 2 && col == 7 {
                     continue; // cursor overwrites selection bg here
-                }
-                if row == 1 && col == 7 {
-                    continue; // label overwrites selection bg here
                 }
                 let cell = fb.get(col, row).unwrap();
                 assert_eq!(
@@ -875,10 +899,21 @@ mod tests {
     #[test]
     fn test_render_multiline_char_selection() {
         // Multi-line char selection: first line partial start, middle full, last line partial end.
-        let mut fb = FrameBuffer::new(20, 10);
+        // Use a wider terminal so the label fits after EOL without overlapping selections.
+        let mut fb = FrameBuffer::new(40, 10);
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
+
+        // Provide buffer content so label renders after EOL
+        state.buffer_cache.insert(
+            100,
+            vec![
+                "0123456789abcdef".to_string(), // 16 chars
+                "0123456789abcdef".to_string(),
+                "0123456789abcdef".to_string(),
+            ],
+        );
 
         state.add_remote_client(RemoteClient {
             client_id: 6,
@@ -917,11 +952,22 @@ mod tests {
 
     #[test]
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn test_remote_cursor_label_rendered() {
+    fn test_remote_cursor_label_rendered_after_eol() {
         let mut fb = FrameBuffer::new(80, 24);
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
+
+        // Provide buffer content so EOL can be calculated
+        state.buffer_cache.insert(
+            100,
+            vec![
+                String::new(),
+                String::new(),
+                String::new(),
+                "hello world".to_string(), // line 3: 11 chars
+            ],
+        );
 
         state.add_remote_client(RemoteClient {
             client_id: 2,
@@ -936,23 +982,26 @@ mod tests {
         let config = RenderConfig::default();
         render_frame(&mut fb, &state, &config);
 
-        // Label is a background overlay on row 2 (one above cursor line 3).
-        // Characters are preserved; only bg+fg change.
-        let expected_bg = Some(client_color(2));
-        let label_x = 5u16; // cursor_col
+        // Label on cursor row (3), after "hello world" (len 11) + 1 gap = col 12
+        let expected_fg = Some(client_color(2));
+        let label = label_text("alice", "NORMAL");
+        let label_x = 12u16; // eol(11) + 1 gap
         #[allow(clippy::cast_possible_truncation)]
-        let label_width = display_width(&label_text("alice")) as u16;
+        let label_width = display_width(&label) as u16;
 
         for i in 0..label_width {
-            let cell = fb.get(label_x + i, 2).unwrap();
-            assert_eq!(cell.style.bg, expected_bg, "col {} should have label bg", label_x + i);
+            let cell = fb.get(label_x + i, 3).unwrap();
+            assert_eq!(cell.style.fg, expected_fg, "col {} should have label fg", label_x + i);
+            assert!(
+                cell.style.attributes.has_any_underline(),
+                "col {} should be underlined",
+                label_x + i,
+            );
         }
 
-        // Cell before label should NOT have label bg
-        if label_x > 0 {
-            let before = fb.get(label_x - 1, 2).unwrap();
-            assert_ne!(before.style.bg, expected_bg, "cell before label should not have label bg");
-        }
+        // Cell before label should NOT have label fg
+        let before = fb.get(label_x - 1, 3).unwrap();
+        assert_ne!(before.style.fg, expected_fg, "cell before label should not have label fg");
     }
 
     #[test]
@@ -961,6 +1010,10 @@ mod tests {
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
+
+        state
+            .buffer_cache
+            .insert(100, vec!["fn main()".to_string()]);
 
         state.add_remote_client(RemoteClient {
             client_id: 3,
@@ -975,14 +1028,17 @@ mod tests {
         let config = RenderConfig::default();
         render_frame(&mut fb, &state, &config);
 
-        // Label bg should appear on row 1 (one below cursor line 0)
-        let expected_bg = Some(client_color(3));
+        // Label on row 0 after "fn main()" (len 9) + 1 gap = col 10
+        let expected_fg = Some(client_color(3));
+        let label = label_text("bob", "NORMAL");
+        let label_x = 10u16;
         #[allow(clippy::cast_possible_truncation)]
-        let label_width = display_width(&label_text("bob")) as u16;
+        let label_width = display_width(&label) as u16;
 
         for i in 0..label_width {
-            let cell = fb.get(i, 1).unwrap();
-            assert_eq!(cell.style.bg, expected_bg, "col {i} on row 1 should have label bg");
+            let cell = fb.get(label_x + i, 0).unwrap();
+            assert_eq!(cell.style.fg, expected_fg, "col {i} on row 0 should have label fg");
+            assert!(cell.style.attributes.has_any_underline(), "col {i} should be underlined");
         }
     }
 
@@ -992,6 +1048,11 @@ mod tests {
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
+
+        state.buffer_cache.insert(
+            100,
+            vec![String::new(); 6], // 6 empty lines
+        );
 
         state.add_remote_client(RemoteClient {
             client_id: 4,
@@ -1006,35 +1067,40 @@ mod tests {
         let config = RenderConfig::default();
         render_frame(&mut fb, &state, &config);
 
-        // Label bg width should be based on truncated name, not the full name.
-        let expected_bg = Some(client_color(4));
-        let truncated_label = label_text("very-long-username-that-exceeds-limit");
+        // Label should be truncated to MAX_LABEL_WIDTH
+        let truncated_label = label_text("very-long-username-that-exceeds-limit", "NORMAL");
         #[allow(clippy::cast_possible_truncation)]
         let label_width = display_width(&truncated_label) as u16;
 
-        // Full name would be 39 chars; truncated should be <= MAX_LABEL_WIDTH + 2 + 3
+        // Full name would be 39 chars; truncated should be <= MAX_LABEL_WIDTH + padding + mode
         assert!(label_width < 39, "Label should be truncated, got width {label_width}");
 
-        // Verify bg applied for the truncated label width
+        // Label at col 1 (empty line EOL=0, +1 gap)
+        let expected_fg = Some(client_color(4));
         for i in 0..label_width {
-            let cell = fb.get(i, 4).unwrap();
-            assert_eq!(cell.style.bg, expected_bg, "col {i} should have label bg");
+            let cell = fb.get(1 + i, 5).unwrap();
+            assert_eq!(cell.style.fg, expected_fg, "col {i} should have label fg");
         }
     }
 
     #[test]
-    fn test_remote_cursor_label_clamped_to_screen() {
-        let mut fb = FrameBuffer::new(30, 10);
+    fn test_remote_cursor_label_skipped_when_no_room() {
+        // Narrow terminal: label should be skipped if it doesn't fit after EOL
+        let mut fb = FrameBuffer::new(20, 10);
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
 
-        // Cursor near right edge
+        // Line fills most of the 20-col screen
+        state
+            .buffer_cache
+            .insert(100, vec!["long content here!".to_string()]);
+
         state.add_remote_client(RemoteClient {
             client_id: 5,
             display_name: "charlie".to_string(),
-            cursor_line: 3,
-            cursor_col: 25,
+            cursor_line: 0,
+            cursor_col: 0,
             buffer_id: Some(100),
             mode: "NORMAL".to_string(),
             selection: None,
@@ -1043,22 +1109,17 @@ mod tests {
         let config = RenderConfig::default();
         render_frame(&mut fb, &state, &config);
 
-        // Label bg should be visible (clamped to fit within 30 columns)
-        let expected_bg = Some(client_color(5));
-        #[allow(clippy::cast_possible_truncation)]
-        let label_width = display_width(&label_text("charlie")) as u16;
-
-        // Label clamped: starts at min(25, 30 - label_width), must end before col 30
-        let mut found_label_cells = 0u16;
-        for col in 0..30u16 {
-            if fb.get(col, 2).map(|c| c.style.bg) == Some(expected_bg) {
-                found_label_cells += 1;
-            }
+        // "long content here!" is 18 chars, label_x = 19 (18+1).
+        // Label " charlie [N] " is 14 chars. 19 + 14 = 33 > 20.
+        // Label should be skipped entirely.
+        let label_fg = Some(client_color(5));
+        for x in 0..20u16 {
+            let cell = fb.get(x, 0).unwrap();
+            assert_ne!(
+                cell.style.fg, label_fg,
+                "No cell should have label fg at col {x} (label should be skipped)"
+            );
         }
-        assert_eq!(
-            found_label_cells, label_width,
-            "Should find exactly {label_width} label cells on row 2"
-        );
     }
 
     #[test]
@@ -1067,6 +1128,8 @@ mod tests {
         let mut state = TuiCoreState::new(1);
         state.windows.push(window(1, 100));
         state.focused_window_id = 1;
+
+        state.buffer_cache.insert(100, vec!["hello".to_string(); 5]);
 
         state.add_remote_client(RemoteClient {
             client_id: 6,
@@ -1081,14 +1144,14 @@ mod tests {
         let config = RenderConfig::default();
         render_frame(&mut fb, &state, &config);
 
-        // No label bg should appear anywhere (client is in a different buffer)
-        let label_bg = Some(client_color(6));
+        // No label should appear anywhere (client is in a different buffer)
+        let label_fg = Some(client_color(6));
         for y in 0..23u16 {
             for x in 0..80u16 {
                 let cell = fb.get(x, y).unwrap();
                 assert_ne!(
-                    cell.style.bg, label_bg,
-                    "No cell should have label bg at ({x}, {y}) for different-buffer client"
+                    cell.style.fg, label_fg,
+                    "No cell should have label fg at ({x}, {y}) for different-buffer client"
                 );
             }
         }
@@ -1096,20 +1159,28 @@ mod tests {
 
     #[test]
     fn test_label_text_helper() {
-        // Normal name
-        assert_eq!(label_text("alice"), " alice ");
+        // Normal name with mode
+        assert_eq!(label_text("alice", "NORMAL"), " alice [N] ");
 
         // Empty name
-        assert_eq!(label_text(""), " ? ");
+        assert_eq!(label_text("", "NORMAL"), " ? [N] ");
 
         // Long name triggers truncation
-        let long = label_text("very-long-username-that-exceeds");
+        let long = label_text("very-long-username-that-exceeds", "INSERT");
         assert!(long.contains("..."), "Long name should be truncated with '...'");
+        assert!(long.contains("[I]"), "Label should contain insert mode indicator");
         assert!(long.starts_with(' '), "Label should have leading space");
         assert!(long.ends_with(' '), "Label should have trailing space");
 
         // Exact limit (16 chars)
-        assert_eq!(label_text("exactly16chars!!"), " exactly16chars!! ");
+        assert_eq!(label_text("exactly16chars!!", "NORMAL"), " exactly16chars!! [N] ");
+
+        // Mode abbreviations
+        assert!(label_text("x", "INSERT").contains("[I]"));
+        assert!(label_text("x", "VISUAL").contains("[V]"));
+        assert!(label_text("x", "COMMAND").contains("[C]"));
+        assert!(label_text("x", "REPLACE").contains("[R]"));
+        assert!(label_text("x", "NORMAL").contains("[N]"));
     }
 
     #[test]

--- a/clients/tui/tests/test_o_cursor.rs
+++ b/clients/tui/tests/test_o_cursor.rs
@@ -1,0 +1,115 @@
+//! Quick test to check if cursor position updates after `o` + typing
+use {
+    reovim_client_tui::{TuiAppError, TuiHandle, connect_headless},
+    reovim_testing::TestServerHarness,
+    std::time::Duration,
+};
+
+async fn headless_tui(addr: &str, width: u16, height: u16) -> Result<TuiHandle, TuiAppError> {
+    let (mut app, handle) = connect_headless(addr, width, height, None, None).await?;
+    tokio::spawn(async move { app.run().await });
+    Ok(handle)
+}
+
+fn extract_cursor_from_statusline(frame: &str) -> Option<(u32, u32)> {
+    let last_line = frame.lines().last()?;
+    for segment in last_line.split('|') {
+        let trimmed = segment.trim();
+        if let Some(colon_idx) = trimmed.rfind(':') {
+            let before = trimmed[..colon_idx].trim();
+            let after = trimmed[colon_idx + 1..].trim();
+            if let Some(line_str) = before.split_whitespace().last()
+                && let (Ok(line), Ok(col)) = (line_str.parse::<u32>(), after.parse::<u32>())
+            {
+                return Some((line, col));
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+#[ignore = "cursor notifications not sent during insert mode - separate issue from #474"]
+async fn test_o_cursor_position() {
+    let harness = TestServerHarness::spawn().await.expect("spawn");
+    let addr = format!("127.0.0.1:{}", harness.port());
+
+    // Two clients
+    let tui_a = headless_tui(&addr, 80, 24).await.expect("TUI A");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let tui_b = headless_tui(&addr, 80, 24).await.expect("TUI B");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // A types some content
+    tui_a
+        .send_keys("ihello<CR>world<Esc>")
+        .await
+        .expect("A type");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Check A's cursor before `o`
+    let frame_pre = tui_a.capture("plain_text").await.expect("cap");
+    let cursor_pre = extract_cursor_from_statusline(&frame_pre);
+    eprintln!("BEFORE o: cursor={cursor_pre:?}");
+    eprintln!("--- frame ---");
+    for (i, line) in frame_pre.lines().enumerate() {
+        eprintln!("  {:>2}| {line}", i + 1);
+    }
+
+    // A presses `o` (open line below, enter INSERT)
+    tui_a.send_keys("o").await.expect("A o");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let frame_after_o = tui_a.capture("plain_text").await.expect("cap");
+    let cursor_after_o = extract_cursor_from_statusline(&frame_after_o);
+    eprintln!("\nAFTER o: cursor={cursor_after_o:?}");
+    eprintln!("--- frame ---");
+    for (i, line) in frame_after_o.lines().enumerate() {
+        eprintln!("  {:>2}| {line}", i + 1);
+    }
+
+    // A types `iii`
+    tui_a.send_keys("iii").await.expect("A iii");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let frame_after_iii = tui_a.capture("plain_text").await.expect("cap");
+    let cursor_after_iii = extract_cursor_from_statusline(&frame_after_iii);
+    eprintln!("\nAFTER iii: cursor={cursor_after_iii:?}");
+    eprintln!("--- frame ---");
+    for (i, line) in frame_after_iii.lines().enumerate() {
+        eprintln!("  {:>2}| {line}", i + 1);
+    }
+
+    // A presses Esc
+    tui_a.send_keys("<Esc>").await.expect("A esc");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let frame_after_esc = tui_a.capture("plain_text").await.expect("cap");
+    let cursor_after_esc = extract_cursor_from_statusline(&frame_after_esc);
+    eprintln!("\nAFTER Esc: cursor={cursor_after_esc:?}");
+    eprintln!("--- frame ---");
+    for (i, line) in frame_after_esc.lines().enumerate() {
+        eprintln!("  {:>2}| {line}", i + 1);
+    }
+
+    // The cursor after `o` should be on line 3 (new line below line 2)
+    assert!(
+        cursor_after_o.is_some_and(|(line, _)| line == 3),
+        "After `o`, cursor should be on line 3, got {cursor_after_o:?}",
+    );
+
+    // The cursor after typing `iii` should still be on line 3
+    assert!(
+        cursor_after_iii.is_some_and(|(line, _)| line == 3),
+        "After `iii`, cursor should be on line 3, got {cursor_after_iii:?}",
+    );
+
+    // After Esc, cursor should be on line 3
+    assert!(
+        cursor_after_esc.is_some_and(|(line, _)| line == 3),
+        "After Esc, cursor should be on line 3, got {cursor_after_esc:?}",
+    );
+
+    tui_a.stop().await;
+    tui_b.stop().await;
+}

--- a/server/lib/drivers/ffi/src/timer.rs
+++ b/server/lib/drivers/ffi/src/timer.rs
@@ -690,7 +690,7 @@ mod tests {
         assert!(handle.is_valid());
 
         let during = reovim_timer_count();
-        assert!(during >= before + 1);
+        assert!(during > before);
 
         reovim_cancel_timer(handle);
     }

--- a/server/lib/drivers/input/src/fallback.rs
+++ b/server/lib/drivers/input/src/fallback.rs
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn test_noop_fallback_default_trait() {
-        let handler = NoOpFallback::default();
+        let handler = NoOpFallback;
         let mut ctx = MockContext::normal();
         let key = KeyEvent::new(KeyCode::Char('z'));
         assert_eq!(handler.handle_unmatched(key, &mut ctx), FallbackResult::Ignored);
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_beep_fallback_default_trait() {
-        let handler = BeepFallback::default();
+        let handler = BeepFallback;
         let mut ctx = MockContext::normal();
         let key = KeyEvent::new(KeyCode::Char('z'));
         assert_eq!(handler.handle_unmatched(key, &mut ctx), FallbackResult::Beep);

--- a/server/lib/drivers/input/src/resolver_registry.rs
+++ b/server/lib/drivers/input/src/resolver_registry.rs
@@ -796,9 +796,6 @@ mod tests {
 
     #[test]
     fn test_resolve_with_keymap_not_handled_no_parent() {
-        let registry = ResolverRegistry::new();
-        let mode = visual_mode();
-
         // NotHandledResolver without parent - just returns NotHandled
         struct NoParentResolver {
             mode: ModeId,
@@ -817,6 +814,9 @@ mod tests {
             }
         }
 
+        let registry = ResolverRegistry::new();
+        let mode = visual_mode();
+
         registry.register(NoParentResolver { mode: mode.clone() });
 
         let key = KeyEvent::new(crate::KeyCode::Char('x'));
@@ -830,9 +830,6 @@ mod tests {
 
     #[test]
     fn test_resolve_with_extensions_not_handled_no_parent() {
-        let registry = ResolverRegistry::new();
-        let mode = visual_mode();
-
         struct NoParentResolver {
             mode: ModeId,
         }
@@ -849,6 +846,9 @@ mod tests {
                 &self.mode
             }
         }
+
+        let registry = ResolverRegistry::new();
+        let mode = visual_mode();
 
         registry.register(NoParentResolver { mode: mode.clone() });
 
@@ -865,9 +865,6 @@ mod tests {
 
     #[test]
     fn test_resolve_with_session_not_handled_no_parent() {
-        let registry = ResolverRegistry::new();
-        let mode = visual_mode();
-
         struct NoParentResolver {
             mode: ModeId,
         }
@@ -884,6 +881,9 @@ mod tests {
                 &self.mode
             }
         }
+
+        let registry = ResolverRegistry::new();
+        let mode = visual_mode();
 
         registry.register(NoParentResolver { mode: mode.clone() });
 

--- a/server/lib/drivers/session/src/runtime.rs
+++ b/server/lib/drivers/session/src/runtime.rs
@@ -99,7 +99,7 @@ pub struct SessionRuntime<'a> {
     /// When `Some`, makes explicit which client's state we're operating on.
     /// When `None`, this is a test runtime without explicit client binding.
     owner: Option<crate::ClientId>,
-    /// Shared session state (compositor, `terminal_size`, `active_buffer`).
+    /// Shared session state (`terminal_size`, `active_buffer`, template compositor).
     ///
     /// Per-client state is stored in SEPARATE fields below, not in session.
     session: &'a mut Session,
@@ -118,6 +118,12 @@ pub struct SessionRuntime<'a> {
     /// Extension operations use this directly. Per-client module state
     /// isolation is enforced by requiring this field at construction time.
     extensions: &'a mut crate::ExtensionMap,
+    /// Per-client compositor for window layout (#474).
+    ///
+    /// Each client owns their own compositor cloned from the shared template.
+    /// `CompositorApi` methods use this instead of `session.shared.compositor`.
+    /// `None` when compositor is not set (tests, headless mode).
+    compositor: &'a mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     /// Kernel context (buffers, registers, marks).
     kernel: &'a KernelContext,
     /// Command executor for looking up and running commands.
@@ -171,11 +177,13 @@ impl<'a> SessionRuntime<'a> {
     /// runtime.windows().active();              // This client's active window
     /// runtime.ext_mut::<VimSessionState>();    // This client's vim state
     /// ```
+    #[allow(clippy::too_many_arguments)] // Per-client execution needs all these parameters
     pub fn new(
         session: &'a mut Session,
         mode_stack: &'a mut reovim_kernel::api::v1::ModeStack,
         windows: &'a mut crate::WindowLayout,
         extensions: &'a mut crate::ExtensionMap,
+        compositor: &'a mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         kernel: &'a KernelContext,
         executor: &'a dyn CommandExecutor,
     ) -> Self {
@@ -189,6 +197,7 @@ impl<'a> SessionRuntime<'a> {
             mode_stack,
             windows,
             extensions,
+            compositor,
             kernel,
             executor,
             screen,
@@ -230,12 +239,14 @@ impl<'a> SessionRuntime<'a> {
     ///
     /// [`new`]: Self::new
     /// [`owner()`]: Self::owner
+    #[allow(clippy::too_many_arguments)] // Per-client execution needs all these parameters
     pub fn with_owner(
         owner: crate::ClientId,
         session: &'a mut Session,
         mode_stack: &'a mut reovim_kernel::api::v1::ModeStack,
         windows: &'a mut crate::WindowLayout,
         extensions: &'a mut crate::ExtensionMap,
+        compositor: &'a mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         kernel: &'a KernelContext,
         executor: &'a dyn CommandExecutor,
     ) -> Self {
@@ -249,6 +260,7 @@ impl<'a> SessionRuntime<'a> {
             mode_stack,
             windows,
             extensions,
+            compositor,
             kernel,
             executor,
             screen,
@@ -285,7 +297,7 @@ impl<'a> SessionRuntime<'a> {
     /// Check if compositor is available.
     #[must_use]
     pub fn has_compositor(&self) -> bool {
-        self.session.shared.compositor.is_some()
+        self.compositor.is_some()
     }
 
     /// Get direct access to the session.
@@ -1089,8 +1101,6 @@ impl SessionRuntime<'_> {
     /// Emit a `LayoutChanged` event via the kernel's event bus.
     fn emit_layout_event(&self, kind: LayoutChangeKind) {
         let (window_count, focused_window) = self
-            .session
-            .shared
             .compositor
             .as_ref()
             .map_or((0, None), |c| (c.window_count(), c.focused().map(|id| id.as_usize() as u64)));
@@ -1105,8 +1115,6 @@ impl SessionRuntime<'_> {
 impl CompositorApi for SessionRuntime<'_> {
     fn navigate(&self, direction: NavigateDirection) -> Result<WindowId, CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_ref()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1128,8 +1136,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn split(&mut self, direction: SplitDirection) -> Result<WindowId, CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1164,8 +1170,6 @@ impl CompositorApi for SessionRuntime<'_> {
         use reovim_driver_display::layout::Zone;
 
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1205,8 +1209,6 @@ impl CompositorApi for SessionRuntime<'_> {
         use reovim_driver_display::layout::Zone;
 
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1248,8 +1250,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn resize(&mut self, direction: NavigateDirection, delta: i16) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1277,8 +1277,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn equalize(&mut self) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1302,8 +1300,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn cycle(&self, forward: bool) -> Result<WindowId, CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_ref()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1325,8 +1321,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn focus(&mut self, window: WindowId) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1350,32 +1344,26 @@ impl CompositorApi for SessionRuntime<'_> {
     }
 
     fn focused_window(&self) -> Option<WindowId> {
-        self.session.shared.compositor.as_ref()?.focused()
+        self.compositor.as_ref()?.focused()
     }
 
     fn compositor_window_count(&self) -> usize {
-        self.session
-            .shared
-            .compositor
-            .as_ref()
-            .map_or(0, |c| c.window_count())
+        self.compositor.as_ref().map_or(0, |c| c.window_count())
     }
 
     fn arrange(&self, screen: Rect) -> Vec<WindowPlacement> {
-        self.session
-            .shared
-            .compositor
+        self.compositor
             .as_ref()
             .map_or_else(Vec::new, |c| c.composite(screen).placements)
     }
 
     fn active_layer(&self) -> Option<LayerId> {
-        self.session.shared.compositor.as_ref()?.active_layer()
+        self.compositor.as_ref()?.active_layer()
     }
 
     fn set_screen(&mut self, screen: Rect) {
         self.screen = screen;
-        if let Some(compositor) = self.session.shared.compositor.as_mut() {
+        if let Some(compositor) = self.compositor.as_mut() {
             compositor.set_screen(screen);
         }
     }
@@ -1386,8 +1374,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn toggle_float(&mut self) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1410,8 +1396,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn raise_float(&mut self) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1433,8 +1417,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn lower_float(&mut self) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1463,8 +1445,6 @@ impl CompositorApi for SessionRuntime<'_> {
         constraints: OverlayConstraints,
     ) -> Result<WindowId, CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1484,8 +1464,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn hide_overlay(&mut self, window: WindowId) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1509,8 +1487,6 @@ impl CompositorApi for SessionRuntime<'_> {
         height: u16,
     ) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1529,8 +1505,6 @@ impl CompositorApi for SessionRuntime<'_> {
 
     fn hide_all_overlays(&mut self) -> Result<(), CompositorError> {
         let compositor = self
-            .session
-            .shared
             .compositor
             .as_mut()
             .ok_or(CompositorError::NoActiveLayer)?;
@@ -1586,12 +1560,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1638,6 +1614,7 @@ mod tests {
         let mut client_mode_stack = ModeStack::new(test_mode());
         let mut client_windows = crate::WindowLayout::empty();
         let mut client_extensions = crate::ExtensionMap::new();
+        let mut client_compositor = None;
 
         // #491: Session no longer has mode_stack field - use home_mode() from shared
         let session_home_mode = session.shared.home_mode().clone();
@@ -1650,6 +1627,7 @@ mod tests {
                 &mut client_mode_stack,
                 &mut client_windows,
                 &mut client_extensions,
+                &mut client_compositor,
                 &kernel,
                 &executor,
             );
@@ -1684,6 +1662,7 @@ mod tests {
         let mut client_stack = ModeStack::new(test_mode());
         let mut client_windows = crate::WindowLayout::empty();
         let mut client_extensions = crate::ExtensionMap::new();
+        let mut client_compositor = None;
 
         // Runtime created with new() has no owner
         {
@@ -1692,6 +1671,7 @@ mod tests {
                 &mut client_stack,
                 &mut client_windows,
                 &mut client_extensions,
+                &mut client_compositor,
                 &kernel,
                 &executor,
             );
@@ -1707,6 +1687,7 @@ mod tests {
                 &mut client_stack,
                 &mut client_windows,
                 &mut client_extensions,
+                &mut client_compositor,
                 &kernel,
                 &executor,
             );
@@ -1727,9 +1708,11 @@ mod tests {
         let mut client1_stack = ModeStack::new(test_mode());
         let mut client1_windows = crate::WindowLayout::empty();
         let mut client1_extensions = crate::ExtensionMap::new();
+        let mut client1_compositor = None;
         let mut client2_stack = ModeStack::new(test_mode());
         let mut client2_windows = crate::WindowLayout::empty();
         let mut client2_extensions = crate::ExtensionMap::new();
+        let mut client2_compositor = None;
 
         // Client 1 enters insert mode (#471 Phase 0: use new())
         {
@@ -1738,6 +1721,7 @@ mod tests {
                 &mut client1_stack,
                 &mut client1_windows,
                 &mut client1_extensions,
+                &mut client1_compositor,
                 &kernel,
                 &executor,
             );
@@ -1751,6 +1735,7 @@ mod tests {
                 &mut client2_stack,
                 &mut client2_windows,
                 &mut client2_extensions,
+                &mut client2_compositor,
                 &kernel,
                 &executor,
             );
@@ -1776,12 +1761,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1838,12 +1825,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1872,12 +1861,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2432,12 +2423,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2454,12 +2447,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2476,12 +2471,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2499,12 +2496,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2522,12 +2521,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -2544,12 +2545,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3100,12 +3103,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3335,12 +3340,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty(); // No windows!
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3367,12 +3374,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty(); // No windows!
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3491,12 +3500,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3516,12 +3527,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3545,12 +3558,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3574,12 +3589,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3601,12 +3618,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3778,12 +3797,14 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3812,12 +3833,14 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3839,12 +3862,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3871,6 +3896,7 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::with_owner(
             client_id,
@@ -3878,6 +3904,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3907,6 +3934,7 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::with_owner(
             client_id,
@@ -3914,6 +3942,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -3938,6 +3967,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode());
         let mut windows = crate::WindowLayout::empty();
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::with_owner(
             client_id,
@@ -3945,6 +3975,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -4085,7 +4116,7 @@ mod tests {
         make_kernel_with_services(services)
     }
 
-    /// Undo with Delete edits covers the Edit::Delete branch in undo() (lines 829-831, 835).
+    /// Undo with Delete edits covers the `Edit::Delete` branch in `undo()` (lines 829-831, 835).
     #[test]
     fn test_undo_with_delete_edits() {
         use reovim_kernel::api::v1::ModeStack;
@@ -4103,12 +4134,14 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -4121,7 +4154,7 @@ mod tests {
         assert!(runtime.changes.buffer_modified);
     }
 
-    /// Redo with Insert edits covers the Edit::Insert branch in redo() (lines 863-865, 872).
+    /// Redo with Insert edits covers the `Edit::Insert` branch in `redo()` (lines 863-865, 872).
     #[test]
     fn test_redo_with_insert_edits() {
         use reovim_kernel::api::v1::ModeStack;
@@ -4139,12 +4172,14 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -4157,7 +4192,7 @@ mod tests {
         assert!(runtime.changes.buffer_modified);
     }
 
-    /// undo_mine with Delete edits covers the Edit::Delete branch (lines 938-940, 943).
+    /// `undo_mine` with Delete edits covers the `Edit::Delete` branch (lines 938-940, 943).
     #[test]
     fn test_undo_mine_with_delete_edits() {
         use reovim_kernel::api::v1::ModeStack;
@@ -4176,6 +4211,7 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::with_owner(
             client_id,
@@ -4183,6 +4219,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -4195,7 +4232,7 @@ mod tests {
         assert!(runtime.changes.buffer_modified);
     }
 
-    /// redo_mine with Insert edits covers the Edit::Insert branch (lines 974-976, 982).
+    /// `redo_mine` with Insert edits covers the `Edit::Insert` branch (lines 974-976, 982).
     #[test]
     fn test_redo_mine_with_insert_edits() {
         use reovim_kernel::api::v1::ModeStack;
@@ -4214,6 +4251,7 @@ mod tests {
         let mut windows = crate::WindowLayout::empty();
         windows.add(window);
         let mut extensions = crate::ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::with_owner(
             client_id,
@@ -4221,6 +4259,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -4477,11 +4516,12 @@ mod tests {
         mode_stack: &'a mut reovim_kernel::api::v1::ModeStack,
         windows: &'a mut crate::WindowLayout,
         extensions: &'a mut crate::ExtensionMap,
+        compositor: &'a mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         kernel: &'a KernelContext,
         executor: &'a StubExecutor,
     ) -> SessionRuntime<'a> {
-        session.set_compositor(Box::new(MockRootCompositor::new()));
-        SessionRuntime::new(session, mode_stack, windows, extensions, kernel, executor)
+        *compositor = Some(Box::new(MockRootCompositor::new()));
+        SessionRuntime::new(session, mode_stack, windows, extensions, compositor, kernel, executor)
     }
 
     #[test]
@@ -4493,8 +4533,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.navigate(NavigateDirection::Right);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), WindowId::from_raw(2));
@@ -4509,9 +4558,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.split(reovim_driver_display::SplitDirection::Horizontal);
         assert!(result.is_ok());
         assert!(rt.changes.windows_created.contains(&result.unwrap()));
@@ -4526,9 +4583,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.close_current_window();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), WindowId::from_raw(2));
@@ -4543,9 +4608,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.close_others();
         assert!(result.is_ok());
         assert!(rt.changes.windows_closed.contains(&WindowId::from_raw(2)));
@@ -4560,9 +4633,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.resize(NavigateDirection::Right, 5);
         assert!(result.is_ok());
         assert!(rt.changes.window_changed);
@@ -4577,9 +4658,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.equalize();
         assert!(result.is_ok());
         assert!(rt.changes.window_changed);
@@ -4594,8 +4683,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.cycle(true);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), WindowId::from_raw(2));
@@ -4610,9 +4708,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.focus(WindowId::from_raw(2));
         assert!(result.is_ok());
         assert!(rt.changes.focus_changed);
@@ -4627,9 +4733,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         // Focus the already-focused window - LayoutChanged event should NOT fire
         let result = rt.focus(WindowId::from_raw(1));
         assert!(result.is_ok());
@@ -4645,8 +4759,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert_eq!(rt.focused_window(), Some(WindowId::from_raw(1)));
     }
 
@@ -4659,8 +4782,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert_eq!(rt.compositor_window_count(), 2);
     }
 
@@ -4673,8 +4805,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.active_layer().is_some());
     }
 
@@ -4687,9 +4828,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.toggle_float().is_ok());
         assert!(rt.changes.window_changed);
     }
@@ -4703,9 +4852,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.raise_float().is_ok());
     }
 
@@ -4718,9 +4875,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.lower_float().is_ok());
     }
 
@@ -4733,9 +4898,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let result = rt.show_overlay(
             reovim_driver_display::layout::OverlayConstraints::centered().with_size(20, 10),
         );
@@ -4751,9 +4924,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.hide_overlay(WindowId::from_raw(99)).is_ok());
     }
 
@@ -4766,9 +4947,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.resize_overlay(WindowId::from_raw(99), 40, 20).is_ok());
     }
 
@@ -4781,9 +4970,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         assert!(rt.hide_all_overlays().is_ok());
     }
 
@@ -4796,9 +4993,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let mut rt =
-            make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         rt.set_screen(Rect::new(0, 0, 120, 40));
     }
 
@@ -4811,8 +5016,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         rt.emit_layout_event(reovim_kernel::api::v1::events::kernel::LayoutChangeKind::Equalize);
     }
 
@@ -4825,8 +5039,17 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
-        let rt = make_compositor_runtime(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
         let placements = rt.arrange(Rect::new(0, 0, 80, 24));
         assert!(placements.is_empty());
     }
@@ -4835,8 +5058,8 @@ mod tests {
     // CompositorApi: close_current_window with single window (CannotCloseLastWindow)
     // =========================================================================
 
-    /// Mock compositor with only ONE tiled window, so close_current_window
-    /// returns CannotCloseLastWindow (covers line 1176).
+    /// Mock compositor with only ONE tiled window, so `close_current_window`
+    /// returns `CannotCloseLastWindow` (covers line 1176).
     struct SingleWindowLayerCompositor {
         id: reovim_driver_display::layout::LayerId,
         window: WindowId,
@@ -4983,7 +5206,7 @@ mod tests {
             Some(reovim_driver_display::layout::LayerId::new(0))
         }
         fn boxed_clone(&self) -> Box<dyn reovim_driver_display::layout::RootCompositor> {
-            Box::new(SingleWindowRootCompositor::new())
+            Box::new(Self::new())
         }
     }
 
@@ -4996,9 +5219,10 @@ mod tests {
         let mut ms = ModeStack::new(test_mode());
         let mut w = crate::WindowLayout::empty();
         let mut e = crate::ExtensionMap::new();
-
-        session.set_compositor(Box::new(SingleWindowRootCompositor::new()));
-        let mut rt = SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &kernel, &executor);
+        let mut c: Option<Box<dyn reovim_driver_display::layout::RootCompositor>> =
+            Some(Box::new(SingleWindowRootCompositor::new()));
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
 
         let result = rt.close_current_window();
         assert!(result.is_err());

--- a/server/lib/drivers/session/src/testing.rs
+++ b/server/lib/drivers/session/src/testing.rs
@@ -85,6 +85,10 @@ pub struct TestSessionRuntime {
     ///
     /// Commands use this via `runtime.ext::<T>()`, `runtime.ext_mut::<T>()`.
     pub extensions: ExtensionMap,
+    /// Per-client compositor (#474).
+    ///
+    /// `None` for tests that don't need compositor. Matches `EditingState.compositor`.
+    compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     kernel: KernelContext,
     executor: StubExecutor,
     /// Accumulated changes from operations.
@@ -126,6 +130,7 @@ impl TestSessionRuntime {
             mode_stack: ModeStack::new(home_mode),                      // Per-client state
             windows: WindowLayout::empty(),                             // Per-client state
             extensions: ExtensionMap::new(),                            // Per-client state
+            compositor: None,                                           // Per-client (#474)
             kernel: Self::make_test_kernel(),
             executor: StubExecutor,
             changes: StateChanges::new(),
@@ -140,6 +145,7 @@ impl TestSessionRuntime {
             mode_stack: ModeStack::new(mode),                      // Per-client state
             windows: WindowLayout::empty(),                        // Per-client state
             extensions: ExtensionMap::new(),                       // Per-client state
+            compositor: None,                                      // Per-client (#474)
             kernel: Self::make_test_kernel(),
             executor: StubExecutor,
             changes: StateChanges::new(),
@@ -198,6 +204,7 @@ impl TestSessionRuntime {
             &mut self.mode_stack, // Separate field (no conflict)
             &mut self.windows,    // Separate field (no conflict)
             &mut self.extensions, // Separate field (no conflict)
+            &mut self.compositor, // Per-client compositor (#474)
             &self.kernel,
             &self.executor,
         );
@@ -222,6 +229,7 @@ impl TestSessionRuntime {
             &mut self.mode_stack,
             &mut self.windows,
             &mut self.extensions,
+            &mut self.compositor,
             &self.kernel,
             &self.executor,
         )
@@ -401,7 +409,7 @@ impl TestSessionRuntime {
         &mut self,
         compositor: Box<dyn reovim_driver_display::layout::RootCompositor>,
     ) {
-        self.session.set_compositor(compositor);
+        self.compositor = Some(compositor);
     }
 }
 

--- a/server/lib/drivers/session/src/types.rs
+++ b/server/lib/drivers/session/src/types.rs
@@ -514,6 +514,21 @@ impl Window {
             selection: None,
         }
     }
+
+    /// Create a window with a specific ID and buffer (#474).
+    ///
+    /// Used when creating per-client windows that must match compositor window IDs.
+    /// Unlike `with_buffer()`, this does NOT generate a new `WindowId`.
+    #[must_use]
+    pub fn with_id_and_buffer(id: WindowId, buffer_id: BufferId) -> Self {
+        Self {
+            id,
+            buffer_id: Some(buffer_id),
+            cursor: CursorPosition::origin(),
+            viewport: Viewport::default(),
+            selection: None,
+        }
+    }
 }
 
 impl Default for Window {
@@ -639,6 +654,35 @@ impl WindowLayout {
     /// Get window by ID mutably.
     pub fn get_mut(&mut self, id: WindowId) -> Option<&mut Window> {
         self.windows.iter_mut().find(|w| w.id == id)
+    }
+
+    /// Remove a window by ID (#474).
+    ///
+    /// Returns `true` if the window was found and removed. If the removed
+    /// window was active, the active index is adjusted.
+    pub fn remove(&mut self, id: WindowId) -> bool {
+        if let Some(idx) = self.windows.iter().position(|w| w.id == id) {
+            self.windows.remove(idx);
+            // Adjust active index after removal
+            match self.active_index {
+                Some(active) if active == idx => {
+                    // Active window was removed - reset to first window (if any)
+                    self.active_index = if self.windows.is_empty() {
+                        None
+                    } else {
+                        Some(0)
+                    };
+                }
+                Some(active) if active > idx => {
+                    // Active was after removed - shift down
+                    self.active_index = Some(active - 1);
+                }
+                _ => {}
+            }
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/server/lib/kernel/src/debug/profiler.rs
+++ b/server/lib/kernel/src/debug/profiler.rs
@@ -893,7 +893,7 @@ mod tests {
         let debug = format!("{cloned:?}");
         assert!(debug.contains("NopProfiler"));
 
-        let default_nop = NopProfiler::default();
+        let default_nop = NopProfiler;
         assert!(!default_nop.enabled("test"));
     }
 

--- a/server/lib/kernel/src/ipc/event.rs
+++ b/server/lib/kernel/src/ipc/event.rs
@@ -711,11 +711,11 @@ mod tests {
 
     #[test]
     fn test_cache_kind_all_variants() {
+        use std::collections::HashSet;
+
         assert_eq!(CacheKind::Highlights, CacheKind::Highlights);
         assert_ne!(CacheKind::Highlights, CacheKind::Decorations);
         assert_ne!(CacheKind::Highlights, CacheKind::Both);
-
-        use std::collections::HashSet;
         let mut set = HashSet::new();
         set.insert(CacheKind::Highlights);
         set.insert(CacheKind::Decorations);

--- a/server/lib/kernel/src/ipc/event_bus/mod.rs
+++ b/server/lib/kernel/src/ipc/event_bus/mod.rs
@@ -1326,6 +1326,7 @@ mod tests {
         let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
 
         let bus2 = bus.clone();
+        drop(bus);
         assert_eq!(bus2.handler_count::<TestEvent>(), 1);
     }
 

--- a/server/lib/kernel/src/sched/timer.rs
+++ b/server/lib/kernel/src/sched/timer.rs
@@ -1068,6 +1068,7 @@ mod tests {
             interval: Some(Duration::from_millis(100)),
             priority: Priority::HIGH,
         };
+        #[allow(clippy::redundant_clone)]
         let cloned = config.clone();
         assert_eq!(cloned.delay, Duration::from_millis(50));
         assert_eq!(cloned.interval, Some(Duration::from_millis(100)));

--- a/server/lib/kernel/src/sched/work_queue.rs
+++ b/server/lib/kernel/src/sched/work_queue.rs
@@ -464,7 +464,7 @@ mod tests {
         queue.push(Task::new(|| {})); // Dropped
         let debug_str = format!("{queue:?}");
         assert!(debug_str.contains("dropped"));
-        assert!(debug_str.contains("1")); // dropped count
+        assert!(debug_str.contains('1')); // dropped count
     }
 
     // === Coverage: try_pop on empty returns None ===

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -2406,8 +2406,10 @@ mod tests {
         use reovim_driver_input::{InputTarget, KeyCode};
 
         // Need a real BufferManager (not StubBufferManager) so buffers are actually stored
-        let mut kernel = reovim_kernel::api::v1::KernelContext::default();
-        kernel.buffers = std::sync::Arc::new(reovim_driver_buffer::TestBufferManager::new());
+        let kernel = reovim_kernel::api::v1::KernelContext {
+            buffers: std::sync::Arc::new(reovim_driver_buffer::TestBufferManager::new()),
+            ..Default::default()
+        };
         let state = crate::session::SessionState::with_kernel(kernel);
         let session =
             crate::session::Session::from_state(SessionId::new("insertchar-modified-test"), state);

--- a/server/lib/server/src/grpc/notification_builder.rs
+++ b/server/lib/server/src/grpc/notification_builder.rs
@@ -260,47 +260,31 @@ fn build_buffer_list_notification(
 /// * `client_id` - Client for per-client focused window
 #[allow(clippy::cast_possible_truncation, clippy::option_if_let_else)]
 fn build_layout_notification(session: &Session, timestamp: u64, client_id: u64) -> Notification {
-    // Phase #486: Try per-client focused window first, fallback to compositor
-    // Phase #491: Removed driver_session.windows fallback (deprecated field removed)
-    let focused_id = session
-        .client_state(ClientId::new(client_id as usize))
-        .and_then(|s| s.windows.active_id())
-        .or_else(|| {
-            // Fallback to compositor focused window
-            session.with_state_sync(|state| {
-                state
-                    .driver_session
-                    .shared
-                    .compositor
-                    .as_ref()
-                    .and_then(|c| c.focused())
-            })
-        });
+    // #474: Use per-client compositor and windows (same ID namespace).
+    // Each client owns a cloned compositor — window IDs from compositor.composite()
+    // match the per-client WindowLayout IDs, fixing the cross-namespace mismatch.
+    let editing_state = session.client_state(ClientId::new(client_id as usize));
 
-    // Phase #491: Get per-client windows for buffer_id lookup
-    let client_windows = session
-        .client_state(ClientId::new(client_id as usize))
-        .map(|s| s.windows);
+    let focused_id = editing_state.as_ref().and_then(|s| s.windows.active_id());
 
-    // Build window info list from shared compositor (layout is session-wide)
-    let windows: Vec<WindowInfo> = session.with_state_sync(|state| {
-        if let Some(compositor) = &state.driver_session.shared.compositor {
-            // Get placements from compositor
-            let (width, height) = state.driver_session.terminal_size();
-            let screen = reovim_driver_display::Rect::new(0, 0, width, height);
+    // Build window info list from per-client compositor (#474)
+    let windows: Vec<WindowInfo> = if let Some(ref state) = editing_state {
+        if let Some(ref compositor) = state.compositor {
+            // Per-client compositor: IDs match per-client windows
+            let terminal_size = session.with_state_sync(|s| s.driver_session.terminal_size());
+            let screen = reovim_driver_display::Rect::new(0, 0, terminal_size.0, terminal_size.1);
             let composite = compositor.composite(screen);
 
-            // Phase #491: Use per-client windows or active_buffer for buffer_id
-            let active_buffer = state.driver_session.active_buffer();
+            let active_buffer = session.with_state_sync(|s| s.driver_session.active_buffer());
 
             composite
                 .placements
                 .iter()
                 .map(|p| {
-                    // Phase #491: Get buffer_id from per-client windows, fallback to active_buffer
-                    let buffer_id = client_windows
-                        .as_ref()
-                        .and_then(|w| w.get(p.window_id))
+                    // #474: w.get(p.window_id) now works — both use same ID namespace
+                    let buffer_id = state
+                        .windows
+                        .get(p.window_id)
                         .and_then(|w| w.buffer_id)
                         .or(active_buffer)
                         .map(|id| id.as_usize() as u64);
@@ -319,37 +303,35 @@ fn build_layout_notification(session: &Session, timestamp: u64, client_id: u64) 
                 })
                 .collect()
         } else {
-            // Phase #491: Fallback when compositor is not set - use per-client windows
-            // or return empty (compositor should always be set in production)
-            if let Some(windows) = &client_windows {
-                windows
-                    .windows
-                    .iter()
-                    .map(|w| WindowInfo {
-                        window_id: w.id.as_usize() as u64,
-                        buffer_id: w.buffer_id.map(|id| id.as_usize() as u64),
-                        rect: Some(WindowRect {
-                            x: 0,
-                            y: 0,
-                            width: 80, // Default size
-                            height: 24,
-                        }),
-                        focused: focused_id == Some(w.id),
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            }
+            // No compositor — use per-client windows with default geometry
+            state
+                .windows
+                .windows
+                .iter()
+                .map(|w| WindowInfo {
+                    window_id: w.id.as_usize() as u64,
+                    buffer_id: w.buffer_id.map(|id| id.as_usize() as u64),
+                    rect: Some(WindowRect {
+                        x: 0,
+                        y: 0,
+                        width: 80,
+                        height: 24,
+                    }),
+                    focused: focused_id == Some(w.id),
+                })
+                .collect()
         }
-    });
+    } else {
+        Vec::new()
+    };
 
     Notification {
         event_type: "layout_changed".to_string(),
         timestamp_ms: timestamp,
         payload: Some(notification::Payload::LayoutChanged(LayoutChangedPayload {
-            // Phase #479: focused_window_id is now Option<u64>
             focused_window_id: focused_id.map(|id| id.as_usize() as u64),
             windows,
+            client_id,
         })),
     }
 }
@@ -1392,6 +1374,7 @@ mod tests {
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_build_layout_notification_with_compositor() {
         use reovim_driver_display::{
             Rect, RootCompositor, WindowId,
@@ -1473,13 +1456,8 @@ mod tests {
             }
         }
 
-        // Create a session state with the compositor
-        let compositor: Box<dyn RootCompositor> = Box::new(TestCompositor {
-            focused: Some(WindowId::from_raw(1)),
-        });
-
-        let mut state = crate::session::SessionState::default();
-        state.driver_session.shared.compositor = Some(compositor);
+        // Create a session state (compositor is now per-client, not shared)
+        let state = crate::session::SessionState::default();
 
         let session = Session::from_state(SessionId::new("compositor-test"), state);
 
@@ -1495,9 +1473,13 @@ mod tests {
         // Override the window id to match the compositor placement
         window.id = reovim_kernel::api::v1::WindowId::from_raw(1);
         let metadata = crate::session::ClientMetadata::default();
-        let client = crate::session::Client::with_mode_stack_and_window(
+        let mut client = crate::session::Client::with_mode_stack_and_window(
             client_id, metadata, mode_stack, window,
         );
+        // #474: Set compositor on per-client state (not shared)
+        client.state.compositor = Some(Box::new(TestCompositor {
+            focused: Some(WindowId::from_raw(1)),
+        }));
         session.add_client_with_state(client);
 
         // Build layout notification - this should hit the compositor branch
@@ -1528,105 +1510,18 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_build_layout_notification_compositor_no_client() {
-        // Test compositor branch when client is NOT registered (no per-client windows)
-        use reovim_driver_display::{
-            Rect, RootCompositor, WindowId,
-            layout::{
-                CompositeResult, Layer, LayerConfig, LayerId, WindowLayerCompositor,
-                WindowPlacement, ZOrder, Zone,
-            },
-        };
-
-        struct TestCompositorNoFocus;
-
-        #[cfg_attr(coverage_nightly, coverage(off))]
-        impl RootCompositor for TestCompositorNoFocus {
-            fn composite(&self, screen: Rect) -> CompositeResult {
-                let placement = WindowPlacement::new(
-                    WindowId::from_raw(5),
-                    LayerId::new(0),
-                    Zone::Tiled,
-                    Rect::new(2, 3, 40, 20),
-                    ZOrder::new(100),
-                );
-                CompositeResult {
-                    placements: vec![placement],
-                    focused: None,
-                    active_layer: None,
-                    screen,
-                }
-            }
-
-            fn create_layer(&mut self, _config: LayerConfig) -> LayerId {
-                LayerId::new(0)
-            }
-            fn remove_layer(&mut self, _layer: LayerId) {}
-            fn layer_by_label(&self, _label: &str) -> Option<LayerId> {
-                None
-            }
-            fn layers(&self) -> Vec<&Layer> {
-                Vec::new()
-            }
-            fn set_layer_visible(&mut self, _layer: LayerId, _visible: bool) {}
-            fn set_layer_opacity(&mut self, _layer: LayerId, _opacity: f32) {}
-            fn reorder_layer(&mut self, _layer: LayerId, _new_z: u16) {}
-            fn set_active_layer(&mut self, _layer: LayerId) {}
-            fn active_layer(&self) -> Option<LayerId> {
-                None
-            }
-            fn set_focus(&mut self, _window: WindowId) {}
-            fn focused(&self) -> Option<WindowId> {
-                None
-            }
-            fn focus_at(&mut self, _x: u16, _y: u16) -> Option<WindowId> {
-                None
-            }
-            fn layer_compositor(&self, _layer: LayerId) -> Option<&dyn WindowLayerCompositor> {
-                None
-            }
-            fn layer_compositor_mut(
-                &mut self,
-                _layer: LayerId,
-            ) -> Option<&mut dyn WindowLayerCompositor> {
-                None
-            }
-            fn window_count(&self) -> usize {
-                1
-            }
-            fn set_screen(&mut self, _screen: Rect) {}
-            fn layer_of(&self, _window: WindowId) -> Option<LayerId> {
-                Some(LayerId::new(0))
-            }
-            fn boxed_clone(&self) -> Box<dyn RootCompositor> {
-                Box::new(Self)
-            }
-        }
-
-        let compositor: Box<dyn RootCompositor> = Box::new(TestCompositorNoFocus);
-        let mut state = crate::session::SessionState::default();
-        state.driver_session.shared.compositor = Some(compositor);
+        // #474: Compositor is now per-client. With no client registered,
+        // there is no per-client state and no compositor, so the result is empty windows.
+        let state = crate::session::SessionState::default();
 
         let session = Session::from_state(SessionId::new("compositor-no-client"), state);
 
-        // No client registered - client_windows will be None,
-        // and active_buffer will be None, so buffer_id in WindowInfo should be None
+        // No client registered - editing_state is None, so windows list is empty
         let notification = build_layout_notification(&session, 54321, 999);
         assert_eq!(notification.event_type, "layout_changed");
 
         if let Some(notification::Payload::LayoutChanged(payload)) = notification.payload {
-            assert_eq!(payload.windows.len(), 1);
-            let win = &payload.windows[0];
-            assert_eq!(win.window_id, 5);
-            // No client_windows and no active_buffer -> buffer_id is None
-            assert!(win.buffer_id.is_none());
-            // No focused window
-            assert!(!win.focused);
-            // Verify rect from compositor
-            let rect = win.rect.as_ref().expect("rect should be present");
-            assert_eq!(rect.x, 2);
-            assert_eq!(rect.y, 3);
-            assert_eq!(rect.width, 40);
-            assert_eq!(rect.height, 20);
+            assert_eq!(payload.windows.len(), 0);
             assert!(payload.focused_window_id.is_none());
         } else {
             panic!("Expected LayoutChangedPayload");
@@ -1635,6 +1530,7 @@ mod tests {
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_build_layout_notification_compositor_with_active_buffer_fallback() {
         // Test compositor branch where client_windows has no matching window
         // but active_buffer is set as fallback
@@ -1739,9 +1635,7 @@ mod tests {
             Arc::new(ServiceRegistry::new()),
         );
 
-        let compositor: Box<dyn RootCompositor> = Box::new(TestCompositorTwoWindows);
         let mut state = crate::session::SessionState::with_kernel(kernel);
-        state.driver_session.shared.compositor = Some(compositor);
 
         // Create a buffer so active_buffer is set
         let buffer_id = state.create_buffer("test content");
@@ -1758,9 +1652,11 @@ mod tests {
         let mut window = reovim_driver_session::Window::with_buffer(buffer_id);
         window.id = reovim_kernel::api::v1::WindowId::from_raw(10);
         let metadata = crate::session::ClientMetadata::default();
-        let client = crate::session::Client::with_mode_stack_and_window(
+        let mut client = crate::session::Client::with_mode_stack_and_window(
             client_id, metadata, mode_stack, window,
         );
+        // #474: Set compositor on per-client state (not shared)
+        client.state.compositor = Some(Box::new(TestCompositorTwoWindows));
         session.add_client_with_state(client);
 
         let notification = build_layout_notification(&session, 99999, 1);

--- a/server/lib/server/src/registry/command.rs
+++ b/server/lib/server/src/registry/command.rs
@@ -138,6 +138,7 @@ impl CommandRegistry {
         client_mode_stack: &mut reovim_kernel::api::v1::ModeStack,
         client_windows: &mut reovim_driver_session::WindowLayout,
         client_extensions: &mut reovim_driver_session::ExtensionMap,
+        client_compositor: &mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         app: &AppState,
         vfs: &Arc<dyn VfsDriver>,
         args: &CommandContext,
@@ -163,6 +164,7 @@ impl CommandRegistry {
                 client_mode_stack,
                 client_windows,
                 client_extensions,
+                client_compositor,
                 &app.kernel,
                 &stub_executor,
             );
@@ -424,6 +426,7 @@ mod tests {
         let mut client_mode_stack = reovim_kernel::api::v1::ModeStack::new(mode);
         let mut client_windows = reovim_driver_session::WindowLayout::empty();
         let mut client_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_compositor = None;
 
         let result = registry.execute_for_client(
             1, // test client_id for per-client undo (#471)
@@ -432,6 +435,7 @@ mod tests {
             &mut client_mode_stack,
             &mut client_windows,
             &mut client_extensions,
+            &mut client_compositor,
             &app,
             &vfs,
             &args,
@@ -615,6 +619,7 @@ mod tests {
         let mut client_mode_stack = reovim_kernel::api::v1::ModeStack::new(mode);
         let mut client_windows = reovim_driver_session::WindowLayout::empty();
         let mut client_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_compositor = None;
 
         let result = registry.execute_for_client(
             1,
@@ -623,6 +628,7 @@ mod tests {
             &mut client_mode_stack,
             &mut client_windows,
             &mut client_extensions,
+            &mut client_compositor,
             &app,
             &vfs,
             &args,
@@ -699,6 +705,7 @@ mod tests {
         let mut client_mode_stack = reovim_kernel::api::v1::ModeStack::new(mode);
         let mut client_windows = reovim_driver_session::WindowLayout::empty();
         let mut client_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_compositor = None;
 
         let result = registry.execute_for_client(
             1,
@@ -707,6 +714,7 @@ mod tests {
             &mut client_mode_stack,
             &mut client_windows,
             &mut client_extensions,
+            &mut client_compositor,
             &app,
             &vfs,
             &args,

--- a/server/lib/server/src/registry/keymap.rs
+++ b/server/lib/server/src/registry/keymap.rs
@@ -918,7 +918,7 @@ mod tests {
         let mode = test_mode();
         let j = KeySequence::parse("j").unwrap();
 
-        registry.register_at_layer(BindingLayer::Policy, &mode, j.clone(), test_command("down"));
+        registry.register_at_layer(BindingLayer::Policy, &mode, j, test_command("down"));
         assert_eq!(registry.total_bindings(), 1);
 
         // Clearing the only layer should remove the mode entry entirely

--- a/server/lib/server/src/session/client.rs
+++ b/server/lib/server/src/session/client.rs
@@ -42,6 +42,7 @@
 use std::{collections::HashMap, time::SystemTime};
 
 use {
+    reovim_driver_display::layout::RootCompositor,
     reovim_driver_session::{
         CursorPosition, ExtensionMap, KeySequence, Selection, SelectionMode, Viewport, Window,
         WindowLayout,
@@ -563,7 +564,6 @@ impl Client {
 /// selection, and module extensions. Each client has independent state
 /// to prevent cross-client interference (e.g., Client A's pending count
 /// affecting Client B's motions).
-#[derive(Debug)]
 pub struct EditingState {
     /// Mode stack (current mode on top).
     pub mode_stack: ModeStack,
@@ -595,6 +595,31 @@ pub struct EditingState {
     /// cause Client B's `j` to move 5 lines instead of 1. This field
     /// ensures complete module state isolation.
     pub extensions: ExtensionMap,
+
+    /// Per-client compositor for window layout (#474).
+    ///
+    /// Each client owns their own compositor, cloned from the shared template
+    /// at join time. This ensures window IDs are consistent between the
+    /// compositor (geometry) and per-client windows (cursor/viewport).
+    ///
+    /// Before this field, the shared compositor and per-client windows used
+    /// independent ID namespaces, causing cross-namespace mismatches in
+    /// notifications and state queries.
+    pub compositor: Option<Box<dyn RootCompositor>>,
+}
+
+impl std::fmt::Debug for EditingState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EditingState")
+            .field("mode_stack", &self.mode_stack)
+            .field("pending_keys", &self.pending_keys)
+            .field("windows", &self.windows)
+            .field("viewport", &self.viewport)
+            .field("selection", &self.selection)
+            .field("extensions", &self.extensions)
+            .field("compositor", &self.compositor.as_ref().map(|_| "..."))
+            .finish()
+    }
 }
 
 // Manual Clone implementation (#477).
@@ -611,6 +636,7 @@ impl Clone for EditingState {
             viewport: self.viewport, // Copy type
             selection: self.selection.clone(),
             extensions: ExtensionMap::new(), // Fresh extensions for cloned state
+            compositor: self.compositor.as_ref().map(|c| c.boxed_clone()), // #474
         }
     }
 }
@@ -625,10 +651,11 @@ impl Default for EditingState {
         Self {
             mode_stack: ModeStack::new(placeholder_mode),
             pending_keys: KeySequence::new(),
-            windows: WindowLayout::empty(), // Per-client windows (#471)
+            windows: WindowLayout::empty(),
             viewport: Viewport::default(),
             selection: None,
-            extensions: ExtensionMap::new(), // Per-client extensions (#477)
+            extensions: ExtensionMap::new(),
+            compositor: None,
         }
     }
 }
@@ -643,7 +670,8 @@ impl EditingState {
             windows: WindowLayout::empty(),
             viewport: Viewport::default(),
             selection: None,
-            extensions: ExtensionMap::new(), // Per-client extensions (#477)
+            extensions: ExtensionMap::new(),
+            compositor: None,
         }
     }
 
@@ -660,7 +688,8 @@ impl EditingState {
             windows,
             viewport: Viewport::default(),
             selection: None,
-            extensions: ExtensionMap::new(), // Per-client extensions (#477)
+            extensions: ExtensionMap::new(),
+            compositor: None,
         }
     }
 

--- a/server/lib/server/src/session/session.rs
+++ b/server/lib/server/src/session/session.rs
@@ -209,6 +209,14 @@ impl Session {
         let state = self.state.read();
         let home_mode = state.home_mode().clone();
         let active_buffer = state.active_buffer();
+        let terminal_size = state.driver_session.terminal_size();
+        // #474: Clone shared compositor for per-client ownership
+        let compositor = state
+            .driver_session
+            .shared
+            .compositor
+            .as_ref()
+            .map(|c| c.boxed_clone());
         drop(state); // Release lock before acquiring clients lock
 
         tracing::debug!(
@@ -216,20 +224,36 @@ impl Session {
             mode_module = %home_mode.module(),
             mode_name = %home_mode.name(),
             ?active_buffer,
+            has_compositor = compositor.is_some(),
             "Initializing client with home mode and per-client windows"
         );
 
         let mode_stack = ModeStack::new(home_mode);
+        let mut client = Client::with_mode_stack(client_id, metadata, mode_stack);
 
-        // Phase #471/#480: Create per-client with metadata and initial window
-        let client = if let Some(buffer_id) = active_buffer {
-            // Session has an active buffer - create window for it
+        // #474: Set per-client compositor and create windows with matching IDs.
+        // The compositor's window IDs must match the per-client WindowLayout IDs
+        // so that cursor notifications (which use WindowLayout IDs) align with
+        // layout notifications (which use compositor IDs).
+        if let Some(compositor) = compositor {
+            if let Some(buffer_id) = active_buffer {
+                let screen =
+                    reovim_driver_display::Rect::new(0, 0, terminal_size.0, terminal_size.1);
+                let result = compositor.composite(screen);
+                for p in &result.placements {
+                    let window = Window::with_id_and_buffer(p.window_id, buffer_id);
+                    client.state.windows.add(window);
+                }
+                if let Some(focused) = result.focused {
+                    client.state.windows.set_active(focused);
+                }
+            }
+            client.state.compositor = Some(compositor);
+        } else if let Some(buffer_id) = active_buffer {
+            // No compositor — create window with new ID (fallback)
             let window = Window::with_buffer(buffer_id);
-            Client::with_mode_stack_and_window(client_id, metadata, mode_stack, window)
-        } else {
-            // No buffer yet - empty windows
-            Client::with_mode_stack(client_id, metadata, mode_stack)
-        };
+            client.state.windows.add(window);
+        }
 
         let mut clients = self.clients.write();
         clients.insert(client_id, client);
@@ -561,8 +585,23 @@ impl Session {
         if editing_state.windows.is_empty()
             && let Some(buffer_id) = state.active_buffer()
         {
-            let window = Window::with_buffer(buffer_id);
-            editing_state.windows.add(window);
+            // #474: If per-client compositor exists, create windows with matching IDs
+            if let Some(ref compositor) = editing_state.compositor {
+                let terminal_size = state.driver_session.terminal_size();
+                let screen =
+                    reovim_driver_display::Rect::new(0, 0, terminal_size.0, terminal_size.1);
+                let result = compositor.composite(screen);
+                for p in &result.placements {
+                    let window = Window::with_id_and_buffer(p.window_id, buffer_id);
+                    editing_state.windows.add(window);
+                }
+                if let Some(focused) = result.focused {
+                    editing_state.windows.set_active(focused);
+                }
+            } else {
+                let window = Window::with_buffer(buffer_id);
+                editing_state.windows.add(window);
+            }
             tracing::debug!(?buffer_id, "Synced per-client windows with active buffer");
         }
     }
@@ -609,14 +648,22 @@ impl Session {
         // Ensure per-client windows are populated (fixes buffer-after-client-join issue)
         Self::ensure_client_has_window(editing_state, &state);
 
-        let (mode_stack, windows, extensions) = (
+        let (mode_stack, windows, extensions, compositor) = (
             &mut editing_state.mode_stack,
             &mut editing_state.windows,
             &mut editing_state.extensions,
+            &mut editing_state.compositor,
         );
 
         // Resolve key with per-client state (#471 Phase 5: pass client_id for undo origin)
-        state.resolve_key_for_client(target_id.as_usize(), mode_stack, windows, extensions, key)
+        state.resolve_key_for_client(
+            target_id.as_usize(),
+            mode_stack,
+            windows,
+            extensions,
+            compositor,
+            key,
+        )
     }
 
     /// Try `on_command_complete` with per-client state (#471, #477).
@@ -641,10 +688,11 @@ impl Session {
         // Ensure per-client windows are populated (fixes buffer-after-client-join issue)
         Self::ensure_client_has_window(editing_state, &state);
 
-        let (mode_stack, windows, extensions) = (
+        let (mode_stack, windows, extensions, compositor) = (
             &mut editing_state.mode_stack,
             &mut editing_state.windows,
             &mut editing_state.extensions,
+            &mut editing_state.compositor,
         );
 
         state.try_on_command_complete_for_client(
@@ -652,6 +700,7 @@ impl Session {
             mode_stack,
             windows,
             extensions,
+            compositor,
         )
     }
 
@@ -698,10 +747,11 @@ impl Session {
         // Ensure per-client windows are populated (fixes buffer-after-client-join issue)
         Self::ensure_client_has_window(editing_state, &state);
 
-        let (mode_stack, windows, extensions) = (
+        let (mode_stack, windows, extensions, compositor) = (
             &mut editing_state.mode_stack,
             &mut editing_state.windows,
             &mut editing_state.extensions,
+            &mut editing_state.compositor,
         );
 
         // Execute command with per-client state, passing client_id for per-client undo (#471)
@@ -710,6 +760,7 @@ impl Session {
             mode_stack,
             windows,
             extensions,
+            compositor,
             cmd_id,
             args,
         )
@@ -2118,6 +2169,7 @@ mod tests {
     // =========================================================================
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_insert_char_for_client_with_undo_recording() {
         // This test covers lines 775-787: the undo recording path in
         // insert_char_for_client when an UndoProviderRegistry with a
@@ -2135,9 +2187,12 @@ mod tests {
             std::sync::{Arc, Mutex},
         };
 
-        /// Minimal mock undo provider that tracks record_for_client calls.
+        /// Recorded undo entries: (buffer, client, edits, `cursor_before`, `cursor_after`).
+        type UndoRecords = Mutex<Vec<(BufferId, usize, Vec<Edit>, Position, Position)>>;
+
+        /// Minimal mock undo provider that tracks `record_for_client` calls.
         struct MockUndoProvider {
-            recorded: Mutex<Vec<(BufferId, usize, Vec<Edit>, Position, Position)>>,
+            recorded: UndoRecords,
         }
 
         #[cfg_attr(coverage_nightly, coverage(off))]
@@ -2265,6 +2320,7 @@ mod tests {
         assert_eq!(*cursor_after, Position::new(0, 1));
         // Buffer ID should match
         assert_eq!(buf_id.as_usize(), result.unwrap().as_usize());
+        drop(recorded);
     }
 
     // =========================================================================
@@ -2280,7 +2336,7 @@ mod tests {
             reovim_driver_session::{SessionExtension, TextInputSink},
         };
 
-        /// Test extension that implements TextInputSink.
+        /// Test extension that implements `TextInputSink`.
         #[derive(Default)]
         struct TestSinkExtension {
             buffer: String,
@@ -2341,7 +2397,7 @@ mod tests {
             reovim_driver_session::{SessionExtension, TextInputSink},
         };
 
-        /// Test extension that implements TextInputSink.
+        /// Test extension that implements `TextInputSink`.
         #[derive(Default)]
         struct SharedSinkExtension {
             buffer: String,

--- a/server/lib/server/src/session/state.rs
+++ b/server/lib/server/src/session/state.rs
@@ -261,12 +261,14 @@ impl SessionState {
     /// * `id` - The command ID to execute
     /// * `args` - Command arguments (count, register, etc.)
     #[must_use]
+    #[allow(clippy::too_many_arguments)] // Per-client execution needs all these parameters
     pub fn execute_command_for_client(
         &mut self,
         client_id: usize,
         client_mode_stack: &mut reovim_kernel::api::v1::ModeStack,
         client_windows: &mut reovim_driver_session::WindowLayout,
         client_extensions: &mut reovim_driver_session::ExtensionMap,
+        client_compositor: &mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         id: &CommandId,
         args: &CommandContext,
     ) -> Option<(CommandResult, reovim_driver_session::api::StateChanges)> {
@@ -281,6 +283,7 @@ impl SessionState {
             client_mode_stack,
             client_windows,
             client_extensions,
+            client_compositor,
             &self.app,
             &self.vfs,
             args,
@@ -409,12 +412,14 @@ impl SessionState {
         let mut temp_mode_stack = ModeStack::new(home_mode);
         let mut temp_windows = reovim_driver_session::WindowLayout::empty();
         let mut temp_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut temp_compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut self.driver_session,
             &mut temp_mode_stack,
             &mut temp_windows,
             &mut temp_extensions,
+            &mut temp_compositor,
             &self.app.kernel,
             &stub_executor,
         );
@@ -475,6 +480,7 @@ impl SessionState {
         client_mode_stack: &mut ModeStack,
         client_windows: &mut reovim_driver_session::WindowLayout,
         client_extensions: &mut reovim_driver_session::ExtensionMap,
+        client_compositor: &mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         key: &reovim_driver_input::KeyEvent,
     ) -> Option<(reovim_driver_input::ResolveResult, reovim_driver_session::api::StateChanges)>
     {
@@ -512,6 +518,7 @@ impl SessionState {
             client_mode_stack,
             client_windows,
             client_extensions,
+            client_compositor,
             &self.app.kernel,
             &stub_executor,
         );
@@ -572,12 +579,14 @@ impl SessionState {
         let mut temp_mode_stack = ModeStack::new(home_mode);
         let mut temp_windows = reovim_driver_session::WindowLayout::empty();
         let mut temp_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut temp_compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut self.driver_session,
             &mut temp_mode_stack,
             &mut temp_windows,
             &mut temp_extensions,
+            &mut temp_compositor,
             &self.app.kernel,
             &stub_executor,
         );
@@ -605,6 +614,7 @@ impl SessionState {
         client_mode_stack: &mut ModeStack,
         client_windows: &mut reovim_driver_session::WindowLayout,
         client_extensions: &mut reovim_driver_session::ExtensionMap,
+        client_compositor: &mut Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     ) -> Option<reovim_driver_input::ModeTransition> {
         use reovim_driver_session::{
             ClientId as DriverClientId, SessionRuntime, api::CommandExecutor,
@@ -633,6 +643,7 @@ impl SessionState {
             client_mode_stack,
             client_windows,
             client_extensions,
+            client_compositor,
             &self.app.kernel,
             &stub_executor,
         );
@@ -774,6 +785,7 @@ mod tests {
         let mut client_mode_stack = ModeStack::new(insert_mode);
         let mut client_windows = reovim_driver_session::WindowLayout::empty();
         let mut client_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_compositor = None;
 
         // #491: Use home_mode() instead of removed current_mode()
         // Verify initial states
@@ -790,6 +802,7 @@ mod tests {
             &mut client_mode_stack,
             &mut client_windows,
             &mut client_extensions,
+            &mut client_compositor,
             &key,
         );
 
@@ -1006,12 +1019,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let result = state.try_on_command_complete_for_client(
             1,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
         );
 
         assert!(result.is_none());
@@ -1027,6 +1042,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let cmd_id = reovim_kernel::api::v1::CommandId::new(
             reovim_kernel::api::v1::ModuleId::new("test"),
@@ -1039,6 +1055,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &cmd_id,
             &ctx,
         );
@@ -1187,10 +1204,17 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let key = reovim_driver_input::KeyEvent::new(reovim_driver_input::KeyCode::Char('x'));
-        let result =
-            state.resolve_key_for_client(1, &mut mode_stack, &mut windows, &mut extensions, &key);
+        let result = state.resolve_key_for_client(
+            1,
+            &mut mode_stack,
+            &mut windows,
+            &mut extensions,
+            &mut compositor,
+            &key,
+        );
 
         // No resolver registered - should return None
         assert!(result.is_none());
@@ -1442,6 +1466,7 @@ mod tests {
         let mut client_mode_stack = ModeStack::new(insert_mode);
         let mut client_windows = reovim_driver_session::WindowLayout::empty();
         let mut client_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_compositor = None;
 
         let key = reovim_driver_input::KeyEvent::new(reovim_driver_input::KeyCode::Char('a'));
         let result = state.resolve_key_for_client(
@@ -1449,6 +1474,7 @@ mod tests {
             &mut client_mode_stack,
             &mut client_windows,
             &mut client_extensions,
+            &mut client_compositor,
             &key,
         );
 
@@ -1500,6 +1526,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let ctx = reovim_driver_command::CommandContext::new();
         let result = state.execute_command_for_client(
@@ -1507,6 +1534,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &cmd_id,
             &ctx,
         );
@@ -1800,7 +1828,7 @@ mod tests {
         }
 
         fn boxed_clone(&self) -> Box<dyn reovim_driver_display::layout::RootCompositor> {
-            Box::new(MockCompositor::new())
+            Box::new(Self::new())
         }
     }
 
@@ -1938,12 +1966,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let result = state.try_on_command_complete_for_client(
             1,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
         );
 
         assert!(result.is_some(), "Should return ModeTransition from resolver");
@@ -2029,12 +2059,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let result = state.try_on_command_complete_for_client(
             1,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
         );
 
         assert!(result.is_some());
@@ -2126,10 +2158,17 @@ mod tests {
         let mut mode_stack = ModeStack::new(test_mode_id());
         let mut windows = reovim_driver_session::WindowLayout::empty();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut compositor = None;
 
         let key = reovim_driver_input::KeyEvent::new(reovim_driver_input::KeyCode::Char('a'));
-        let result =
-            state.resolve_key_for_client(1, &mut mode_stack, &mut windows, &mut extensions, &key);
+        let result = state.resolve_key_for_client(
+            1,
+            &mut mode_stack,
+            &mut windows,
+            &mut extensions,
+            &mut compositor,
+            &key,
+        );
 
         assert!(result.is_some(), "Resolver should handle the key");
         let (resolve_result, _changes) = result.unwrap();

--- a/server/modules/commands/src/edit.rs
+++ b/server/modules/commands/src/edit.rs
@@ -396,6 +396,7 @@ mod tests {
         let buffer = buffer_arc.read();
         assert_eq!(buffer.content(), "");
         assert!(!buffer.is_modified());
+        drop(buffer);
     }
 
     #[test]
@@ -420,6 +421,7 @@ mod tests {
         assert!(buffer.content().contains("line1"));
         assert!(buffer.content().contains("line3"));
         assert_eq!(buffer.file_path(), Some("/multi.txt"));
+        drop(buffer);
     }
 
     #[test]
@@ -442,13 +444,15 @@ mod tests {
         let buffer_arc = kernel.buffers.get(buffer_id).unwrap();
         let buffer = buffer_arc.read();
         assert_eq!(buffer.file_path(), Some("/path/to/file.rs"));
+        drop(buffer);
     }
 
     #[test]
     fn test_edit_command_clone_copy() {
         let cmd = EditCommand;
-        let _cloned = cmd;
+        let copy = cmd;
         // Both should be valid since it's Copy
         assert_eq!(cmd.id(), "edit");
+        assert_eq!(copy.id(), "edit");
     }
 }

--- a/server/modules/editor/src/command/cursor.rs
+++ b/server/modules/editor/src/command/cursor.rs
@@ -445,6 +445,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -456,6 +457,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -474,6 +476,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -495,11 +498,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -519,11 +524,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -543,11 +550,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -567,11 +576,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/delete.rs
+++ b/server/modules/editor/src/command/delete.rs
@@ -418,6 +418,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -429,6 +430,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -447,6 +449,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -487,11 +490,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -511,11 +516,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -656,11 +663,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -680,11 +689,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -860,11 +871,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1047,11 +1060,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1071,11 +1086,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1234,5 +1251,6 @@ mod tests {
         assert_eq!(buf_read.line_count(), 2);
         assert_eq!(buf_read.line(0), Some("hello"));
         assert_eq!(buf_read.line(1), Some("world"));
+        drop(buf_read);
     }
 }

--- a/server/modules/editor/src/command/display_line.rs
+++ b/server/modules/editor/src/command/display_line.rs
@@ -419,6 +419,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -430,6 +431,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -448,6 +450,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -488,11 +491,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -512,11 +517,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -637,11 +644,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -661,11 +670,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/file.rs
+++ b/server/modules/editor/src/command/file.rs
@@ -205,6 +205,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -216,6 +217,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -234,6 +236,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -293,11 +296,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -446,11 +451,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/insert_edit.rs
+++ b/server/modules/editor/src/command/insert_edit.rs
@@ -262,6 +262,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -273,6 +274,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -291,6 +293,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -356,11 +359,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -380,11 +385,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -561,11 +568,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -585,11 +594,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/mod.rs
+++ b/server/modules/editor/src/command/mod.rs
@@ -275,6 +275,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -286,6 +287,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             }
         }
 
@@ -308,6 +310,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -330,11 +333,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/operators.rs
+++ b/server/modules/editor/src/command/operators.rs
@@ -227,11 +227,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -249,11 +251,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -271,11 +275,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -293,11 +299,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -315,11 +323,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/paste.rs
+++ b/server/modules/editor/src/command/paste.rs
@@ -353,6 +353,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -364,6 +365,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -382,6 +384,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -421,11 +424,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -481,11 +486,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -701,11 +708,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -761,11 +770,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/replace.rs
+++ b/server/modules/editor/src/command/replace.rs
@@ -317,6 +317,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -328,6 +329,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -346,6 +348,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -436,11 +439,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -460,11 +465,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/undo.rs
+++ b/server/modules/editor/src/command/undo.rs
@@ -248,6 +248,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -259,6 +260,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -277,6 +279,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -322,11 +325,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -401,11 +406,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -459,11 +466,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -481,11 +490,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/command/yank.rs
+++ b/server/modules/editor/src/command/yank.rs
@@ -192,6 +192,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -203,6 +204,7 @@ mod tests {
                 mode_stack: ModeStack::new(home_mode),
                 windows: WindowLayout::empty(),
                 extensions: ExtensionMap::new(),
+                compositor: None,
             };
             let mut window = Window::new();
             window.buffer_id = Some(buffer_id);
@@ -221,6 +223,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -271,11 +274,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -295,11 +300,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/editor/src/lib.rs
+++ b/server/modules/editor/src/lib.rs
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_editor_module_default() {
-        let module: EditorModule = Default::default();
+        let module = EditorModule;
         assert_eq!(module.name(), "Editor");
     }
 

--- a/server/modules/motions/Cargo.toml
+++ b/server/modules/motions/Cargo.toml
@@ -21,5 +21,8 @@ reovim-driver-search = { workspace = true }
 reovim-module-macros = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+reovim-driver-display = { workspace = true }
+
 [lints]
 workspace = true

--- a/server/modules/motions/src/find_char.rs
+++ b/server/modules/motions/src/find_char.rs
@@ -328,6 +328,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -343,6 +344,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -356,6 +358,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )

--- a/server/modules/motions/src/line.rs
+++ b/server/modules/motions/src/line.rs
@@ -446,6 +446,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         buffer_id: BufferId,
     }
 
@@ -485,6 +486,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
                 buffer_id,
             }
         }
@@ -521,6 +523,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 &self.ctx,
                 &executor,
             );
@@ -544,11 +547,13 @@ mod tests {
         windows.add(Window::new());
 
         let executor = StubExecutor;
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1076,6 +1081,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1084,6 +1090,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1151,6 +1158,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1158,6 +1166,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1175,6 +1184,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1182,6 +1192,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1199,6 +1210,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1206,6 +1218,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1227,6 +1240,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1235,6 +1249,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1252,6 +1267,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1260,6 +1276,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1277,6 +1294,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1285,6 +1303,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1302,6 +1321,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1310,6 +1330,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );

--- a/server/modules/motions/src/search.rs
+++ b/server/modules/motions/src/search.rs
@@ -558,6 +558,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -566,6 +567,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -663,6 +665,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -671,6 +674,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -689,6 +693,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -697,6 +702,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -720,6 +726,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -728,6 +735,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -749,6 +757,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -757,6 +766,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -778,6 +788,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -786,6 +797,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -814,6 +826,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -822,6 +835,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -850,6 +864,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -858,6 +873,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -902,6 +918,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -910,6 +927,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -930,6 +948,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -938,6 +957,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -962,6 +982,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -970,6 +991,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1007,6 +1029,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1015,6 +1038,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1038,6 +1062,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1046,6 +1071,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1187,6 +1213,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -1195,6 +1222,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1222,6 +1250,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -1230,6 +1259,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1256,6 +1286,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 12; // position past the second hello
@@ -1267,6 +1298,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1298,6 +1330,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -1306,6 +1339,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1326,6 +1360,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 12; // At second 'hello'
@@ -1337,6 +1372,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1358,6 +1394,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 5; // On space between hello and world
@@ -1369,6 +1406,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1390,6 +1428,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 100; // way past end
@@ -1401,6 +1440,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1421,6 +1461,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 5; // On space
@@ -1432,6 +1473,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1453,6 +1495,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 12;
@@ -1464,6 +1507,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1491,6 +1535,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -1499,6 +1544,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1528,6 +1574,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1536,6 +1583,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1564,6 +1612,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1572,6 +1621,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1594,6 +1644,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 0; // At 'h' of hello
@@ -1605,6 +1656,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1626,6 +1678,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 6; // At 'w' of world
@@ -1637,6 +1690,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1687,6 +1741,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty(); // No window added
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1694,6 +1749,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1711,6 +1767,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1718,6 +1775,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1736,6 +1794,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1743,6 +1802,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1763,6 +1823,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1770,6 +1831,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1796,6 +1858,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1803,6 +1866,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1823,6 +1887,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::with_buffer(buffer_id));
 
         let executor = StubExecutor;
@@ -1831,6 +1896,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1851,6 +1917,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1859,6 +1926,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1885,6 +1953,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 2; // 'l' in hello (middle of word)
@@ -1896,6 +1965,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -1916,6 +1986,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut win = Window::with_buffer(buffer_id);
         win.cursor.column = 14; // 'l' in second hello
@@ -1927,6 +1998,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/motions/src/word.rs
+++ b/server/modules/motions/src/word.rs
@@ -468,6 +468,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
         buffer_id: BufferId,
     }
 
@@ -507,6 +508,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
                 buffer_id,
             }
         }
@@ -543,6 +545,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 &self.ctx,
                 &executor,
             );
@@ -566,11 +569,13 @@ mod tests {
         windows.add(Window::new());
 
         let executor = StubExecutor;
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1126,6 +1131,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         windows.add(Window::new());
 
         let executor = StubExecutor;
@@ -1134,6 +1140,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );
@@ -1151,6 +1158,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty(); // No windows
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let executor = StubExecutor;
         let mut runtime = SessionRuntime::new(
@@ -1158,6 +1166,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &executor,
         );

--- a/server/modules/textobjects/Cargo.toml
+++ b/server/modules/textobjects/Cargo.toml
@@ -19,5 +19,8 @@ reovim-driver-command = { workspace = true }
 reovim-driver-session = { workspace = true }
 reovim-module-macros = { workspace = true }
 
+[dev-dependencies]
+reovim-driver-display = { workspace = true }
+
 [lints]
 workspace = true

--- a/server/modules/textobjects/src/bracket.rs
+++ b/server/modules/textobjects/src/bracket.rs
@@ -495,6 +495,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -509,6 +510,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -523,6 +525,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -537,6 +540,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -550,6 +554,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -1774,6 +1779,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1798,6 +1804,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1822,6 +1829,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1846,6 +1854,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1870,6 +1879,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);

--- a/server/modules/textobjects/src/paragraph.rs
+++ b/server/modules/textobjects/src/paragraph.rs
@@ -261,6 +261,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -275,6 +276,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -289,6 +291,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -303,6 +306,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -316,6 +320,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -815,6 +820,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -839,6 +845,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);

--- a/server/modules/textobjects/src/quote.rs
+++ b/server/modules/textobjects/src/quote.rs
@@ -457,6 +457,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -471,6 +472,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -485,6 +487,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -499,6 +502,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -512,6 +516,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -1406,6 +1411,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1430,6 +1436,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1454,6 +1461,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1478,6 +1486,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);

--- a/server/modules/textobjects/src/word.rs
+++ b/server/modules/textobjects/src/word.rs
@@ -377,6 +377,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -394,6 +395,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -411,6 +413,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -428,6 +431,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -442,6 +446,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -1197,6 +1202,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1221,6 +1227,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1245,6 +1252,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);
@@ -1269,6 +1277,7 @@ mod tests {
             mode_stack,
             windows,
             extensions,
+            compositor: None,
         };
         let executor = StubExecutor;
         let mut runtime = state.runtime(&kernel, &executor);

--- a/server/modules/vfs-local/src/lib.rs
+++ b/server/modules/vfs-local/src/lib.rs
@@ -291,8 +291,7 @@ mod tests {
         // Read a known system file
         let result = vfs.read(std::path::Path::new("/proc/self/status"));
         // On Linux, this should succeed
-        if result.is_ok() {
-            let bytes = result.unwrap();
+        if let Ok(bytes) = result {
             assert!(!bytes.is_empty());
         }
     }

--- a/server/modules/vim/src/commands/change.rs
+++ b/server/modules/vim/src/commands/change.rs
@@ -296,6 +296,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -317,6 +318,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -326,6 +328,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )

--- a/server/modules/vim/src/commands/find_char.rs
+++ b/server/modules/vim/src/commands/find_char.rs
@@ -208,6 +208,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -229,6 +230,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -238,6 +240,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -626,11 +629,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty(); // No windows
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/commands/mode.rs
+++ b/server/modules/vim/src/commands/mode.rs
@@ -605,6 +605,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -626,6 +627,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -635,6 +637,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -1954,12 +1957,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/commands/mode_entry.rs
+++ b/server/modules/vim/src/commands/mode_entry.rs
@@ -503,6 +503,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -524,6 +525,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -533,6 +535,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -1254,12 +1257,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );
@@ -1285,12 +1290,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );
@@ -1316,12 +1323,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );
@@ -1348,12 +1357,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/commands/repeat.rs
+++ b/server/modules/vim/src/commands/repeat.rs
@@ -231,6 +231,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -248,6 +249,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -262,6 +264,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 executor,
             )
@@ -486,11 +489,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );
@@ -724,11 +729,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(mode);
         let mut windows = WindowLayout::empty(); // No windows
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &kernel,
             &executor,
         );

--- a/server/modules/vim/src/operators/change.rs
+++ b/server/modules/vim/src/operators/change.rs
@@ -222,11 +222,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             ctx,
             &executor,
         );

--- a/server/modules/vim/src/operators/commands.rs
+++ b/server/modules/vim/src/operators/commands.rs
@@ -357,6 +357,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -378,6 +379,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -387,6 +389,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -994,6 +997,7 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         // Add a window without buffer to have an active window
         let window = reovim_driver_session::Window::new();
@@ -1004,6 +1008,7 @@ mod tests {
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/operators/delete.rs
+++ b/server/modules/vim/src/operators/delete.rs
@@ -295,11 +295,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             ctx,
             &executor,
         );

--- a/server/modules/vim/src/operators/yank.rs
+++ b/server/modules/vim/src/operators/yank.rs
@@ -158,11 +158,13 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             ctx,
             &executor,
         );

--- a/server/modules/vim/src/visual/entry.rs
+++ b/server/modules/vim/src/visual/entry.rs
@@ -292,6 +292,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -314,6 +315,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -323,6 +325,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -401,12 +404,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty(); // No windows at all
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );
@@ -473,12 +478,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );
@@ -545,12 +552,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/visual/exit.rs
+++ b/server/modules/vim/src/visual/exit.rs
@@ -162,6 +162,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -184,6 +185,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -193,6 +195,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )
@@ -364,12 +367,14 @@ mod tests {
         let mut mode_stack = ModeStack::new(home_mode);
         let mut windows = WindowLayout::empty();
         let mut extensions = ExtensionMap::new();
+        let mut compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut session,
             &mut mode_stack,
             &mut windows,
             &mut extensions,
+            &mut compositor,
             &ctx,
             &StubExecutor,
         );

--- a/server/modules/vim/src/visual/manipulation.rs
+++ b/server/modules/vim/src/visual/manipulation.rs
@@ -424,6 +424,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -446,6 +447,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -455,6 +457,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )

--- a/server/modules/vim/src/visual/mod.rs
+++ b/server/modules/vim/src/visual/mod.rs
@@ -137,6 +137,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -160,6 +161,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -185,6 +187,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -195,6 +198,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )

--- a/server/modules/vim/src/visual/operators.rs
+++ b/server/modules/vim/src/visual/operators.rs
@@ -629,6 +629,7 @@ mod tests {
         mode_stack: ModeStack,
         windows: WindowLayout,
         extensions: ExtensionMap,
+        compositor: Option<Box<dyn reovim_driver_display::layout::RootCompositor>>,
     }
 
     impl TestState {
@@ -650,6 +651,7 @@ mod tests {
                 mode_stack,
                 windows,
                 extensions,
+                compositor: None,
             }
         }
 
@@ -659,6 +661,7 @@ mod tests {
                 &mut self.mode_stack,
                 &mut self.windows,
                 &mut self.extensions,
+                &mut self.compositor,
                 kernel,
                 &StubExecutor,
             )

--- a/server/modules/window-ops/src/command.rs
+++ b/server/modules/window-ops/src/command.rs
@@ -848,7 +848,7 @@ mod tests {
         }
 
         fn boxed_clone(&self) -> Box<dyn reovim_driver_display::layout::RootCompositor> {
-            Box::new(MockRootCompositor {
+            Box::new(Self {
                 layer: MockLayerCompositor {
                     id: self.layer.id,
                     windows: self.layer.windows.clone(),

--- a/shared/clients/model/src/sync/presence.rs
+++ b/shared/clients/model/src/sync/presence.rs
@@ -223,8 +223,7 @@ mod tests {
         tracker.upsert(test_presence("a"));
         tracker.upsert(test_presence("b"));
 
-        let all: Vec<_> = tracker.all().collect();
-        assert_eq!(all.len(), 2);
+        assert_eq!(tracker.all().count(), 2);
     }
 
     #[test]

--- a/shared/clients/model/src/wire/client.rs
+++ b/shared/clients/model/src/wire/client.rs
@@ -316,8 +316,8 @@ mod tests {
 
     #[test]
     fn test_client_metadata_with_joined_at() {
-        let metadata = ClientMetadata::new("tui", "laptop").with_joined_at(1234567890);
-        assert_eq!(metadata.joined_at_ms, 1234567890);
+        let metadata = ClientMetadata::new("tui", "laptop").with_joined_at(1_234_567_890);
+        assert_eq!(metadata.joined_at_ms, 1_234_567_890);
     }
 
     #[test]

--- a/shared/protocol/proto/reovim/v2/notification.proto
+++ b/shared/protocol/proto/reovim/v2/notification.proto
@@ -92,6 +92,8 @@ message LayoutChangedPayload {
   optional uint64 focused_window_id = 1;
   // Window list with positions (simplified from full tree)
   repeated WindowInfo windows = 2;
+  // Client ID that triggered this layout change (for multi-client filtering)
+  uint64 client_id = 3;
 }
 
 message WindowInfo {


### PR DESCRIPTION
Each client now owns an independent compositor clone, eliminating the cross-namespace window ID mismatch between shared compositor IDs and per-client WindowLayout IDs.

Core changes:
- Move compositor from SessionShared into per-client EditingState
- SessionRuntime accepts per-client compositor parameter
- All CompositorApi methods operate on self.compositor (per-client)
- Window IDs from compositor.composite() match per-client WindowLayout
- Notification builder reads per-client compositor for layout data
- Window creation at client join uses compositor-matching IDs
- Proto: add client_id field to LayoutChangedPayload

Test infrastructure:
- Update all SessionRuntime::new() callsites with compositor param
- TestSessionRuntime.set_compositor() sets per-client compositor
- Fix notification_builder tests for per-client compositor
- Fix upstream clippy warnings from coverage enhancement rebase

Refs #474