### PR TITLE
fix(resolvers): split shared/client extensions, explicit module loading (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 For old changelog, see `changelog/CHANGELOG-{version}.md`
 
-## [Unreleased] - v0.9.4-dev
+## [Unreleased] - v0.9.5-dev
+
+### Changed
+
+- **Explicit shared vs client extensions in resolver API (#474)**: Split the
+  single `extensions: &mut ExtensionMap` parameter in `ModeKeyResolver` trait
+  methods into `shared_extensions` and `client_extensions`. Modules now
+  explicitly choose which extension map to use. `VimSessionState` and
+  `OperatorPendingState` moved to `client_extensions` (per-client isolation),
+  fixing a bug where all operator+textobject combinations (`diw`, `ciw`, `yiw`,
+  `di"`, `ci{`, etc.) were broken because text objects wrote to per-client
+  extensions via `runtime.ext_mut()` but operator resolvers read from shared
+  `self.app.extensions`. Affected methods: `resolve_with_extensions`,
+  `resolve_with_session`, `on_command_complete`. Server call sites use a
+  placeholder `ExtensionMap` for `SessionRuntime` (resolvers access session
+  only via `SessionApiDyn`, not `ExtensionApi`), freeing `client_extensions`
+  to be passed separately without borrow conflicts.
+
+## [0.9.4-dev]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   only via `SessionApiDyn`, not `ExtensionApi`), freeing `client_extensions`
   to be passed separately without borrow conflicts.
 
+- **Extra module loading via `REOVIM_EXTRA_MODULES` env var (#474)**:
+  Integration tests can now explicitly load modules not in the defaults bundle.
+  `TextObjectsModule::init()` fixed to self-register commands via
+  `CommandHandlerStore` (was a no-op). `TestServerHarness::spawn_with_modules()`
+  and `IntegrationTest::with_modules()` pass the env var to the spawned server.
+  Four text object integration tests (`diw`, `daw`, `di"`, `ci{`) un-ignored
+  and passing.
+
 ## [0.9.4-dev]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ dependencies = [
  "reovim-driver-vfs",
  "reovim-kernel",
  "reovim-module-defaults",
+ "reovim-module-textobjects",
  "reovim-server",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reovim-app"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "clap",
  "parking_lot",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-arch"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "arc-swap",
  "crossterm",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-bench"
-version = "0.9.2-dev"
+version = "0.9.5-dev"
 dependencies = [
  "criterion",
  "reovim-kernel",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-client-cli"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "clap",
  "reovim-protocol",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-client-model"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-client-tui"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "chrono",
  "clap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-buffer"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-kernel",
@@ -1849,14 +1849,14 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-clipboard"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
 ]
 
 [[package]]
 name = "reovim-driver-command"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-command-types",
  "reovim-driver-display",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-command-types"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-vfs",
  "reovim-kernel",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-display"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "dirs",
  "reovim-arch",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-ffi"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "libc",
  "reovim-kernel",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-ffi-python"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "pyo3",
  "reovim-kernel",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-input"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "bitflags 2.10.0",
  "reovim-arch",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-log"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "tracing",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-lsp"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "lsp-types",
  "reovim-kernel",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-net"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-kernel",
@@ -1951,14 +1951,14 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-search"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
 ]
 
 [[package]]
 name = "reovim-driver-session"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-driver-clipboard",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-syntax"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "parking_lot",
  "reovim-kernel",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-syntax-treesitter"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "parking_lot",
  "reovim-driver-syntax",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-trace"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "tracing",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-tui"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "crossterm",
  "futures",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-undo"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-vfs",
  "reovim-kernel",
@@ -2023,21 +2023,21 @@ dependencies = [
 
 [[package]]
 name = "reovim-driver-vfs"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
 ]
 
 [[package]]
 name = "reovim-kernel"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
 ]
 
 [[package]]
 name = "reovim-module-buffer-ops"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-buffer-simple"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-driver-buffer",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-clipboard"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "arboard",
  "reovim-arch",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-commands"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-driver-command",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-defaults"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-buffer-simple",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-editor"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-command",
  "reovim-driver-display",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-keymap"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-macros"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-mode-manager"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-motions"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-command",
  "reovim-driver-display",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-options"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-scratch-buffer"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-session",
  "reovim-kernel",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-search"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "regex",
  "reovim-driver-search",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-textobjects"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-command",
  "reovim-driver-display",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-treesitter-markdown"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-syntax",
  "reovim-driver-syntax-treesitter",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-treesitter-rust"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-syntax",
  "reovim-driver-syntax-treesitter",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-undo"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-arch",
  "reovim-driver-undo",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-vfs-local"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-vfs",
  "reovim-kernel",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-vim"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-clipboard",
  "reovim-driver-command",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-module-window-ops"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "reovim-driver-command",
  "reovim-driver-display",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-protocol"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "prost",
  "reovim-arch",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-server"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "reovim-testing"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 dependencies = [
  "chrono",
  "reovim-client-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ default-members = ["apps/bin"]
 
 [workspace.package]
 rust-version = "1.92"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 edition = "2024"
 authors = ["ds1sqe(dukim) <ds1sqe@mensakorea.org>"]
 license = "AGPL-3.0-only"
@@ -123,71 +123,71 @@ tracing-appender = "0.2"
 chrono = "0.4"
 
 # Shared crates
-reovim-arch = { path = "./shared/arch", version = "0.9.4-dev" }
-reovim-protocol = { path = "./shared/protocol", version = "0.9.4-dev" }
-reovim-module-macros = { path = "./shared/module-macros", version = "0.9.4-dev" }
-reovim-testing = { path = "./shared/testing", version = "0.9.4-dev" }
-reovim-net = { path = "./shared/net", version = "0.9.4-dev" }
-reovim-log = { path = "./shared/log", version = "0.9.4-dev" }
-reovim-trace = { path = "./shared/trace", version = "0.9.4-dev" }
+reovim-arch = { path = "./shared/arch", version = "0.9.5-dev" }
+reovim-protocol = { path = "./shared/protocol", version = "0.9.5-dev" }
+reovim-module-macros = { path = "./shared/module-macros", version = "0.9.5-dev" }
+reovim-testing = { path = "./shared/testing", version = "0.9.5-dev" }
+reovim-net = { path = "./shared/net", version = "0.9.5-dev" }
+reovim-log = { path = "./shared/log", version = "0.9.5-dev" }
+reovim-trace = { path = "./shared/trace", version = "0.9.5-dev" }
 
 # Server crates
-reovim-kernel = { path = "./server/lib/kernel", version = "0.9.4-dev" }
-reovim-server = { path = "./server/lib/server", version = "0.9.4-dev" }
+reovim-kernel = { path = "./server/lib/kernel", version = "0.9.5-dev" }
+reovim-server = { path = "./server/lib/server", version = "0.9.5-dev" }
 
 # Server drivers
-reovim-driver-command-types = { path = "./server/lib/drivers/command-types", version = "0.9.4-dev" }
-reovim-driver-command = { path = "./server/lib/drivers/command", version = "0.9.4-dev" }
-reovim-driver-input = { path = "./server/lib/drivers/input", version = "0.9.4-dev" }
-reovim-driver-syntax = { path = "./server/lib/drivers/syntax", version = "0.9.4-dev" }
-reovim-driver-syntax-treesitter = { path = "./server/lib/drivers/syntax-treesitter", version = "0.9.4-dev" }
-reovim-driver-lsp = { path = "./server/lib/drivers/lsp", version = "0.9.4-dev" }
-reovim-driver-vfs = { path = "./server/lib/drivers/vfs", version = "0.9.4-dev" }
-reovim-driver-session = { path = "./server/lib/drivers/session", version = "0.9.4-dev" }
-reovim-driver-undo = { path = "./server/lib/drivers/undo", version = "0.9.4-dev" }
-reovim-driver-buffer = { path = "./server/lib/drivers/buffer", version = "0.9.4-dev" }
-reovim-driver-search = { path = "./server/lib/drivers/search", version = "0.9.4-dev" }
-reovim-driver-clipboard = { path = "./server/lib/drivers/clipboard", version = "0.9.4-dev" }
-reovim-driver-ffi = { path = "./server/lib/drivers/ffi", version = "0.9.4-dev" }
-reovim-driver-ffi-python = { path = "./server/lib/drivers/ffi-python", version = "0.9.4-dev" }
+reovim-driver-command-types = { path = "./server/lib/drivers/command-types", version = "0.9.5-dev" }
+reovim-driver-command = { path = "./server/lib/drivers/command", version = "0.9.5-dev" }
+reovim-driver-input = { path = "./server/lib/drivers/input", version = "0.9.5-dev" }
+reovim-driver-syntax = { path = "./server/lib/drivers/syntax", version = "0.9.5-dev" }
+reovim-driver-syntax-treesitter = { path = "./server/lib/drivers/syntax-treesitter", version = "0.9.5-dev" }
+reovim-driver-lsp = { path = "./server/lib/drivers/lsp", version = "0.9.5-dev" }
+reovim-driver-vfs = { path = "./server/lib/drivers/vfs", version = "0.9.5-dev" }
+reovim-driver-session = { path = "./server/lib/drivers/session", version = "0.9.5-dev" }
+reovim-driver-undo = { path = "./server/lib/drivers/undo", version = "0.9.5-dev" }
+reovim-driver-buffer = { path = "./server/lib/drivers/buffer", version = "0.9.5-dev" }
+reovim-driver-search = { path = "./server/lib/drivers/search", version = "0.9.5-dev" }
+reovim-driver-clipboard = { path = "./server/lib/drivers/clipboard", version = "0.9.5-dev" }
+reovim-driver-ffi = { path = "./server/lib/drivers/ffi", version = "0.9.5-dev" }
+reovim-driver-ffi-python = { path = "./server/lib/drivers/ffi-python", version = "0.9.5-dev" }
 
 # Client drivers (TUI-specific)
-reovim-driver-tui = { path = "./clients/tui/lib/drivers/tui", version = "0.9.4-dev" }
-reovim-driver-display = { path = "./clients/tui/lib/drivers/display", version = "0.9.4-dev" }
+reovim-driver-tui = { path = "./clients/tui/lib/drivers/tui", version = "0.9.5-dev" }
+reovim-driver-display = { path = "./clients/tui/lib/drivers/display", version = "0.9.5-dev" }
 
 # Client crates
-reovim-client-tui = { path = "./clients/tui", version = "0.9.4-dev" }
-reovim-client-cli = { path = "./clients/cli", version = "0.9.4-dev" }
+reovim-client-tui = { path = "./clients/tui", version = "0.9.5-dev" }
+reovim-client-cli = { path = "./clients/cli", version = "0.9.5-dev" }
 
 # Common client model (platform-agnostic abstractions)
-reovim-client-model = { path = "./shared/clients/model", version = "0.9.4-dev" }
+reovim-client-model = { path = "./shared/clients/model", version = "0.9.5-dev" }
 
 # Application binary
-reovim-app = { path = "./apps/bin", version = "0.9.4-dev" }
+reovim-app = { path = "./apps/bin", version = "0.9.5-dev" }
 
 # Python FFI
 pyo3 = { version = "0.27", features = ["auto-initialize"] }
 
 # Server modules
-reovim-module-vim = { path = "./server/modules/vim", version = "0.9.4-dev" }
-reovim-module-editor = { path = "./server/modules/editor", version = "0.9.4-dev" }
-reovim-module-motions = { path = "./server/modules/motions", version = "0.9.4-dev" }
-reovim-module-textobjects = { path = "./server/modules/textobjects", version = "0.9.4-dev" }
-reovim-module-commands = { path = "./server/modules/commands", version = "0.9.4-dev" }
-reovim-module-keymap = { path = "./server/modules/keymap", version = "0.9.4-dev" }
-reovim-module-mode-manager = { path = "./server/modules/mode-manager", version = "0.9.4-dev" }
-reovim-module-options = { path = "./server/modules/options", version = "0.9.4-dev" }
-reovim-module-buffer-ops = { path = "./server/modules/buffer-ops", version = "0.9.4-dev" }
-reovim-module-buffer-simple = { path = "./server/modules/buffer-simple", version = "0.9.4-dev" }
-reovim-module-scratch-buffer = { path = "./server/modules/scratch-buffer", version = "0.9.4-dev" }
-reovim-module-clipboard = { path = "./server/modules/clipboard", version = "0.9.4-dev" }
-reovim-module-search = { path = "./server/modules/search", version = "0.9.4-dev" }
-reovim-module-undo = { path = "./server/modules/undo", version = "0.9.4-dev" }
-reovim-module-vfs-local = { path = "./server/modules/vfs-local", version = "0.9.4-dev" }
-reovim-module-window-ops = { path = "./server/modules/window-ops", version = "0.9.4-dev" }
-reovim-module-defaults = { path = "./server/modules/defaults", version = "0.9.4-dev" }
-reovim-module-treesitter-rust = { path = "./server/modules/treesitter-rust", version = "0.9.4-dev" }
-reovim-module-treesitter-markdown = { path = "./server/modules/treesitter-markdown", version = "0.9.4-dev" }
+reovim-module-vim = { path = "./server/modules/vim", version = "0.9.5-dev" }
+reovim-module-editor = { path = "./server/modules/editor", version = "0.9.5-dev" }
+reovim-module-motions = { path = "./server/modules/motions", version = "0.9.5-dev" }
+reovim-module-textobjects = { path = "./server/modules/textobjects", version = "0.9.5-dev" }
+reovim-module-commands = { path = "./server/modules/commands", version = "0.9.5-dev" }
+reovim-module-keymap = { path = "./server/modules/keymap", version = "0.9.5-dev" }
+reovim-module-mode-manager = { path = "./server/modules/mode-manager", version = "0.9.5-dev" }
+reovim-module-options = { path = "./server/modules/options", version = "0.9.5-dev" }
+reovim-module-buffer-ops = { path = "./server/modules/buffer-ops", version = "0.9.5-dev" }
+reovim-module-buffer-simple = { path = "./server/modules/buffer-simple", version = "0.9.5-dev" }
+reovim-module-scratch-buffer = { path = "./server/modules/scratch-buffer", version = "0.9.5-dev" }
+reovim-module-clipboard = { path = "./server/modules/clipboard", version = "0.9.5-dev" }
+reovim-module-search = { path = "./server/modules/search", version = "0.9.5-dev" }
+reovim-module-undo = { path = "./server/modules/undo", version = "0.9.5-dev" }
+reovim-module-vfs-local = { path = "./server/modules/vfs-local", version = "0.9.5-dev" }
+reovim-module-window-ops = { path = "./server/modules/window-ops", version = "0.9.5-dev" }
+reovim-module-defaults = { path = "./server/modules/defaults", version = "0.9.5-dev" }
+reovim-module-treesitter-rust = { path = "./server/modules/treesitter-rust", version = "0.9.5-dev" }
+reovim-module-treesitter-markdown = { path = "./server/modules/treesitter-markdown", version = "0.9.5-dev" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/apps/bin/Cargo.toml
+++ b/apps/bin/Cargo.toml
@@ -33,6 +33,9 @@ reovim-driver-session = { workspace = true }
 # Module bundle (provides DefaultsModule::create_modules)
 reovim-module-defaults = { workspace = true }
 
+# Extra modules available via REOVIM_EXTRA_MODULES env var
+reovim-module-textobjects = { workspace = true }
+
 # Syntax driver (for SyntaxFactoryStore registry extraction)
 reovim-driver-syntax = { workspace = true }
 

--- a/apps/bin/src/bootstrap.rs
+++ b/apps/bin/src/bootstrap.rs
@@ -33,7 +33,7 @@ use {
     reovim_driver_syntax::SyntaxFactoryStore,
     reovim_driver_vfs::VfsInstance,
     reovim_kernel::api::v1::{
-        EventBus, KernelContext, MarkBank, ModeId, ModuleContext, ModuleId, MotionEngine,
+        EventBus, KernelContext, MarkBank, ModeId, Module, ModuleContext, ModuleId, MotionEngine,
         OptionRegistry, ProbeResult, RegisterBank, ServiceRegistry, TextObjectEngine,
     },
     reovim_module_defaults::DefaultsModule,
@@ -310,7 +310,7 @@ fn create_module_context(kernel: KernelContext, services: Arc<ServiceRegistry>) 
     ModuleContext::new(kernel, services, data_dir, cache_dir)
 }
 
-/// Initialize all default modules.
+/// Initialize all default modules plus any extra modules from environment.
 ///
 /// Modules self-register their services during `init()`:
 /// - Resolvers → `ResolverRegistry`
@@ -319,33 +319,85 @@ fn create_module_context(kernel: KernelContext, services: Arc<ServiceRegistry>) 
 /// - Mode info → `ModeInfoStore`
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn initialize_modules(ctx: &ModuleContext) {
-    // Get all default modules
     let modules = DefaultsModule::create_modules();
 
     tracing::info!(count = modules.len(), "Initializing default modules");
 
     for mut module in modules {
-        let id = module.id();
-        let name = module.name();
-
-        tracing::debug!(%id, name, "Initializing module");
-
-        match module.init(ctx) {
-            ProbeResult::Success => {
-                tracing::info!(%id, name, "Module initialized successfully");
-            }
-            ProbeResult::Defer(msg) => {
-                tracing::warn!(%id, name, %msg, "Module deferred initialization");
-                // TODO: Implement deferred module loading
-            }
-            ProbeResult::Failed(err) => {
-                tracing::error!(%id, name, ?err, "Module initialization failed");
-                // Continue with other modules - don't fail the whole bootstrap
-            }
-        }
+        init_single_module(&mut *module, ctx);
     }
 
+    // Load extra modules from REOVIM_EXTRA_MODULES env var
+    initialize_extra_modules(ctx);
+
     tracing::info!("Module initialization complete");
+}
+
+/// Initialize a single module, logging the result.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn init_single_module(module: &mut dyn Module, ctx: &ModuleContext) {
+    let id = module.id();
+    let name = module.name();
+
+    tracing::debug!(%id, name, "Initializing module");
+
+    match module.init(ctx) {
+        ProbeResult::Success => {
+            tracing::info!(%id, name, "Module initialized successfully");
+        }
+        ProbeResult::Defer(msg) => {
+            tracing::warn!(%id, name, %msg, "Module deferred initialization");
+        }
+        ProbeResult::Failed(err) => {
+            tracing::error!(%id, name, ?err, "Module initialization failed");
+        }
+    }
+}
+
+/// Initialize extra modules from `REOVIM_EXTRA_MODULES` environment variable.
+///
+/// Parses a comma-separated list of module names and initializes each.
+/// Unknown names are logged as warnings and skipped.
+///
+/// # Example
+///
+/// ```bash
+/// REOVIM_EXTRA_MODULES=textobjects cargo run -- server --grpc 0
+/// ```
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn initialize_extra_modules(ctx: &ModuleContext) {
+    let Ok(extra) = std::env::var("REOVIM_EXTRA_MODULES") else {
+        return;
+    };
+
+    let names: Vec<&str> = extra
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if names.is_empty() {
+        return;
+    }
+
+    tracing::info!(count = names.len(), ?names, "Loading extra modules");
+
+    for name in names {
+        if let Some(mut module) = create_extra_module(name) {
+            init_single_module(&mut *module, ctx);
+        } else {
+            tracing::warn!(name, "Unknown extra module, skipping");
+        }
+    }
+}
+
+/// Create an extra module by name.
+///
+/// Returns `None` for unknown module names.
+fn create_extra_module(name: &str) -> Option<Box<dyn Module>> {
+    match name {
+        "textobjects" => Some(Box::new(reovim_module_textobjects::TextObjectsModule::new())),
+        _ => None,
+    }
 }
 
 /// Configure syntax highlighting from `SyntaxFactoryStore`.
@@ -522,5 +574,18 @@ mod tests {
         let kernel = create_kernel_context(Arc::clone(&services));
         // The kernel should have been constructed successfully
         drop(kernel);
+    }
+
+    #[test]
+    fn test_create_extra_module_textobjects() {
+        let module = create_extra_module("textobjects");
+        assert!(module.is_some());
+        assert_eq!(module.unwrap().id().as_str(), "textobjects");
+    }
+
+    #[test]
+    fn test_create_extra_module_unknown() {
+        assert!(create_extra_module("nonexistent").is_none());
+        assert!(create_extra_module("").is_none());
     }
 }

--- a/docs/architecture/client-extensions.md
+++ b/docs/architecture/client-extensions.md
@@ -1,0 +1,1911 @@
+# Plugin and Module Architecture Design
+
+Reference: #468 (which-key), #469 (cmdline UI)
+
+## 1. Taxonomy
+
+This section establishes precise definitions for the four component types
+in reovim. Getting the naming right prevents confusion in all future work.
+
+### 1.1 Module (Server-Side Policy)
+
+A **module** is a server-side component that implements the `Module` trait.
+Modules define policy -- HOW the editor behaves. They are loaded as `.so`
+shared libraries via `declare_module!` and run inside the server process.
+
+- Lives in: `server/modules/`
+- Trait: `reovim_kernel::api::v1::Module`
+- FFI: `declare_module!` macro generates entry points
+- Loading: Dynamic `.so` loading via `libloading`
+- Communication: Direct kernel API calls (`ModuleContext`)
+- Examples: vim, editor, motions, textobjects, keymap, commands
+
+Modules have NO knowledge of rendering. They produce data and state
+changes. They never emit terminal escape sequences, DOM nodes, or
+pixels.
+
+### 1.2 Client Extension (Client-Side UI)
+
+A **client extension** is a client-side component that renders UI
+and handles client-local interactions. Each platform (TUI, web)
+implements its own extensions using platform-native facilities.
+
+- Lives in: `clients/{tui,web}/extensions/` (each extension is a separate crate)
+- Trait (TUI): `ClientExtension` with `composable()` bridge to `Composable`
+- Trait (Web): TypeScript `ClientExtension` with `getRenderer()` bridge to `DomRenderer`
+- Loading: Compiled into the client binary (TUI) or bundled (web)
+- Communication: Subscribes to event topics, receives only subscribed events
+- Examples: which-key popup, cmdline renderer, completion popup
+
+**Game-mod separation**: The client engine (TUI main loop, web app shell)
+has ZERO knowledge of specific extensions. It only knows the
+`ClientExtension` trait. Concrete extensions are provided by a
+`defaults` meta-crate that mirrors the server's `DefaultsModule` pattern:
+
+```
+clients/tui/extensions/
+  defaults/src/lib.rs     -- pub fn create_extensions() -> Vec<Box<dyn ClientExtension>>
+  which-key/src/lib.rs    -- WhichKeyExtension (separate crate)
+  cmdline/src/lib.rs      -- CmdlineExtension (separate crate)
+```
+
+The engine calls `create_extensions()` at startup. It never imports,
+names, or constructs individual extensions. This prevents architectural
+coupling where the engine "knows" about which-key, cmdline, etc.
+
+Client extensions are platform-specific. The TUI extension for which-key
+uses `FrameBuffer` and terminal cells. The web extension uses DOM elements.
+They share no code at the rendering level.
+
+### 1.3 Feature (Module + Extension Pair)
+
+A **feature** is the user-visible capability produced by combining a
+server module with zero or more client extensions. Features are what
+users think about: "completion", "which-key", "cmdline".
+
+Not all features require both halves:
+
+| Feature | Server Module | Client Extension |
+|---------|--------------|-----------------|
+| vim mode | Yes (vim) | No (no special UI) |
+| which-key | No (reads existing keymap data) | Yes (popup renderer) |
+| cmdline | Yes (CmdlineState) | Yes (input renderer) |
+| completion | Yes (completion provider) | Yes (popup renderer) |
+| diagnostics | Yes (LSP driver) | Yes (gutter + inline) |
+| file explorer | Yes (VFS + tree state) | Yes (panel renderer) |
+
+### 1.4 Session Extension (Per-Session State)
+
+A **session extension** is a typed storage slot in an `ExtensionMap`
+for server-side mutable state. Session extensions are the mechanism
+by which modules store state that varies across sessions.
+
+- Trait: `reovim_driver_session::SessionExtension`
+- Storage: `ExtensionMap` (TypeId-keyed HashMap)
+- Lifetime: Per-session (created on first access, destroyed with session)
+
+**Shared vs Per-Client state** (see ongoing work in resolver API split):
+
+There are TWO `ExtensionMap` instances per session:
+
+| Map | Scope | Examples |
+|-----|-------|---------|
+| `shared_extensions` | Shared across all clients in a session | Keymap registrations, completion sources |
+| `client_extensions` | Per-client, isolated | `VimSessionState`, `CmdlineState`, `OperatorPendingState` |
+
+This distinction is critical: `CmdlineState` is per-client (each client
+has its own `:` prompt and cursor position). `VimSessionState` (pending
+motion, count, register) is also per-client. Mixing these up causes bugs
+where one client's operator state leaks into another's.
+
+**Impact on ExtensionStateBridge**: Bridges must declare which map they
+read from (see Section 4.4). `CmdlineBridge` reads `client_extensions`.
+
+Session extensions are NOT the same as modules or client extensions.
+They are the server-side state layer that modules and the runner share.
+
+
+## 2. Layer Model
+
+This section shows where each component type fits in the existing
+Linux-kernel-inspired architecture.
+
+```
+CLIENT LAYER (Application)
+===========================================================================
+clients/tui/                         clients/web/
+  src/
+    extension.rs  (ClientExtension trait + ClientEvent + DeserializerRegistry)
+    router.rs     (ExtensionRouter -- topic-based dispatch)
+  extensions/                          extensions/
+    defaults/     (meta-crate)           defaults/   (meta-module)
+      create_extensions()                  createExtensions()
+    which-key/    (separate crate)       which-key/  (separate module)
+    cmdline/      (separate crate)       cmdline/    (separate module)
+    completion/   (separate crate)       completion/ (separate module)
+  lib/drivers/display/               src/render/
+    compositor/                          overlay.ts
+      composable.rs                      layout.ts
+      layer.rs                           buffer.ts
+
+  Engine imports ONLY: create_extensions() -> Vec<Box<dyn ClientExtension>>
+  Engine NEVER imports individual extension crates.
+  Extensions declare subscriptions; router dispatches by topic.
+---------------------------------------------------------------------------
+                      gRPC v2 Protocol
+                  (shared/protocol/proto/)
+---------------------------------------------------------------------------
+SERVER LAYER (Policy + Mechanism)
+===========================================================================
+
+SHARED CLIENT MODEL (platform-agnostic logic)
+  shared/clients/model/
+    wire/       -- LogicalOverlay, Anchor, OverlayState
+    rendered/   -- RenderedOverlay, WindowTree
+    traits/     -- OverlayRenderer, OverlayManager
+    interaction/ -- Interaction, InteractionResult
+    sync/       -- LayoutSyncMode, OverlaySyncMode
+
+MODULE LAYER (Policy)
+  server/modules/
+    vim/            -- Vim keybindings, operators, modes
+    editor/         -- Core editing operations
+    commands/       -- Ex-commands (:w, :q, :e)
+    keymap/         -- Keymap definitions
+    motions/        -- Movement commands
+    textobjects/    -- Text object definitions
+    ...             -- 19 modules total
+
+DRIVER LAYER (Mechanism)
+  server/lib/drivers/
+    session/        -- Session state, ExtensionMap, CmdlineState
+    input/          -- Key events, mode resolution
+    command/        -- Command dispatch
+    buffer/         -- Buffer operations
+    syntax/         -- Syntax highlighting
+    ...             -- 14 drivers total
+
+KERNEL LAYER (Mechanism)
+  server/lib/kernel/
+    api/            -- Module trait, ServiceRegistry, ModuleContext
+    mm/             -- Buffer memory management
+    ipc/            -- EventBus, pub/sub
+    core/           -- MotionEngine, TextObjectEngine, RegisterBank
+    block/          -- File I/O
+    sched/          -- Scheduling primitives
+```
+
+
+## 3. Lifecycle Diagrams
+
+### 3.1 Server Module Lifecycle
+
+This is the EXISTING lifecycle. No changes needed -- it is mature and
+well-tested with 19 modules.
+
+```
+                    load .so
+                       |
+                       v
+   +-----------+   +-----------+   +--------+   +-----------+
+   | Discovered|-->| Probed    |-->| Init   |-->| Running   |
+   +-----------+   +-----------+   +--------+   +-----------+
+        |               |              |              |
+        |               |              |              | on_all_loaded()
+        |               |              |              | on_buffer_focus()
+        |               |              |              |
+        |               |        ProbeResult::Defer   | exit() + on_unload()
+        |               |              |              |
+        |               v              v              v
+        |          +---------+   +---------+   +-----------+
+        |          | Rejected|   | Deferred|   | Unloaded  |
+        |          +---------+   +---------+   +-----------+
+        |                             |
+        |                             | retry
+        |                             v
+        |                        +--------+
+        +----------------------->| Init   |
+                                 +--------+
+```
+
+Key states:
+- **Discovered**: `.so` file found on disk
+- **Probed**: `reovim_module_probe()` called, metadata read
+- **Init**: `Module::init(&mut self, ctx: &ModuleContext)` called
+- **Running**: Module is active, processing events
+- **Deferred**: Init returned `ProbeResult::Defer`, will retry
+- **Unloaded**: `exit()` called, `.so` can be unloaded
+
+### 3.2 Client Extension Lifecycle
+
+This is the NEW lifecycle for client-side extensions.
+
+Extensions self-manage their active/suspended states based on events
+they receive through subscriptions. The engine never calls activate()
+or deactivate() -- it only queries `is_active()` and `wants_input()`
+as capability checks.
+
+```
+   +-----------+   +-----------+   +-----------+   +-----------+
+   | Created   |-->| Routed    |-->| Active    |-->| Inactive  |
+   +-----------+   +-----------+   +-----------+   +-----------+
+        |               |               |               |
+        |  Router builds|               |               | (self-managed)
+        |  routing table|               |               | on_event() triggers
+        |  from subs()  |               |               | is_active() -> true
+        |               |               |               v
+        |               |               +<---------+-----------+
+        |               |               |          | Active    |
+        |               |               |          +-----------+
+        |               |               |
+        |               |               | destroy()
+        |               |               v
+        |               |          +-----------+
+        +-------------->+--------->| Destroyed |
+                                   +-----------+
+```
+
+Key states:
+- **Created**: Extension instantiated by `create_extensions()`, not yet routed
+- **Routed**: Engine has indexed this extension's subscriptions into routing table
+- **Active**: Extension is visible (`is_active() == true`), receiving subscribed events
+- **Inactive**: Extension is hidden but still receiving subscribed events (self-manages transition)
+- **Destroyed**: Extension cleaned up (client disconnect)
+
+Note: Active/Inactive transitions are INTERNAL to the extension. The
+engine only observes them via `is_active()` for rendering decisions and
+`wants_input()` for keyboard routing. The engine never commands an
+extension to activate or deactivate.
+
+### 3.3 Feature Lifecycle (Coordinated)
+
+A feature that spans server and client coordinates both lifecycles.
+
+Example: **cmdline** feature lifecycle:
+
+```
+  Server (CmdlineState)              Client (CmdlineExtension)
+  =======================            =========================
+
+  1. Module init()                   1. Extension registered
+     - CmdlineState registered          at client startup
+       as SessionExtension
+
+  2. User presses ':'                2. Client receives
+     - VimModule enters cmdline mode    ModeChanged notification
+     - CmdlineState.enter(Command)      (mode = "command_line")
+     - ModeChanged event emitted
+
+                                     3. CmdlineExtension.activate()
+                                        - Queries CmdlineState
+                                          via new gRPC endpoint
+                                        - Renders prompt ":" at bottom
+                                        - Captures keyboard focus
+
+  3. User types "wq"                 4. Each keystroke:
+     - Input routed to CmdlineState     - Notification: cmdline_updated
+     - CmdlineState.insert_char('w')    - Re-render with "wq" + cursor
+     - CmdlineState.insert_char('q')
+
+  4. User presses Enter              5. CmdlineExtension.deactivate()
+     - ExitCommandLineMode runs         - Hides prompt
+     - CmdlineState.exit()              - Returns keyboard focus
+     - ModeChanged event (normal)
+     - Commands module executes ":wq"
+```
+
+
+## 4. Interaction Protocol
+
+### 4.1 State Ownership Principle
+
+**The server owns ALL editing state. Clients own ALL rendering state.**
+
+This means:
+- Buffer content, cursor positions, mode, selections --> server
+- Frame buffers, compositors, DOM elements, scroll state --> client
+- Overlay data (what to show) --> server
+- Overlay rendering (how to show it) --> client
+
+### 4.2 Communication Patterns
+
+Three patterns cover all server-client communication:
+
+#### Pattern A: Push Notification (Real-time Updates)
+
+Server pushes state changes to clients via gRPC streaming.
+
+```
+Server                              Client
+  |                                   |
+  |--- Notification (stream) -------->|
+  |    event_type: "mode_changed"     |
+  |    payload: {name: "cmdline"}     |
+  |                                   |
+```
+
+Used for: mode changes, cursor moves, buffer modifications, layout
+changes, viewport updates, presence updates.
+
+This is the EXISTING pattern. No changes needed for the core protocol.
+
+#### Pattern B: Pull Query (On-Demand State)
+
+Client queries server state via unary gRPC RPCs.
+
+```
+Server                              Client
+  |                                   |
+  |<-- GetMode(client_id) ------------|
+  |--- ModeResponse {name, display} ->|
+  |                                   |
+```
+
+Used for: initial state sync, frame capture, register queries.
+
+This is the EXISTING pattern. Extensions need new RPCs (see 4.3).
+
+#### Pattern C: Extension State Streaming (NEW)
+
+A new gRPC service for querying extension-specific state. This is the
+key addition that enables client extensions to read server module state.
+
+```
+Server                              Client
+  |                                   |
+  |<-- GetExtensionState(kind) -------|
+  |--- ExtensionState {json_data} --->|
+  |                                   |
+  |--- Notification ----------------->|
+  |    event_type: "extension_updated"|
+  |    payload: {kind, data}          |
+  |                                   |
+```
+
+This is the NEW pattern that bridges modules and client extensions.
+
+
+### 4.3 New Protocol Additions
+
+#### 4.3.1 Extension State Service
+
+A new gRPC service for extension state queries:
+
+```protobuf
+// shared/protocol/proto/reovim/v2/extension.proto
+
+service ExtensionService {
+  // Query extension state by kind.
+  rpc GetState(GetExtensionStateRequest) returns (GetExtensionStateResponse);
+
+  // List available extension kinds and their capabilities.
+  rpc ListExtensions(ListExtensionsRequest) returns (ListExtensionsResponse);
+}
+
+message GetExtensionStateRequest {
+  // Extension kind (e.g., "cmdline", "which-key", "completion")
+  string kind = 1;
+  // Client ID for per-client state
+  uint64 client_id = 2;
+}
+
+message GetExtensionStateResponse {
+  bool active = 1;
+  // JSON-encoded state (schema depends on kind)
+  string data = 2;
+}
+
+message ListExtensionsRequest {}
+
+message ListExtensionsResponse {
+  repeated ExtensionInfo extensions = 1;
+}
+
+message ExtensionInfo {
+  string kind = 1;           // Extension identifier
+  string description = 2;    // Human-readable description
+  bool push_supported = 3;   // Whether push notifications are available
+  bool query_supported = 4;  // Whether pull queries are available
+}
+```
+
+#### 4.3.2 Extension Update Notification
+
+Add to existing notification proto:
+
+```protobuf
+// In notification.proto, add to Notification.payload oneof:
+
+ExtensionUpdatedPayload extension_updated = 26;
+
+message ExtensionUpdatedPayload {
+  string kind = 1;     // Which extension changed
+  string data = 2;     // JSON-encoded state
+  uint64 client_id = 3; // Which client this applies to
+}
+```
+
+**Who emits these notifications and where:**
+
+Extension update notifications are emitted by the same pipeline that emits
+all other notifications (mode changes, cursor moves, buffer edits):
+
+1. Key resolved in `server/lib/server/src/grpc/input.rs`
+2. State changes accumulated into `StateChanges` struct
+3. `emit_notifications(&session, &accumulated_changes, client_id)` called
+4. `build_notifications()` in `notification_builder.rs` converts `StateChanges`
+   to gRPC `Notification` messages (including `ExtensionUpdatedPayload`)
+5. `session.emit_notification()` broadcasts to all connected clients
+
+The new `ExtensionUpdatedPayload` variant is added to `build_notifications()`.
+When a bridge's `is_active()` state changes (detected by comparing pre/post
+snapshots), the builder emits an `extension_updated` notification with the
+bridge's `kind()` and `snapshot()` data. No new emission site is needed --
+the existing notification pipeline handles it.
+
+#### 4.3.3 Keymap Query Service
+
+For which-key specifically, the server needs to expose keymap state:
+
+```protobuf
+// In a new keymap.proto:
+
+service KeymapService {
+  // Get keybindings matching a prefix in the current mode.
+  rpc GetBindings(GetBindingsRequest) returns (GetBindingsResponse);
+}
+
+message GetBindingsRequest {
+  string prefix = 1;     // Key prefix (e.g., "<Space>", "g")
+  string mode = 2;       // Mode name (e.g., "normal")
+  uint64 client_id = 3;  // For per-client mode
+}
+
+message GetBindingsResponse {
+  repeated KeyBinding bindings = 1;
+}
+
+message KeyBinding {
+  string keys = 1;          // Full key sequence
+  string description = 2;   // Human-readable description
+  string category = 3;      // Category for grouping
+  string command_id = 4;    // Command that will be executed
+}
+```
+
+### 4.4 Extension State Bridge
+
+The server needs a mechanism to expose session extension state to clients
+without violating the separation of concerns.
+
+The solution: an **ExtensionStateBridge** in the server that adapts
+typed `SessionExtension` state into serializable wire format.
+
+```rust
+// server/lib/drivers/session/src/bridges/mod.rs
+//
+// Lives in the DRIVER layer, not the runner/server layer.
+// Bridges adapt driver-layer state (ExtensionMap) to wire format.
+// The runner imports bridges from the driver crate and registers them
+// with the gRPC handler.
+
+/// [PROPOSED] Which ExtensionMap a bridge reads from.
+///
+/// NOTE: This enum does not exist yet. It is proposed as part of this
+/// architecture document. The dual ExtensionMap (shared vs client) is
+/// being introduced by the resolver API split (see active plan in
+/// ~/.claude/plans/ for issue #474). ExtensionScope will be added to
+/// the driver layer once that work lands.
+///
+/// Sessions have TWO extension maps (see Section 1.4):
+/// - Shared: state visible to all clients (keymap registrations, etc.)
+/// - Client: per-client isolated state (CmdlineState, VimSessionState, etc.)
+///
+/// Bridges must declare which map they need. The runner passes the
+/// correct map when calling snapshot().
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionScope {
+    /// Read from shared_extensions (same for all clients).
+    Shared,
+    /// Read from client_extensions (different per client).
+    /// Requires client_id to identify which client's map.
+    Client,
+}
+
+/// Trait for adapting session extension state to wire format.
+///
+/// Each extension that wants to expose state to clients implements
+/// this trait. The server calls snapshot() when a client queries
+/// state or when the extension notifies of changes.
+pub trait ExtensionStateBridge: Send + Sync + 'static {
+    /// Extension kind identifier (matches proto GetExtensionStateRequest.kind).
+    fn kind(&self) -> &'static str;
+
+    /// Which ExtensionMap this bridge reads from.
+    ///
+    /// The runner uses this to pass the correct map to snapshot().
+    /// Client-scoped bridges receive the requesting client's map.
+    fn scope(&self) -> ExtensionScope;
+
+    /// Snapshot current state as JSON.
+    ///
+    /// The `extensions` parameter is the map indicated by scope():
+    /// - Shared -> shared_extensions
+    /// - Client -> client_extensions for the requesting client
+    fn snapshot(&self, extensions: &ExtensionMap) -> Option<serde_json::Value>;
+
+    /// Whether this extension is currently active.
+    fn is_active(&self, extensions: &ExtensionMap) -> bool;
+}
+```
+
+Concrete bridge implementations live in the **driver layer** alongside
+the state types they adapt. This respects the layer model: bridges read
+driver state (`ExtensionMap`, `CmdlineState`), so they belong with drivers.
+
+```rust
+// server/lib/drivers/session/src/bridges/cmdline.rs
+
+pub struct CmdlineBridge;
+
+impl ExtensionStateBridge for CmdlineBridge {
+    fn kind(&self) -> &'static str { "cmdline" }
+
+    // CmdlineState is per-client: each client has its own : prompt.
+    fn scope(&self) -> ExtensionScope { ExtensionScope::Client }
+
+    fn snapshot(&self, extensions: &ExtensionMap) -> Option<serde_json::Value> {
+        // `extensions` is the CLIENT's ExtensionMap (per scope()).
+        let state = extensions.get::<CmdlineState>()?;
+        Some(serde_json::json!({
+            "active": state.is_active(),
+            "prompt": state.prompt().char().to_string(),
+            "input": state.input(),
+            "cursor": state.cursor(),
+        }))
+    }
+
+    fn is_active(&self, extensions: &ExtensionMap) -> bool {
+        extensions.get::<CmdlineState>()
+            .map_or(false, |s| s.is_active())
+    }
+}
+```
+
+**Runner dispatch logic:**
+```rust
+// In gRPC handler for GetExtensionState:
+fn get_state(&self, kind: &str, client_id: ClientId) -> Option<Value> {
+    let bridge = self.bridges.get(kind)?;
+    let extensions = match bridge.scope() {
+        ExtensionScope::Shared => &self.app.extensions,
+        ExtensionScope::Client => &self.clients.get(client_id)?.state.extensions,
+    };
+    bridge.snapshot(extensions)
+}
+```
+
+**Layer dependency direction:**
+```
+server/lib/server (runner)
+  ↓ imports ExtensionStateBridge trait + CmdlineBridge from
+server/lib/drivers/session (driver)
+  ↓ reads from
+ExtensionMap (shared OR client, based on scope())
+```
+
+The runner registers bridges and wires them to gRPC handlers. The
+driver defines bridges alongside the state they serialize. No circular
+dependencies.
+
+**Dependency note**: `ExtensionStateBridge::snapshot()` returns
+`serde_json::Value`. The session driver crate (`reovim-driver-session`)
+does not currently depend on `serde_json`. Adding this dependency is
+required when implementing bridges. This is acceptable: `serde_json` is
+already a transitive dependency via the server crate, and bridges need
+JSON serialization by design.
+
+
+## 5. Client Extension Traits
+
+### 5.1 TUI Client Extension Trait (Rust)
+
+The design uses a **single trait with capability bridge methods** rather
+than a sub-trait hierarchy. This avoids Rust's trait-object downcasting
+limitation: you cannot cast `dyn ClientExtension` to `dyn Composable`
+at runtime without additional infrastructure.
+
+Instead, extensions that render UI implement `Composable` on their
+concrete type AND override `composable()` to return `Some(self)`.
+The router calls `composable()` to discover renderable extensions
+without knowing their concrete type.
+
+```rust
+// clients/tui/src/extension.rs
+
+use std::any::Any;
+use reovim_display::compositor::{Composable, FrameBuffer, Style, Bounds, ZOrder};
+
+// ---------------------------------------------------------------------------
+// ClientEvent: typed event delivered to extensions
+// ---------------------------------------------------------------------------
+
+/// Type-erased event delivered to extensions.
+///
+/// Wraps a topic string and a typed payload. Extensions use
+/// downcast_ref::<T>() to recover the concrete payload type.
+///
+/// The router owns a DeserializerRegistry that converts raw gRPC
+/// bytes into typed payloads. Extensions never touch raw bytes.
+pub struct ClientEvent {
+    topic: String,
+    payload: Box<dyn Any + Send + Sync>,
+}
+
+impl ClientEvent {
+    pub fn new<T: Any + Send + Sync>(topic: String, payload: T) -> Self {
+        Self { topic, payload: Box::new(payload) }
+    }
+
+    pub fn topic(&self) -> &str { &self.topic }
+
+    /// Downcast the payload to a concrete type.
+    ///
+    /// Returns None if the type doesn't match. Extensions should
+    /// log a warning and return early on type mismatch.
+    pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.payload.downcast_ref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeserializerRegistry: topic -> typed payload conversion
+// ---------------------------------------------------------------------------
+
+/// Registry mapping topic strings to deserialization functions.
+///
+/// The router uses this to convert raw gRPC bytes into typed
+/// ClientEvent payloads. Each topic has exactly one deserializer.
+///
+/// Registered by the defaults meta-crate alongside extensions:
+///   registry.register(topics::MODE_CHANGED, |bytes| {
+///       serde_json::from_slice::<ModeChangedPayload>(bytes)
+///           .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+///   });
+pub struct DeserializerRegistry {
+    deserializers: HashMap<String, DeserializerFn>,
+}
+
+/// A function that deserializes raw bytes into a type-erased payload.
+///
+/// Uses Box<dyn Error> rather than serde_json::Error because the wire
+/// format is protobuf (gRPC). Concrete deserializers may use serde_json
+/// internally (for JSON-encoded extension state), protobuf decoding,
+/// or any other format. The router only cares about success/failure.
+type DeserializerFn = Box<dyn Fn(&[u8]) -> Result<Box<dyn Any + Send + Sync>, Box<dyn std::error::Error + Send + Sync>>
+    + Send + Sync>;
+
+impl DeserializerRegistry {
+    pub fn new() -> Self {
+        Self { deserializers: HashMap::new() }
+    }
+
+    /// Register a deserializer for a topic.
+    pub fn register<T, F>(&mut self, topic: &str, f: F)
+    where
+        T: Any + Send + Sync + 'static,
+        F: Fn(&[u8]) -> Result<T, Box<dyn std::error::Error + Send + Sync>> + Send + Sync + 'static,
+    {
+        self.deserializers.insert(
+            topic.to_owned(),
+            Box::new(move |bytes| f(bytes).map(|v| Box::new(v) as Box<dyn Any + Send + Sync>)),
+        );
+    }
+
+    /// Deserialize raw bytes for a given topic into a ClientEvent.
+    ///
+    /// Returns None if no deserializer is registered for this topic.
+    pub fn deserialize(&self, topic: &str, bytes: &[u8]) -> Option<ClientEvent> {
+        let f = self.deserializers.get(topic)?;
+        let payload = f(bytes).ok()?;
+        Some(ClientEvent { topic: topic.to_owned(), payload })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Topic constants: prevent typos in subscription strings
+// ---------------------------------------------------------------------------
+
+/// Well-known topic strings used by extensions and the defaults meta-crate.
+///
+/// Extensions subscribe to these topics. The server emits notifications
+/// tagged with these strings. Using constants prevents hard-to-debug
+/// typos ("mode.change" vs "mode.changed").
+///
+/// New topics are added here as new notification types are introduced.
+/// The engine never interprets these strings -- they are opaque keys.
+pub mod topics {
+    pub const MODE_CHANGED: &str = "mode.changed";
+    pub const CMDLINE_UPDATED: &str = "cmdline.updated";
+    pub const KEYMAP_TIMEOUT: &str = "keymap.timeout";
+    pub const BUFFER_CHANGED: &str = "buffer.changed";
+    pub const CURSOR_MOVED: &str = "cursor.moved";
+    pub const COMPLETION_UPDATED: &str = "completion.updated";
+    pub const DIAGNOSTIC_UPDATED: &str = "diagnostic.updated";
+}
+
+// ---------------------------------------------------------------------------
+// ClientExtension: the single trait for all extensions
+// ---------------------------------------------------------------------------
+
+/// Trait for ALL client extensions.
+///
+/// One trait with capability bridge methods, not a sub-trait hierarchy.
+/// This design avoids Rust's trait-object downcasting limitation.
+///
+/// Extensions that render UI: implement Composable on their concrete
+/// type AND override composable()/composable_mut() to return Some(self).
+///
+/// Extensions that capture input: override wants_input()/handle_key().
+///
+/// DESIGN INVARIANT: The engine (TUI main loop) NEVER routes by
+/// extension identity. It uses only capability queries and the
+/// subscription-based routing table.
+pub trait ClientExtension: Send + Sync {
+    /// Extension identifier, used ONLY for logging and debugging.
+    ///
+    /// The engine MUST NOT use this for routing, dispatch, or any
+    /// behavioral decision.
+    fn id(&self) -> &'static str;
+
+    /// Event topics this extension subscribes to.
+    ///
+    /// Called at registration time to build the routing table.
+    /// Returns Vec<String> to allow config-dependent subscriptions.
+    ///
+    /// Topics are opaque strings. Convention: "domain.event_name"
+    /// Use constants from `topics` module to prevent typos:
+    ///   vec![topics::MODE_CHANGED.into(), topics::CMDLINE_UPDATED.into()]
+    fn subscriptions(&self) -> Vec<String>;
+
+    /// Called when a subscribed event arrives.
+    ///
+    /// The router guarantees: event.topic() is one of self.subscriptions().
+    /// Use event.downcast_ref::<T>() to recover the typed payload.
+    fn on_event(&mut self, event: &ClientEvent);
+
+    /// Whether this extension is currently active.
+    ///
+    /// For renderable extensions: active means visible (composable() renders).
+    /// For non-renderable extensions: active means processing events.
+    /// Extensions self-manage this state via on_event().
+    fn is_active(&self) -> bool;
+
+    // -- Rendering capability (bridge to Composable) --
+
+    /// Return a Composable view of this extension for rendering.
+    ///
+    /// Override to return Some(self) if this extension renders UI.
+    /// The router uses this to discover renderable extensions without
+    /// knowing their concrete type.
+    ///
+    /// Default: None (non-rendering extension).
+    fn composable(&self) -> Option<&dyn Composable> { None }
+
+    /// Mutable Composable view (for set_z_order, etc).
+    fn composable_mut(&mut self) -> Option<&mut dyn Composable> { None }
+
+    // -- Input capability (optional) --
+
+    /// Whether this extension should receive keyboard input.
+    ///
+    /// Override to return true for modal extensions (cmdline, etc).
+    /// Default: false.
+    fn wants_input(&self) -> bool { false }
+
+    /// Handle a key event. Returns true if consumed.
+    ///
+    /// Only called when wants_input() returns true.
+    /// Default: not consumed.
+    fn handle_key(&mut self, key: &KeyEvent) -> bool { let _ = key; false }
+}
+```
+
+**How the bridge method works:**
+
+```rust
+// Example: WhichKeyExtension renders UI AND captures input
+
+struct WhichKeyExtension { /* state */ }
+
+// Implement Composable on the concrete type (6 required + 2 default methods)
+impl Composable for WhichKeyExtension {
+    fn id(&self) -> ComposableId { /* ... */ }
+    fn z_order(&self) -> ZOrder { /* ... */ }
+    fn set_z_order(&mut self, z: ZOrder) { /* ... */ }
+    fn is_visible(&self) -> bool { self.active }
+    fn bounds(&self, w: u16, h: u16) -> Bounds { /* popup bounds */ }
+    fn render(&self, buf: &mut FrameBuffer, style: &Style) { /* draw popup */ }
+}
+
+// Implement ClientExtension, bridging to Composable via self
+impl ClientExtension for WhichKeyExtension {
+    fn id(&self) -> &'static str { "which-key" }
+    fn subscriptions(&self) -> Vec<String> {
+        vec![topics::KEYMAP_TIMEOUT.into(), topics::MODE_CHANGED.into()]
+    }
+    fn on_event(&mut self, event: &ClientEvent) {
+        if let Some(data) = event.downcast_ref::<KeymapTimeoutPayload>() {
+            self.show_popup(data);
+        }
+    }
+    fn is_active(&self) -> bool { self.active }
+
+    // Bridge: return self as &dyn Composable
+    fn composable(&self) -> Option<&dyn Composable> { Some(self) }
+    fn composable_mut(&mut self) -> Option<&mut dyn Composable> { Some(self) }
+
+    // This extension captures input
+    fn wants_input(&self) -> bool { self.active }
+    fn handle_key(&mut self, key: &KeyEvent) -> bool { /* ... */ }
+}
+
+// Example: BackgroundSyncExtension does NOT render or capture input
+
+struct BackgroundSyncExtension { /* state */ }
+
+impl ClientExtension for BackgroundSyncExtension {
+    fn id(&self) -> &'static str { "bg-sync" }
+    fn subscriptions(&self) -> Vec<String> { vec![topics::BUFFER_CHANGED.into()] }
+    fn on_event(&mut self, event: &ClientEvent) { /* update cache */ }
+    fn is_active(&self) -> bool { true }
+    // composable() defaults to None -- no rendering
+    // wants_input() defaults to false -- no input capture
+}
+```
+
+**Capability discovery at a glance:**
+
+| Extension | `composable()` | `wants_input()` | Rendering | Input |
+|-----------|:-:|:-:|:-:|:-:|
+| which-key popup | `Some(self)` | `true` | Yes | Yes |
+| cmdline | `Some(self)` | `true` | Yes | Yes |
+| completion popup | `Some(self)` | `true` | Yes | Yes |
+| background sync | `None` | `false` | No | No |
+| macro recorder | `None` | `true` | No | Yes |
+| status indicator | `Some(self)` | `false` | Yes | No |
+
+**Anti-coupling guarantee**: The engine never calls `ext.id()` for routing.
+It never matches on topic strings. It builds the routing table mechanically
+from `subscriptions()` and dispatches by table lookup. This means:
+
+1. Adding a new extension = add crate + register in `defaults` meta-crate
+2. The engine binary does NOT need to change
+3. No string matching like `if ext.id() == "which_key"` anywhere in engine code
+
+### 5.2 Web Client Extension Interface (TypeScript)
+
+Same bridge method pattern, adapted for TypeScript. Web uses
+`unknown` payloads (deserialized from JSON by the router) with
+type guards in each extension.
+
+```typescript
+// clients/web/src/extensions/types.ts
+
+/**
+ * Type-erased event delivered to extensions.
+ * Mirrors Rust ClientEvent.
+ */
+export interface ClientEvent {
+  readonly topic: string;
+  readonly payload: unknown;  // deserialized JSON, use type guards
+}
+
+/**
+ * Single interface for ALL web client extensions.
+ *
+ * Uses capability methods (getRenderer, wantsInput) instead of
+ * sub-interfaces, matching the Rust bridge method pattern.
+ *
+ * DESIGN INVARIANT: The engine never routes by extension identity.
+ */
+export interface ClientExtension {
+  /** Extension identifier, used ONLY for logging/debugging. */
+  readonly id: string;
+
+  /** Event topics this extension subscribes to. */
+  subscriptions(): string[];
+
+  /** Called when a subscribed event arrives. */
+  onEvent(event: ClientEvent): void;
+
+  /** Whether the extension is currently active. */
+  isActive(): boolean;
+
+  /** Cleanup when client disconnects. */
+  destroy(): void;
+
+  // -- Rendering capability (bridge to DOM) --
+
+  /** Return a DOM renderer if this extension renders UI. */
+  getRenderer(): DomRenderer | null;
+
+  // -- Input capability (optional) --
+
+  /** Whether this extension should capture keyboard input. */
+  wantsInput(): boolean;
+
+  /** Handle a keyboard event. Returns true if consumed. */
+  handleKey(event: KeyboardEvent): boolean;
+}
+
+/** Renderer interface for extensions that produce DOM output. */
+export interface DomRenderer {
+  mount(container: HTMLElement): void;
+  render(): void;
+  unmount(): void;
+}
+```
+
+### 5.3 Extension Router (Subscription-Based Dispatch)
+
+Both TUI and web clients use a router that dispatches events by topic
+subscription. The router has ZERO knowledge of specific extensions.
+
+**Conceptual parallel to kernel's EventBus**: Both are pub/sub systems
+where publishers don't know subscribers. However, they differ in
+implementation:
+
+| | Kernel EventBus | Client Router |
+|--|-----------------|---------------|
+| Key type | `TypeId` (compile-time) | `String` (runtime) |
+| Dispatch | Lock-free `ArcSwap` | `HashMap` lookup |
+| Priorities | Yes (ordered handlers) | No (insertion order) |
+| Consumption | Yes (`EventResult::Consumed`) | No (all subscribers get event) |
+| Subscriptions | RAII (dropped with `Subscription`) | Explicit (`rebuild_routes()`) |
+| Boundary | In-process | Cross-process (gRPC) |
+
+The parallel is conceptual (pub/sub decoupling), not implementation-level.
+
+**Deserialization pipeline**: The router owns a `DeserializerRegistry`
+that converts raw gRPC bytes into typed `ClientEvent` payloads. Extensions
+receive typed events via `downcast_ref::<T>()` and never touch raw bytes.
+
+```rust
+// clients/tui/src/router.rs
+
+use std::collections::HashMap;
+
+/// Routes events to extensions by topic subscription.
+///
+/// The router treats topic strings as opaque keys. It never interprets
+/// them, never matches on them, never makes behavioral decisions based
+/// on their content. It only builds a lookup table and dispatches.
+///
+/// The router also owns the DeserializerRegistry: it knows how to
+/// convert raw gRPC bytes into typed ClientEvent payloads.
+pub struct ExtensionRouter {
+    extensions: Vec<Box<dyn ClientExtension>>,
+    /// Topic -> list of extension indices that subscribed to this topic.
+    routes: HashMap<String, Vec<usize>>,
+    /// Topic -> deserializer function (converts gRPC bytes to typed payload).
+    deserializers: DeserializerRegistry,
+}
+
+impl ExtensionRouter {
+    /// Create a router from extensions and a deserializer registry.
+    ///
+    /// Called once at startup. The defaults meta-crate provides both:
+    ///   let (extensions, deserializers) = defaults::create_extensions();
+    ///   let router = ExtensionRouter::new(extensions, deserializers);
+    pub fn new(
+        extensions: Vec<Box<dyn ClientExtension>>,
+        deserializers: DeserializerRegistry,
+    ) -> Self {
+        let routes = Self::build_routes(&extensions);
+        Self { extensions, routes, deserializers }
+    }
+
+    fn build_routes(extensions: &[Box<dyn ClientExtension>]) -> HashMap<String, Vec<usize>> {
+        let mut routes: HashMap<String, Vec<usize>> = HashMap::new();
+        for (idx, ext) in extensions.iter().enumerate() {
+            for topic in ext.subscriptions() {
+                routes.entry(topic).or_default().push(idx);
+            }
+        }
+        routes
+    }
+
+    /// Rebuild the routing table.
+    ///
+    /// Called if extensions change their subscriptions at runtime
+    /// (e.g., after LSP connects and extension subscribes to
+    /// "lsp.diagnostic").
+    pub fn rebuild_routes(&mut self) {
+        self.routes = Self::build_routes(&self.extensions);
+    }
+
+    /// Receive raw gRPC bytes: deserialize and dispatch.
+    ///
+    /// This is the entry point from the gRPC notification handler.
+    /// The router deserializes ONCE, then dispatches the typed event.
+    pub fn dispatch_raw(&mut self, topic: &str, bytes: &[u8]) {
+        let Some(event) = self.deserializers.deserialize(topic, bytes) else {
+            // No deserializer registered -- drop silently.
+            // Server may emit events that no extension cares about yet.
+            return;
+        };
+        self.dispatch(&event);
+    }
+
+    /// Dispatch a pre-built typed event (useful for tests).
+    pub fn dispatch(&mut self, event: &ClientEvent) {
+        let Some(indices) = self.routes.get(event.topic()) else {
+            return;
+        };
+        // Clone indices to avoid borrow conflict with self.extensions.
+        let indices = indices.clone();
+        for idx in indices {
+            self.extensions[idx].on_event(event);
+        }
+    }
+
+    /// Find the extension that wants keyboard input (if any).
+    ///
+    /// Uses capability queries only -- never checks extension identity.
+    /// Iterates in reverse (last registered = highest priority).
+    pub fn input_target(&mut self) -> Option<&mut dyn ClientExtension> {
+        // Two-pass to avoid borrow conflict:
+        // Pass 1: find the index.
+        let target_idx = self.extensions.iter()
+            .enumerate()
+            .rev()
+            .find(|(_, ext)| ext.is_active() && ext.wants_input())
+            .map(|(idx, _)| idx);
+
+        // Pass 2: return mutable reference.
+        target_idx.map(|idx| self.extensions[idx].as_mut())
+    }
+
+    /// Get all active renderable extensions for the compositor.
+    ///
+    /// Returns (index, &dyn Composable) pairs for extensions where
+    /// composable() returns Some.
+    pub fn active_composables(&self) -> Vec<&dyn Composable> {
+        self.extensions.iter()
+            .filter(|ext| ext.is_active())
+            .filter_map(|ext| ext.composable())
+            .collect()
+    }
+}
+```
+
+**Web equivalent:**
+
+```typescript
+// clients/web/src/extensions/router.ts
+
+type Deserializer = (bytes: Uint8Array) => unknown;
+
+export class ExtensionRouter {
+  private extensions: ClientExtension[] = [];
+  private routes: Map<string, number[]> = new Map();
+  private deserializers: Map<string, Deserializer> = new Map();
+
+  constructor(
+    extensions: ClientExtension[],
+    deserializers: Map<string, Deserializer>,
+  ) {
+    this.extensions = extensions;
+    this.deserializers = deserializers;
+    this.buildRoutes();
+  }
+
+  private buildRoutes(): void {
+    this.routes.clear();
+    for (const [idx, ext] of this.extensions.entries()) {
+      for (const topic of ext.subscriptions()) {
+        const list = this.routes.get(topic) ?? [];
+        list.push(idx);
+        this.routes.set(topic, list);
+      }
+    }
+  }
+
+  rebuildRoutes(): void { this.buildRoutes(); }
+
+  dispatchRaw(topic: string, bytes: Uint8Array): void {
+    const deserialize = this.deserializers.get(topic);
+    if (!deserialize) return;
+    this.dispatch({ topic, payload: deserialize(bytes) });
+  }
+
+  dispatch(event: ClientEvent): void {
+    const indices = this.routes.get(event.topic);
+    if (!indices) return;
+    for (const idx of indices) {
+      this.extensions[idx].onEvent(event);
+    }
+  }
+
+  inputTarget(): ClientExtension | undefined {
+    return [...this.extensions].reverse()
+      .find(ext => ext.isActive() && ext.wantsInput());
+  }
+
+  activeRenderables(): DomRenderer[] {
+    return this.extensions
+      .filter(ext => ext.isActive())
+      .map(ext => ext.getRenderer())
+      .filter((r): r is DomRenderer => r !== null);
+  }
+}
+```
+
+**Why this works:**
+
+| Concern | How it's handled |
+|---------|-----------------|
+| Which extension gets which event? | Subscription table (built at startup, rebuildable) |
+| Does the engine know extension names? | NO -- only trait methods |
+| Can the engine route by identity? | NO -- no `ext.id()` calls in dispatch |
+| Is broadcast wasteful? | NO -- only subscribers receive events |
+| Can new extensions be added? | YES -- add crate + register in defaults |
+| Does engine code change? | NO -- router is generic over all extensions |
+| Who deserializes gRPC bytes? | DeserializerRegistry (once per event) |
+| Can subscriptions change at runtime? | YES -- call `rebuild_routes()` |
+| Does the router code compile? | YES -- no trait downcasting, no borrow violations |
+| How does router find renderables? | `ext.composable()` bridge method |
+| How does router find input targets? | `ext.wants_input()` capability query |
+
+
+## 6. Concrete Feature Mappings
+
+### 6.1 Which-Key (#468)
+
+Which-key shows a popup of available keybindings after a timeout when
+the user has typed a partial key sequence.
+
+**Architecture: Client extension only (no server module needed)**
+
+The which-key popup is purely a client-side visualization of data
+that already exists on the server (keybinding registrations). The
+server exposes keymap data via the new `KeymapService`.
+
+```
+Server Side                          Client Side
+===========                          ===========
+
+[Existing] KeybindingStore           [NEW] WhichKeyExtension
+  - Stores all keybindings             - Watches for key timeout
+  - Queryable by prefix/mode           - Queries KeymapService.GetBindings()
+                                       - Renders popup with categories
+[NEW] KeymapService (gRPC)
+  - GetBindings(prefix, mode)        TUI: FrameBuffer popup at bottom
+  - Returns matching bindings        Web: DOM floating panel
+```
+
+**Subscriptions:** `["keymap.timeout", "mode.changed"]`
+
+**Data flow:**
+1. User presses `<Space>` (or any prefix key)
+2. Server emits `keymap.timeout` event (after configurable delay)
+3. Router dispatches to WhichKeyExtension (subscribed to `keymap.timeout`)
+4. WhichKeyExtension calls `KeymapService.GetBindings(prefix="<Space>", mode="normal")`
+5. Server returns matching bindings with descriptions
+6. WhichKeyExtension renders popup, sets `is_active() = true`
+7. User presses next key: extension hides popup, sets `is_active() = false`
+8. `mode.changed` events also trigger hide (e.g., user pressed `<Esc>`)
+
+**Why no server module?**
+The keymap data is already registered by existing modules via
+`KeybindingRegistration`. The server just needs a query endpoint.
+The popup is entirely a client rendering concern.
+
+### 6.2 Command Line (#469)
+
+Command line provides the `:`, `/`, and `?` prompts.
+
+**Architecture: Server module (state) + Client extension (rendering)**
+
+```
+Server Side                          Client Side
+===========                          ===========
+
+[Existing] CmdlineState              [NEW] CmdlineExtension
+  - SessionExtension                   - Renders prompt + input + cursor
+  - Stores: active, prompt,           - Captures keyboard in cmdline mode
+    input, cursor position            - Shows at bottom of screen
+  - TextInputSink for char routing
+
+[Existing] VimModule                 [NEW] CmdlineBridge (server)
+  - EnterCommandLineMode               - ExtensionStateBridge impl
+  - ExitCommandLineMode                - Snapshots CmdlineState to JSON
+  - EnterSearchForward/Backward
+
+[NEW] ExtensionService (gRPC)
+  - GetState("cmdline")
+  - Returns: {active, prompt, input, cursor}
+
+[NEW] ExtensionUpdated notification
+  - kind: "cmdline"
+  - Pushed on every CmdlineState change
+```
+
+**Subscriptions:** `["mode.changed", "cmdline.updated"]`
+
+**Data flow (`:wq<Enter>`):**
+1. User presses `:` in normal mode
+2. VimModule dispatches `EnterCommandLineMode`
+3. CmdlineState.enter(Command) -- server state change
+4. Server emits `mode.changed` notification (mode = "command_line")
+5. Server emits `cmdline.updated` notification (active, prompt, input, cursor)
+6. Router dispatches both to CmdlineExtension (subscribed to both topics)
+7. CmdlineExtension.on_event("mode.changed", ...) -- self-activates, `is_active() = true`
+8. CmdlineExtension.on_event("cmdline.updated", ...) -- renders prompt ":" at bottom
+9. User types `w`: input routed to CmdlineState via TextInputSink
+10. Server emits `cmdline.updated` with updated input
+11. CmdlineExtension re-renders with ":wq" and cursor
+12. User presses Enter: `ExitCommandLineMode` fires
+13. Server processes `:wq`, emits `mode.changed` (normal)
+14. CmdlineExtension.on_event("mode.changed", ...) -- self-deactivates, `is_active() = false`
+
+Note: The engine never tells CmdlineExtension to activate or deactivate.
+The extension self-manages its state based on the events it receives.
+
+### 6.3 Completion (Future)
+
+**Architecture: Server module + Client extension**
+
+```
+Server Side                          Client Side
+===========                          ===========
+
+[Future] CompletionModule            [Future] CompletionExtension
+  - Collects completion sources        - Renders popup near cursor
+  - Ranks/filters candidates           - Handles navigation (C-n, C-p)
+  - Stores CompletionState             - Shows documentation preview
+    as SessionExtension
+
+[Future] CompletionState             TUI: Floating FrameBuffer popup
+  - items: Vec<CompletionItem>       Web: DOM listbox with scroll
+  - selected_index: usize
+  - filter_text: String
+
+[Future] CompletionBridge
+  - ExtensionStateBridge impl
+  - Snapshots items + selection
+```
+
+### 6.4 LSP Diagnostics (Future)
+
+**Architecture: Server driver + Client extension**
+
+```
+Server Side                          Client Side
+===========                          ===========
+
+[Existing] LspDriver                 [Future] DiagnosticsExtension
+  - Manages LSP connections            - Renders gutter signs
+  - Receives diagnostics               - Renders inline hints
+  - Stores in DiagnosticStore          - Renders diagnostic popup on hover
+
+[Future] DiagnosticBridge            TUI: Gutter column + virtual text
+  - ExtensionStateBridge impl        Web: DOM gutter + inline spans
+  - Snapshots per-buffer diagnostics
+```
+
+### 6.5 File Explorer (Future)
+
+**Architecture: Server module + Client extension**
+
+```
+Server Side                          Client Side
+===========                          ===========
+
+[Future] ExplorerModule              [Future] ExplorerExtension
+  - Tree state (expanded nodes)        - Renders tree in side panel
+  - VFS integration for listing        - Handles navigation
+  - ExplorerState as SessionExt        - File open on Enter
+
+[Future] ExplorerBridge              TUI: Panel composable (left side)
+  - Snapshots tree state             Web: DOM tree component
+```
+
+
+## 7. Architecture Diagram
+
+```
++===================================================================+
+|                        CLIENT LAYER                                |
++===================================================================+
+|                                                                    |
+|  clients/tui/                          clients/web/                |
+|  +------------------------------+     +---------------------------+|
+|  | ENGINE (zero extension         |     | ENGINE (zero extension    ||
+|  |         knowledge)             |     |         knowledge)        ||
+|  | src/                          |     | src/                      ||
+|  |   extension.rs  (trait only)  |     |   extensions/             ||
+|  |   router.rs     (topic-based) |     |     types.ts  (interface) ||
+|  |                               |     |     router.ts (topic-based||
+|  | Only imports:                 |     |                           ||
+|  |   create_extensions()         |     | Only imports:             ||
+|  |     -> Vec<Box<dyn            |     |   createExtensions()      ||
+|  |          ClientExtension>>    |     |     -> ClientExtension[]  ||
+|  +------------------------------+     +---------------------------+|
+|                                                                    |
+|  EXTENSIONS (separate crates, engine never imports these)          |
+|  +------------------------------+     +---------------------------+|
+|  | extensions/                   |     | extensions/               ||
+|  |   defaults/   (meta-crate)   |     |   defaults/  (meta-module)||
+|  |   which-key/  (crate)        |     |   which-key/ (module)     ||
+|  |   cmdline/    (crate)        |     |   cmdline/   (module)     ||
+|  |   completion/ (crate)        |     |   completion/(module)     ||
+|  +------------------------------+     +---------------------------+|
+|  | lib/drivers/display/          |     | src/render/               ||
+|  |   compositor/                 |     |   overlay.ts              ||
+|  |     composable.rs             |     |   layout.ts               ||
+|  |     layer.rs                  |     |   buffer.ts               ||
+|  +------------------------------+     +---------------------------+|
+|                                                                    |
++============================ gRPC ===================================+
+|                                                                    |
+|  shared/protocol/proto/reovim/v2/                                  |
+|  +--------------------------------------------------------------+ |
+|  | notification.proto   -- ExtensionUpdatedPayload (NEW)         | |
+|  | extension.proto      -- ExtensionService (NEW)                | |
+|  | keymap.proto         -- KeymapService (NEW)                   | |
+|  | input.proto          -- InputService (existing)               | |
+|  | state.proto          -- StateService (existing)               | |
+|  | notification.proto   -- NotificationService (existing)        | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++============================ Server ==================================+
+|                                                                    |
+|  shared/clients/model/              (Platform-Agnostic Types)      |
+|  +--------------------------------------------------------------+ |
+|  | wire/      -- LogicalOverlay, Anchor, OverlayState            | |
+|  | rendered/  -- RenderedOverlay, WindowTree                     | |
+|  | traits/    -- OverlayRenderer, OverlayManager                 | |
+|  | interaction/ -- Interaction, InteractionResult                | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
+|  server/lib/server/                 (Server Runtime)               |
+|  +--------------------------------------------------------------+ |
+|  | grpc/                                                         | |
+|  |   extension.rs    -- ExtensionService handler (NEW)           | |
+|  |   keymap.rs       -- KeymapService handler (NEW)              | |
+|  |   input.rs        -- InputService handler (existing)          | |
+|  |   state.rs        -- StateService handler (existing)          | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
+|  server/modules/                    (Policy)                       |
+|  +--------------------------------------------------------------+ |
+|  | vim/       -- VimModule (existing, 19 modules)                | |
+|  | editor/    -- EditorModule                                    | |
+|  | commands/  -- CommandsModule                                  | |
+|  | keymap/    -- KeymapModule                                    | |
+|  | ...                                                           | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
+|  server/lib/drivers/                (Mechanism)                    |
+|  +--------------------------------------------------------------+ |
+|  | session/   -- SessionExtension, ExtensionMap, CmdlineState    | |
+|  |   bridges/ -- ExtensionStateBridge trait (NEW)                | |
+|  |              CmdlineBridge, CompletionBridge (future)         | |
+|  | input/     -- KeybindingStore, ResolverRegistry               | |
+|  | command/   -- CommandHandler, CommandProvider                  | |
+|  | buffer/    -- BufferOps                                       | |
+|  | ...                                                           | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
+|  server/lib/kernel/                 (Mechanism)                    |
+|  +--------------------------------------------------------------+ |
+|  | api/       -- Module trait, ServiceRegistry                   | |
+|  | mm/        -- Buffer, BufferId                                | |
+|  | ipc/       -- EventBus                                        | |
+|  | core/      -- MotionEngine, RegisterBank, etc.                | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++====================================================================+
+```
+
+
+## 8. Design Decisions and Tradeoffs
+
+### 8.1 Why Not Server-Side Overlays?
+
+The archived v0.8.x `WhichKeyPlugin` rendered directly in the server.
+This violated the server/client separation established in Epic #465.
+
+**Decision**: All rendering is client-side.
+
+**Tradeoffs**:
+- (+) Server remains a pure data provider
+- (+) Each platform can render optimally
+- (+) No rendering code in server tests
+- (-) Duplicated rendering logic across platforms
+- (-) More gRPC traffic for state sync
+
+**Mitigation**: The `shared/clients/model/` crate provides platform-agnostic
+logic (positioning, z-ordering, interaction handling) that all platforms share.
+Only the final rendering step (terminal cells vs DOM nodes) is platform-specific.
+
+### 8.2 Why JSON for Extension State?
+
+Extension state is serialized as JSON over gRPC.
+
+**Decision**: Use `string data` (JSON) in proto messages rather than
+typed proto messages per extension.
+
+**Tradeoffs**:
+- (+) New extensions don't require proto changes
+- (+) Schema evolution without breaking wire compat
+- (+) Simpler server-side bridge implementation
+- (-) No compile-time type safety on the wire
+- (-) Parsing overhead (minimal for small payloads)
+
+**Mitigation**: Each `ExtensionStateBridge` impl defines the JSON schema
+in documentation. The client extension knows what shape to expect from
+its paired server module.
+
+### 8.3 Why Not a Plugin Trait in the Kernel?
+
+We could add a `ClientPlugin` trait to the kernel, mirroring `Module`.
+
+**Decision**: NO plugin trait in kernel. Client extensions are NOT kernel
+concepts.
+
+**Reasoning**:
+- Kernel purity: kernel knows about server-side modules, not client UI
+- Client independence: each client defines its own extension interface
+- WASM compatibility: the web client cannot load `.so` files
+- Platform divergence: TUI extensions work with `FrameBuffer`,
+  web extensions work with DOM -- they share no rendering interface
+
+Client extensions are a client-layer concept, defined by each client.
+
+### 8.4 Why Push + Pull Instead of Pure Push?
+
+Extensions use both push notifications (for real-time updates) and
+pull queries (for initial state and on-demand refresh).
+
+**Decision**: Dual communication mode.
+
+**Reasoning**:
+- Push alone requires tracking connection state for initial sync
+- Pull alone has latency -- user sees stale state
+- Push + Pull: client pulls on connect, then receives push updates
+- This matches the existing notification model used by TUI and web
+
+### 8.5 Why Compiled-In Extensions (Not Dynamic)?
+
+TUI extensions are compiled into the client binary. Web extensions
+are bundled at build time.
+
+**Decision**: No dynamic client-side plugin loading (initially).
+
+**Reasoning**:
+- WASM dynamic loading is complex and fragile
+- TUI `.so` plugins require a separate FFI boundary (complexity)
+- The v0.8.x dynamic plugin system was removed for good reason
+- Compiled-in extensions are simpler, faster, and fully type-safe
+
+**Future**: If dynamic client extensions become needed, they can be
+added as a second loading mechanism without changing the trait.
+
+
+### 8.6 Why Game-Mod Separation (Defaults Meta-Crate)?
+
+The engine could directly import and construct extensions:
+```rust
+// BAD: engine knows about specific extensions
+use which_key::WhichKeyExtension;
+use cmdline::CmdlineExtension;
+let extensions = vec![
+    Box::new(WhichKeyExtension::new()),
+    Box::new(CmdlineExtension::new()),
+];
+```
+
+**Decision**: Engine imports ONLY `create_extensions()` from a `defaults`
+meta-crate. It never names or constructs individual extensions.
+
+**Reasoning**:
+- Mirrors server's `DefaultsModule` pattern -- consistency across layers
+- Adding/removing extensions requires NO engine code changes
+- Engine binary has a single dependency point, not N extension crates
+- Prevents "just this one import" slippery slope into tight coupling
+- Custom builds can swap `defaults` meta-crate for different extension sets
+
+**Parallel to server architecture**:
+- Server: `ModuleLoader` loads `.so` files, calls `reovim_module_probe()`
+- Client: Engine calls `create_extensions()`, never knows what's inside
+- Both: The aggregation layer (defaults) is the only place that lists modules/extensions
+
+### 8.7 Why Subscription-Based Routing (Not Broadcast)?
+
+Events could be broadcast to all extensions:
+```rust
+// BAD: every extension receives every event, wastes cycles
+for ext in &mut extensions {
+    ext.on_event(event);
+}
+```
+
+Or routed by identity:
+```rust
+// BAD: engine knows extension identities, leaks coupling
+for ext in &mut extensions {
+    if ext.id() == event.topic().split('.').next().unwrap() {
+        ext.on_event(event);
+    }
+}
+```
+
+**Decision**: Extensions declare `subscriptions()` at registration time.
+Router builds `HashMap<topic, Vec<index>>` and dispatches only to
+subscribers. Subscriptions return `Vec<String>` to allow config-dependent
+topics, and `rebuild_routes()` supports runtime resubscription.
+
+**Reasoning**:
+- Extensions self-select which events matter -- engine is passive
+- O(subscribers) dispatch, not O(all_extensions) broadcast
+- Engine treats topics as opaque keys -- no string parsing or matching
+- Mirrors kernel's `EventBus` pattern: `TypeId -> handlers` in kernel,
+  `topic -> extensions` in client
+- Extensions can subscribe to multiple topics, topics can have multiple
+  subscribers -- pure many-to-many pub/sub
+- Adding new event topics requires NO router changes
+- `Vec<String>` allows config-dependent subscriptions (e.g., LSP topics
+  only when LSP is enabled)
+- `rebuild_routes()` allows dynamic resubscription at runtime
+
+**Anti-coupling guarantee**: The engine code NEVER contains:
+- `ext.id() == "something"` -- identity-based routing
+- `match topic { "mode.changed" => ... }` -- topic interpretation
+- `if ext.is::<SomeConcreteType>()` -- downcasting
+
+The engine is a dumb pipe: `event -> routing table lookup -> deliver`.
+
+### 8.8 Why Typed Events (Not Raw Bytes)?
+
+Event payloads could be raw bytes:
+```rust
+// BAD: every extension deserializes manually, error-prone
+fn on_event(&mut self, topic: &str, payload: &[u8]) {
+    let state: CmdlineSnapshot = serde_json::from_slice(payload).unwrap();
+}
+```
+
+**Decision**: Events use `ClientEvent` with type-erased `Box<dyn Any>`
+payload. Extensions use `event.downcast_ref::<T>()` to recover typed data.
+
+**Reasoning**:
+- Router deserializes gRPC bytes ONCE, not once-per-extension
+- Extensions get type-safe payloads (compiler catches type mismatches)
+- Mirrors kernel's EventBus: handlers receive `&BufferChanged`, not `&[u8]`
+- No serialization format knowledge leaks into extensions
+- `downcast_ref()` returns `Option<&T>` -- safe, no panics on mismatch
+
+**Deserialization ownership:**
+```
+gRPC bytes → DeserializerRegistry (topic lookup) → ClientEvent → Extensions (downcast)
+```
+
+The router owns a `DeserializerRegistry`: a `HashMap<String, DeserializerFn>`
+mapping topic strings to deserialization functions. Each function converts
+`&[u8]` into `Box<dyn Any + Send + Sync>`. The registry is provided by the
+`defaults` meta-crate alongside extensions:
+
+```rust
+// clients/tui/extensions/defaults/src/lib.rs
+pub fn create_deserializers() -> DeserializerRegistry {
+    let mut reg = DeserializerRegistry::new();
+    reg.register::<ModeChangedPayload>(topics::MODE_CHANGED, |bytes| {
+        serde_json::from_slice(bytes).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    });
+    reg.register::<CmdlineUpdatedPayload>(topics::CMDLINE_UPDATED, |bytes| {
+        serde_json::from_slice(bytes).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    });
+    reg
+}
+```
+
+This keeps deserialization knowledge in the defaults meta-crate (alongside
+extension registration), not in the engine.
+
+### 8.9 Why Bridge Methods (Not Sub-Traits or God Trait)?
+
+Three approaches were considered for optional capabilities:
+
+```rust
+// OPTION 1 (rejected): God trait -- forces ALL Composable methods on all extensions
+pub trait ClientExtension: Composable { /* ... */ }
+
+// OPTION 2 (rejected): Sub-traits -- can't downcast dyn ClientExtension to dyn Composable
+pub trait RenderableExtension: ClientExtension + Composable {}
+// Router stores Vec<Box<dyn ClientExtension>>, can't recover dyn Composable
+
+// OPTION 3 (chosen): Bridge methods -- opt-in capability via self-reference
+pub trait ClientExtension {
+    fn composable(&self) -> Option<&dyn Composable> { None }
+    fn wants_input(&self) -> bool { false }
+    fn handle_key(&mut self, key: &KeyEvent) -> bool { false }
+}
+```
+
+**Decision**: Single `ClientExtension` trait with bridge methods that
+return `Option<&dyn Composable>`. Extensions that render override
+`composable()` to return `Some(self)`.
+
+**Why Option 2 (sub-traits) was rejected**:
+- Rust's trait objects don't support upcasting/downcasting between traits
+- `Box<dyn ClientExtension>` cannot be cast to `Box<dyn Composable>`
+- Would require `enum Extension { Bg(Box<dyn ClientExtension>), Ui(Box<dyn RenderableExtension>) }`
+  which is a combinatorial explosion
+- Or `Any`-based downcasting which is fragile
+
+**Why bridge methods work**:
+- Extensions implement `Composable` on their CONCRETE type
+- `composable()` returns `Some(self)` -- a self-reference that the
+  compiler can verify (concrete type implements both traits)
+- Router calls `ext.composable()` -- returns `Option<&dyn Composable>`
+  without knowing the concrete type
+- Same pattern as `std::error::Error::source()` returning `Option<&dyn Error>`
+
+**Result**:
+- Non-rendering extensions: don't override `composable()`, get `None` default
+- Rendering extensions: implement `Composable` + override `composable()` → `Some(self)`
+- No stub implementations, no trait downcasting, compiles cleanly
+
+
+## 9. Implementation Phases
+
+### Phase 1: Foundation (Extension Bridge + Protocol)
+
+1. Define `ExtensionStateBridge` trait in `server/lib/drivers/session/src/bridges/`
+2. Add `extension.proto` with `ExtensionService`
+3. Add `ExtensionUpdatedPayload` to `notification.proto`
+4. Implement `CmdlineBridge` as first concrete bridge
+5. Add gRPC handler for `ExtensionService`
+6. Emit `ExtensionUpdated` notifications when CmdlineState changes
+
+### Phase 2: TUI Client Extensions
+
+1. Define `ClientEvent`, `DeserializerRegistry`, and `ClientExtension` trait in `clients/tui/src/extension.rs`
+2. Implement `ExtensionRouter` with subscription-based dispatch in `clients/tui/src/router.rs`
+3. Create `defaults` meta-crate in `clients/tui/extensions/defaults/`
+4. Integrate `ExtensionRouter` with TUI event loop (engine calls `create_extensions()` + `Router::new()`)
+5. Wire gRPC notification handler to call `router.dispatch_raw(topic, bytes)`
+6. Implement `CmdlineExtension` as first extension crate (#469)
+
+### Phase 3: Which-Key (#468)
+
+1. Add `keymap.proto` with `KeymapService`
+2. Implement `KeymapService` gRPC handler (queries KeybindingStore)
+3. Implement `WhichKeyExtension` for TUI
+4. Wire timeout-based activation into TUI input loop
+5. Implement `WhichKeyExtension` for web client
+
+### Phase 4: Web Client Extensions
+
+1. Define `ClientExtension` TypeScript interface
+2. Implement `ExtensionRouter` for web (same subscription-based dispatch)
+3. Create `defaults` meta-module with `createExtensions()`
+4. Integrate with web client notification handler
+5. Port `CmdlineExtension` to web
+6. Port `WhichKeyExtension` to web
+
+### Phase 5: Completion (Future)
+
+1. `CompletionModule` server module
+2. `CompletionState` session extension
+3. `CompletionBridge` server bridge
+4. `CompletionExtension` for TUI and web
+
+
+## 10. Relationship to Existing Systems
+
+### 10.1 How Client Extensions Relate to Composable
+
+`ClientExtension` is the single trait for all extensions. `Composable`
+is a separate trait that rendering extensions implement on their
+concrete type. The connection is via the `composable()` bridge method:
+
+```
+ClientExtension (all extensions implement this)
+  ├── composable() -> None          (non-rendering: bg sync, macro recorder)
+  └── composable() -> Some(self)    (rendering: which-key, cmdline, completion)
+        └── self also implements Composable (6 required + 2 default methods)
+```
+
+`Composable` has 8 methods (from `clients/tui/lib/drivers/display/`):
+- **Required (6)**: `id`, `z_order`, `set_z_order`, `is_visible`, `bounds`, `render`
+- **Default (2)**: `captures_keyboard` (true), `cursor_position` (None)
+
+Extensions that return `Some(self)` from `composable()` participate in
+the compositor (z-order rendering, hit-testing, cursor ownership).
+Extensions that return `None` have zero rendering footprint.
+
+**`captures_keyboard()` vs `wants_input()` -- two different layers:**
+
+These two methods serve different purposes and live in different traits:
+
+| Method | Trait | Default | Purpose |
+|--------|-------|---------|---------|
+| `captures_keyboard()` | `Composable` | `true` | Compositor-level: prevents keystrokes from reaching layers beneath this composable |
+| `wants_input()` | `ClientExtension` | `false` | Router-level: opts this extension into the `input_target()` selection |
+
+The relationship: `wants_input()` is a PREREQUISITE for receiving keys at
+the extension router level. `captures_keyboard()` determines whether the
+compositor stops propagating keys AFTER the extension has consumed them.
+An extension that returns `wants_input() = true` but `captures_keyboard() = false`
+would receive keys but allow them to also reach lower z-order composables.
+
+Typical patterns:
+- **cmdline** (modal): `wants_input() = true` + `captures_keyboard() = true` (exclusive input)
+- **completion popup**: `wants_input() = true` + `captures_keyboard() = true` (C-n/C-p captured)
+- **status indicator**: `wants_input() = false` + `captures_keyboard() = false` (display only)
+- **background sync**: `wants_input() = false` (no composable, no input)
+
+The engine discovers renderables via `router.active_composables()` which
+calls `ext.composable()` on each active extension. No trait downcasting,
+no enum matching, no identity checks.
+
+### 10.2 How ExtensionStateBridge Relates to SessionExtension
+
+`SessionExtension` is the mechanism: type-erased state storage in `ExtensionMap`.
+`ExtensionStateBridge` is the adapter: serializes extension state to JSON
+for gRPC transmission. Both live in the driver layer (`server/lib/drivers/session/`)
+because bridges adapt driver-layer state.
+
+Each bridge declares its `ExtensionScope` (Shared or Client). The runner
+passes the correct `ExtensionMap` based on scope:
+
+```
+SessionExtension (mechanism)     ExtensionStateBridge (adapter)
+  |                                |
+  | ExtensionMap stores state      | Reads from ExtensionMap
+  | Modules read/write directly    | scope() declares which map
+  | In-process, type-safe          | Cross-process, JSON-encoded
+  |                                |
+  v                                v
+CmdlineState                     CmdlineBridge
+  active: bool                     scope() = Client (per-client)
+  prompt: CmdlinePrompt            snapshot(client_ext) -> json!({
+  input: String                       "active": true,
+  cursor: usize                       "prompt": ":",
+  (in client_extensions)              "input": "wq",
+                                      "cursor": 2
+                                   })
+```
+
+### 10.3 How LogicalOverlay Relates to ClientExtension
+
+`LogicalOverlay` from `shared/clients/model/` is a generic overlay
+descriptor. Client extensions that produce popup-style UI can use
+`LogicalOverlay` as their data model, but it is NOT required.
+
+- `LogicalOverlay`: generic overlay with JSON data and anchor
+- `ClientExtension`: specific, typed extension with known behavior
+
+For simple overlays (hover, tooltip), `LogicalOverlay` + `OverlayRenderer`
+is sufficient. For complex interactive UI (cmdline, completion, which-key),
+a dedicated `ClientExtension` provides better type safety and interaction
+handling.
+
+### 10.4 Backward Compatibility with 19 Existing Modules
+
+All 19 existing server modules continue to work unchanged:
+
+- `Module` trait is untouched
+- `declare_module!` is untouched
+- `ServiceRegistry` is untouched
+- `ExtensionMap` is untouched
+
+The new work adds:
+- `ExtensionStateBridge` (opt-in, no existing module needs it yet)
+- New gRPC services (additive, no breaking changes)
+- New notification type (additive)
+- Client-side extension infrastructure (client-only, no server impact)
+
+
+## 11. Summary: Decision Matrix
+
+| Question | Answer |
+|----------|--------|
+| Where does rendering happen? | Client only (TUI, web) |
+| Where does state live? | Server (SessionExtension) |
+| How do clients learn state? | Push (notifications) + Pull (gRPC) |
+| Are client extensions dynamic? | No (compiled-in for now) |
+| Is there a kernel Plugin trait? | No (kernel purity) |
+| How is state serialized? | JSON via ExtensionStateBridge |
+| Do all features need both halves? | No (see taxonomy in section 1.3) |
+| How do platforms share code? | shared/clients/model/ crate |
+| Is this backward compatible? | Yes (all additive changes) |
+| WASM compatible? | Yes (no .so loading, JSON wire format) |
+| How does the engine know extensions? | Via defaults meta-crate ONLY |
+| How are events dispatched? | Subscription-based routing table |
+| Does engine match on ext identity? | NEVER (anti-coupling invariant) |
+| Can extensions be added without engine changes? | Yes (add crate + register in defaults) |
+| Must all extensions render UI? | No (only those with composable() -> Some) |
+| Who deserializes gRPC bytes? | Router (once), extensions get typed ClientEvent |
+| Can subscriptions change at runtime? | Yes (Vec\<String\> + rebuild_routes()) |
+| Where do bridges live? | Driver layer (server/lib/drivers/session/) |
+| Which ExtensionMap do bridges read? | Declared via scope() -- Shared or Client |
+
+
+## 12. File Inventory
+
+New files to create:
+
+```
+shared/protocol/proto/reovim/v2/
+  extension.proto                    -- ExtensionService
+  keymap.proto                       -- KeymapService
+
+server/lib/drivers/session/src/
+  bridges/
+    mod.rs                           -- ExtensionStateBridge trait
+    cmdline.rs                       -- CmdlineBridge
+
+server/lib/server/src/
+  grpc/
+    extension.rs                     -- ExtensionService handler
+    keymap.rs                        -- KeymapService handler
+
+clients/tui/
+  src/
+    extension.rs                     -- ClientExtension trait, ClientEvent, DeserializerRegistry
+    router.rs                        -- ExtensionRouter (subscription-based dispatch)
+  extensions/                        -- SEPARATE CRATES (not in src/)
+    defaults/
+      Cargo.toml                     -- depends on which-key, cmdline, etc.
+      src/lib.rs                     -- create_extensions() + create_deserializers()
+    which-key/
+      Cargo.toml                     -- standalone crate
+      src/lib.rs                     -- WhichKeyExtension
+    cmdline/
+      Cargo.toml                     -- standalone crate
+      src/lib.rs                     -- CmdlineExtension
+
+clients/web/src/
+  extensions/
+    types.ts                         -- ClientExtension interface
+    router.ts                        -- ExtensionRouter (subscription-based)
+    defaults/
+      index.ts                       -- export function createExtensions(): ClientExtension[]
+    which-key/
+      index.ts                       -- WhichKeyExtension
+    cmdline/
+      index.ts                       -- CmdlineExtension
+```
+
+Files to modify:
+
+```
+shared/protocol/proto/reovim/v2/
+  notification.proto                 -- Add ExtensionUpdatedPayload
+
+server/lib/server/src/
+  grpc/mod.rs                        -- Register new services
+  session/                           -- Emit extension_updated notifications
+
+clients/tui/
+  Cargo.toml                         -- Depend on tui-ext-defaults (NOT individual extensions)
+```
+
+**Dependency graph (TUI):**
+```
+clients/tui (engine)
+  └── clients/tui/extensions/defaults (meta-crate)
+        ├── clients/tui/extensions/which-key
+        ├── clients/tui/extensions/cmdline
+        └── clients/tui/extensions/completion (future)
+```
+
+The engine crate depends on `defaults` only. Individual extension crates
+are dependencies of `defaults`, invisible to the engine.
+
+No files in kernel, drivers, or existing modules need modification.

--- a/server/lib/drivers/input/src/resolver.rs
+++ b/server/lib/drivers/input/src/resolver.rs
@@ -376,18 +376,19 @@ pub trait ModeKeyResolver: Send + Sync {
     /// - **Mechanism**: Runner routes keys to resolvers, provides extension access
     /// - **Policy**: Vim resolver stores/reads `VimSessionState` in extensions
     ///
-    /// By passing `extensions` as a mutable reference, resolvers can:
-    /// - Read pending operator state
-    /// - Set pending char state (for f/t/r commands)
-    /// - Execute operators directly when motion provides range
-    /// - All without returning vim-specific `CommandResult` variants
+    /// # Extension Maps
+    ///
+    /// Two extension maps are provided so modules can choose the correct scope:
+    /// - `shared_extensions` - Shared across all clients in a session (e.g., syntax state)
+    /// - `client_extensions` - Per-client isolated state (e.g., vim operator state, counts)
     ///
     /// # Arguments
     ///
     /// * `key` - The key event to process
     /// * `state` - Mutable access to shared mode state
     /// * `input` - Input context with keymap access
-    /// * `extensions` - Per-session extension storage for module state
+    /// * `shared_extensions` - Session-wide extension storage (shared across clients)
+    /// * `client_extensions` - Per-client extension storage (isolated per connection)
     ///
     /// # Returns
     ///
@@ -408,10 +409,11 @@ pub trait ModeKeyResolver: Send + Sync {
     ///     key: &KeyEvent,
     ///     state: &mut ModeState,
     ///     input: &ResolveInput<'_>,
-    ///     extensions: &mut ExtensionMap,
+    ///     shared_extensions: &mut ExtensionMap,
+    ///     client_extensions: &mut ExtensionMap,
     /// ) -> ResolveResult {
-    ///     // Get vim-specific state
-    ///     let vim = extensions.get_or_insert::<VimSessionState>();
+    ///     // Per-client vim state (pending operator, counts)
+    ///     let vim = client_extensions.get_or_insert::<VimSessionState>();
     ///
     ///     // Check for pending operator
     ///     if let Some(pending) = &vim.pending_operator {
@@ -426,7 +428,8 @@ pub trait ModeKeyResolver: Send + Sync {
         key: &KeyEvent,
         state: &mut ModeState,
         input: &ResolveInput<'_>,
-        _extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        _client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         // Default: delegate to resolve_with_keymap for backward compatibility
         self.resolve_with_keymap(key, state, input)
@@ -444,19 +447,24 @@ pub trait ModeKeyResolver: Send + Sync {
     /// - **Mechanism (runner)**: Creates `SessionRuntime`, routes keys to resolvers
     /// - **Policy (resolvers)**: Perform actions directly via `session.*` methods
     ///
+    /// # Extension Maps
+    ///
+    /// Two extension maps are provided so modules can choose the correct scope:
+    /// - `shared_extensions` - Shared across all clients in a session
+    /// - `client_extensions` - Per-client isolated state
+    ///
+    /// `ExtensionApi` has generic methods, making it incompatible with trait objects.
+    /// By passing extensions separately, we preserve dyn-compatibility for
+    /// `ModeKeyResolver` while still providing full access.
+    ///
     /// # Arguments
     ///
     /// * `key` - The key event to process
     /// * `state` - Mutable access to shared mode state
     /// * `input` - Input context with keymap access
     /// * `session` - Dyn-compatible session API (mode, buffer, window, command, changes)
-    /// * `extensions` - Per-session extension storage for module state
-    ///
-    /// # Why Separate `extensions`?
-    ///
-    /// `ExtensionApi` has generic methods (`ext<T>`, `ext_mut<T>`), making it
-    /// incompatible with trait objects. By passing extensions separately, we preserve
-    /// dyn-compatibility for `ModeKeyResolver` while still providing full access.
+    /// * `shared_extensions` - Session-wide extension storage (shared across clients)
+    /// * `client_extensions` - Per-client extension storage (isolated per connection)
     ///
     /// # Returns
     ///
@@ -479,14 +487,15 @@ pub trait ModeKeyResolver: Send + Sync {
     ///     state: &mut ModeState,
     ///     input: &ResolveInput<'_>,
     ///     session: &mut dyn SessionApiDyn,
-    ///     extensions: &mut ExtensionMap,
+    ///     shared_extensions: &mut ExtensionMap,
+    ///     client_extensions: &mut ExtensionMap,
     /// ) -> ResolveResult {
     ///     // Directly manipulate state via session
     ///     session.push_mode(insert_mode, TransitionContext::new());
     ///     session.move_cursor(buffer, Position::new(0, 5));
     ///
-    ///     // Access module state via extensions
-    ///     let vim = extensions.get_or_insert::<VimSessionState>();
+    ///     // Per-client module state
+    ///     let vim = client_extensions.get_or_insert::<VimSessionState>();
     ///     vim.pending_count = None;
     ///
     ///     // Tell runner: "I'm done, just broadcast the changes"
@@ -499,11 +508,12 @@ pub trait ModeKeyResolver: Send + Sync {
         state: &mut ModeState,
         input: &ResolveInput<'_>,
         _session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         // Default: delegate to resolve_with_extensions for backward compatibility.
         // Resolvers that need session access should override this method.
-        self.resolve_with_extensions(key, state, input, extensions)
+        self.resolve_with_extensions(key, state, input, shared_extensions, client_extensions)
     }
 
     /// Hook called after a command executes successfully.
@@ -541,7 +551,8 @@ pub trait ModeKeyResolver: Send + Sync {
     /// # Arguments
     ///
     /// * `session` - Session API for cursor/buffer access
-    /// * `extensions` - Per-session extension storage (e.g., `VimSessionState`)
+    /// * `shared_extensions` - Session-wide extension storage (shared across clients)
+    /// * `client_extensions` - Per-client extension storage (isolated per connection)
     ///
     /// # Returns
     ///
@@ -554,7 +565,8 @@ pub trait ModeKeyResolver: Send + Sync {
     fn on_command_complete(
         &self,
         _session: &mut dyn SessionApiDyn,
-        _extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        _client_extensions: &mut ExtensionMap,
     ) -> Option<ModeTransition> {
         // Default: no pending operation to complete
         None
@@ -1955,8 +1967,15 @@ mod tests {
         let keymap = NoOpKeymap;
         let input = ResolveInput::new(&keys, &mode, &keymap);
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_ext = reovim_driver_session::ExtensionMap::new();
 
-        let result = resolver.resolve_with_extensions(&key, &mut state, &input, &mut extensions);
+        let result = resolver.resolve_with_extensions(
+            &key,
+            &mut state,
+            &input,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(matches!(result, ResolveResult::Pending));
     }
 
@@ -1977,7 +1996,8 @@ mod tests {
                 _key: &KeyEvent,
                 _state: &mut ModeState,
                 _input: &ResolveInput<'_>,
-                _extensions: &mut reovim_driver_session::ExtensionMap,
+                _shared_extensions: &mut reovim_driver_session::ExtensionMap,
+                _client_extensions: &mut reovim_driver_session::ExtensionMap,
             ) -> ResolveResult {
                 ResolveResult::Completed
             }
@@ -1998,13 +2018,20 @@ mod tests {
         let keymap = NoOpKeymap;
         let input = ResolveInput::new(&keys, &mode, &keymap);
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_ext = reovim_driver_session::ExtensionMap::new();
 
         // Use a test session runtime to get a dyn SessionApiDyn
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
-        let result =
-            resolver.resolve_with_session(&key, &mut state, &input, &mut runtime, &mut extensions);
+        let result = resolver.resolve_with_session(
+            &key,
+            &mut state,
+            &input,
+            &mut runtime,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(matches!(result, ResolveResult::Completed));
     }
 
@@ -2026,8 +2053,9 @@ mod tests {
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_ext = reovim_driver_session::ExtensionMap::new();
 
-        let result = resolver.on_command_complete(&mut runtime, &mut extensions);
+        let result = resolver.on_command_complete(&mut runtime, &mut extensions, &mut client_ext);
         assert!(result.is_none());
     }
 
@@ -2245,9 +2273,16 @@ mod tests {
         let keymap = NoOpKeymap;
         let input = ResolveInput::new(&keys, &mode, &keymap);
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_ext = reovim_driver_session::ExtensionMap::new();
 
         // Call resolve_with_extensions -> delegates to resolve_with_keymap -> delegates to resolve
-        let result = resolver.resolve_with_extensions(&key, &mut state, &input, &mut extensions);
+        let result = resolver.resolve_with_extensions(
+            &key,
+            &mut state,
+            &input,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(matches!(result, ResolveResult::InsertChar { char: 'z', .. }));
         assert_eq!(resolver.call_count.load(Ordering::SeqCst), 1);
     }
@@ -2292,11 +2327,18 @@ mod tests {
         let keymap = NoOpKeymap;
         let input = ResolveInput::new(&keys, &mode, &keymap);
         let mut extensions = reovim_driver_session::ExtensionMap::new();
+        let mut client_ext = reovim_driver_session::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
-        let result =
-            resolver.resolve_with_session(&key, &mut state, &input, &mut runtime, &mut extensions);
+        let result = resolver.resolve_with_session(
+            &key,
+            &mut state,
+            &input,
+            &mut runtime,
+            &mut extensions,
+            &mut client_ext,
+        );
         if let ResolveResult::Execute(cmd, ctx) = result {
             assert_eq!(cmd, test_command());
             assert_eq!(ctx.count, Some(42));

--- a/server/lib/drivers/input/src/resolver_registry.rs
+++ b/server/lib/drivers/input/src/resolver_registry.rs
@@ -251,20 +251,34 @@ impl ResolverRegistry {
         key: &KeyEvent,
         state: &mut ModeState,
         keymap: &dyn KeymapQuery,
-        extensions: &mut ExtensionMap,
+        shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> Option<ResolveResult> {
         let resolver = self.get(mode)?;
 
         // Clone pending keys to avoid borrow checker issues
         let keys = state.pending_keys.clone();
         let input = ResolveInput::new(&keys, mode, keymap);
-        let result = resolver.resolve_with_extensions(key, state, &input, extensions);
+        let result = resolver.resolve_with_extensions(
+            key,
+            state,
+            &input,
+            shared_extensions,
+            client_extensions,
+        );
 
         // If not handled, try parent mode
         if matches!(result, ResolveResult::NotHandled)
             && let Some(parent) = resolver.inherits_from()
         {
-            return self.resolve_with_extensions(parent, key, state, keymap, extensions);
+            return self.resolve_with_extensions(
+                parent,
+                key,
+                state,
+                keymap,
+                shared_extensions,
+                client_extensions,
+            );
         }
 
         Some(result)
@@ -313,6 +327,7 @@ impl ResolverRegistry {
     ///     }
     /// }
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn resolve_with_session(
         &self,
         mode: &ModeId,
@@ -320,20 +335,36 @@ impl ResolverRegistry {
         state: &mut ModeState,
         keymap: &dyn KeymapQuery,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> Option<ResolveResult> {
         let resolver = self.get(mode)?;
 
         // Clone pending keys to avoid borrow checker issues
         let keys = state.pending_keys.clone();
         let input = ResolveInput::new(&keys, mode, keymap);
-        let result = resolver.resolve_with_session(key, state, &input, session, extensions);
+        let result = resolver.resolve_with_session(
+            key,
+            state,
+            &input,
+            session,
+            shared_extensions,
+            client_extensions,
+        );
 
         // If not handled, try parent mode
         if matches!(result, ResolveResult::NotHandled)
             && let Some(parent) = resolver.inherits_from()
         {
-            return self.resolve_with_session(parent, key, state, keymap, session, extensions);
+            return self.resolve_with_session(
+                parent,
+                key,
+                state,
+                keymap,
+                session,
+                shared_extensions,
+                client_extensions,
+            );
         }
 
         Some(result)
@@ -628,9 +659,16 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
 
-        let result =
-            registry.resolve_with_extensions(&mode, &key, &mut state, &keymap, &mut extensions);
+        let result = registry.resolve_with_extensions(
+            &mode,
+            &key,
+            &mut state,
+            &keymap,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(result.is_none());
     }
 
@@ -644,9 +682,16 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
 
-        let result =
-            registry.resolve_with_extensions(&mode, &key, &mut state, &keymap, &mut extensions);
+        let result = registry.resolve_with_extensions(
+            &mode,
+            &key,
+            &mut state,
+            &keymap,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::Pending));
     }
@@ -664,6 +709,7 @@ mod tests {
         let mut state = ModeState::new(op_pending.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
 
         let result = registry.resolve_with_extensions(
             &op_pending,
@@ -671,6 +717,7 @@ mod tests {
             &mut state,
             &keymap,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::Pending));
@@ -723,6 +770,7 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
@@ -733,6 +781,7 @@ mod tests {
             &keymap,
             &mut runtime,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_none());
     }
@@ -747,6 +796,7 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
@@ -757,6 +807,7 @@ mod tests {
             &keymap,
             &mut runtime,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::Pending));
@@ -775,6 +826,7 @@ mod tests {
         let mut state = ModeState::new(op_pending.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
@@ -785,6 +837,7 @@ mod tests {
             &keymap,
             &mut runtime,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::Pending));
@@ -856,9 +909,16 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
 
-        let result =
-            registry.resolve_with_extensions(&mode, &key, &mut state, &keymap, &mut extensions);
+        let result = registry.resolve_with_extensions(
+            &mode,
+            &key,
+            &mut state,
+            &keymap,
+            &mut extensions,
+            &mut client_ext,
+        );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::NotHandled));
     }
@@ -891,6 +951,7 @@ mod tests {
         let mut state = ModeState::new(mode.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
@@ -901,6 +962,7 @@ mod tests {
             &keymap,
             &mut runtime,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), ResolveResult::NotHandled));
@@ -1009,6 +1071,7 @@ mod tests {
         let mut state = ModeState::new(op_pending.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
 
         let result = registry.resolve_with_extensions(
             &op_pending,
@@ -1016,6 +1079,7 @@ mod tests {
             &mut state,
             &keymap,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_none());
     }
@@ -1032,6 +1096,7 @@ mod tests {
         let mut state = ModeState::new(op_pending.clone());
         let keymap = NoOpKeymap;
         let mut extensions = crate::ExtensionMap::new();
+        let mut client_ext = crate::ExtensionMap::new();
         let mut test_rt = reovim_driver_session::testing::TestSessionRuntime::new();
         let mut runtime = test_rt.runtime();
 
@@ -1042,6 +1107,7 @@ mod tests {
             &keymap,
             &mut runtime,
             &mut extensions,
+            &mut client_ext,
         );
         assert!(result.is_none());
     }

--- a/server/lib/server/Cargo.toml
+++ b/server/lib/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reovim-server"
-version = "0.9.4-dev"
+version = "0.9.5-dev"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/server/lib/server/src/grpc/input.rs
+++ b/server/lib/server/src/grpc/input.rs
@@ -2510,7 +2510,8 @@ mod tests {
             fn on_command_complete(
                 &self,
                 _session: &mut dyn SessionApiDyn,
-                _extensions: &mut ExtensionMap,
+                _shared_extensions: &mut ExtensionMap,
+                _client_extensions: &mut ExtensionMap,
             ) -> Option<ModeTransition> {
                 Some(ModeTransition::Pop { result: None })
             }

--- a/server/lib/server/src/session/state.rs
+++ b/server/lib/server/src/session/state.rs
@@ -411,14 +411,15 @@ impl SessionState {
         let stub_executor = StubExecutor;
         let mut temp_mode_stack = ModeStack::new(home_mode);
         let mut temp_windows = reovim_driver_session::WindowLayout::empty();
-        let mut temp_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut runtime_ext = reovim_driver_session::ExtensionMap::new();
+        let mut temp_client_extensions = reovim_driver_session::ExtensionMap::new();
         let mut temp_compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut self.driver_session,
             &mut temp_mode_stack,
             &mut temp_windows,
-            &mut temp_extensions,
+            &mut runtime_ext,
             &mut temp_compositor,
             &self.app.kernel,
             &stub_executor,
@@ -432,6 +433,7 @@ impl SessionState {
             &self.keymap_registry,
             &mut runtime,
             &mut self.app.extensions,
+            &mut temp_client_extensions,
         );
 
         // Take accumulated changes
@@ -510,14 +512,18 @@ impl SessionState {
 
         // Create SessionRuntime with per-client state and owner (#471 Phase 5)
         // The owner enables undo_mine()/redo_mine() for per-client undo
+        //
+        // Use placeholder extensions in runtime - resolvers access session only
+        // via SessionApiDyn (excludes ExtensionApi), so placeholder is safe.
         let stub_executor = StubExecutor;
         let driver_client_id = DriverClientId::new(client_id);
+        let mut runtime_ext = reovim_driver_session::ExtensionMap::new();
         let mut runtime = SessionRuntime::with_owner(
             driver_client_id,
             &mut self.driver_session,
             client_mode_stack,
             client_windows,
-            client_extensions,
+            &mut runtime_ext,
             client_compositor,
             &self.app.kernel,
             &stub_executor,
@@ -531,6 +537,7 @@ impl SessionState {
             &self.keymap_registry,
             &mut runtime,
             &mut self.app.extensions,
+            client_extensions,
         );
 
         // Take accumulated changes
@@ -578,20 +585,25 @@ impl SessionState {
         let stub_executor = StubExecutor;
         let mut temp_mode_stack = ModeStack::new(home_mode);
         let mut temp_windows = reovim_driver_session::WindowLayout::empty();
-        let mut temp_extensions = reovim_driver_session::ExtensionMap::new();
+        let mut runtime_ext = reovim_driver_session::ExtensionMap::new();
+        let mut temp_client_extensions = reovim_driver_session::ExtensionMap::new();
         let mut temp_compositor = None;
 
         let mut runtime = SessionRuntime::new(
             &mut self.driver_session,
             &mut temp_mode_stack,
             &mut temp_windows,
-            &mut temp_extensions,
+            &mut runtime_ext,
             &mut temp_compositor,
             &self.app.kernel,
             &stub_executor,
         );
 
-        resolver.on_command_complete(&mut runtime, &mut self.app.extensions)
+        resolver.on_command_complete(
+            &mut runtime,
+            &mut self.app.extensions,
+            &mut temp_client_extensions,
+        )
     }
 
     /// Try to call `on_command_complete` with per-client state (#471, #477).
@@ -633,22 +645,26 @@ impl SessionState {
         }
 
         // Phase #471, #477: Use per-client state with owner for per-client undo
+        //
+        // Use placeholder extensions in runtime - resolvers access session only
+        // via SessionApiDyn (excludes ExtensionApi), so placeholder is safe.
         let mode = client_mode_stack.current().clone();
         let resolver = self.resolver_registry.get(&mode)?;
         let stub_executor = StubExecutor;
         let driver_client_id = DriverClientId::new(client_id);
+        let mut runtime_ext = reovim_driver_session::ExtensionMap::new();
         let mut runtime = SessionRuntime::with_owner(
             driver_client_id,
             &mut self.driver_session,
             client_mode_stack,
             client_windows,
-            client_extensions,
+            &mut runtime_ext,
             client_compositor,
             &self.app.kernel,
             &stub_executor,
         );
 
-        resolver.on_command_complete(&mut runtime, &mut self.app.extensions)
+        resolver.on_command_complete(&mut runtime, &mut self.app.extensions, client_extensions)
     }
 }
 
@@ -1918,7 +1934,8 @@ mod tests {
         fn on_command_complete(
             &self,
             _session: &mut dyn reovim_driver_input::SessionApiDyn,
-            _extensions: &mut reovim_driver_input::ExtensionMap,
+            _shared_extensions: &mut reovim_driver_input::ExtensionMap,
+            _client_extensions: &mut reovim_driver_input::ExtensionMap,
         ) -> Option<reovim_driver_input::ModeTransition> {
             // Return a Pop transition to indicate completion
             Some(reovim_driver_input::ModeTransition::Pop { result: None })
@@ -2011,7 +2028,8 @@ mod tests {
         fn on_command_complete(
             &self,
             session: &mut dyn reovim_driver_input::SessionApiDyn,
-            _extensions: &mut reovim_driver_input::ExtensionMap,
+            _shared_extensions: &mut reovim_driver_input::ExtensionMap,
+            _client_extensions: &mut reovim_driver_input::ExtensionMap,
         ) -> Option<reovim_driver_input::ModeTransition> {
             // Call execute_command to exercise the StubExecutor path
             let cmd_id = reovim_kernel::api::v1::CommandId::new(
@@ -2095,7 +2113,8 @@ mod tests {
             _state: &mut reovim_driver_input::ModeState,
             _input: &reovim_driver_input::ResolveInput<'_>,
             session: &mut dyn reovim_driver_input::SessionApiDyn,
-            _extensions: &mut reovim_driver_input::ExtensionMap,
+            _shared_extensions: &mut reovim_driver_input::ExtensionMap,
+            _client_extensions: &mut reovim_driver_input::ExtensionMap,
         ) -> reovim_driver_input::ResolveResult {
             // Call execute_command to exercise the StubExecutor
             let cmd_id = reovim_kernel::api::v1::CommandId::new(

--- a/server/lib/server/tests/vim_commands.rs
+++ b/server/lib/server/tests/vim_commands.rs
@@ -3,10 +3,10 @@
 //! These tests verify that vim commands work correctly through the full
 //! server/client architecture using gRPC v2 protocol.
 //!
-//! # Status (Phase 15)
+//! # Status
 //!
-//! - 28 of 34 tests are enabled and passing
-//! - 6 tests are ignored pending text object and dot repeat fixes
+//! - 32 of 34 tests are enabled and passing
+//! - 2 tests are ignored pending dot repeat implementation
 //!
 //! # Running Tests
 //!
@@ -359,9 +359,8 @@ async fn test_yw_p_yank_put_word() {
 
 /// Test `diw` deletes inner word.
 #[tokio::test]
-#[ignore = "Text object iw not fully implemented"]
 async fn test_diw_delete_inner_word() {
-    let result = IntegrationTest::new()
+    let result = IntegrationTest::with_modules(&["textobjects"])
         .await
         .with_buffer("hello world test")
         .with_cursor_at(0, 7) // On 'o' of 'world'
@@ -373,9 +372,8 @@ async fn test_diw_delete_inner_word() {
 
 /// Test `daw` deletes a word (with surrounding whitespace).
 #[tokio::test]
-#[ignore = "Text object aw not fully implemented"]
 async fn test_daw_delete_a_word() {
-    let result = IntegrationTest::new()
+    let result = IntegrationTest::with_modules(&["textobjects"])
         .await
         .with_buffer("hello world test")
         .with_cursor_at(0, 6) // On 'w' of 'world'
@@ -387,9 +385,8 @@ async fn test_daw_delete_a_word() {
 
 /// Test `di"` deletes inside quotes.
 #[tokio::test]
-#[ignore = "Text object i\" not fully implemented"]
 async fn test_di_quote_delete_inside() {
-    let result = IntegrationTest::new()
+    let result = IntegrationTest::with_modules(&["textobjects"])
         .await
         .with_buffer(r#"say "hello" please"#)
         .with_cursor_at(0, 5) // On '"'
@@ -401,9 +398,8 @@ async fn test_di_quote_delete_inside() {
 
 /// Test `ci{` changes inside braces.
 #[tokio::test]
-#[ignore = "Text object i{ not fully implemented"]
 async fn test_ci_brace_change_inside() {
-    let result = IntegrationTest::new()
+    let result = IntegrationTest::with_modules(&["textobjects"])
         .await
         .with_buffer("fn() { old }")
         .with_cursor_at(0, 7) // Inside braces

--- a/server/modules/textobjects/src/lib.rs
+++ b/server/modules/textobjects/src/lib.rs
@@ -31,7 +31,7 @@ pub mod quote;
 pub mod word;
 
 use {
-    reovim_driver_command::CommandHandler,
+    reovim_driver_command::{CommandHandler, CommandHandlerStore, CommandProvider},
     reovim_kernel::api::v1::{Module, ModuleContext, ModuleError, ModuleId, ProbeResult, Version},
 };
 
@@ -68,12 +68,23 @@ impl Module for TextObjectsModule {
         Version::new(0, 9, 0)
     }
 
-    fn init(&mut self, _ctx: &ModuleContext) -> ProbeResult {
+    fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+        // Self-register commands (same pattern as EditorModule)
+        let command_store = ctx.services.get_or_create::<CommandHandlerStore>();
+        for handler in self.command_handlers() {
+            command_store.add(handler);
+        }
         ProbeResult::Success
     }
 
     fn exit(&mut self) -> Result<(), ModuleError> {
         Ok(())
+    }
+}
+
+impl CommandProvider for TextObjectsModule {
+    fn command_handlers(&self) -> Vec<Box<dyn CommandHandler>> {
+        all_commands()
     }
 }
 
@@ -114,11 +125,36 @@ mod tests {
 
     #[test]
     fn test_module_init() {
-        use reovim_kernel::api::v1::ModuleContext;
+        use {
+            reovim_kernel::api::v1::{KernelContext, ModuleContext, ServiceRegistry},
+            std::{path::PathBuf, sync::Arc},
+        };
+
+        let kernel = KernelContext::default();
+        let services = Arc::new(ServiceRegistry::new());
+        let ctx = ModuleContext::new(
+            kernel,
+            services.clone(),
+            PathBuf::from("/tmp/test-data"),
+            PathBuf::from("/tmp/test-cache"),
+        );
+
         let mut module = TextObjectsModule::new();
-        let ctx = ModuleContext::default();
         let result = module.init(&ctx);
         assert_eq!(result, ProbeResult::Success);
+
+        // Verify commands were registered in CommandHandlerStore
+        let store = services.get::<CommandHandlerStore>();
+        assert!(store.is_some(), "CommandHandlerStore should be registered");
+        let handlers = store.unwrap().take_handlers();
+        assert_eq!(handlers.len(), 20, "All 20 text object commands should be registered");
+    }
+
+    #[test]
+    fn test_command_provider_trait() {
+        let module = TextObjectsModule::new();
+        let handlers = module.command_handlers();
+        assert_eq!(handlers.len(), all_commands().len());
     }
 
     #[test]

--- a/server/modules/vim/src/resolvers/change.rs
+++ b/server/modules/vim/src/resolvers/change.rs
@@ -183,7 +183,8 @@ impl ModeKeyResolver for VimChangeResolver {
         _mstate: &mut ModeState,
         input: &ResolveInput<'_>,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         tracing::debug!(key = ?key, "change resolver: resolve_with_session");
 
@@ -196,7 +197,7 @@ impl ModeKeyResolver for VimChangeResolver {
 
         // Initialize state from VimSessionState on first key in this mode entry
         if !state.initialized {
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
                 tracing::debug!(
@@ -289,7 +290,7 @@ impl ModeKeyResolver for VimChangeResolver {
                 // Inclusive motions need end position adjustment ($ returns ON last char)
                 let inclusive = !linewise && is_inclusive_motion(&cmd);
                 let word_forward = !linewise && is_word_forward_motion(&cmd);
-                if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+                if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                     vim.pending_motion =
                         Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
@@ -327,7 +328,8 @@ impl ModeKeyResolver for VimChangeResolver {
     fn on_command_complete(
         &self,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> Option<ModeTransition> {
         let state = self.state.read().expect("lock poisoned");
         let count = state.operator_count;
@@ -335,7 +337,7 @@ impl ModeKeyResolver for VimChangeResolver {
         drop(state);
 
         // Check for text object range first (Epic #465)
-        if let Some(op_state) = extensions.get_mut::<OperatorPendingState>()
+        if let Some(op_state) = client_extensions.get_mut::<OperatorPendingState>()
             && let Some(textobj_range) = op_state.take_textobj_range()
         {
             tracing::debug!(
@@ -347,7 +349,7 @@ impl ModeKeyResolver for VimChangeResolver {
 
             // Record for dot repeat (Epic #465)
             // Note: The inserted text will be recorded when insert mode exits
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 vim.last_change = Some(LastChange {
                     change_type: ChangeType::OperatorTextObject {
                         operator: SessionOperatorType::Change,
@@ -375,7 +377,7 @@ impl ModeKeyResolver for VimChangeResolver {
         }
 
         // Fall back to motion-based range calculation
-        let vim = extensions.get_mut::<crate::VimSessionState>()?;
+        let vim = client_extensions.get_mut::<crate::VimSessionState>()?;
         let motion = vim.pending_motion.take()?;
 
         let state = self.state.read().expect("lock poisoned");
@@ -417,7 +419,7 @@ impl ModeKeyResolver for VimChangeResolver {
 
         // Record for dot repeat (Epic #465)
         // Note: The inserted text will be recorded when insert mode exits
-        if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+        if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
             vim.last_change = Some(LastChange {
                 change_type: ChangeType::OperatorMotion {
                     operator: SessionOperatorType::Change,
@@ -941,12 +943,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -966,6 +970,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(3, 2);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         {
             let vim = extensions.get_or_insert::<crate::VimSessionState>();
@@ -978,6 +983,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1002,12 +1008,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(4, 2);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('c'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1041,6 +1049,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(2, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         {
             let vim = extensions.get_or_insert::<crate::VimSessionState>();
@@ -1052,6 +1061,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1086,12 +1096,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('9'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1105,6 +1117,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1112,6 +1125,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1133,6 +1147,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1140,6 +1155,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1158,6 +1174,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1165,6 +1182,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1187,12 +1205,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('z'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1216,6 +1236,7 @@ mod tests {
         let resolver = VimChangeResolver::with_context(Some(1), None);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
         op_state.set_textobj_range(TextObjRange {
@@ -1226,7 +1247,7 @@ mod tests {
 
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1267,11 +1288,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1308,11 +1330,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 4);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, true, false)); // inclusive
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1343,11 +1366,12 @@ mod tests {
         // Motion moved to col 6 (start of next word), but cw should end at col 5
         let mut session = MockSession::with_cursor(0, 6);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, true)); // word_forward
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1376,11 +1400,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(2, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(true, false, false)); // linewise
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1408,11 +1433,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 2);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1437,8 +1463,9 @@ mod tests {
         let resolver = VimChangeResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1447,9 +1474,10 @@ mod tests {
         let resolver = VimChangeResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1458,6 +1486,7 @@ mod tests {
         let resolver = VimChangeResolver::with_context(Some(3), Some('x'));
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
         op_state.set_textobj_range(TextObjRange {
@@ -1468,7 +1497,7 @@ mod tests {
 
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let _ = resolver.on_command_complete(&mut session, &mut extensions);
+        let _ = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
 
         let vim = extensions.get::<crate::VimSessionState>().unwrap();
         let lc = vim.last_change.as_ref().unwrap();
@@ -1493,11 +1522,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let _ = resolver.on_command_complete(&mut session, &mut extensions);
+        let _ = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
 
         let vim = extensions.get::<crate::VimSessionState>().unwrap();
         let lc = vim.last_change.as_ref().unwrap();
@@ -1542,6 +1572,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         // Do NOT insert VimSessionState
 
         let result = resolver.resolve_with_session(
@@ -1549,6 +1580,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1573,12 +1605,14 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('c'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1610,12 +1644,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('g'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1635,6 +1671,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(1, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // First key '3' - motion count
         let result = resolver.resolve_with_session(
@@ -1642,6 +1679,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1652,6 +1690,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1681,12 +1720,13 @@ mod tests {
         let resolver = VimChangeResolver::new();
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
         // Don't set start_position in resolver state
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when start_position is not set");
     }
 
@@ -1705,11 +1745,12 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when cursor_position is None");
     }
 
@@ -1724,6 +1765,7 @@ mod tests {
 
         // Shared extensions map (like in the runner)
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Step 1: Normal resolver processes '2'
         {
@@ -1736,6 +1778,7 @@ mod tests {
                 &key('2'),
                 &mut state,
                 &input,
+                &mut shared_ext,
                 &mut extensions,
             );
             assert!(
@@ -1765,6 +1808,7 @@ mod tests {
                 &key('c'),
                 &mut state,
                 &input,
+                &mut shared_ext,
                 &mut extensions,
             );
             assert!(

--- a/server/modules/vim/src/resolvers/delete.rs
+++ b/server/modules/vim/src/resolvers/delete.rs
@@ -202,7 +202,8 @@ impl ModeKeyResolver for VimDeleteResolver {
         _mstate: &mut ModeState,
         input: &ResolveInput<'_>,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         tracing::debug!(key = ?key, "delete resolver: resolve_with_session");
 
@@ -216,7 +217,7 @@ impl ModeKeyResolver for VimDeleteResolver {
 
         // Initialize state from VimSessionState on first key in this mode entry
         if !state.initialized {
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
                 tracing::debug!(
@@ -316,7 +317,7 @@ impl ModeKeyResolver for VimDeleteResolver {
                 // Inclusive motions need end position adjustment ($ returns ON last char)
                 let inclusive = !linewise && is_inclusive_motion(&cmd);
                 let word_forward = !linewise && is_word_forward_motion(&cmd);
-                if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+                if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                     vim.pending_motion =
                         Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
@@ -361,7 +362,8 @@ impl ModeKeyResolver for VimDeleteResolver {
     fn on_command_complete(
         &self,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> Option<ModeTransition> {
         let state = self.state.read().expect("lock poisoned");
         let count = state.operator_count;
@@ -370,7 +372,7 @@ impl ModeKeyResolver for VimDeleteResolver {
 
         // Check for text object range first (Epic #465)
         // Text objects set this range directly, so it takes priority over motion-based calculation
-        if let Some(op_state) = extensions.get_mut::<OperatorPendingState>()
+        if let Some(op_state) = client_extensions.get_mut::<OperatorPendingState>()
             && let Some(textobj_range) = op_state.take_textobj_range()
         {
             tracing::debug!(
@@ -381,7 +383,7 @@ impl ModeKeyResolver for VimDeleteResolver {
             );
 
             // Record for dot repeat (Epic #465)
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 vim.last_change = Some(LastChange {
                     change_type: ChangeType::OperatorTextObject {
                         operator: SessionOperatorType::Delete,
@@ -408,7 +410,7 @@ impl ModeKeyResolver for VimDeleteResolver {
         }
 
         // Fall back to motion-based range calculation
-        let vim = extensions.get_mut::<crate::VimSessionState>()?;
+        let vim = client_extensions.get_mut::<crate::VimSessionState>()?;
         let motion = vim.pending_motion.take()?;
 
         let state = self.state.read().expect("lock poisoned");
@@ -437,7 +439,7 @@ impl ModeKeyResolver for VimDeleteResolver {
         };
 
         // Record for dot repeat (Epic #465)
-        if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+        if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
             vim.last_change = Some(LastChange {
                 change_type: ChangeType::OperatorMotion {
                     operator: SessionOperatorType::Delete,
@@ -983,12 +985,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1008,6 +1012,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(5, 3);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Pre-set pending count and register in VimSessionState
         {
@@ -1021,6 +1026,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1047,12 +1053,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(3, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('d'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1087,12 +1095,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('5'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1106,6 +1116,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(2, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1113,6 +1124,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1135,6 +1147,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1142,6 +1155,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1161,6 +1175,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1168,6 +1183,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1189,12 +1205,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('z'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1218,6 +1236,7 @@ mod tests {
         let resolver = VimDeleteResolver::with_context(Some(1), None);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Set up a text object range in OperatorPendingState
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
@@ -1229,7 +1248,7 @@ mod tests {
 
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1271,12 +1290,13 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5); // end position after motion
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Set up pending_motion in VimSessionState (characterwise, not inclusive)
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1313,11 +1333,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 4); // cursor ON last char
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, true, false)); // inclusive
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1346,11 +1367,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(2, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(true, false, false)); // linewise
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1379,11 +1401,12 @@ mod tests {
         // Cursor moved backward
         let mut session = MockSession::with_cursor(0, 2);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1409,9 +1432,10 @@ mod tests {
         let resolver = VimDeleteResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // No VimSessionState, no OperatorPendingState -> None
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1420,10 +1444,11 @@ mod tests {
         let resolver = VimDeleteResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
         // VimSessionState has no pending_motion
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1432,6 +1457,7 @@ mod tests {
         let resolver = VimDeleteResolver::with_context(Some(2), Some('a'));
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
         op_state.set_textobj_range(TextObjRange {
@@ -1442,7 +1468,7 @@ mod tests {
 
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let _ = resolver.on_command_complete(&mut session, &mut extensions);
+        let _ = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
 
         let vim = extensions.get::<crate::VimSessionState>().unwrap();
         let lc = vim.last_change.as_ref().unwrap();
@@ -1482,6 +1508,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         // Do NOT insert VimSessionState
 
         let result = resolver.resolve_with_session(
@@ -1489,6 +1516,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1512,12 +1540,14 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('d'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1549,12 +1579,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('g'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1574,6 +1606,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(2, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         {
             let vim = extensions.get_or_insert::<crate::VimSessionState>();
@@ -1585,6 +1618,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1617,6 +1651,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // First key '3' - motion count
         let result = resolver.resolve_with_session(
@@ -1624,6 +1659,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1634,6 +1670,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1654,12 +1691,13 @@ mod tests {
         let resolver = VimDeleteResolver::new();
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
         // Don't set start_position in resolver state
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when start_position is not set");
     }
 
@@ -1678,11 +1716,12 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when cursor_position is None");
     }
 
@@ -1699,11 +1738,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let _ = resolver.on_command_complete(&mut session, &mut extensions);
+        let _ = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
 
         let vim = extensions.get::<crate::VimSessionState>().unwrap();
         let lc = vim.last_change.as_ref().unwrap();

--- a/server/modules/vim/src/resolvers/insert.rs
+++ b/server/modules/vim/src/resolvers/insert.rs
@@ -127,12 +127,13 @@ impl ModeKeyResolver for VimInsertResolver {
         key: &KeyEvent,
         state: &mut ModeState,
         input: &ResolveInput<'_>,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         // Check for insertable character first
         if let Some(c) = Self::is_insertable(key) {
             // Track inserted character for dot repeat (Epic #465)
-            if let Some(vim) = extensions.get_mut::<VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<VimSessionState>() {
                 vim.insert_buffer.push(c);
             }
             return ResolveResult::insert_char(c);
@@ -543,11 +544,17 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         // Pre-populate with VimSessionState
         let _ = extensions.get_or_insert::<VimSessionState>();
 
-        let result =
-            resolver.resolve_with_extensions(&key('a'), &mut state, &input, &mut extensions);
+        let result = resolver.resolve_with_extensions(
+            &key('a'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
         assert!(matches!(result, ResolveResult::InsertChar { char: 'a', .. }));
 
         // Check insert_buffer was populated
@@ -563,13 +570,44 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         let _ = extensions.get_or_insert::<VimSessionState>();
 
-        resolver.resolve_with_extensions(&key('h'), &mut state, &input, &mut extensions);
-        resolver.resolve_with_extensions(&key('e'), &mut state, &input, &mut extensions);
-        resolver.resolve_with_extensions(&key('l'), &mut state, &input, &mut extensions);
-        resolver.resolve_with_extensions(&key('l'), &mut state, &input, &mut extensions);
-        resolver.resolve_with_extensions(&key('o'), &mut state, &input, &mut extensions);
+        resolver.resolve_with_extensions(
+            &key('h'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
+        resolver.resolve_with_extensions(
+            &key('e'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
+        resolver.resolve_with_extensions(
+            &key('l'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
+        resolver.resolve_with_extensions(
+            &key('l'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
+        resolver.resolve_with_extensions(
+            &key('o'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
 
         let vim = extensions.get::<VimSessionState>().unwrap();
         assert_eq!(vim.insert_buffer, "hello");
@@ -583,12 +621,14 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         let _ = extensions.get_or_insert::<VimSessionState>();
 
         resolver.resolve_with_extensions(
             &KeyEvent::new(KeyCode::Tab),
             &mut state,
             &input,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -604,12 +644,14 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         let _ = extensions.get_or_insert::<VimSessionState>();
 
         resolver.resolve_with_extensions(
             &KeyEvent::new(KeyCode::Enter),
             &mut state,
             &input,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -626,6 +668,7 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         let _ = extensions.get_or_insert::<VimSessionState>();
 
         // Escape is non-insertable - should delegate to keymap
@@ -633,6 +676,7 @@ mod tests {
             &KeyEvent::new(KeyCode::Escape),
             &mut state,
             &input,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -656,6 +700,7 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         let _ = extensions.get_or_insert::<VimSessionState>();
 
         // Ctrl+H is non-insertable - should not be tracked
@@ -663,6 +708,7 @@ mod tests {
             &key_with_mod('h', Modifiers::CTRL),
             &mut state,
             &input,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::NotHandled));
@@ -679,10 +725,16 @@ mod tests {
         let input = resolve_input(&keymap);
 
         let mut extensions = reovim_driver_input::ExtensionMap::new();
+        let mut shared_ext = reovim_driver_input::ExtensionMap::new();
         // Don't insert VimSessionState - should still work
 
-        let result =
-            resolver.resolve_with_extensions(&key('x'), &mut state, &input, &mut extensions);
+        let result = resolver.resolve_with_extensions(
+            &key('x'),
+            &mut state,
+            &input,
+            &mut shared_ext,
+            &mut extensions,
+        );
         assert!(matches!(result, ResolveResult::InsertChar { char: 'x', .. }));
     }
 

--- a/server/modules/vim/src/resolvers/normal.rs
+++ b/server/modules/vim/src/resolvers/normal.rs
@@ -664,10 +664,11 @@ impl ModeKeyResolver for VimNormalResolver {
         key: &KeyEvent,
         _state: &mut ModeState,
         input: &ResolveInput<'_>,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
-        // Get vim session state from extensions
-        let vim = extensions.get_or_insert::<VimSessionState>();
+        // Get vim session state from client extensions (per-client state)
+        let vim = client_extensions.get_or_insert::<VimSessionState>();
 
         // Handle escape - reset state and return NotHandled
         if key.code == KeyCode::Escape {
@@ -1423,7 +1424,8 @@ mod tests {
         input: &ResolveInput<'_>,
         extensions: &mut ExtensionMap,
     ) -> ResolveResult {
-        resolver.resolve_with_extensions(key, state, input, extensions)
+        let mut shared_ext = ExtensionMap::new();
+        resolver.resolve_with_extensions(key, state, input, &mut shared_ext, extensions)
     }
 
     #[test]

--- a/server/modules/vim/src/resolvers/visual.rs
+++ b/server/modules/vim/src/resolvers/visual.rs
@@ -260,7 +260,8 @@ impl ModeKeyResolver for VimVisualResolver {
         _mstate: &mut ModeState,
         input: &ResolveInput<'_>,
         _session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         tracing::debug!(key = ?key, mode = ?self.mode_id, "visual resolver: resolve_with_session");
 
@@ -278,7 +279,7 @@ impl ModeKeyResolver for VimVisualResolver {
 
         // Initialize state on first key (read any pending count from normal mode)
         if !state.initialized {
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 // Transfer any pending count from normal mode
                 if let Some(count) = vim.pending_count.take() {
                     state.motion_count = Some(count);
@@ -1027,12 +1028,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1052,12 +1055,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::with_modifiers(KeyCode::Char('c'), Modifiers::CTRL),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1077,6 +1082,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Pre-set pending count in VimSessionState (from normal mode count before entering visual)
         {
@@ -1089,6 +1095,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1113,12 +1120,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('3'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1133,12 +1142,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('w'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1157,12 +1168,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('z'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1177,12 +1190,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('g'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1199,6 +1214,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         // No VimSessionState inserted
 
         let result = resolver.resolve_with_session(
@@ -1206,6 +1222,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1226,12 +1243,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1251,12 +1270,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1307,12 +1328,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('g'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1333,6 +1356,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>(); // no pending_count
 
         let result = resolver.resolve_with_session(
@@ -1340,6 +1364,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1360,6 +1385,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // First call initializes
         let result = resolver.resolve_with_session(
@@ -1367,6 +1393,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1377,6 +1404,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));

--- a/server/modules/vim/src/resolvers/yank.rs
+++ b/server/modules/vim/src/resolvers/yank.rs
@@ -176,7 +176,8 @@ impl ModeKeyResolver for VimYankResolver {
         _mstate: &mut ModeState,
         input: &ResolveInput<'_>,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> ResolveResult {
         tracing::debug!(key = ?key, "yank resolver: resolve_with_session");
 
@@ -189,7 +190,7 @@ impl ModeKeyResolver for VimYankResolver {
 
         // Initialize state from VimSessionState on first key in this mode entry
         if !state.initialized {
-            if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+            if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                 state.operator_count = vim.pending_count.take();
                 state.register = vim.pending_register.take();
                 tracing::debug!(
@@ -281,7 +282,7 @@ impl ModeKeyResolver for VimYankResolver {
                 // Inclusive motions need end position adjustment ($ returns ON last char)
                 let inclusive = !linewise && is_inclusive_motion(&cmd);
                 let word_forward = !linewise && is_word_forward_motion(&cmd);
-                if let Some(vim) = extensions.get_mut::<crate::VimSessionState>() {
+                if let Some(vim) = client_extensions.get_mut::<crate::VimSessionState>() {
                     vim.pending_motion =
                         Some(PendingMotion::new(linewise, inclusive, word_forward));
                 }
@@ -319,7 +320,8 @@ impl ModeKeyResolver for VimYankResolver {
     fn on_command_complete(
         &self,
         session: &mut dyn SessionApiDyn,
-        extensions: &mut ExtensionMap,
+        _shared_extensions: &mut ExtensionMap,
+        client_extensions: &mut ExtensionMap,
     ) -> Option<ModeTransition> {
         let state = self.state.read().expect("lock poisoned");
         let count = state.operator_count;
@@ -327,7 +329,7 @@ impl ModeKeyResolver for VimYankResolver {
         drop(state);
 
         // Check for text object range first (Epic #465)
-        if let Some(op_state) = extensions.get_mut::<OperatorPendingState>()
+        if let Some(op_state) = client_extensions.get_mut::<OperatorPendingState>()
             && let Some(textobj_range) = op_state.take_textobj_range()
         {
             tracing::debug!(
@@ -352,7 +354,7 @@ impl ModeKeyResolver for VimYankResolver {
         }
 
         // Fall back to motion-based range calculation
-        let vim = extensions.get_mut::<crate::VimSessionState>()?;
+        let vim = client_extensions.get_mut::<crate::VimSessionState>()?;
         let motion = vim.pending_motion.take()?;
 
         let state = self.state.read().expect("lock poisoned");
@@ -846,12 +848,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &KeyEvent::new(KeyCode::Escape),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -871,6 +875,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(5, 3);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Pre-set pending count and register in VimSessionState
         {
@@ -884,6 +889,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -910,12 +916,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(2, 7);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('y'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -950,6 +958,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(1, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // Set count=3 from VimSessionState
         {
@@ -962,6 +971,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -996,12 +1006,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('7'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1015,6 +1027,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(1, 3);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1022,6 +1035,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1043,6 +1057,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1050,6 +1065,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1068,6 +1084,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
         let result = resolver.resolve_with_session(
@@ -1075,6 +1092,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1097,12 +1115,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('z'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1126,6 +1146,7 @@ mod tests {
         let resolver = VimYankResolver::with_context(Some(1), None);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
         op_state.set_textobj_range(TextObjRange {
@@ -1134,7 +1155,7 @@ mod tests {
             is_linewise: false,
         });
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1165,6 +1186,7 @@ mod tests {
         let resolver = VimYankResolver::with_context(Some(1), Some('a'));
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let op_state = extensions.get_or_insert::<OperatorPendingState>();
         op_state.set_textobj_range(TextObjRange {
@@ -1173,7 +1195,7 @@ mod tests {
             is_linewise: true,
         });
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1214,11 +1236,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1255,11 +1278,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 4);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, true, false)); // inclusive
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1288,11 +1312,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(2, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(true, false, false)); // linewise
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1321,11 +1346,12 @@ mod tests {
         // Cursor moved backward
         let mut session = MockSession::with_cursor(0, 3);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {
@@ -1351,9 +1377,10 @@ mod tests {
         let resolver = VimYankResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // No VimSessionState, no OperatorPendingState -> None
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1362,9 +1389,10 @@ mod tests {
         let resolver = VimYankResolver::new();
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         extensions.get_or_insert::<crate::VimSessionState>();
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none());
     }
 
@@ -1396,6 +1424,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(0, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
         // Do NOT insert VimSessionState
 
         let result = resolver.resolve_with_session(
@@ -1403,6 +1432,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1426,12 +1456,14 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('y'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1463,12 +1495,14 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::new();
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let result = resolver.resolve_with_session(
             &key('g'),
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1488,6 +1522,7 @@ mod tests {
         let input = resolve_input(&keymap);
         let mut session = MockSession::with_cursor(1, 0);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         // First key '3' - motion count
         let result = resolver.resolve_with_session(
@@ -1495,6 +1530,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
         assert!(matches!(result, ResolveResult::Pending));
@@ -1505,6 +1541,7 @@ mod tests {
             &mut mstate,
             &input,
             &mut session,
+            &mut shared_ext,
             &mut extensions,
         );
 
@@ -1534,12 +1571,13 @@ mod tests {
         let resolver = VimYankResolver::new();
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
         // Don't set start_position in resolver state
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when start_position is not set");
     }
 
@@ -1558,11 +1596,12 @@ mod tests {
             cursor: None,
         };
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_none(), "should return None when cursor_position is None");
     }
 
@@ -1580,11 +1619,12 @@ mod tests {
 
         let mut session = MockSession::with_cursor(0, 5);
         let mut extensions = ExtensionMap::new();
+        let mut shared_ext = ExtensionMap::new();
 
         let vim = extensions.get_or_insert::<crate::VimSessionState>();
         vim.pending_motion = Some(PendingMotion::new(false, false, false));
 
-        let result = resolver.on_command_complete(&mut session, &mut extensions);
+        let result = resolver.on_command_complete(&mut session, &mut shared_ext, &mut extensions);
         assert!(result.is_some());
 
         if let Some(ModeTransition::Pop {

--- a/shared/testing/src/harness.rs
+++ b/shared/testing/src/harness.rs
@@ -216,7 +216,7 @@ impl TestServerHarness {
             .name()
             .unwrap_or("unknown_test")
             .to_string();
-        Self::spawn_with_name(&test_name).await
+        Self::spawn_inner(&test_name, &[]).await
     }
 
     /// Spawn server with explicit test name for log capture.
@@ -250,6 +250,38 @@ impl TestServerHarness {
     pub async fn spawn_with_name(
         test_name: &str,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::spawn_inner(test_name, &[]).await
+    }
+
+    /// Spawn server with extra modules loaded.
+    ///
+    /// Sets `REOVIM_EXTRA_MODULES` env var on the spawned server process.
+    /// Test name is auto-extracted from the current thread name.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let harness = TestServerHarness::spawn_with_modules(&["textobjects"]).await?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns error if server fails to spawn or start.
+    pub async fn spawn_with_modules(
+        modules: &[&str],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let test_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown_test")
+            .to_string();
+        Self::spawn_inner(&test_name, modules).await
+    }
+
+    /// Internal spawn implementation.
+    async fn spawn_inner(
+        test_name: &str,
+        extra_modules: &[&str],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Create log directory
         let log_dir = PathBuf::from(TEST_LOG_DIR);
         std::fs::create_dir_all(&log_dir)?;
@@ -261,23 +293,26 @@ impl TestServerHarness {
         let _test_id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
 
         // Use debug level by default for test log capture
-        // Note: Both REOVIM_LOG (kernel) and RUST_LOG (tracing) must be set
-        // for full log capture. The composite logger forwards kernel logs to
-        // tracing, so RUST_LOG controls what gets written to stderr.
         let log_level = std::env::var("REOVIM_LOG").unwrap_or_else(|_| "debug".to_string());
 
         // Use worktree modules instead of globally installed ones (#433)
         let module_dir = workspace_module_dir();
 
-        let mut process = Command::new(binary_path())
-            .args(["server", "--grpc", "0"])
+        let mut cmd = Command::new(binary_path());
+        cmd.args(["server", "--grpc", "0"])
             .env("REOVIM_LOG", &log_level)
             .env("RUST_LOG", &log_level) // Enable tracing output for log capture
             .env("REOVIM_MODULE_PATH", &module_dir)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()?;
+            .kill_on_drop(true);
+
+        // Set extra modules if specified
+        if !extra_modules.is_empty() {
+            cmd.env("REOVIM_EXTRA_MODULES", extra_modules.join(","));
+        }
+
+        let mut process = cmd.spawn()?;
 
         // Extract stderr for port reading and log capture
         let stderr = process.stderr.take().ok_or("Failed to capture stderr")?;

--- a/shared/testing/src/integration.rs
+++ b/shared/testing/src/integration.rs
@@ -87,6 +87,42 @@ impl IntegrationTest {
         }
     }
 
+    /// Create new test with extra modules loaded.
+    ///
+    /// Spawns a server with the default modules plus the specified extra
+    /// modules. Use this for testing functionality that requires modules
+    /// not in the defaults bundle (e.g., textobjects).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let result = IntegrationTest::with_modules(&["textobjects"])
+    ///     .await
+    ///     .with_buffer("hello world")
+    ///     .send_keys("diw")
+    ///     .run()
+    ///     .await;
+    /// result.assert_buffer_eq(" world");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if server fails to spawn.
+    pub async fn with_modules(modules: &[&str]) -> Self {
+        let harness = TestServerHarness::spawn_with_modules(modules)
+            .await
+            .expect("Failed to spawn server with extra modules");
+        let addr = format!("127.0.0.1:{}", harness.port());
+        Self {
+            harness,
+            addr,
+            initial_content: None,
+            initial_cursor: None,
+            key_sequences: Vec::new(),
+            default_delay: DEFAULT_DELAY_MS,
+        }
+    }
+
     /// Get the path to the server log file for debugging.
     ///
     /// Returns `None` if log capture is not enabled.

--- a/shared/testing/src/step_test.rs
+++ b/shared/testing/src/step_test.rs
@@ -173,6 +173,28 @@ impl StepTest {
         }
     }
 
+    /// Create new step test with extra modules loaded.
+    ///
+    /// See [`super::IntegrationTest::with_modules`] for details.
+    ///
+    /// # Panics
+    ///
+    /// Panics if server fails to spawn.
+    pub async fn with_modules(modules: &[&str]) -> Self {
+        let harness = TestServerHarness::spawn_with_modules(modules)
+            .await
+            .expect("Failed to spawn server with extra modules");
+        let addr = format!("127.0.0.1:{}", harness.port());
+        Self {
+            harness,
+            addr,
+            initial_content: None,
+            initial_cursor: None,
+            steps: Vec::new(),
+            default_delay: DEFAULT_STEP_DELAY_MS,
+        }
+    }
+
     /// Get the path to the server log file for debugging.
     ///
     /// Returns `None` if log capture is not enabled.

--- a/tools/bench/Cargo.toml
+++ b/tools/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reovim-bench"
-version = "0.9.2-dev"
+version = "0.9.5-dev"
 edition = "2024"
 description = "Benchmarks for reovim kernel operations"
 publish = false


### PR DESCRIPTION
## Summary

Fix broken operator+textobject combinations (`diw`, `ciw`, `yiw`, `di"`, `ci{`, etc.) caused by extension map mismatch between shared and per-client state. Enable integration tests for text objects via explicit extra module loading.

## Issue

Refs #474

## Changes

### Extension map split (commit 1)
- Split single `extensions: &mut ExtensionMap` parameter in `ModeKeyResolver` trait into `shared_extensions` and `client_extensions`
- `VimSessionState` and `OperatorPendingState` moved to `client_extensions` (per-client isolation)
- Updated all resolver implementations: normal, insert, delete, change, yank, visual
- Server call sites use a placeholder `ExtensionMap` for `SessionRuntime`, freeing `client_extensions` to be passed without borrow conflicts
- Affected methods: `resolve_with_extensions`, `resolve_with_session`, `on_command_complete`

### Explicit extra module loading (commit 2)
- Fixed `TextObjectsModule::init()` to self-register commands via `CommandHandlerStore` (was a no-op)
- Added `REOVIM_EXTRA_MODULES` env var support to bootstrap for loading modules beyond the 13 defaults
- `TestServerHarness::spawn_with_modules()` sets the env var on spawned server process
- `IntegrationTest::with_modules()` and `StepTest::with_modules()` for tests needing extra modules
- 4 text object integration tests (`diw`, `daw`, `di"`, `ci{`) un-ignored and passing (32/34 tests enabled, 2 dot-repeat remain ignored)

### Other
- Version bump to 0.9.5-dev
- Added client extension architecture design doc

## Test Plan

- [x] `./scripts/check.sh` passed (fmt, build, clippy, all tests)
- [x] MC/DC coverage 100.0% (25,683/25,683 lines, 0 uncovered)
- [x] 32/34 vim_commands integration tests pass (2 dot-repeat ignored)
- [x] All workspace tests pass (0 failures)