### PR TITLE
feat: visual selection sync, web presence, 100% MC/DC coverage (#474)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
           RUSTFLAGS="--cfg coverage_nightly" \
           cargo +nightly llvm-cov -p reovim-server \
             --lcov --output-path server-lcov.info
+      - name: Filter test code from LCOV
+        run: |
+          ./scripts/lcov-filter-tests.sh mcdc-lcov.info
+          ./scripts/lcov-filter-tests.sh server-lcov.info
       - name: Merge coverage reports
         run: cat mcdc-lcov.info server-lcov.info > lcov.info
       - name: Generate coverage reports

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 tmp/
+COVERAGE.md
 
 # Python cache
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   [#119558](https://github.com/llvm/llvm-project/issues/119558)
   (`getInstantiationGroups` SIGSEGV on branch coverage data from
   `#[tonic::async_trait]` service implementations). Use `server` mode for
-  text-only branch coverage of the server crate.
+  text-only branch coverage of the server crate. Test code (`#[cfg(test)]`
+  modules) is automatically stripped from LCOV via `scripts/lcov-filter-tests.sh`
+  so coverage metrics reflect production code only.
 
 - **Floating cursor labels for remote clients (#474)**: TUI and Web clients now
   show a colored background overlay above each remote client's cursor, making it
@@ -80,6 +82,24 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   `buffer_id: None`, so the `PresenceJoined` notification lacked the buffer_id.
   A's render engine skipped B (different-buffer filter). Fix: server now reads
   the new client's active window buffer_id before broadcasting the notification.
+
+- **Visual selection highlighting past EOL (#474)**: Char and block mode visual
+  selections highlighted empty space beyond end-of-line content, unlike vim which
+  only highlights actual characters. Fix: `render_selection_range` now accepts
+  buffer lines and clamps `col_end` to actual line length for char/block modes.
+  Line mode (`V`) retains full-width highlighting to match vim behavior.
+
+- **Web remote cursors disappearing on self move (#474)**: Moving the local cursor
+  in the web client caused remote cursors and selections to vanish. Root cause:
+  `renderMultiWindow()` and `renderSingleWindow()` rebuild the DOM, destroying
+  remote cursor/selection elements. Fix: call `renderRemoteCursors()` at the end
+  of both render paths to re-create remote presence after DOM rebuilds.
+
+- **Web cursor scroll offset in single-window mode (#474)**: Cursor and remote
+  presence positions in the web client's single-window mode used raw buffer
+  coordinates without subtracting the viewport scroll offset. Fix: added `topLine`
+  to `EditorState`, updated from `viewportUpdated` notifications, subtracted in
+  `renderCursor()`, `renderRemoteCursors()`, and `renderRemoteSelection()`.
 
 - **Resize propagation to all TUIs (#474)**: `ResizeRequestPayload` had no
   `target_client_id` field, causing all TUI clients to resize when any one

--- a/clients/tui/src/handle.rs
+++ b/clients/tui/src/handle.rs
@@ -286,4 +286,112 @@ mod tests {
         let result = handle.send_keys("ihello").await;
         assert!(result.is_err());
     }
+
+    /// Test `wait_for` succeeds when the predicate is met immediately.
+    ///
+    /// This exercises lines 181-184: the while loop body, capture call,
+    /// and the `if predicate(&frame)` true branch returning `Ok(frame)`.
+    #[tokio::test]
+    async fn test_wait_for_succeeds_when_predicate_met() {
+        let (tx, mut rx) = mpsc::channel::<TuiInput>(8);
+        let handle = TuiHandle::new(tx);
+
+        // Spawn a task that responds to Capture requests with "hello world"
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                if let TuiInput::Control(ControlRequest::Capture { response, .. }) = msg {
+                    let _ = response.send("hello world".to_string());
+                }
+            }
+        });
+
+        let result = handle
+            .wait_for(Duration::from_millis(500), |frame| frame.contains("hello"))
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello world");
+    }
+
+    /// Test `wait_for` loops when the predicate is not yet met, then succeeds.
+    ///
+    /// This exercises the loop continuing when `predicate(&frame)` returns false,
+    /// then eventually returning `Ok(frame)` when the predicate becomes true.
+    #[tokio::test]
+    async fn test_wait_for_loops_then_succeeds() {
+        use std::sync::{Arc, Mutex};
+
+        let (tx, mut rx) = mpsc::channel::<TuiInput>(8);
+        let handle = TuiHandle::new(tx);
+
+        // Counter: first call returns "not ready", second returns "ready"
+        let call_count = Arc::new(Mutex::new(0u32));
+        let call_count_clone = Arc::clone(&call_count);
+
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                if let TuiInput::Control(ControlRequest::Capture { response, .. }) = msg {
+                    let mut count = call_count_clone.lock().unwrap();
+                    *count += 1;
+                    let frame = if *count == 1 {
+                        "not ready".to_string()
+                    } else {
+                        "ready content".to_string()
+                    };
+                    drop(count);
+                    let _ = response.send(frame);
+                }
+            }
+        });
+
+        let result = handle
+            .wait_for(Duration::from_millis(500), |frame| frame.contains("ready content"))
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "ready content");
+    }
+
+    /// Test `wait_for` returns `Timeout` when the predicate is never met.
+    #[tokio::test]
+    async fn test_wait_for_timeout() {
+        let (tx, mut rx) = mpsc::channel::<TuiInput>(8);
+        let handle = TuiHandle::new(tx);
+
+        // Always respond with "nothing" (predicate never matches)
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                if let TuiInput::Control(ControlRequest::Capture { response, .. }) = msg {
+                    let _ = response.send("nothing".to_string());
+                }
+            }
+        });
+
+        let result = handle
+            .wait_for(Duration::from_millis(25), |frame| frame.contains("never"))
+            .await;
+
+        assert!(matches!(result, Err(TuiHandleError::Timeout)));
+    }
+
+    /// Test `wait_for` returns error when channel closes mid-loop.
+    #[tokio::test]
+    async fn test_wait_for_channel_closed() {
+        let (tx, rx) = mpsc::channel::<TuiInput>(1);
+        let handle = TuiHandle::new(tx);
+
+        // Close the receiver immediately so capture fails
+        drop(rx);
+
+        let result = handle.wait_for(Duration::from_millis(100), |_| false).await;
+
+        assert!(matches!(result, Err(TuiHandleError::NotRunning)));
+    }
+
+    /// Test `TuiHandleError` implements `std::error::Error`.
+    #[test]
+    fn test_tui_handle_error_is_error() {
+        let err: Box<dyn std::error::Error> = Box::new(TuiHandleError::NotRunning);
+        assert!(!err.to_string().is_empty());
+    }
 }

--- a/clients/tui/src/render_engine.rs
+++ b/clients/tui/src/render_engine.rs
@@ -144,7 +144,7 @@ const LOCAL_SELECTION_BG: Color = Color::Rgb {
 /// This is a basic implementation that renders:
 /// - Buffer content (simple text, no syntax highlighting yet)
 /// - Remote selections (dimmed background overlay)
-/// - Local selection (headless mode only)
+/// - Local selection (background overlay)
 /// - Remote cursors (CBF-8 colorblind-friendly palette)
 /// - Self cursor (if `render_self_cursor` is true)
 /// - Statusline
@@ -166,9 +166,7 @@ pub fn render_frame<B: RenderBackend>(
 
     // Render selections (behind cursors — background overlay)
     render_remote_selections(backend, state, config.gutter_width, content_height);
-    if config.render_self_cursor {
-        render_local_selection(backend, state, config.gutter_width, content_height);
-    }
+    render_local_selection(backend, state, config.gutter_width, content_height);
 
     // Render cursors (on top of selections)
     render_remote_cursors(backend, state, config.gutter_width, content_height);
@@ -305,6 +303,7 @@ fn render_remote_selections<B: RenderBackend>(
 
     // TODO(#494): Multi-window — iterate all windows with tiling layout
     let current_buffer_id = state.windows.first().and_then(|w| w.buffer_id);
+    let lines = current_buffer_id.and_then(|id| state.buffer_cache.get(&id));
 
     for remote in state.other_clients.values() {
         if remote.buffer_id != current_buffer_id {
@@ -315,13 +314,21 @@ fn render_remote_selections<B: RenderBackend>(
         };
 
         let sel_color = dimmed_client_color(remote.client_id);
-        render_selection_range(backend, sel, sel_color, gutter_width, content_height, width);
+        render_selection_range(
+            backend,
+            sel,
+            sel_color,
+            gutter_width,
+            content_height,
+            width,
+            lines.map(Vec::as_slice),
+        );
     }
 }
 
-/// Render local client's visual selection (headless mode only).
+/// Render local client's visual selection.
 ///
-/// Interactive TUI uses terminal-level selection highlighting via crossterm.
+/// Overlays a subtle background color on the local selection range.
 #[allow(clippy::cast_possible_truncation)]
 fn render_local_selection<B: RenderBackend>(
     backend: &mut B,
@@ -334,7 +341,19 @@ fn render_local_selection<B: RenderBackend>(
         return;
     };
 
-    render_selection_range(backend, sel, LOCAL_SELECTION_BG, gutter_width, content_height, width);
+    // TODO(#494): Multi-window — iterate all windows with tiling layout
+    let current_buffer_id = state.windows.first().and_then(|w| w.buffer_id);
+    let lines = current_buffer_id.and_then(|id| state.buffer_cache.get(&id));
+
+    render_selection_range(
+        backend,
+        sel,
+        LOCAL_SELECTION_BG,
+        gutter_width,
+        content_height,
+        width,
+        lines.map(Vec::as_slice),
+    );
 }
 
 /// Render a selection range with a background color overlay.
@@ -352,6 +371,7 @@ fn render_selection_range<B: RenderBackend>(
     gutter_width: u16,
     content_height: u16,
     screen_width: u16,
+    lines: Option<&[String]>,
 ) {
     let (start_line, start_col, end_line, end_col) = normalize_selection(sel);
     let content_width = screen_width.saturating_sub(gutter_width);
@@ -361,19 +381,24 @@ fn render_selection_range<B: RenderBackend>(
             break;
         }
 
+        // Actual content length for this line (for clamping char/block modes)
+        let line_len = lines
+            .and_then(|l| l.get(line as usize))
+            .map_or(content_width, |s| s.len() as u16);
+
         let (col_start, col_end) = match sel.mode.as_str() {
             "line" => (0u16, content_width),
-            "block" => (start_col as u16, end_col as u16 + 1),
+            "block" => (start_col as u16, (end_col as u16 + 1).min(line_len)),
             _ => {
-                // Char mode
+                // Char mode — clamp to line content length (skip empty cells past EOL)
                 if start_line == end_line {
-                    (start_col as u16, end_col as u16 + 1)
+                    (start_col as u16, (end_col as u16 + 1).min(line_len))
                 } else if line == start_line {
-                    (start_col as u16, content_width)
+                    (start_col as u16, line_len)
                 } else if line == end_line {
-                    (0, end_col as u16 + 1)
+                    (0, (end_col as u16 + 1).min(line_len))
                 } else {
-                    (0, content_width)
+                    (0, line_len)
                 }
             }
         };

--- a/clients/web/src/editor.ts
+++ b/clients/web/src/editor.ts
@@ -8,6 +8,7 @@
 import type { ReovimClient } from "./client.js";
 import type { Notification } from "./gen/reovim/v2/notification_pb.js";
 import type { WindowInfo } from "./gen/reovim/v2/notification_pb.js";
+import type { ClientInfo } from "./gen/reovim/v2/presence_pb.js";
 
 // WASM bindings and types
 import {
@@ -63,6 +64,7 @@ interface EditorState {
   // Legacy single-window state (for backward compatibility)
   cursorLine: number;
   cursorCol: number;
+  topLine: number;
   lines: string[];
   hasSelection: boolean;
   selectionAnchor: Position | null;
@@ -85,6 +87,7 @@ interface RemoteClient {
   cursorLine: number;
   cursorCol: number;
   bufferId: number;
+  mode?: string;
   selection: { anchor: Position; cursor: Position; mode: VisualMode } | null;
 }
 
@@ -130,8 +133,9 @@ export class Editor {
    *
    * @param client - gRPC client for server communication
    * @param myClientId - This client's unique ID (Phase 11.2)
+   * @param peers - Connected peers from JoinResponse (#474)
    */
-  constructor(client: ReovimClient, myClientId: bigint) {
+  constructor(client: ReovimClient, myClientId: bigint, peers: ClientInfo[] = []) {
     this.client = client;
     this.myClientId = myClientId;
     this.state = {
@@ -139,6 +143,7 @@ export class Editor {
       modeDisplay: "NORMAL",
       cursorLine: 0,
       cursorCol: 0,
+      topLine: 0,
       lines: [""],
       hasSelection: false,
       selectionAnchor: null,
@@ -174,6 +179,44 @@ export class Editor {
     this.cursorElement = document.getElementById("cursor");
     this.positionElement = document.getElementById("position");
     this.editorElement = document.getElementById("editor");
+
+    // #474: Initialize remote clients from JoinResponse peers
+    for (const peer of peers) {
+      const peerId = BigInt(peer.id);
+      if (peerId !== this.myClientId) {
+        const cursor = peer.view?.cursor;
+        this.remoteClients.set(peerId, {
+          clientId: peerId,
+          displayName: peer.metadata?.displayName ?? `Client ${peer.id}`,
+          cursorLine: Number(cursor?.line ?? 0n),
+          cursorCol: Number(cursor?.column ?? 0n),
+          bufferId: Number(peer.view?.bufferId ?? 0n),
+          selection: null,
+        });
+      }
+    }
+  }
+
+  /**
+   * Get or create a remote client entry (#474).
+   *
+   * If the client is unknown (e.g., notification arrived before presenceJoined),
+   * creates a placeholder entry so cursor/selection updates are not lost.
+   */
+  private getOrCreateRemote(clientId: bigint): RemoteClient {
+    let remote = this.remoteClients.get(clientId);
+    if (!remote) {
+      remote = {
+        clientId,
+        displayName: `Client ${clientId}`,
+        cursorLine: 0,
+        cursorCol: 0,
+        bufferId: 0,
+        selection: null,
+      };
+      this.remoteClients.set(clientId, remote);
+    }
+    return remote;
   }
 
   /**
@@ -406,11 +449,9 @@ export class Editor {
           this.state.modeDisplay = display || "NORMAL";
           this.renderMode();
         } else {
-          // Remote mode update - update tracking map
-          const remote = this.remoteClients.get(notifClientId);
-          if (remote) {
-            remote.mode = display || "NORMAL";
-          }
+          // Remote mode update - update tracking map (#474: auto-create if unknown)
+          const remote = this.getOrCreateRemote(notifClientId);
+          remote.mode = display || "NORMAL";
         }
         break;
       }
@@ -445,12 +486,10 @@ export class Editor {
             this.renderPosition();
           }
         } else {
-          // Remote cursor update - update tracking map and re-render
-          const remote = this.remoteClients.get(notifClientId);
-          if (remote) {
-            remote.cursorLine = line;
-            remote.cursorCol = col;
-          }
+          // Remote cursor update (#474: auto-create if unknown)
+          const remote = this.getOrCreateRemote(notifClientId);
+          remote.cursorLine = line;
+          remote.cursorCol = col;
           this.renderRemoteCursors();
         }
         break;
@@ -538,26 +577,24 @@ export class Editor {
             this.renderBuffer();
           }
         } else {
-          // Remote selection update - track in remoteClients map
-          const remote = this.remoteClients.get(notifClientId);
-          if (remote) {
-            if (hasSelection && selection) {
-              remote.selection = {
-                anchor: {
-                  line: Number(selection.start?.line ?? 0n),
-                  col: Number(selection.start?.column ?? 0n),
-                },
-                cursor: {
-                  line: Number(selection.end?.line ?? 0n),
-                  col: Number(selection.end?.column ?? 0n),
-                },
-                mode: (visualMode as VisualMode) ?? "char",
-              };
-            } else {
-              remote.selection = null;
-            }
+          // Remote selection update (#474: auto-create if unknown)
+          const remote = this.getOrCreateRemote(notifClientId);
+          if (hasSelection && selection) {
+            remote.selection = {
+              anchor: {
+                line: Number(selection.start?.line ?? 0n),
+                col: Number(selection.start?.column ?? 0n),
+              },
+              cursor: {
+                line: Number(selection.end?.line ?? 0n),
+                col: Number(selection.end?.column ?? 0n),
+              },
+              mode: (visualMode as VisualMode) ?? "char",
+            };
+          } else {
+            remote.selection = null;
           }
-          // TODO: Render remote selections (future enhancement)
+          this.renderRemoteCursors();
         }
         break;
       }
@@ -603,8 +640,20 @@ export class Editor {
           // Only re-render the affected viewport/window
           this.renderMultiWindow();
         }
-        // Note: No single-window fallback needed here - viewport updates are
-        // only meaningful in multi-window mode
+        // Single-window fallback: track topLine for cursor offset (#474)
+        if (!this.state.useMultiWindow || !this.state.layout) {
+          if (update.topLine !== undefined) {
+            this.state.topLine = Number(update.topLine);
+          }
+          if (update.cursorLine !== undefined) {
+            this.state.cursorLine = Number(update.cursorLine);
+          }
+          if (update.cursorCol !== undefined) {
+            this.state.cursorCol = Number(update.cursorCol);
+          }
+          this.renderCursor();
+          this.renderPosition();
+        }
         break;
       }
 
@@ -864,6 +913,9 @@ export class Editor {
     // Also render mode indicator
     this.renderMode();
     this.renderPosition();
+
+    // Re-render remote cursors after DOM rebuild (#474)
+    this.renderRemoteCursors();
   }
 
   /**
@@ -874,6 +926,9 @@ export class Editor {
     this.renderBuffer();
     this.renderCursor();
     this.renderPosition();
+
+    // Re-render remote cursors after DOM rebuild (#474)
+    this.renderRemoteCursors();
   }
 
   /**
@@ -977,7 +1032,7 @@ export class Editor {
     const padding = 8;
 
     const x = padding + lineNumberWidth + this.state.cursorCol * charWidth;
-    const y = padding + this.state.cursorLine * lineHeight;
+    const y = padding + (this.state.cursorLine - this.state.topLine) * lineHeight;
 
     this.cursorElement.style.left = `${x}px`;
     this.cursorElement.style.top = `${y}px`;
@@ -1035,6 +1090,9 @@ export class Editor {
       ? (focusedWindow(this.state.layout, this.state.focusedWindowId)?.buffer_id ?? 0)
       : 0;
 
+    // Scroll offset for single-window mode (#474)
+    const topLine = this.state.topLine;
+
     for (const [clientId, remote] of this.remoteClients) {
       // Only show cursors for clients viewing the same buffer
       if (remote.bufferId !== currentBufferId && currentBufferId !== 0) continue;
@@ -1044,16 +1102,16 @@ export class Editor {
 
       // Render remote selection if present (Issue #474)
       if (remote.selection) {
-        this.renderRemoteSelection(container, clientId, remote, charWidth, lineHeight, lineNumberWidth, padding);
+        this.renderRemoteSelection(container, clientId, remote, charWidth, lineHeight, lineNumberWidth, padding, topLine);
       }
 
-      // Render remote cursor
+      // Render remote cursor (#474: subtract topLine for scroll offset)
       const el = document.createElement("div");
       el.className = "remote-cursor";
       el.style.cssText = `
         position: absolute;
         left: ${padding + lineNumberWidth + remote.cursorCol * charWidth}px;
-        top: ${padding + remote.cursorLine * lineHeight}px;
+        top: ${padding + (remote.cursorLine - topLine) * lineHeight}px;
         width: 2px;
         height: ${lineHeight}px;
         background: ${cursorColor};
@@ -1103,7 +1161,8 @@ export class Editor {
     charWidth: number,
     lineHeight: number,
     lineNumberWidth: number,
-    padding: number
+    padding: number,
+    topLine: number = 0,
   ): void {
     const selection = remote.selection;
     if (!selection) return;
@@ -1159,7 +1218,7 @@ export class Editor {
       el.style.cssText = `
         position: absolute;
         left: ${padding + lineNumberWidth + startCol * charWidth}px;
-        top: ${padding + line * lineHeight}px;
+        top: ${padding + (line - topLine) * lineHeight}px;
         width: ${(endCol - startCol) * charWidth}px;
         height: ${lineHeight}px;
         background: ${selectionColor};

--- a/clients/web/src/input.ts
+++ b/clients/web/src/input.ts
@@ -12,15 +12,15 @@ import { browserKeyToVim, shouldPreventDefault } from "./keymapper.js";
  * Setup keyboard event handler for the editor.
  *
  * Captures keydown events on the document and sends them to the server.
+ * Client identity is provided via the x-reovim-token header (#483),
+ * so no clientId parameter is needed in the request body.
  *
  * @param client - gRPC client for server communication
  * @param _editor - Editor instance (unused - state updates via notifications)
- * @param myClientId - This client's unique ID (Phase 11.2)
  */
 export function setupKeyboardHandler(
   client: ReovimClient,
   _editor: Editor,
-  myClientId: bigint
 ): void {
   document.addEventListener("keydown", async (event: KeyboardEvent) => {
     // Check if we should prevent browser default behavior
@@ -35,12 +35,10 @@ export function setupKeyboardHandler(
     }
 
     try {
-      // Send key to server WITH client ID (Phase 11.2)
-      // CRITICAL: Without clientId, all clients share state as ClientId(0)
-      console.log(`[input] Sending key: ${vimKey} (client ${myClientId})`);
+      // Send key to server (#483: identity via x-reovim-token header)
+      console.log(`[input] Sending key: ${vimKey}`);
       const response = await client.input.sendKeys({
         keys: vimKey,
-        clientId: myClientId,
       });
       console.log(`[input] Response: ok=${response.ok}, status=${response.status}`);
 

--- a/clients/web/src/main.ts
+++ b/clients/web/src/main.ts
@@ -37,14 +37,18 @@ async function main() {
     const myClientId = joinResponse.clientId;
     console.log("Joined presence session, client ID:", myClientId.toString());
 
-    // Initialize editor state
-    const editor = new Editor(client, myClientId);
+    // #474: Store session token for authenticated RPCs (#483)
+    // Without this, all subsequent requests (sendKeys, etc.) are rejected
+    client.setSessionToken(joinResponse.sessionToken);
+
+    // Initialize editor state with existing peers (#474)
+    const editor = new Editor(client, myClientId, joinResponse.peersV2);
 
     // Initialize WASM module for multi-window support
     await editor.init();
 
-    // Setup keyboard input with client ID
-    setupKeyboardHandler(client, editor, myClientId);
+    // Setup keyboard input (#483: identity via token, not clientId parameter)
+    setupKeyboardHandler(client, editor);
 
     // Initial state fetch
     await editor.refresh();

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -98,20 +98,39 @@ esac
 
 echo -e "\033[1;33m==> Running $MODE coverage...\033[0m"
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if $LCOV; then
   OUTPUT_PATH="target/llvm-cov/lcov.${MODE}.info"
   RUSTFLAGS="$EXTRA_RUSTFLAGS" cargo +nightly llvm-cov "${MODE_FLAG[@]}" \
     --workspace "${EXCLUDE[@]}" \
     --lcov --output-path "$OUTPUT_PATH"
+  # Strip #[cfg(test)] regions from LCOV (test code is not a coverage target)
+  "$SCRIPT_DIR/lcov-filter-tests.sh" "$OUTPUT_PATH"
   echo -e "\033[0;32m✓ LCOV report: $OUTPUT_PATH\033[0m"
 else
-  OUTPUT_DIR="target/llvm-cov/html"
-  OPEN_FLAG=()
-  if $OPEN; then
-    OPEN_FLAG=(--open)
-  fi
+  # For HTML, generate LCOV first, filter, then convert
+  LCOV_TMP="target/llvm-cov/lcov.${MODE}.info"
   RUSTFLAGS="$EXTRA_RUSTFLAGS" cargo +nightly llvm-cov "${MODE_FLAG[@]}" \
     --workspace "${EXCLUDE[@]}" \
-    --html --output-dir "$OUTPUT_DIR" "${OPEN_FLAG[@]}"
-  echo -e "\033[0;32m✓ HTML report: $OUTPUT_DIR/index.html\033[0m"
+    --lcov --output-path "$LCOV_TMP"
+  # Strip #[cfg(test)] regions
+  "$SCRIPT_DIR/lcov-filter-tests.sh" "$LCOV_TMP"
+  # Generate HTML from filtered LCOV
+  OUTPUT_DIR="target/llvm-cov/html"
+  if command -v genhtml &>/dev/null; then
+    genhtml "$LCOV_TMP" --output-directory "$OUTPUT_DIR" --quiet
+    if $OPEN; then
+      xdg-open "$OUTPUT_DIR/index.html" 2>/dev/null || open "$OUTPUT_DIR/index.html" 2>/dev/null || true
+    fi
+    echo -e "\033[0;32m✓ HTML report: $OUTPUT_DIR/index.html\033[0m"
+  else
+    echo -e "\033[0;33m⚠ genhtml not found, falling back to cargo llvm-cov HTML (unfiltered)\033[0m"
+    OPEN_FLAG=()
+    if $OPEN; then OPEN_FLAG=(--open); fi
+    RUSTFLAGS="$EXTRA_RUSTFLAGS" cargo +nightly llvm-cov "${MODE_FLAG[@]}" \
+      --workspace "${EXCLUDE[@]}" \
+      --html --output-dir "$OUTPUT_DIR" "${OPEN_FLAG[@]}"
+    echo -e "\033[0;32m✓ HTML report: $OUTPUT_DIR/index.html\033[0m"
+  fi
 fi

--- a/scripts/lcov-filter-tests.sh
+++ b/scripts/lcov-filter-tests.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/lcov-filter-tests.sh <input.lcov> [output.lcov]
+#
+# Strips #[cfg(test)] regions from LCOV data. For each source file, finds the
+# first #[cfg(test)] line and removes all DA/BRDA entries at or after that line.
+# Recalculates LF/LH/BRF/BRH counts.
+#
+# If output is omitted, overwrites the input file in-place.
+
+INPUT="${1:?Usage: lcov-filter-tests.sh <input.lcov> [output.lcov]}"
+OUTPUT="${2:-$INPUT}"
+
+if [ ! -f "$INPUT" ]; then
+  echo "Error: $INPUT not found" >&2
+  exit 1
+fi
+
+awk '
+function find_test_line(filepath,    cmd, line, num) {
+  if (filepath in test_line_cache) return test_line_cache[filepath]
+  # Find the first #[cfg(test)] in the source file
+  num = 0
+  cmd = "grep -n \"#\\[cfg(test)\\]\" \"" filepath "\" 2>/dev/null | head -1"
+  if ((cmd | getline line) > 0) {
+    split(line, parts, ":")
+    num = parts[1] + 0
+  }
+  close(cmd)
+  test_line_cache[filepath] = num
+  return num
+}
+
+/^SF:/ {
+  cur_file = substr($0, 4)
+  test_start = find_test_line(cur_file)
+  # Buffer the SF line
+  buf[++buf_n] = $0
+  lf = 0; lh = 0; brf = 0; brh = 0
+  next
+}
+
+/^DA:/ {
+  val = substr($0, 4)
+  split(val, da, ",")
+  line_num = da[1] + 0
+  count = da[2] + 0
+  # Skip if inside test region
+  if (test_start > 0 && line_num >= test_start) next
+  buf[++buf_n] = $0
+  lf++
+  if (count > 0) lh++
+  next
+}
+
+/^BRDA:/ {
+  # BRDA:line,block,branch,count
+  val = substr($0, 6)
+  split(val, br, ",")
+  line_num = br[1] + 0
+  if (test_start > 0 && line_num >= test_start) next
+  buf[++buf_n] = $0
+  brf++
+  if (br[4] != "-" && br[4] + 0 > 0) brh++
+  next
+}
+
+# Skip original LF/LH/BRF/BRH (we recalculate)
+/^LF:/ || /^LH:/ || /^BRF:/ || /^BRH:/ { next }
+
+# Skip FN/FNDA/FNF/FNH in test regions
+/^FN:/ {
+  val = substr($0, 4)
+  split(val, fn_parts, ",")
+  line_num = fn_parts[1] + 0
+  if (test_start > 0 && line_num >= test_start) next
+  buf[++buf_n] = $0
+  next
+}
+
+/^FNDA:/ {
+  # FNDA:count,name - cannot filter by line, keep all (they reference function names)
+  buf[++buf_n] = $0
+  next
+}
+
+/^FNF:/ || /^FNH:/ {
+  # Recalculating function counts is complex; pass through for now
+  buf[++buf_n] = $0
+  next
+}
+
+/^end_of_record/ {
+  # Only emit if there are DA lines left
+  if (lf > 0) {
+    for (i = 1; i <= buf_n; i++) print buf[i]
+    print "LF:" lf
+    print "LH:" lh
+    if (brf > 0) {
+      print "BRF:" brf
+      print "BRH:" brh
+    }
+    print "end_of_record"
+  }
+  # Reset
+  delete buf
+  buf_n = 0
+  lf = 0; lh = 0; brf = 0; brh = 0
+  cur_file = ""
+  test_start = 0
+  next
+}
+
+# Other lines (TN: etc) - pass through
+{ buf[++buf_n] = $0 }
+' "$INPUT" > "${OUTPUT}.tmp"
+
+mv "${OUTPUT}.tmp" "$OUTPUT"

--- a/server/lib/drivers/session/src/api/changes.rs
+++ b/server/lib/drivers/session/src/api/changes.rs
@@ -308,6 +308,13 @@ pub trait ChangeTracker: Send {
     /// Commands should call this after moving the cursor via
     /// `BufferApi::set_cursor_position()`.
     fn record_cursor_move(&mut self, buffer: BufferId);
+
+    /// Record that the selection changed in a buffer (#474).
+    ///
+    /// Commands should call this after creating, modifying, or clearing
+    /// a visual selection. The notification pipeline uses this to
+    /// broadcast selection state to other clients.
+    fn record_selection_change(&mut self, buffer: BufferId);
 }
 
 #[cfg(test)]

--- a/server/lib/drivers/session/src/runtime.rs
+++ b/server/lib/drivers/session/src/runtime.rs
@@ -1084,6 +1084,22 @@ impl ChangeTracker for SessionRuntime<'_> {
 
     fn record_cursor_move(&mut self, buffer: BufferId) {
         self.changes.record_cursor_move(buffer);
+        // #474: Centralized visual selection extension.
+        // When cursor moves and selection exists, auto-update sel.end
+        // to match cursor position. This ensures ALL commands that call
+        // record_cursor_move() automatically extend visual selection.
+        // Note: For line-wise selections, operators normalize end via
+        // expand_selection_range(), so the column+1 here is harmless.
+        if let Some(window) = self.windows.active_mut()
+            && let Some(ref mut sel) = window.selection
+        {
+            sel.end = Position::new(window.cursor.line, window.cursor.column + 1);
+            self.changes.record_selection_change(buffer);
+        }
+    }
+
+    fn record_selection_change(&mut self, buffer: BufferId) {
+        self.changes.record_selection_change(buffer);
     }
 }
 
@@ -5227,5 +5243,185 @@ mod tests {
         let result = rt.close_current_window();
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), CompositorError::CannotCloseLastWindow));
+    }
+
+    // === #474: Centralized selection extension tests ===
+
+    /// When cursor moves with an active selection, `sel.end` should auto-update
+    /// and `selection_changed` should be set.
+    #[test]
+    fn test_record_cursor_move_extends_selection() {
+        use reovim_kernel::api::v1::ModeStack;
+
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
+
+        // Add a window with selection and move cursor
+        let mut window = crate::Window::new();
+        window.cursor = Position::new(0, 5).into();
+        window.selection =
+            Some(crate::api::Selection::character(Position::new(0, 0), Position::new(0, 1)));
+        w.add(window);
+
+        let buf = BufferId::new();
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+        rt.record_cursor_move(buf);
+
+        let changes = rt.take_changes();
+        assert!(changes.cursor_moved);
+        assert!(changes.selection_changed);
+
+        // sel.end should match cursor position + 1
+        let sel = rt.windows().active().unwrap().selection.as_ref().unwrap();
+        assert_eq!(sel.end, Position::new(0, 6));
+    }
+
+    /// When cursor moves without a selection, `selection_changed` should NOT be set.
+    #[test]
+    fn test_record_cursor_move_no_selection() {
+        use reovim_kernel::api::v1::ModeStack;
+
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
+
+        let mut window = crate::Window::new();
+        window.cursor = Position::new(0, 3).into();
+        // No selection
+        w.add(window);
+
+        let buf = BufferId::new();
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+        rt.record_cursor_move(buf);
+
+        let changes = rt.take_changes();
+        assert!(changes.cursor_moved);
+        assert!(!changes.selection_changed);
+    }
+
+    /// Direct `record_selection_change` should set `selection_changed`.
+    #[test]
+    fn test_record_selection_change_directly() {
+        use reovim_kernel::api::v1::ModeStack;
+
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
+
+        let buf = BufferId::new();
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+        rt.record_selection_change(buf);
+
+        let changes = rt.take_changes();
+        assert!(changes.selection_changed);
+        assert!(changes.affected_buffers.contains(&buf));
+    }
+
+    // =========================================================================
+    // CompositorApi: focus() with same window (line 1352 false branch)
+    // =========================================================================
+
+    /// Calling `focus()` on the already-focused window should NOT emit a layout
+    /// event (the `if previous_focus != Some(window)` branch is false).
+    #[test]
+    fn test_compositor_focus_same_window_no_layout_event() {
+        use reovim_kernel::api::v1::ModeStack;
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
+
+        let mut rt = make_compositor_runtime(
+            &mut session,
+            &mut ms,
+            &mut w,
+            &mut e,
+            &mut c,
+            &kernel,
+            &executor,
+        );
+
+        // MockRootCompositor starts with focus on WindowId::from_raw(1).
+        // Calling focus() on the already-focused window exercises the
+        // `previous_focus == Some(window)` path (line 1352 false branch).
+        let already_focused = WindowId::from_raw(1);
+        let result = rt.focus(already_focused);
+        assert!(result.is_ok());
+
+        // Changes should record focus even though no layout event is emitted
+        let changes = rt.take_changes();
+        assert!(changes.focus_changed);
+    }
+
+    // =========================================================================
+    // BufferApi: delete_range() with empty result (line 610 false branch)
+    // =========================================================================
+
+    /// Calling `delete_range()` where start==end produces empty deleted text.
+    /// This exercises the `if !deleted_text.is_empty()` false branch (line 610).
+    #[test]
+    fn test_delete_range_empty_result_no_undo_record() {
+        use crate::testing::TestSessionRuntime;
+
+        let mut harness = TestSessionRuntime::with_buffer("hello world");
+        let buffer_id = harness.with_runtime(|runtime| runtime.active_buffer().unwrap());
+
+        // Delete an empty range (start == end): nothing is deleted
+        harness.with_runtime(|runtime| {
+            runtime.delete_range(buffer_id, Position::new(0, 3), Position::new(0, 3));
+        });
+
+        // Buffer content unchanged
+        harness.assert_buffer_content("hello world");
+
+        // buffer_modified is still recorded (changes.record_buffer_modified is called
+        // unconditionally), but no undo edit is recorded for empty deletions.
+        let changes = harness.take_changes();
+        assert!(changes.buffer_modified);
+    }
+
+    // =========================================================================
+    // CompositorApi: set_screen() without compositor (line 1382 false branch)
+    // =========================================================================
+
+    /// `set_screen()` without a compositor should only update `self.screen`.
+    /// This exercises the `if let Some(compositor) = ...` false branch (line 1382).
+    #[test]
+    fn test_set_screen_without_compositor() {
+        use reovim_kernel::api::v1::ModeStack;
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        // No compositor
+        let mut c: Option<Box<dyn reovim_driver_display::layout::RootCompositor>> = None;
+
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+
+        let screen = Rect::new(0, 0, 80, 24);
+        rt.set_screen(screen);
+        assert_eq!(rt.screen, screen);
     }
 }

--- a/server/lib/drivers/session/src/runtime.rs
+++ b/server/lib/drivers/session/src/runtime.rs
@@ -487,7 +487,6 @@ impl BufferApi for SessionRuntime<'_> {
     }
 
     #[allow(clippy::significant_drop_tightening)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn buffer_text_range(
         &self,
         buffer: BufferId,
@@ -741,7 +740,6 @@ impl WindowApi for SessionRuntime<'_> {
 // === RegisterApi ===
 
 impl RegisterApi for SessionRuntime<'_> {
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn get_register(&self, name: Option<char>) -> Option<RegisterContent> {
         match name {
             // System clipboard (+)
@@ -781,7 +779,6 @@ impl RegisterApi for SessionRuntime<'_> {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn set_register(&mut self, name: Option<char>, content: RegisterContent) {
         match name {
             // System clipboard (+)
@@ -823,8 +820,30 @@ impl RegisterApi for SessionRuntime<'_> {
 
 // === UndoApi ===
 
+impl SessionRuntime<'_> {
+    /// Apply undo/redo edits to the kernel buffer.
+    ///
+    /// Extracted from the 4 undo/redo methods to deduplicate the edit-application
+    /// loop and avoid an LLVM coverage gap-region bug on `if let` closing braces.
+    fn apply_undo_edits(&self, buffer: BufferId, edits: &[Edit]) {
+        let Some(buf) = self.kernel.buffers.get(buffer) else {
+            return;
+        };
+        let mut buf = buf.write();
+        for edit in edits {
+            match edit {
+                Edit::Insert { position, text } => {
+                    buf.insert_at(*position, text);
+                }
+                Edit::Delete { position, text } => {
+                    buf.delete_at(*position, text.chars().count());
+                }
+            }
+        }
+    }
+}
+
 impl UndoApi for SessionRuntime<'_> {
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn undo(&mut self, buffer: BufferId) -> Option<UndoResult> {
         let undo_provider = self
             .kernel
@@ -833,22 +852,7 @@ impl UndoApi for SessionRuntime<'_> {
             .get(&UndoKey::Buffer)?;
 
         let result = undo_provider.undo(buffer)?;
-
-        // Apply the inverse edits to the buffer
-        if let Some(buf) = self.kernel.buffers.get(buffer) {
-            let mut buf = buf.write();
-            for edit in &result.edits {
-                match edit {
-                    Edit::Insert { position, text } => {
-                        buf.insert_at(*position, text);
-                    }
-                    Edit::Delete { position, text } => {
-                        buf.delete_at(*position, text.chars().count());
-                    }
-                }
-            }
-            // NOTE: Don't set kernel buffer cursor - it no longer exists (#471)
-        }
+        self.apply_undo_edits(buffer, &result.edits);
 
         // Phase #471: Restore cursor to per-client active window
         if let Some(window) = self.windows_mut().active_mut() {
@@ -862,7 +866,6 @@ impl UndoApi for SessionRuntime<'_> {
         Some(result)
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn redo(&mut self, buffer: BufferId) -> Option<UndoResult> {
         let undo_provider = self
             .kernel
@@ -871,22 +874,7 @@ impl UndoApi for SessionRuntime<'_> {
             .get(&UndoKey::Buffer)?;
 
         let result = undo_provider.redo(buffer)?;
-
-        // Apply the edits to the buffer
-        if let Some(buf) = self.kernel.buffers.get(buffer) {
-            let mut buf = buf.write();
-            for edit in &result.edits {
-                match edit {
-                    Edit::Insert { position, text } => {
-                        buf.insert_at(*position, text);
-                    }
-                    Edit::Delete { position, text } => {
-                        buf.delete_at(*position, text.chars().count());
-                    }
-                }
-            }
-            // NOTE: Don't set kernel buffer cursor - it no longer exists (#471)
-        }
+        self.apply_undo_edits(buffer, &result.edits);
 
         // Phase #471: Restore cursor to per-client active window
         if let Some(window) = self.windows_mut().active_mut() {
@@ -900,7 +888,6 @@ impl UndoApi for SessionRuntime<'_> {
         Some(result)
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn record_edit(
         &mut self,
         buffer: BufferId,
@@ -933,7 +920,6 @@ impl UndoApi for SessionRuntime<'_> {
             .is_some_and(|tree| tree.can_redo())
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn undo_mine(&mut self, buffer: BufferId) -> Option<UndoResult> {
         // #471: Get the client ID from the owner field
         let client_id = self.owner?.as_usize();
@@ -945,21 +931,7 @@ impl UndoApi for SessionRuntime<'_> {
             .get(&UndoKey::Buffer)?;
 
         let result = undo_provider.undo_for_client(buffer, client_id)?;
-
-        // Apply the inverse edits to the buffer
-        if let Some(buf) = self.kernel.buffers.get(buffer) {
-            let mut buf = buf.write();
-            for edit in &result.edits {
-                match edit {
-                    Edit::Insert { position, text } => {
-                        buf.insert_at(*position, text);
-                    }
-                    Edit::Delete { position, text } => {
-                        buf.delete_at(*position, text.chars().count());
-                    }
-                }
-            }
-        }
+        self.apply_undo_edits(buffer, &result.edits);
 
         // Restore cursor to per-client active window
         if let Some(window) = self.windows_mut().active_mut() {
@@ -973,7 +945,6 @@ impl UndoApi for SessionRuntime<'_> {
         Some(result)
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn redo_mine(&mut self, buffer: BufferId) -> Option<UndoResult> {
         // #471: Get the client ID from the owner field
         let client_id = self.owner?.as_usize();
@@ -985,21 +956,7 @@ impl UndoApi for SessionRuntime<'_> {
             .get(&UndoKey::Buffer)?;
 
         let result = undo_provider.redo_for_client(buffer, client_id)?;
-
-        // Apply the edits to the buffer
-        if let Some(buf) = self.kernel.buffers.get(buffer) {
-            let mut buf = buf.write();
-            for edit in &result.edits {
-                match edit {
-                    Edit::Insert { position, text } => {
-                        buf.insert_at(*position, text);
-                    }
-                    Edit::Delete { position, text } => {
-                        buf.delete_at(*position, text.chars().count());
-                    }
-                }
-            }
-        }
+        self.apply_undo_edits(buffer, &result.edits);
 
         // Restore cursor to per-client active window
         if let Some(window) = self.windows_mut().active_mut() {
@@ -1013,7 +970,6 @@ impl UndoApi for SessionRuntime<'_> {
         Some(result)
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn record_edit_mine(
         &mut self,
         buffer: BufferId,
@@ -1220,7 +1176,6 @@ impl CompositorApi for SessionRuntime<'_> {
         Ok(neighbor)
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
     fn close_others(&mut self) -> Result<(), CompositorError> {
         use reovim_driver_display::layout::Zone;
 
@@ -4288,6 +4243,33 @@ mod tests {
         assert!(runtime.changes.buffer_modified);
     }
 
+    /// `apply_undo_edits` returns early when the buffer is not in the kernel.
+    #[test]
+    fn test_apply_undo_edits_buffer_not_found() {
+        use reovim_kernel::api::v1::ModeStack;
+
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty();
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
+
+        let rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+
+        // BufferId::new() is not registered in the kernel
+        let buf = BufferId::new();
+        let edits = vec![Edit::Insert {
+            position: Position::new(0, 0),
+            text: "X".to_string(),
+        }];
+
+        // Should return without panic (early return from let...else)
+        rt.apply_undo_edits(buf, &edits);
+    }
+
     // =========================================================================
     // CompositorApi with compositor (lines 1081-1537)
     // =========================================================================
@@ -5299,6 +5281,29 @@ mod tests {
         window.cursor = Position::new(0, 3).into();
         // No selection
         w.add(window);
+
+        let buf = BufferId::new();
+        let mut rt =
+            SessionRuntime::new(&mut session, &mut ms, &mut w, &mut e, &mut c, &kernel, &executor);
+        rt.record_cursor_move(buf);
+
+        let changes = rt.take_changes();
+        assert!(changes.cursor_moved);
+        assert!(!changes.selection_changed);
+    }
+
+    /// When cursor moves with no active window, only `cursor_moved` is set.
+    #[test]
+    fn test_record_cursor_move_no_active_window() {
+        use reovim_kernel::api::v1::ModeStack;
+
+        let mut session = Session::new(ClientId::new(1), test_mode());
+        let kernel = KernelContext::default();
+        let executor = StubExecutor;
+        let mut ms = ModeStack::new(test_mode());
+        let mut w = crate::WindowLayout::empty(); // No windows added
+        let mut e = crate::ExtensionMap::new();
+        let mut c = None;
 
         let buf = BufferId::new();
         let mut rt =

--- a/server/lib/kernel/src/core/config.rs
+++ b/server/lib/kernel/src/core/config.rs
@@ -1508,6 +1508,113 @@ mod tests {
         assert_eq!(table.to_string(), "{50 entries}");
     }
 
+    // === MC/DC: ConfigValue type_name() - all 5 arms ===
+    // Exercises each arm of `const fn type_name()` for complete BRDA coverage.
+
+    #[test]
+    fn test_config_value_type_name_all_variants() {
+        assert_eq!(ConfigValue::Bool(true).type_name(), "bool");
+        assert_eq!(ConfigValue::Bool(false).type_name(), "bool");
+        assert_eq!(ConfigValue::Integer(0).type_name(), "integer");
+        assert_eq!(ConfigValue::Integer(-1).type_name(), "integer");
+        assert_eq!(ConfigValue::String(String::new()).type_name(), "string");
+        assert_eq!(ConfigValue::Array(Vec::new()).type_name(), "array");
+        assert_eq!(ConfigValue::Table(HashMap::new()).type_name(), "table");
+    }
+
+    // === MC/DC: Config::get_bool / get_int / get_str - both None and Some branches ===
+    // Each and_then chain has two MC/DC arms: None (short-circuit) and Some (apply closure).
+
+    #[test]
+    fn test_config_get_bool_none_and_some_branches() {
+        let config = Config::new();
+
+        // None branch: key does not exist
+        assert!(config.get_bool("nonexistent").is_none());
+
+        // Some(Bool) branch: key exists as Bool
+        config.set_bool("flag", true);
+        assert_eq!(config.get_bool("flag"), Some(true));
+
+        // Some(non-Bool) branch: key exists but wrong type - as_bool returns None
+        config.set_int("num", 1);
+        assert!(config.get_bool("num").is_none());
+    }
+
+    #[test]
+    fn test_config_get_int_none_and_some_branches() {
+        let config = Config::new();
+
+        // None branch: key does not exist
+        assert!(config.get_int("nonexistent").is_none());
+
+        // Some(Integer) branch: key exists as Integer
+        config.set_int("count", 7);
+        assert_eq!(config.get_int("count"), Some(7));
+
+        // Some(non-Integer) branch: key exists but wrong type - as_int returns None
+        config.set_bool("flag", false);
+        assert!(config.get_int("flag").is_none());
+    }
+
+    #[test]
+    fn test_config_get_str_none_and_some_branches() {
+        let config = Config::new();
+
+        // None branch: key does not exist
+        assert!(config.get_str("nonexistent").is_none());
+
+        // Some(String) branch: key exists as String
+        config.set_str("name", "alice");
+        assert_eq!(config.get_str("name"), Some("alice".to_string()));
+
+        // Some(non-String) branch: key exists but wrong type - as_str returns None
+        config.set_int("num", 42);
+        assert!(config.get_str("num").is_none());
+    }
+
+    // === MC/DC: Config::keys_with_prefix filter - TRUE and FALSE branches ===
+    // The filter closure `|k| k.starts_with(prefix)` has two branches.
+
+    #[test]
+    fn test_config_keys_with_prefix_true_and_false_branches() {
+        let config = Config::new();
+        config.set_str("editor.theme", "dark");
+        config.set_str("editor.font", "mono");
+        config.set_str("plugin.lsp", "enabled");
+
+        // Filter TRUE branch: "editor.theme" and "editor.font" start with "editor"
+        let editor_keys = config.keys_with_prefix("editor");
+        assert_eq!(editor_keys.len(), 2);
+
+        // Filter FALSE branch: "plugin.lsp" does NOT start with "editor" (filtered out)
+        // (Same call exercises both TRUE and FALSE branches of the predicate)
+        assert!(!editor_keys.iter().any(|k| k.starts_with("plugin")));
+    }
+
+    // === MC/DC: Config::merge - empty and non-empty iteration ===
+    // The for loop in merge() exercises both the loop-body and the no-iteration paths.
+
+    #[test]
+    fn test_config_merge_loop_iterations() {
+        let config1 = Config::new();
+        config1.set_str("key_a", "value_a");
+
+        // Merge empty config: loop body never executes (0 iterations)
+        let empty = Config::new();
+        config1.merge(&empty);
+        assert_eq!(config1.len(), 1); // unchanged
+
+        // Merge non-empty config: loop body executes (1+ iterations)
+        let source = Config::new();
+        source.set_str("key_b", "value_b");
+        source.set_int("key_c", 99);
+        config1.merge(&source);
+        assert_eq!(config1.len(), 3);
+        assert_eq!(config1.get_str("key_b"), Some("value_b".to_string()));
+        assert_eq!(config1.get_int("key_c"), Some(99));
+    }
+
     #[test]
     fn test_config_dot_notation_keys() {
         let config = Config::new();

--- a/server/lib/kernel/src/core/option/mod.rs
+++ b/server/lib/kernel/src/core/option/mod.rs
@@ -1144,4 +1144,153 @@ mod tests {
         assert!(all.contains(&"a".to_string()));
         assert!(all.contains(&"b".to_string()));
     }
+
+    // === MC/DC: register() - AlreadyExists branch (line ~128-129) ===
+    // Exercises the duplicate name check returning AlreadyExists error.
+
+    #[test]
+    fn test_registry_register_already_exists_error() {
+        let registry = OptionRegistry::new();
+        let spec = OptionSpec::new("tabstop", "Tab stop width", OptionValue::int(8));
+        assert!(registry.register(spec).is_ok());
+
+        // Second registration of the same name must return AlreadyExists
+        let dup = OptionSpec::new("tabstop", "Duplicate", OptionValue::int(4));
+        let result = registry.register(dup);
+        assert!(matches!(result, Err(OptionError::AlreadyExists(name)) if name == "tabstop"));
+    }
+
+    // === MC/DC: register() - AliasConflict when alias matches existing spec name ===
+    // Exercises the check at line ~137: alias == an existing full spec name.
+
+    #[test]
+    fn test_registry_register_alias_conflicts_with_existing_spec_name() {
+        let registry = OptionRegistry::new();
+        // Register "ts" as a full spec name
+        assert!(
+            registry
+                .register(OptionSpec::new("ts", "Existing spec", OptionValue::int(4)))
+                .is_ok()
+        );
+        // Try to register "tabstop" with short alias "ts" - should fail because "ts" is a spec name
+        let result = registry
+            .register(OptionSpec::new("tabstop", "desc", OptionValue::int(8)).with_short("ts"));
+        assert!(matches!(result, Err(OptionError::AliasConflict(alias)) if alias == "ts"));
+    }
+
+    // === MC/DC: register() - AliasConflict when alias matches existing alias ===
+    // Exercises the check at line ~142: alias already registered as an alias.
+
+    #[test]
+    fn test_registry_register_alias_conflicts_with_existing_alias() {
+        let registry = OptionRegistry::new();
+        // Register "number" with alias "nu"
+        assert!(
+            registry
+                .register(
+                    OptionSpec::new("number", "Line numbers", OptionValue::bool(false))
+                        .with_short("nu"),
+                )
+                .is_ok()
+        );
+        // Try to register "numberwidth" with the same alias "nu"
+        let result = registry.register(
+            OptionSpec::new("numberwidth", "Number column width", OptionValue::int(4))
+                .with_short("nu"),
+        );
+        assert!(matches!(result, Err(OptionError::AliasConflict(alias)) if alias == "nu"));
+    }
+
+    // === MC/DC: resolve_name() - TRUE branch: name is a direct spec name (line ~163) ===
+    // Exercises `if self.specs.read().contains_key(name)` returning true.
+
+    #[test]
+    fn test_resolve_name_returns_direct_spec_name() {
+        let registry = OptionRegistry::new();
+        assert!(
+            registry
+                .register(OptionSpec::new("wrap", "Line wrap", OptionValue::bool(true)))
+                .is_ok()
+        );
+
+        // "wrap" is a registered spec name - resolve_name should return it directly
+        let resolved = registry.resolve_name("wrap");
+        assert_eq!(resolved, Some("wrap".to_string()));
+    }
+
+    // === MC/DC: get() - Window scope value found (line ~207) ===
+    // Exercises `if let Some(value) = self.window_values.read().get(...)` TRUE branch.
+
+    #[test]
+    fn test_get_returns_window_local_value_when_set() {
+        let registry = OptionRegistry::new();
+        assert!(
+            registry
+                .register(
+                    OptionSpec::new("number", "Line numbers", OptionValue::bool(false))
+                        .with_scope(OptionScope::Window),
+                )
+                .is_ok()
+        );
+
+        let window_id = WindowId::new();
+        // Set a window-local value
+        assert!(
+            registry
+                .set_for_window("number", OptionValue::bool(true), window_id)
+                .is_ok()
+        );
+
+        // get() with Window scope must return the window-local value (TRUE branch at ~207)
+        let value = registry.get("number", OptionScopeId::Window(window_id));
+        assert_eq!(value, Some(OptionValue::bool(true)));
+    }
+
+    // === MC/DC: get() - Buffer scope value found (line ~217) ===
+    // Exercises `if let Some(value) = self.buffer_values.read().get(...)` TRUE branch.
+
+    #[test]
+    fn test_get_returns_buffer_local_value_when_set() {
+        let registry = OptionRegistry::new();
+        assert!(
+            registry
+                .register(
+                    OptionSpec::new("tabstop", "Tab width", OptionValue::int(4))
+                        .with_scope(OptionScope::Buffer),
+                )
+                .is_ok()
+        );
+
+        let buffer_id = BufferId::new();
+        // Set a buffer-local value
+        assert!(
+            registry
+                .set_for_buffer("tabstop", OptionValue::int(2), buffer_id)
+                .is_ok()
+        );
+
+        // get() with Buffer scope must return the buffer-local value (TRUE branch at ~217)
+        let value = registry.get("tabstop", OptionScopeId::Buffer(buffer_id));
+        assert_eq!(value, Some(OptionValue::int(2)));
+    }
+
+    // === MC/DC: get() - global override value present (line ~229) ===
+    // Exercises `if let Some(value) = self.global_values.read().get(&full_name)` TRUE branch.
+
+    #[test]
+    fn test_get_returns_global_override_when_set() {
+        let registry = OptionRegistry::new();
+        assert!(
+            registry
+                .register(OptionSpec::new("tabstop", "Tab width", OptionValue::int(4)))
+                .is_ok()
+        );
+
+        // Set a global override (different from default)
+        assert!(registry.set_global("tabstop", OptionValue::int(8)).is_ok());
+
+        // get() with Global scope must return the global override (TRUE branch at ~229)
+        let value = registry.get("tabstop", OptionScopeId::Global);
+        assert_eq!(value, Some(OptionValue::int(8)));
+    }
 }

--- a/server/lib/kernel/src/ipc/event.rs
+++ b/server/lib/kernel/src/ipc/event.rs
@@ -741,4 +741,73 @@ mod tests {
         let mut event = DynEvent::new(TestEvent { value: 1 });
         assert!(event.take_scope().is_none());
     }
+
+    // === MC/DC: downcast_ref FALSE branch (type mismatch) ===
+    // Exercises line 330 FALSE branch: type_id != TypeId::of::<E>()
+
+    #[test]
+    fn test_dyn_event_downcast_ref_type_mismatch_returns_none() {
+        #[derive(Debug)]
+        struct EventA;
+        impl Event for EventA {}
+
+        #[derive(Debug)]
+        struct EventB;
+        impl Event for EventB {}
+
+        let event = DynEvent::new(EventA);
+        // Downcast to the wrong type must return None (FALSE branch of type check)
+        assert!(event.downcast_ref::<EventB>().is_none());
+        // Downcast to the correct type must return Some (TRUE branch of type check)
+        assert!(event.downcast_ref::<EventA>().is_some());
+    }
+
+    // === MC/DC: downcast_mut TRUE and FALSE branches ===
+    // Exercises line 343 TRUE branch (correct type) and FALSE branch (type mismatch)
+
+    #[test]
+    fn test_dyn_event_downcast_mut_type_mismatch_returns_none() {
+        #[derive(Debug)]
+        struct EventC {
+            x: i32,
+        }
+        impl Event for EventC {}
+
+        #[derive(Debug)]
+        struct EventD;
+        impl Event for EventD {}
+
+        let mut event = DynEvent::new(EventC { x: 7 });
+        // FALSE branch: wrong type returns None
+        assert!(event.downcast_mut::<EventD>().is_none());
+        // TRUE branch: correct type returns Some and allows mutation
+        if let Some(inner) = event.downcast_mut::<EventC>() {
+            inner.x = 99;
+        }
+        assert_eq!(event.downcast_ref::<EventC>().unwrap().x, 99);
+    }
+
+    // === MC/DC: into_inner FALSE branch (type mismatch returns Err) ===
+    // Exercises line 378 FALSE branch: type_id != TypeId::of::<E>()
+
+    #[test]
+    fn test_dyn_event_into_inner_type_mismatch_returns_err() {
+        #[derive(Debug, PartialEq)]
+        struct EventE {
+            val: u32,
+        }
+        impl Event for EventE {}
+
+        #[derive(Debug)]
+        struct EventF;
+        impl Event for EventF {}
+
+        let event = DynEvent::new(EventE { val: 55 });
+        // FALSE branch: wrong type causes into_inner to return Err(self)
+        let result = event.into_inner::<EventF>();
+        assert!(result.is_err());
+        // The returned Err still contains the original event
+        let recovered = result.unwrap_err();
+        assert!(recovered.is::<EventE>());
+    }
 }

--- a/server/lib/kernel/src/ipc/event_bus/mod.rs
+++ b/server/lib/kernel/src/ipc/event_bus/mod.rs
@@ -1337,4 +1337,105 @@ mod tests {
         let bus = EventBus::new();
         assert_eq!(bus.handler_count::<OtherEvent>(), 0);
     }
+
+    // === MC/DC: subscribe_targeted - FALSE branch (target mismatch) ===
+    // Exercises line 429 FALSE branch: event.target() != target
+    // Also covers the TRUE branch (matching target) to satisfy MC/DC.
+
+    #[test]
+    fn test_subscribe_targeted_false_branch_target_mismatch() {
+        #[derive(Debug)]
+        struct PluginEvent {
+            target: &'static str,
+        }
+        impl Event for PluginEvent {}
+        impl TargetedEvent for PluginEvent {
+            fn target(&self) -> &str {
+                self.target
+            }
+        }
+
+        let bus = EventBus::new();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let call_count2 = call_count.clone();
+
+        let _sub =
+            bus.subscribe_targeted::<PluginEvent, _>("correct_target", 100, move |_event, _ctx| {
+                call_count2.fetch_add(1, Ordering::SeqCst);
+                EventResult::Handled
+            });
+
+        // Emit with non-matching target: FALSE branch of `if event.target() == target`
+        // Handler should NOT be called
+        let wrong_target_event = DynEvent::new(PluginEvent {
+            target: "wrong_target",
+        });
+        let mut ctx = HandlerContext::new();
+        let result = bus.dispatch_with_context(&wrong_target_event, &mut ctx);
+        assert_eq!(result.result, EventResult::NotHandled);
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+
+        // Emit with matching target: TRUE branch of `if event.target() == target`
+        // Handler SHOULD be called
+        let correct_target_event = DynEvent::new(PluginEvent {
+            target: "correct_target",
+        });
+        let mut ctx2 = HandlerContext::new();
+        let result2 = bus.dispatch_with_context(&correct_target_event, &mut ctx2);
+        assert_eq!(result2.result, EventResult::Handled);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    // === MC/DC: process_queue - scope present branch ===
+    // Exercises line 560 TRUE branch: scope is Some, decrement is called
+
+    #[test]
+    fn test_process_queue_with_scope_decrements() {
+        let bus = EventBus::new();
+        let scope = EventScope::new();
+
+        // emit_async_scoped increments the scope counter
+        bus.emit_async_scoped(TestEvent { value: 1 }, &scope);
+        bus.emit_async_scoped(TestEvent { value: 2 }, &scope);
+        assert_eq!(scope.in_flight(), 2);
+
+        // process_queue should decrement the scope for each event (TRUE branch at line 560)
+        let count = bus.process_queue();
+        assert_eq!(count, 2);
+        assert_eq!(scope.in_flight(), 0);
+    }
+
+    // === MC/DC: dispatch - no handlers registered for event type ===
+    // Exercises line 577 early return when handlers map has no entry for type_id
+
+    #[test]
+    fn test_dispatch_returns_not_handled_when_no_handlers_for_type() {
+        let bus = EventBus::new();
+
+        // Register a handler for TestEvent (so the handlers map is non-empty)
+        let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+
+        // Dispatch OtherEvent which has NO handlers: early return at line 577
+        let dyn_event = DynEvent::new(OtherEvent);
+        let result = bus.dispatch(&dyn_event);
+        assert_eq!(result, EventResult::NotHandled);
+    }
+
+    // === MC/DC: dispatch_with_context - no handlers for event type ===
+    // Exercises line 637 early return: no handlers in the map for the event's TypeId
+
+    #[test]
+    fn test_dispatch_with_context_no_handlers_for_type() {
+        let bus = EventBus::new();
+
+        // Register a handler for TestEvent (so map is non-empty overall)
+        let _sub = bus.subscribe::<TestEvent, _>(100, |_| EventResult::Handled);
+
+        // Dispatch OtherEvent (no handlers): hits the early return at line 637
+        let dyn_event = DynEvent::new(OtherEvent);
+        let mut ctx = HandlerContext::new();
+        let result = bus.dispatch_with_context(&dyn_event, &mut ctx);
+        assert_eq!(result.result, EventResult::NotHandled);
+        assert!(!result.render_requested);
+    }
 }

--- a/server/lib/kernel/src/mm/saturator.rs
+++ b/server/lib/kernel/src/mm/saturator.rs
@@ -604,4 +604,101 @@ mod tests {
         let completed = scope.wait_timeout(Duration::from_millis(100));
         assert!(completed);
     }
+
+    // === MC/DC: submit() - scope present (TRUE branch at line 110) ===
+    // Exercises `if let Some(s) = scope` in submit() with a Some scope.
+
+    #[test]
+    fn test_submit_with_scope_increments_and_decrements() {
+        let scope = EventScope::new();
+
+        let handle = spawn_saturator(|x: i32| x, |_result| {});
+
+        // Before submit: in_flight is 0
+        assert_eq!(scope.in_flight(), 0);
+
+        // submit() with Some scope: TRUE branch increments the scope counter
+        handle.submit(42, Some(&scope));
+
+        // The scope counter was incremented by submit before sending to worker
+        // After worker processes it, it'll be decremented back to 0
+        let completed = scope.wait_timeout(Duration::from_millis(200));
+        assert!(completed, "Scope should reach 0 after worker processes the item");
+        assert_eq!(scope.in_flight(), 0);
+    }
+
+    // === MC/DC: submit_background() - scope present (TRUE branch at line 126) ===
+    // Exercises `if let Some(s) = scope` in submit_background() with a Some scope.
+
+    #[test]
+    fn test_submit_background_scope_increments_and_decrements() {
+        let scope = EventScope::new();
+
+        let handle = spawn_saturator(|x: i32| x, |_result| {});
+
+        assert_eq!(scope.in_flight(), 0);
+
+        // submit_background() with Some scope: TRUE branch at line 126
+        handle.submit_background(10, Some(&scope));
+
+        // Worker processes and decrements
+        let completed = scope.wait_timeout(Duration::from_millis(200));
+        assert!(completed, "Background scope should complete after worker processes");
+        assert_eq!(scope.in_flight(), 0);
+    }
+
+    // === MC/DC: Drop - worker present (TRUE branch at line 172) ===
+    // Exercises `if let Some(worker) = self.worker.take()` when the original
+    // handle (which owns the worker JoinHandle) is dropped.
+
+    #[test]
+    fn test_drop_original_handle_joins_worker_thread() {
+        use std::sync::atomic::AtomicBool;
+        let worker_started = Arc::new(AtomicBool::new(false));
+        let worker_started_clone = Arc::clone(&worker_started);
+
+        {
+            let handle = spawn_saturator(
+                move |x: i32| {
+                    worker_started_clone.store(true, Ordering::SeqCst);
+                    x
+                },
+                |_result| {},
+            );
+
+            // Submit work so the worker thread definitely starts
+            handle.submit(1, None);
+            // Give worker thread time to process
+            thread::sleep(Duration::from_millis(30));
+
+            // Drop the original handle here. The Drop impl TRUE branch is exercised:
+            // `if let Some(worker) = self.worker.take()` will be Some (original handle owns it).
+            // This sets shutdown=true and joins the worker thread.
+        }
+        // After drop, worker has been joined. The submitted work was processed.
+        assert!(worker_started.load(Ordering::SeqCst));
+    }
+
+    // === MC/DC: Drop - cloned handle has no worker (FALSE branch at line 172) ===
+    // A cloned SaturatorHandle has `worker: None`, so the Drop impl FALSE branch
+    // (`worker.take()` returns None) is exercised.
+
+    #[test]
+    fn test_drop_cloned_handle_does_not_join_worker() {
+        let handle = spawn_saturator(|x: i32| x, |_result| {});
+
+        // Clone does not own the worker thread (worker: None)
+        let clone = handle.clone();
+
+        // Dropping the clone exercises the FALSE branch of the Drop impl:
+        // `if let Some(worker) = self.worker.take()` -> None branch is taken
+        drop(clone);
+
+        // The original handle still works after the clone is dropped
+        handle.submit(1, None);
+        thread::sleep(Duration::from_millis(30));
+
+        // Original handle drops last, joining the worker thread
+        drop(handle);
+    }
 }

--- a/server/lib/kernel/src/panic/recovery.rs
+++ b/server/lib/kernel/src/panic/recovery.rs
@@ -291,4 +291,55 @@ mod tests {
         assert!(debug.contains("RecoverySnapshot"));
         assert!(debug.contains("UnsavedBuffer"));
     }
+
+    // === MC/DC: save_buffer_for_recovery() with original_path = Some(...) (line 89) ===
+
+    #[test]
+    fn test_save_buffer_with_original_path_exercises_some_branch() {
+        // Explicitly exercises the `if let Some(orig) = original_path` true branch
+        // (line 89) by passing Some(path). The content must contain "Original path".
+        // Uses the standard recovery dir; skips gracefully if the dir is not writable.
+        let content = "fn hello() {}";
+        let result =
+            save_buffer_for_recovery(111, Some(Path::new("/home/user/project/hello.rs")), content);
+
+        if result.is_err() {
+            // Recovery directory not writable in this environment - skip.
+            return;
+        }
+
+        let path = result.unwrap();
+        let saved = std::fs::read_to_string(&path).unwrap();
+
+        // True branch: "Original path" header must be present
+        assert!(saved.contains("# Original path: /home/user/project/hello.rs"));
+        assert!(saved.contains("buffer 111"));
+        assert!(saved.contains(content));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    // === MC/DC: save_buffer_for_recovery() with original_path = None (line 89 false branch) ===
+
+    #[test]
+    fn test_save_buffer_without_original_path_exercises_none_branch() {
+        // Explicitly exercises the `if let Some(orig) = original_path` false branch
+        // (None case) so the "Original path" line is NOT written.
+        let content = "scratch content";
+        let result = save_buffer_for_recovery(222, None, content);
+
+        if result.is_err() {
+            return;
+        }
+
+        let path = result.unwrap();
+        let saved = std::fs::read_to_string(&path).unwrap();
+
+        // False branch: "Original path" must NOT appear
+        assert!(!saved.contains("# Original path:"));
+        assert!(saved.contains("buffer 222"));
+        assert!(saved.contains(content));
+
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/server/lib/kernel/src/panic/report.rs
+++ b/server/lib/kernel/src/panic/report.rs
@@ -342,4 +342,49 @@ mod tests {
 
         std::fs::remove_file(&path).ok();
     }
+
+    // === MC/DC: write_to_file() with server_logs present (line 146 true branch) ===
+
+    #[test]
+    fn test_crash_report_write_with_server_logs_covered() {
+        // This test (without coverage(off)) exercises the true branch of
+        // `if let Some(ref logs) = self.server_logs` (line 146) and the
+        // true branch of `if !self.client_dump_paths.is_empty()` (line 154).
+        let report = CrashReport {
+            timestamp: std::time::SystemTime::now(),
+            panic_message: "covered panic".to_string(),
+            panic_location: Some("src/kernel.rs:10:1".to_string()),
+            backtrace: "backtrace text".to_string(),
+            rust_version: "1.92.0",
+            reovim_version: "0.9.0",
+            thread_name: Some("covered-thread".to_string()),
+            thread_id: Some(7),
+            server_logs: Some("INFO: boot complete\nWARN: low memory".to_string()),
+            client_dump_paths: vec![
+                PathBuf::from("/tmp/tui-dump-1.txt"),
+                PathBuf::from("/tmp/tui-dump-2.txt"),
+            ],
+        };
+
+        let result = report.write_to_file();
+        if result.is_err() {
+            // Recovery dir unavailable in this environment - skip.
+            return;
+        }
+
+        let path = result.unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+
+        // Verify server_logs branch wrote the section
+        assert!(content.contains("Server Debug Logs:"));
+        assert!(content.contains("INFO: boot complete"));
+        assert!(content.contains("WARN: low memory"));
+
+        // Verify client_dump_paths branch wrote the section
+        assert!(content.contains("Client Debug Dumps:"));
+        assert!(content.contains("/tmp/tui-dump-1.txt"));
+        assert!(content.contains("/tmp/tui-dump-2.txt"));
+
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/server/lib/kernel/src/sched/runtime.rs
+++ b/server/lib/kernel/src/sched/runtime.rs
@@ -1161,4 +1161,61 @@ mod tests {
         runtime.emergency_stop();
         assert!(!runtime.tick());
     }
+
+    // === MC/DC: schedule_work() when state is Emergency (not accepting work) ===
+
+    #[test]
+    fn test_runtime_schedule_work_when_emergency() {
+        // Emergency state: can_accept_work() == false -> return false.
+        // This exercises the `!self.state.can_accept_work()` true branch of
+        // schedule_work() from a different non-accepting state than Booting.
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        runtime.emergency_stop();
+        assert_eq!(runtime.state(), RuntimeState::Emergency);
+        assert!(!runtime.schedule_work(|| {}));
+    }
+
+    // === MC/DC: schedule_work_with_priority() when state is Emergency ===
+
+    #[test]
+    fn test_runtime_schedule_work_with_priority_when_emergency() {
+        // Emergency state: can_accept_work() == false -> return false.
+        // Covers the rejection branch of schedule_work_with_priority() from
+        // a state distinct from Booting (already tested) to satisfy MC/DC.
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        runtime.emergency_stop();
+        assert!(!runtime.schedule_work_with_priority(Priority::HIGH, || {}));
+    }
+
+    // === MC/DC: schedule_task() when state is Emergency ===
+
+    #[test]
+    fn test_runtime_schedule_task_when_emergency() {
+        // Emergency state: can_accept_work() == false -> return false.
+        // Covers the rejection branch of schedule_task() from Emergency state.
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        runtime.emergency_stop();
+        let task = Task::new(|| {});
+        assert!(!runtime.schedule_task(task));
+    }
+
+    // === MC/DC: shutdown() when state is already Stopping (no-op) ===
+
+    #[test]
+    fn test_runtime_shutdown_when_already_stopping() {
+        // state == Stopping: the `if self.state == RuntimeState::Running` condition
+        // is false -> no-op. State remains Stopping.
+        // This provides a distinct false-branch case from test_runtime_shutdown_from_booting.
+        let mut runtime = Runtime::new();
+        runtime.boot();
+        runtime.shutdown(); // Running -> Stopping
+        assert_eq!(runtime.state(), RuntimeState::Stopping);
+
+        // Second shutdown call: state is Stopping, not Running -> no state change
+        runtime.shutdown();
+        assert_eq!(runtime.state(), RuntimeState::Stopping);
+    }
 }

--- a/server/lib/kernel/src/sched/task.rs
+++ b/server/lib/kernel/src/sched/task.rs
@@ -651,4 +651,21 @@ mod tests {
         assert!(set.contains(&TaskState::Pending));
         assert!(!set.contains(&TaskState::Running));
     }
+
+    // === MC/DC: execute() on a task that is already in Failed state ===
+
+    #[test]
+    fn test_task_execute_on_failed_task_returns_err() {
+        // mark_failed() sets state to Failed (not Pending).
+        // Calling execute() on a Failed task exercises the true branch of
+        // `if self.state != TaskState::Pending` (line 325) with a distinct
+        // non-Pending state (Failed) separate from the Completed case.
+        let mut task = Task::new(|| {});
+        task.mark_failed();
+        assert_eq!(task.state(), TaskState::Failed);
+
+        let result = task.execute();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "task already executed or cancelled");
+    }
 }

--- a/server/lib/kernel/src/sched/timer.rs
+++ b/server/lib/kernel/src/sched/timer.rs
@@ -1161,4 +1161,45 @@ mod tests {
         let wheel = Arc::new(TimerWheel::new());
         assert!(!wheel.cancel(TimerId::from_raw(99999)));
     }
+
+    // === MC/DC: schedule_internal capacity overflow with max_timers=1 ===
+
+    #[test]
+    fn test_timer_wheel_capacity_overflow_at_one() {
+        // max_timers=1: first schedule succeeds (len < 1), second hits the
+        // `if timers.len() >= self.max_timers` true branch and returns a failed handle.
+        let wheel = Arc::new(TimerWheel::with_max_timers(1));
+
+        let h1 = wheel.schedule_oneshot(Duration::from_secs(10), Priority::NORMAL, || {});
+        assert!(!h1.is_failed());
+        assert_eq!(wheel.pending_count(), 1);
+        assert_eq!(wheel.dropped_count(), 0);
+
+        // Second scheduling hits the overflow branch
+        let h2 = wheel.schedule_oneshot(Duration::from_secs(10), Priority::NORMAL, || {});
+        assert!(h2.is_failed());
+        assert_eq!(wheel.dropped_count(), 1);
+        assert_eq!(wheel.pending_count(), 1); // Still only 1 timer
+    }
+
+    // === MC/DC: cancel() already-cancelled timer (is_cancelled() true branch) ===
+
+    #[test]
+    fn test_timer_cancel_already_cancelled_returns_false() {
+        // Cancel a timer once (succeeds, is_cancelled() was false -> sets to true).
+        // Cancel the same timer again: is_cancelled() is now true -> returns false.
+        // This exercises the true branch of `if entry.is_cancelled()` in cancel().
+        let wheel = Arc::new(TimerWheel::new());
+
+        let handle = wheel.schedule_oneshot(Duration::from_secs(10), Priority::NORMAL, || {});
+        let id = handle.id();
+
+        // First cancel: is_cancelled() == false -> cancel and return true
+        let first = wheel.cancel(id);
+        assert!(first, "first cancel should succeed");
+
+        // Second cancel: is_cancelled() == true -> return false (already cancelled)
+        let second = wheel.cancel(id);
+        assert!(!second, "second cancel should return false (already cancelled)");
+    }
 }

--- a/server/lib/kernel/src/sched/work_queue.rs
+++ b/server/lib/kernel/src/sched/work_queue.rs
@@ -496,4 +496,34 @@ mod tests {
         assert!(!queue.push(Task::new(|| {})));
         assert_eq!(queue.dropped_count(), 1);
     }
+
+    // === MC/DC: push() overflow branch (capacity == 1, second push drops) ===
+
+    #[test]
+    fn test_push_overflow_capacity_one() {
+        // Capacity = 1: first push succeeds (len < capacity), second fails (len >= capacity).
+        // This ensures the true branch of `if queue.len() >= self.capacity` is taken
+        // with capacity=1 to isolate the single-condition MC/DC branch.
+        let queue = WorkQueue::with_capacity(1);
+        assert!(queue.push(Task::new(|| {}))); // len was 0 < 1, succeeds
+        assert!(!queue.push(Task::new(|| {}))); // len is now 1 >= 1, drops
+        assert_eq!(queue.dropped_count(), 1);
+        assert_eq!(queue.len(), 1);
+    }
+
+    // === MC/DC: process_pending() empty-queue break branch ===
+
+    #[test]
+    fn test_process_pending_breaks_on_empty_queue() {
+        // Exercises the `else { break }` arm of the `let Some(mut task) = self.try_pop()`
+        // pattern when the queue is exhausted before the limit is reached.
+        let queue = WorkQueue::with_capacity(2);
+        queue.push(Task::new(|| {}));
+        queue.push(Task::new(|| {}));
+
+        // limit=100 but only 2 tasks: loop must break early via the else branch
+        let processed = queue.process_pending(100);
+        assert_eq!(processed, 2);
+        assert!(queue.is_empty());
+    }
 }

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -191,6 +191,29 @@ impl InputService for InputServiceImpl {
             accumulated_changes.record_cursor_move(buffer_id);
         }
 
+        // #474: Auto-detect selection changes (defense-in-depth).
+        // If cursor moved and client has an active selection, ensure
+        // selection_changed is recorded for the notification pipeline.
+        // This is a pure safety net: accumulated_changes is a plain
+        // StateChanges (not SessionRuntime), so the centralized sel.end
+        // extension doesn't apply here. Catches any future commands
+        // that record cursor_moved on accumulated_changes directly.
+        if accumulated_changes.cursor_moved
+            && !accumulated_changes.selection_changed
+            && let Some(state) = session.client_state(client_id)
+        {
+            let has_selection = state
+                .windows
+                .active()
+                .is_some_and(|w| w.selection.is_some());
+            if has_selection {
+                #[allow(clippy::redundant_closure_for_method_calls)]
+                if let Some(buffer_id) = session.with_state(|s| s.active_buffer()).await {
+                    accumulated_changes.record_selection_change(buffer_id);
+                }
+            }
+        }
+
         // Emit notifications for accumulated state changes
         // Phase 14 (#471): Pass client_id for cursor/selection filtering
         // Phase #486: emit_notifications is now sync (uses sync per-client state access)

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -192,26 +192,14 @@ impl InputService for InputServiceImpl {
         }
 
         // #474: Auto-detect selection changes (defense-in-depth).
-        // If cursor moved and client has an active selection, ensure
-        // selection_changed is recorded for the notification pipeline.
-        // This is a pure safety net: accumulated_changes is a plain
-        // StateChanges (not SessionRuntime), so the centralized sel.end
-        // extension doesn't apply here. Catches any future commands
-        // that record cursor_moved on accumulated_changes directly.
-        if accumulated_changes.cursor_moved
-            && !accumulated_changes.selection_changed
-            && let Some(state) = session.client_state(client_id)
-        {
-            let has_selection = state
-                .windows
-                .active()
-                .is_some_and(|w| w.selection.is_some());
-            if has_selection {
-                #[allow(clippy::redundant_closure_for_method_calls)]
-                if let Some(buffer_id) = session.with_state(|s| s.active_buffer()).await {
-                    accumulated_changes.record_selection_change(buffer_id);
-                }
-            }
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        if let Some(state) = session.client_state(client_id) {
+            let active_buffer = session.with_state(|s| s.active_buffer()).await;
+            Self::ensure_selection_change_recorded(
+                &mut accumulated_changes,
+                &state.windows,
+                active_buffer,
+            );
         }
 
         // Emit notifications for accumulated state changes
@@ -230,6 +218,26 @@ impl InputService for InputServiceImpl {
 }
 
 impl InputServiceImpl {
+    /// Defense-in-depth: if cursor moved but `selection_changed` was not set by
+    /// the resolver pipeline, check whether the client has an active selection and
+    /// record `selection_changed` so the notification pipeline picks it up.
+    ///
+    /// This catches commands that set `cursor_moved` on `accumulated_changes`
+    /// directly (outside `SessionRuntime::record_cursor_move`).
+    fn ensure_selection_change_recorded(
+        changes: &mut StateChanges,
+        windows: &reovim_driver_session::WindowLayout,
+        active_buffer: Option<reovim_kernel::api::v1::BufferId>,
+    ) {
+        if !changes.cursor_moved || changes.selection_changed {
+            return;
+        }
+        let has_selection = windows.active().is_some_and(|w| w.selection.is_some());
+        if has_selection && let Some(buffer_id) = active_buffer {
+            changes.record_selection_change(buffer_id);
+        }
+    }
+
     /// Emit notifications for state changes.
     ///
     /// Converts accumulated `StateChanges` to gRPC notifications and emits them
@@ -2626,5 +2634,82 @@ mod tests {
         .await;
 
         assert!(handled);
+    }
+
+    // =========================================================================
+    // ensure_selection_change_recorded tests
+    // =========================================================================
+
+    #[test]
+    fn test_ensure_selection_change_cursor_moved_with_selection() {
+        let buffer_id = reovim_kernel::api::v1::BufferId::from_raw(1);
+        let mut changes = StateChanges::new();
+        changes.record_cursor_move(buffer_id);
+        assert!(!changes.selection_changed);
+
+        // Window with selection
+        let mut window = reovim_driver_session::Window::with_buffer(buffer_id);
+        window.selection = Some(reovim_driver_session::api::Selection::character(
+            reovim_kernel::api::v1::Position::new(0, 0),
+            reovim_kernel::api::v1::Position::new(0, 5),
+        ));
+        let windows = reovim_driver_session::WindowLayout::single(window);
+
+        InputServiceImpl::ensure_selection_change_recorded(&mut changes, &windows, Some(buffer_id));
+
+        assert!(changes.selection_changed);
+    }
+
+    #[test]
+    fn test_ensure_selection_change_already_recorded_is_noop() {
+        let buffer_id = reovim_kernel::api::v1::BufferId::from_raw(1);
+        let mut changes = StateChanges::new();
+        changes.record_cursor_move(buffer_id);
+        changes.selection_changed = true;
+
+        let mut window = reovim_driver_session::Window::with_buffer(buffer_id);
+        window.selection = Some(reovim_driver_session::api::Selection::character(
+            reovim_kernel::api::v1::Position::new(0, 0),
+            reovim_kernel::api::v1::Position::new(0, 5),
+        ));
+        let windows = reovim_driver_session::WindowLayout::single(window);
+
+        // Already recorded — should not change anything
+        InputServiceImpl::ensure_selection_change_recorded(&mut changes, &windows, Some(buffer_id));
+
+        assert!(changes.selection_changed);
+    }
+
+    #[test]
+    fn test_ensure_selection_change_no_selection_is_noop() {
+        let buffer_id = reovim_kernel::api::v1::BufferId::from_raw(1);
+        let mut changes = StateChanges::new();
+        changes.record_cursor_move(buffer_id);
+
+        // Window without selection
+        let window = reovim_driver_session::Window::with_buffer(buffer_id);
+        let windows = reovim_driver_session::WindowLayout::single(window);
+
+        InputServiceImpl::ensure_selection_change_recorded(&mut changes, &windows, Some(buffer_id));
+
+        assert!(!changes.selection_changed);
+    }
+
+    #[test]
+    fn test_ensure_selection_change_no_cursor_moved_is_noop() {
+        let buffer_id = reovim_kernel::api::v1::BufferId::from_raw(1);
+        let mut changes = StateChanges::new();
+        // cursor_moved is false
+
+        let mut window = reovim_driver_session::Window::with_buffer(buffer_id);
+        window.selection = Some(reovim_driver_session::api::Selection::character(
+            reovim_kernel::api::v1::Position::new(0, 0),
+            reovim_kernel::api::v1::Position::new(0, 5),
+        ));
+        let windows = reovim_driver_session::WindowLayout::single(window);
+
+        InputServiceImpl::ensure_selection_change_recorded(&mut changes, &windows, Some(buffer_id));
+
+        assert!(!changes.selection_changed);
     }
 }

--- a/server/modules/editor/src/command/cursor.rs
+++ b/server/modules/editor/src/command/cursor.rs
@@ -83,14 +83,10 @@ impl CommandHandler for CursorUp {
         // Normal mode: move cursor via per-client Window (#471)
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.cursor = new_pos.into();
-            // In visual mode, extend selection to cursor (#471)
-            // Selection end is exclusive, so add 1 to include the character under cursor
-            if let Some(ref mut sel) = window.selection {
-                sel.end = Position::new(new_pos.line, new_pos.column + 1);
-            }
         }
 
         // Record cursor move via ChangeTracker
+        // #474: Selection extension is centralized in SessionRuntime::record_cursor_move
         runtime.record_cursor_move(buffer_id);
 
         CommandResult::Success
@@ -164,14 +160,10 @@ impl CommandHandler for CursorDown {
         // Normal mode: move cursor via per-client Window (#471)
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.cursor = new_pos.into();
-            // In visual mode, extend selection to cursor (#471)
-            // Selection end is exclusive, so add 1 to include the character under cursor
-            if let Some(ref mut sel) = window.selection {
-                sel.end = Position::new(new_pos.line, new_pos.column + 1);
-            }
         }
 
         // Record cursor move via ChangeTracker
+        // #474: Selection extension is centralized in SessionRuntime::record_cursor_move
         runtime.record_cursor_move(buffer_id);
 
         CommandResult::Success
@@ -238,14 +230,10 @@ impl CommandHandler for CursorLeft {
         // Normal mode: move cursor via per-client Window (#471)
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.cursor = new_pos.into();
-            // In visual mode, extend selection to cursor (#471)
-            // Selection end is exclusive, so add 1 to include the character under cursor
-            if let Some(ref mut sel) = window.selection {
-                sel.end = Position::new(new_pos.line, new_pos.column + 1);
-            }
         }
 
         // Record cursor move via ChangeTracker
+        // #474: Selection extension is centralized in SessionRuntime::record_cursor_move
         runtime.record_cursor_move(buffer_id);
 
         CommandResult::Success
@@ -322,14 +310,10 @@ impl CommandHandler for CursorRight {
         // Normal mode: move cursor via per-client Window (#471)
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.cursor = new_pos.into();
-            // In visual mode, extend selection to cursor (#471)
-            // Selection end is exclusive, so add 1 to include the character under cursor
-            if let Some(ref mut sel) = window.selection {
-                sel.end = Position::new(new_pos.line, new_pos.column + 1);
-            }
         }
 
         // Record cursor move via ChangeTracker
+        // #474: Selection extension is centralized in SessionRuntime::record_cursor_move
         runtime.record_cursor_move(buffer_id);
 
         CommandResult::Success

--- a/server/modules/vim/src/commands/find_char.rs
+++ b/server/modules/vim/src/commands/find_char.rs
@@ -22,7 +22,7 @@
 
 use {
     reovim_driver_command::{ArgValue, Command, CommandContext, CommandHandler, CommandResult},
-    reovim_driver_session::SessionRuntime,
+    reovim_driver_session::{SessionRuntime, api::ChangeTracker},
     reovim_kernel::api::v1::{CommandId, Cursor, Motion, MotionEngine, Position},
 };
 
@@ -103,10 +103,13 @@ impl CommandHandler for ExecuteFindChar {
         };
 
         // Apply motion if target found
-        if let Some(pos) = target
-            && let Some(window) = runtime.windows_mut().active_mut()
-        {
-            window.cursor = pos.into();
+        if let Some(pos) = target {
+            if let Some(window) = runtime.windows_mut().active_mut() {
+                window.cursor = pos.into();
+            }
+            // #474: Record cursor move so notification pipeline and
+            // centralized selection extension are triggered.
+            runtime.record_cursor_move(buffer_id);
         }
         // Character not found - this is not an error, just don't move
         // (Vim behavior: cursor stays in place, no beep)

--- a/server/modules/vim/src/resolvers/change.rs
+++ b/server/modules/vim/src/resolvers/change.rs
@@ -929,6 +929,7 @@ mod tests {
             StateChanges::new()
         }
         fn record_cursor_move(&mut self, _b: BufferId) {}
+        fn record_selection_change(&mut self, _b: BufferId) {}
     }
 
     #[test]

--- a/server/modules/vim/src/resolvers/delete.rs
+++ b/server/modules/vim/src/resolvers/delete.rs
@@ -971,6 +971,7 @@ mod tests {
             StateChanges::new()
         }
         fn record_cursor_move(&mut self, _b: BufferId) {}
+        fn record_selection_change(&mut self, _b: BufferId) {}
     }
 
     #[test]

--- a/server/modules/vim/src/resolvers/visual.rs
+++ b/server/modules/vim/src/resolvers/visual.rs
@@ -30,8 +30,8 @@ use std::sync::RwLock;
 
 use {
     reovim_driver_input::{
-        ExtensionMap, KeyCode, KeyEvent, KeySequence, ModeKeyResolver, ModeState, ModeTransition,
-        Modifiers, ResolveContext, ResolveInput, ResolveResult, SessionApiDyn, TransitionContext,
+        ExtensionMap, KeyCode, KeyEvent, KeySequence, ModeKeyResolver, ModeState, Modifiers,
+        ResolveContext, ResolveInput, ResolveResult, SessionApiDyn,
     },
     reovim_kernel::api::v1::ModeId,
 };
@@ -191,15 +191,13 @@ impl ModeKeyResolver for VimVisualResolver {
         _state: &mut ModeState,
         input: &ResolveInput<'_>,
     ) -> ResolveResult {
-        // Escape or Ctrl-C exits visual mode
+        // Escape or Ctrl-C exits visual mode via ExitVisualMode command.
+        // The command clears selection, records selection_changed, and sets NORMAL mode.
         if is_escape(key)
             || (key.code == KeyCode::Char('c') && key.modifiers.contains(Modifiers::CTRL))
         {
             self.clear_state();
-            return ResolveResult::ModeTransition(ModeTransition::Set {
-                mode: VimMode::NORMAL_ID,
-                context: TransitionContext::new(),
-            });
+            return ResolveResult::Execute(crate::ids::EXIT_VISUAL, ResolveContext::new());
         }
 
         let mut state = self.state.write().expect("lock poisoned");
@@ -266,16 +264,14 @@ impl ModeKeyResolver for VimVisualResolver {
     ) -> ResolveResult {
         tracing::debug!(key = ?key, mode = ?self.mode_id, "visual resolver: resolve_with_session");
 
-        // Escape or Ctrl-C exits visual mode
+        // Escape or Ctrl-C exits visual mode via ExitVisualMode command.
+        // The command clears selection, records selection_changed, and sets NORMAL mode.
         if is_escape(key)
             || (key.code == KeyCode::Char('c') && key.modifiers.contains(Modifiers::CTRL))
         {
-            tracing::debug!("visual resolver: escape/ctrl-c - exiting visual mode");
+            tracing::debug!("visual resolver: escape/ctrl-c - executing EXIT_VISUAL command");
             self.clear_state();
-            return ResolveResult::ModeTransition(ModeTransition::Set {
-                mode: VimMode::NORMAL_ID,
-                context: TransitionContext::new(),
-            });
+            return ResolveResult::Execute(crate::ids::EXIT_VISUAL, ResolveContext::new());
         }
 
         let mut state = self.state.write().expect("lock poisoned");
@@ -466,10 +462,10 @@ mod tests {
         let result =
             resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -487,10 +483,10 @@ mod tests {
             &input,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -797,10 +793,10 @@ mod tests {
         let result =
             resolver.resolve_with_keymap(&KeyEvent::new(KeyCode::Escape), &mut state, &input);
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -818,10 +814,10 @@ mod tests {
             &input,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -1019,6 +1015,7 @@ mod tests {
             StateChanges::new()
         }
         fn record_cursor_move(&mut self, _b: BufferId) {}
+        fn record_selection_change(&mut self, _b: BufferId) {}
     }
 
     #[test]
@@ -1039,10 +1036,10 @@ mod tests {
             &mut extensions,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -1064,10 +1061,10 @@ mod tests {
             &mut extensions,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -1238,10 +1235,10 @@ mod tests {
             &mut extensions,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 
@@ -1263,10 +1260,10 @@ mod tests {
             &mut extensions,
         );
 
-        if let ResolveResult::ModeTransition(ModeTransition::Set { mode, .. }) = result {
-            assert_eq!(mode, VimMode::NORMAL_ID);
+        if let ResolveResult::Execute(cmd_id, _) = result {
+            assert_eq!(cmd_id, crate::ids::EXIT_VISUAL);
         } else {
-            panic!("expected Set to Normal, got {result:?}");
+            panic!("expected Execute(EXIT_VISUAL), got {result:?}");
         }
     }
 

--- a/server/modules/vim/src/resolvers/yank.rs
+++ b/server/modules/vim/src/resolvers/yank.rs
@@ -834,6 +834,7 @@ mod tests {
             StateChanges::new()
         }
         fn record_cursor_move(&mut self, _b: BufferId) {}
+        fn record_selection_change(&mut self, _b: BufferId) {}
     }
 
     #[test]

--- a/server/modules/vim/src/visual/entry.rs
+++ b/server/modules/vim/src/visual/entry.rs
@@ -8,8 +8,8 @@
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
     reovim_driver_session::{
-        SessionRuntime, TransitionContext,
-        api::{ModeApi, Selection},
+        BufferApi, SessionRuntime, TransitionContext,
+        api::{ChangeTracker, ModeApi, Selection},
     },
     reovim_kernel::api::v1::{CommandId, Position},
 };
@@ -48,6 +48,11 @@ impl CommandHandler for EnterVisualMode {
 
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = Some(selection);
+        }
+
+        // #474: Notify other clients about new selection
+        if let Some(buffer_id) = runtime.active_buffer() {
+            runtime.record_selection_change(buffer_id);
         }
 
         // Verify selection was set
@@ -93,6 +98,11 @@ impl CommandHandler for EnterVisualLineMode {
             window.selection = Some(selection);
         }
 
+        // #474: Notify other clients about new selection
+        if let Some(buffer_id) = runtime.active_buffer() {
+            runtime.record_selection_change(buffer_id);
+        }
+
         // Change to visual line mode
         runtime.set_mode(VimMode::VISUAL_LINE_ID, TransitionContext::new());
 
@@ -130,6 +140,11 @@ impl CommandHandler for EnterVisualBlockMode {
 
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = Some(selection);
+        }
+
+        // #474: Notify other clients about new selection
+        if let Some(buffer_id) = runtime.active_buffer() {
+            runtime.record_selection_change(buffer_id);
         }
 
         // Change to visual block mode

--- a/server/modules/vim/src/visual/exit.rs
+++ b/server/modules/vim/src/visual/exit.rs
@@ -4,7 +4,10 @@
 
 use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
-    reovim_driver_session::{SessionRuntime, TransitionContext, api::ModeApi},
+    reovim_driver_session::{
+        BufferApi, SessionRuntime, TransitionContext,
+        api::{ChangeTracker, ModeApi},
+    },
     reovim_kernel::api::v1::CommandId,
 };
 
@@ -30,6 +33,11 @@ impl CommandHandler for ExitVisualMode {
         // Clear selection on the active window
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = None;
+        }
+
+        // #474: Notify other clients that selection was cleared
+        if let Some(buffer_id) = runtime.active_buffer() {
+            runtime.record_selection_change(buffer_id);
         }
 
         // Change to normal mode

--- a/server/modules/vim/src/visual/operators.rs
+++ b/server/modules/vim/src/visual/operators.rs
@@ -11,7 +11,7 @@ use {
     reovim_driver_command::{Command, CommandContext, CommandHandler, CommandResult},
     reovim_driver_session::{
         BufferApi, SessionRuntime, TransitionContext,
-        api::{ModeApi, RegisterApi, RegisterContent, Selection, SelectionMode},
+        api::{ChangeTracker, ModeApi, RegisterApi, RegisterContent, Selection, SelectionMode},
     },
     reovim_kernel::api::v1::{CommandId, Position},
 };
@@ -116,6 +116,9 @@ impl CommandHandler for DeleteSelection {
             window.cursor = cursor_pos.into();
         }
 
+        // #474: Notify other clients that selection was cleared
+        runtime.record_selection_change(buffer_id);
+
         // Mode transition to Normal
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
 
@@ -174,6 +177,9 @@ impl CommandHandler for YankSelection {
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = None;
         }
+
+        // #474: Notify other clients that selection was cleared
+        runtime.record_selection_change(buffer_id);
 
         // Mode transition to Normal
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
@@ -238,6 +244,9 @@ impl CommandHandler for ChangeSelection {
             window.cursor = cursor_pos.into();
         }
 
+        // #474: Notify other clients that selection was cleared
+        runtime.record_selection_change(buffer_id);
+
         // Mode transition to Insert (change = delete + insert mode)
         runtime.set_mode(VimMode::INSERT_ID, TransitionContext::new());
 
@@ -290,6 +299,9 @@ impl CommandHandler for IndentSelection {
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = None;
         }
+
+        // #474: Notify other clients that selection was cleared
+        runtime.record_selection_change(buffer_id);
 
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
 
@@ -357,6 +369,9 @@ impl CommandHandler for DedentSelection {
         if let Some(window) = runtime.windows_mut().active_mut() {
             window.selection = None;
         }
+
+        // #474: Notify other clients that selection was cleared
+        runtime.record_selection_change(buffer_id);
 
         runtime.set_mode(VimMode::NORMAL_ID, TransitionContext::new());
 


### PR DESCRIPTION
## Summary

Multi-client visual selection rendering, web client presence fixes, and 100% MC/DC coverage infrastructure.

## Changes

### Feature: Visual Selection & Web Presence (#474)
- `record_selection_change()` called in `record_cursor_move()` so visual selections auto-extend on cursor movement and broadcast to peers
- Visual mode entry/exit/operators updated to use `ModeTransition` for proper state change notification
- Clamp char/block visual selection to actual line content length in TUI (line mode keeps full screen width matching vim `V` behavior)
- Re-render remote cursors after DOM rebuild in web client so remote presence survives `renderMultiWindow`/`renderSingleWindow` calls
- Subtract `topLine` scroll offset in web single-window mode for correct cursor and remote presence positioning
- Web auth: `setSessionToken()` called after `join()`, stale `clientId` removed

### Tests: 100% MC/DC Coverage (#474)
- ~44 new tests covering kernel (sched, panic, ipc, core, mm), session runtime, and TUI handle
- Fixed duplicate test name `test_set_screen_with_compositor` (compile error E0428)

### Infrastructure: LCOV Test Code Filter (#474)
- Added `scripts/lcov-filter-tests.sh` that strips `#[cfg(test)]` regions from LCOV data
- Integrated into both local (`coverage.sh`) and CI (`.github/workflows/ci.yml`) pipelines
- Coverage metrics now reflect production code only: 100.0% MC/DC (25417/25417 lines, 379 files)

## Test plan

- [x] `./scripts/check.sh` passed (format, build, clippy zero warnings, all tests)
- [x] `./scripts/coverage.sh mcdc --lcov` produces 100.0% MC/DC
- [x] CI pipeline applies LCOV filter before Codecov upload
- [x] CHANGELOG.md updated

Refs #474