### PR TITLE
chore(ci): enforce 100% coverage in CI (#501)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,13 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
-        informational: true
+        target: 100%
+        threshold: 0.5%
     patch:
       default:
-        target: 70%
-        informational: true
+        target: 100%
 
 ignore:
   - "tools/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,23 @@ jobs:
             --lcov --output-path server-lcov.info
       - name: Merge coverage reports
         run: cat mcdc-lcov.info server-lcov.info > lcov.info
+      - name: Generate coverage reports
+        run: |
+          ./scripts/coverage-report.sh mcdc-lcov.info
+          mv COVERAGE.md COVERAGE-workspace.md
+          ./scripts/coverage-report.sh server-lcov.info --server
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            COVERAGE-workspace.md
+            COVERAGE-server.md
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           flags: coverage
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,32 @@ nursery = "deny"
 - **All warnings are compile errors** - code won't build with warnings
 - `#[allow(...)]` - escape-hatch only with justification, try not to use
 
+### Coverage Policy
+
+This project enforces **100% code coverage** in CI via Codecov status checks.
+
+**Requirements:**
+- All non-server crates: 100% MC/DC coverage (line + condition)
+- Server crate (`reovim-server`): 100% line coverage (MC/DC excluded due to LLVM bug #119558)
+- PRs that regress coverage will be blocked by Codecov
+
+**Writing covered code:**
+- Every new function must have test coverage for all code paths
+- Use `#[cfg_attr(coverage_nightly, coverage(off))]` only for genuinely untestable code:
+  - Tracing closure bodies (execute only at debug level)
+  - `tokio::spawn` task bodies (require real stream lifecycle)
+  - Async channel error variants
+  - OnceLock-dependent globals
+- Test mock/stub trait impls should also use `coverage(off)` to suppress false BRDA entries
+
+**Coverage tools:**
+```bash
+./scripts/coverage.sh line --lcov      # Line coverage (full workspace)
+./scripts/coverage.sh mcdc --lcov      # MC/DC coverage (excludes server)
+./scripts/coverage.sh server           # Server branch coverage (text only)
+./scripts/coverage-report.sh <lcov>    # Generate COVERAGE.md from LCOV
+```
+
 ### Kernel Purity Policy
 
 **NEVER add plugin/module-specific code to kernel.** Kernel must remain policy-agnostic.

--- a/docs/contributing/guides/testing.md
+++ b/docs/contributing/guides/testing.md
@@ -541,6 +541,46 @@ fn test_count_parser() {
 3. **Use descriptive assertions**: `assert_eq!` over `assert!`
 4. **Keep tests fast**: Avoid I/O in unit tests
 
+## Code Coverage
+
+Reovim enforces **100% code coverage** in CI. Every PR must maintain full coverage.
+
+### Running Coverage Locally
+
+```bash
+# MC/DC coverage (non-server crates) — primary metric
+./scripts/coverage.sh mcdc --lcov
+
+# Line coverage (full workspace including server)
+./scripts/coverage.sh line --lcov
+
+# Generate human-readable report
+./scripts/coverage-report.sh target/llvm-cov/lcov.mcdc.info
+
+# Open HTML report in browser
+./scripts/coverage.sh mcdc --open
+```
+
+### Coverage Annotations
+
+For genuinely untestable code, use the `coverage(off)` attribute:
+
+```rust
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn untestable_function() { /* ... */ }
+```
+
+This requires `#![cfg_attr(coverage_nightly, feature(coverage_attribute))]` in the crate's `lib.rs`.
+
+Use sparingly — only for code paths that cannot be exercised in unit tests (async runtime internals, tracing closures, panic handlers).
+
+### Codecov Integration
+
+Coverage is enforced via Codecov status checks on PRs:
+- **Project target**: 100% (0.5% threshold for float rounding)
+- **Patch target**: 100% (all new code must be covered)
+- Reports uploaded as CI artifacts (`COVERAGE-workspace.md`, `COVERAGE-server.md`)
+
 ## Performance Benchmarks
 
 Reovim uses Criterion for performance benchmarking.


### PR DESCRIPTION
Lock in 100% coverage achieved in #497 so no PR can regress it.

- Set codecov project and patch targets to 100% (0.5% threshold)
- Remove informational flag so codecov status checks block PRs
- Set fail_ci_if_error: true for codecov upload step
- Generate COVERAGE.md reports as CI artifacts
- Document coverage policy in CLAUDE.md (requirements, annotations, tools)
- Add Code Coverage section to testing guide (local usage, codecov integration)

Closes #501, Refs #497