### PR TITLE
fix(ci): add --cfg coverage_nightly to CI coverage RUSTFLAGS (#497)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           cargo +nightly build -p reovim-module-defaults --features dynamic
       - name: MC/DC coverage (non-server crates)
         run: |
-          RUSTFLAGS="-Z coverage-options=condition" \
+          RUSTFLAGS="--cfg coverage_nightly -Z coverage-options=condition" \
           cargo +nightly llvm-cov --workspace \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
@@ -100,6 +100,7 @@ jobs:
       - name: Line coverage (server crate)
         run: |
           cargo +nightly llvm-cov clean --workspace
+          RUSTFLAGS="--cfg coverage_nightly" \
           cargo +nightly llvm-cov -p reovim-server \
             --lcov --output-path server-lcov.info
       - name: Merge coverage reports


### PR DESCRIPTION
The local coverage script (scripts/coverage.sh) passes --cfg coverage_nightly which activates #[cfg_attr(coverage_nightly, coverage(off))] annotations. The CI workflow was missing this flag, causing ~230 annotated functions to produce 648 uncovered DA entries and dropping codecov from 100% to 99.3%.

- Add --cfg coverage_nightly to MC/DC coverage step RUSTFLAGS
- Add RUSTFLAGS="--cfg coverage_nightly" to server line coverage step

Refs #497
