### PR TITLE
fix(ci): export RUSTFLAGS in build steps for fingerprint match (#588)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build workspace + tests + bins (instrumented)
         run: |
-          eval "$(RUSTFLAGS='${{ env.MCDC_RUSTFLAGS }}' \
-            cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           cargo +${{ env.NIGHTLY }} build --workspace --tests --bins \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
@@ -79,8 +79,8 @@ jobs:
             --exclude reovim-server
       - name: Build FFI modules (instrumented)
         run: |
-          eval "$(RUSTFLAGS='${{ env.MCDC_RUSTFLAGS }}' \
-            cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           cargo +${{ env.NIGHTLY }} build -p reovim-module-defaults --features dynamic
       - name: Save build cache
         uses: actions/cache/save@v4
@@ -108,8 +108,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build server + app binary + tests (instrumented)
         run: |
-          eval "$(RUSTFLAGS='${{ env.SERVER_RUSTFLAGS }}' \
-            cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          export RUSTFLAGS="${{ env.SERVER_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           cargo +${{ env.NIGHTLY }} build -p reovim-server -p reovim-app --tests --bins
       - name: Save build cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
## Summary

- Fix broken build cache where test jobs recompiled 305 crates despite cache hit
- Root cause: `RUSTFLAGS` was set as a command prefix for `show-env` only, not exported for `cargo build`

## Problem

In #591, build steps used:
```yaml
eval "$(RUSTFLAGS='...' cargo llvm-cov show-env --sh)"
cargo build ...   # <-- RUSTFLAGS not in environment here
```

`RUSTFLAGS` as a command prefix only applies to the `show-env` command. The subsequent `cargo build` ran **without RUSTFLAGS** in its environment. Cargo's fingerprint hash includes RUSTFLAGS, so when test jobs restored the cache and ran `cargo llvm-cov` (which sets RUSTFLAGS internally), all fingerprints were invalidated — 305 crates recompiled.

Verified in CI run #22959815758 logs: `Cache restored successfully` followed by 305 `Compiling` lines.

## Fix

Export RUSTFLAGS before both `eval` and `cargo build`:
```yaml
export RUSTFLAGS="..."
eval "$(cargo llvm-cov show-env --sh)"
cargo build ...   # <-- RUSTFLAGS now in environment
```

Applied to all 3 build steps (build-mcdc workspace, build-mcdc FFI, build-server).

## Test plan

- [ ] Build jobs compile with RUSTFLAGS in environment (visible in logs)
- [ ] Test jobs show ~0 `Compiling` lines for cached deps after cache restore
- [ ] CI passes end-to-end

Refs #588