### PR TITLE
fix(input): cursor position not updating during insert mode (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
 
 ### Fixed
 
+- **Cursor position not updating during insert mode (#505)**: The TUI statusline
+  showed 1:1 for the cursor position throughout insert mode, only updating after
+  leaving insert mode with Esc. Root cause: the fallback cursor recording in
+  `send_keys` had a flawed guard `!affected_buffers.contains(&buffer_id)` that
+  was defeated when `record_buffer_modified()` already added the buffer. Fix:
+  always record cursor movement when any key is handled (the call is idempotent).
+  Also added explicit `record_cursor_move` in the InsertChar handler.
+
 - **One-way presence visibility (#474)**: When Client B joined after Client A,
   A could not see B's cursor. Root cause: `ClientPresence::new()` initialized
   `buffer_id: None`, so the `PresenceJoined` notification lacked the buffer_id.

--- a/clients/tui/tests/test_o_cursor.rs
+++ b/clients/tui/tests/test_o_cursor.rs
@@ -29,7 +29,6 @@ fn extract_cursor_from_statusline(frame: &str) -> Option<(u32, u32)> {
 }
 
 #[tokio::test]
-#[ignore = "cursor notifications not sent during insert mode - separate issue from #474"]
 async fn test_o_cursor_position() {
     let harness = TestServerHarness::spawn().await.expect("spawn");
     let addr = format!("127.0.0.1:{}", harness.port());

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -182,16 +182,13 @@ impl InputService for InputServiceImpl {
             }
         }
 
-        // Phase 11.2: Record cursor movement for active buffer
-        // This ensures cursor_moved notifications have affected_buffers populated.
-        // Most key operations move the cursor, so record it if any key was handled.
+        // Record cursor movement for active buffer whenever any key was handled.
+        // Most key operations move the cursor (typing, motions, commands like `o`).
+        // `record_cursor_move` is idempotent on `affected_buffers`, so calling it
+        // even when InsertChar already recorded cursor_move is safe (#505).
         #[allow(clippy::redundant_closure_for_method_calls)]
-        if any_handled
-            && let Some(buffer_id) = session.with_state(|s| s.active_buffer()).await
-            && !accumulated_changes.affected_buffers.contains(&buffer_id)
-        {
+        if any_handled && let Some(buffer_id) = session.with_state(|s| s.active_buffer()).await {
             accumulated_changes.record_cursor_move(buffer_id);
-            tracing::trace!(?buffer_id, "Recorded cursor move for active buffer");
         }
 
         // Emit notifications for accumulated state changes
@@ -342,9 +339,10 @@ impl InputServiceImpl {
                     // Phase #477: Use insert_char_for_client which checks per-client extensions first
                     let modified_buffer = session.insert_char_for_client(client_id, ch, target);
 
-                    // Record buffer modification for notification
+                    // Record buffer modification and cursor movement for notification
                     if let Some(buffer_id) = modified_buffer {
                         changes.record_buffer_modified(buffer_id);
+                        changes.record_cursor_move(buffer_id);
                         tracing::debug!(?buffer_id, "Recorded buffer modification for InsertChar");
                     }
                     (true, changes)


### PR DESCRIPTION
The TUI statusline showed 1:1 throughout insert mode because cursor notifications were not emitted. Root cause: the fallback cursor recording in send_keys had guard !affected_buffers.contains(&buffer_id) which was defeated when record_buffer_modified() already added the buffer.

- Always record cursor_move when any key is handled (idempotent)
- Add explicit record_cursor_move in InsertChar handler
- Enable test_o_cursor_position integration test

Fixes #505