### PR TITLE
feat(options): GetOptions endpoint + option picker with detail panel (#597, #599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   `shiftwidth`, `expandtab`, `autoindent`, `textwidth` (5 Buffer-scoped options). Test helpers
   consolidated to use module-level option specs instead of per-test inline registrations.
 
+- **Option picker with detail panel (#599)**: New `picker-options` module provides a fuzzy finder
+  for editor options (`<Space>o`). Shows `[module] option_name` display with type/value detail.
+  Preview panel shows full metadata: type, current value, default, constraint, scope, owner module,
+  description, and available choices. Also fixes: command picker now shows qualified names with
+  module prefix (e.g., `editor:save` instead of `save`), and preview panel now refreshes on
+  navigation for all pickers.
+
 ### Changed
 
 - **Parallel check.sh (#588)**: Rewrite `scripts/check.sh` with parallel execution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "reovim-picker-commands",
  "reovim-picker-files",
  "reovim-picker-grep",
+ "reovim-picker-options",
 ]
 
 [[package]]
@@ -2714,6 +2715,16 @@ dependencies = [
  "reovim-kernel",
  "reovim-module-macros",
  "tempfile",
+]
+
+[[package]]
+name = "reovim-picker-options"
+version = "0.10.0-dev"
+dependencies = [
+ "reovim-driver-picker",
+ "reovim-driver-session",
+ "reovim-kernel",
+ "reovim-module-macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "server/modules/picker-buffers",
     "server/modules/picker-commands",
     "server/modules/picker-grep",
+    "server/modules/picker-options",
     "server/modules/treesitter-markdown",
     "server/modules/lsp",
     "server/modules/snippet",
@@ -239,6 +240,7 @@ reovim-picker-files = { path = "./server/modules/picker-files", version = "0.10.
 reovim-picker-buffers = { path = "./server/modules/picker-buffers", version = "0.10.0-dev" }
 reovim-picker-commands = { path = "./server/modules/picker-commands", version = "0.10.0-dev" }
 reovim-picker-grep = { path = "./server/modules/picker-grep", version = "0.10.0-dev" }
+reovim-picker-options = { path = "./server/modules/picker-options", version = "0.10.0-dev" }
 reovim-module-treesitter-markdown = { path = "./server/modules/treesitter-markdown", version = "0.10.0-dev" }
 reovim-module-lsp = { path = "./server/modules/lsp", version = "0.10.0-dev" }
 reovim-module-snippet = { path = "./server/modules/snippet", version = "0.10.0-dev" }

--- a/server/lib/drivers/picker/src/context.rs
+++ b/server/lib/drivers/picker/src/context.rs
@@ -11,6 +11,8 @@ pub struct PickerContext {
     pub buffers: Vec<BufferInfo>,
     /// Available commands (for command palette).
     pub commands: Vec<CommandInfo>,
+    /// Available options (for option picker).
+    pub options: Vec<OptionInfo>,
 }
 
 /// Information about an open buffer.
@@ -33,6 +35,31 @@ pub struct CommandInfo {
     pub description: String,
 }
 
+/// Information about a registered option.
+#[derive(Debug, Clone)]
+pub struct OptionInfo {
+    /// Option name (e.g. "number", "`picker_height`").
+    pub name: String,
+    /// Short alias if any (e.g. "nu" for "number").
+    pub short_form: Option<String>,
+    /// Human-readable description.
+    pub description: String,
+    /// Type name: "bool", "integer", "string", or "choice".
+    pub type_name: String,
+    /// Display string of the current value.
+    pub current_value: String,
+    /// Display string of the default value.
+    pub default_value: String,
+    /// Human-readable constraint description (e.g. "3..50").
+    pub constraint: Option<String>,
+    /// Scope: "global", "buffer", or "window".
+    pub scope: String,
+    /// Owning module ID (e.g. "microscope").
+    pub owner: Option<String>,
+    /// Available choices for choice-type options.
+    pub choices: Option<Vec<String>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,6 +71,7 @@ mod tests {
             query: "main".to_owned(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         assert_eq!(ctx.cwd, PathBuf::from("/home/user/project"));
         assert_eq!(ctx.query, "main");
@@ -69,6 +97,7 @@ mod tests {
                 },
             ],
             commands: vec![],
+            options: vec![],
         };
         assert_eq!(ctx.buffers.len(), 2);
         assert_eq!(ctx.buffers[0].name, "main.rs");
@@ -86,6 +115,7 @@ mod tests {
                 qualified_name: "editor:save".to_owned(),
                 description: "Save file".to_owned(),
             }],
+            options: vec![],
         };
         assert_eq!(ctx.commands.len(), 1);
         assert_eq!(ctx.commands[0].qualified_name, "editor:save");
@@ -102,6 +132,7 @@ mod tests {
                 modified: false,
             }],
             commands: vec![],
+            options: vec![],
         };
         #[allow(clippy::redundant_clone)]
         let cloned = ctx.clone();
@@ -116,6 +147,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         let debug = format!("{ctx:?}");
         assert!(debug.contains("PickerContext"));
@@ -144,5 +176,50 @@ mod tests {
         assert_eq!(cloned.qualified_name, "vim:delete");
         let debug = format!("{info:?}");
         assert!(debug.contains("CommandInfo"));
+    }
+
+    #[test]
+    fn option_info_debug_clone() {
+        let info = OptionInfo {
+            name: "number".to_owned(),
+            short_form: Some("nu".to_owned()),
+            description: "Show line numbers".to_owned(),
+            type_name: "bool".to_owned(),
+            current_value: "false".to_owned(),
+            default_value: "false".to_owned(),
+            constraint: None,
+            scope: "window".to_owned(),
+            owner: Some("options".to_owned()),
+            choices: None,
+        };
+        let cloned = info.clone();
+        assert_eq!(cloned.name, "number");
+        assert_eq!(cloned.short_form.as_deref(), Some("nu"));
+        let debug = format!("{info:?}");
+        assert!(debug.contains("OptionInfo"));
+    }
+
+    #[test]
+    fn context_with_options() {
+        let ctx = PickerContext {
+            cwd: PathBuf::from("."),
+            query: String::new(),
+            buffers: vec![],
+            commands: vec![],
+            options: vec![OptionInfo {
+                name: "number".to_owned(),
+                short_form: None,
+                description: "Line numbers".to_owned(),
+                type_name: "bool".to_owned(),
+                current_value: "true".to_owned(),
+                default_value: "false".to_owned(),
+                constraint: None,
+                scope: "window".to_owned(),
+                owner: None,
+                choices: None,
+            }],
+        };
+        assert_eq!(ctx.options.len(), 1);
+        assert_eq!(ctx.options[0].name, "number");
     }
 }

--- a/server/lib/drivers/picker/src/lib.rs
+++ b/server/lib/drivers/picker/src/lib.rs
@@ -23,7 +23,7 @@ mod registry;
 
 pub use {
     action::PickerAction,
-    context::{BufferInfo, CommandInfo, PickerContext},
+    context::{BufferInfo, CommandInfo, OptionInfo, PickerContext},
     engine::{EngineItem, PickerEngine, TickStatus, push_item, push_items},
     item::{PickerData, PickerItem},
     picker::Picker,

--- a/server/lib/drivers/picker/src/picker.rs
+++ b/server/lib/drivers/picker/src/picker.rs
@@ -167,6 +167,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         let items = picker.items(&ctx, &services());
         assert_eq!(items.len(), 1);
@@ -181,6 +182,7 @@ mod tests {
             query: "search".to_owned(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         let items = picker.items(&ctx, &services());
         assert!(items.is_empty());

--- a/server/lib/server/src/grpc/state.rs
+++ b/server/lib/server/src/grpc/state.rs
@@ -58,6 +58,24 @@ fn window_to_leaf(window: &reovim_driver_session::Window) -> WindowLeaf {
     }
 }
 
+/// Convert a kernel `OptionValue` to a proto `OptionValue`.
+fn kernel_to_proto_option(
+    value: &reovim_kernel::api::v1::OptionValue,
+) -> reovim_protocol::v2::OptionValue {
+    use reovim_protocol::v2::option_value::Value;
+
+    let proto_value = match value {
+        reovim_kernel::api::v1::OptionValue::Bool(b) => Some(Value::BoolValue(*b)),
+        reovim_kernel::api::v1::OptionValue::Integer(i) => Some(Value::IntValue(*i)),
+        reovim_kernel::api::v1::OptionValue::String(s) => Some(Value::StringValue(s.clone())),
+        reovim_kernel::api::v1::OptionValue::Choice { value, .. } => {
+            Some(Value::StringValue(value.clone()))
+        }
+    };
+
+    reovim_protocol::v2::OptionValue { value: proto_value }
+}
+
 /// gRPC `StateService` implementation.
 ///
 /// Bridges v2 protocol state queries to the session system.
@@ -186,12 +204,45 @@ impl StateService for StateServiceImpl {
 
     /// Get editor options.
     ///
-    /// Not yet implemented - requires option registry integration.
+    /// Returns the current values of requested options. If `names` is empty,
+    /// returns all registered options. Values are resolved at global scope.
+    ///
+    /// # Errors
+    ///
+    /// - `NotFound`: No active session
+    #[allow(clippy::cast_possible_truncation)]
     async fn get_options(
         &self,
-        _request: Request<GetOptionsRequest>,
+        request: Request<GetOptionsRequest>,
     ) -> Result<Response<GetOptionsResponse>, Status> {
-        Err(Status::unimplemented("GetOptions not yet implemented"))
+        let req = request.into_inner();
+        let session = self.get_session()?;
+
+        let options = session
+            .with_state(|state| {
+                use reovim_kernel::api::v1::OptionScopeId;
+
+                let registry = &state.app.kernel.options;
+                let names: Vec<String> = if req.names.is_empty() {
+                    registry.list_all()
+                } else {
+                    req.names
+                        .iter()
+                        .filter_map(|n| registry.resolve_name(n))
+                        .collect()
+                };
+
+                let mut map = std::collections::HashMap::new();
+                for name in &names {
+                    if let Some(value) = registry.get(name, OptionScopeId::Global) {
+                        map.insert(name.clone(), kernel_to_proto_option(&value));
+                    }
+                }
+                map
+            })
+            .await;
+
+        Ok(Response::new(GetOptionsResponse { options }))
     }
 
     /// Get window layout tree.
@@ -779,15 +830,108 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_options_unimplemented() {
+    async fn test_get_options_empty_registry() {
         let registry = test_registry();
         let service = StateServiceImpl::new(registry, SessionId::new("test"));
 
         let request = Request::new(GetOptionsRequest { names: vec![] });
         let response = service.get_options(request).await;
 
-        assert!(response.is_err());
-        assert_eq!(response.unwrap_err().code(), tonic::Code::Unimplemented);
+        assert!(response.is_ok());
+        let resp = response.unwrap().into_inner();
+        assert!(resp.options.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_options_with_registered_options() {
+        let (registry, session) = test_registry_with_session();
+        let service = StateServiceImpl::new(Arc::clone(&registry), SessionId::new("test"));
+
+        // Register options in the kernel
+        session
+            .with_state(|state| {
+                use reovim_kernel::api::v1::{OptionSpec, OptionValue as KernelOptionValue};
+
+                state
+                    .app
+                    .kernel
+                    .options
+                    .register(OptionSpec::new(
+                        "number",
+                        "Show line numbers",
+                        KernelOptionValue::bool(false),
+                    ))
+                    .unwrap();
+            })
+            .await;
+
+        // Query all options
+        let request = Request::new(GetOptionsRequest { names: vec![] });
+        let response = service.get_options(request).await;
+
+        assert!(response.is_ok());
+        let resp = response.unwrap().into_inner();
+        assert_eq!(resp.options.len(), 1);
+        assert!(resp.options.contains_key("number"));
+
+        let val = resp.options.get("number").unwrap();
+        assert_eq!(val.value, Some(reovim_protocol::v2::option_value::Value::BoolValue(false)));
+    }
+
+    #[tokio::test]
+    async fn test_get_options_by_name() {
+        let (registry, session) = test_registry_with_session();
+        let service = StateServiceImpl::new(Arc::clone(&registry), SessionId::new("test"));
+
+        session
+            .with_state(|state| {
+                use reovim_kernel::api::v1::{OptionSpec, OptionValue as KernelOptionValue};
+
+                state
+                    .app
+                    .kernel
+                    .options
+                    .register(OptionSpec::new(
+                        "number",
+                        "Show line numbers",
+                        KernelOptionValue::bool(false),
+                    ))
+                    .unwrap();
+                state
+                    .app
+                    .kernel
+                    .options
+                    .register(OptionSpec::new("tabstop", "Tab width", KernelOptionValue::int(8)))
+                    .unwrap();
+            })
+            .await;
+
+        // Query only "number"
+        let request = Request::new(GetOptionsRequest {
+            names: vec!["number".to_string()],
+        });
+        let response = service.get_options(request).await;
+
+        assert!(response.is_ok());
+        let resp = response.unwrap().into_inner();
+        assert_eq!(resp.options.len(), 1);
+        assert!(resp.options.contains_key("number"));
+        assert!(!resp.options.contains_key("tabstop"));
+    }
+
+    #[tokio::test]
+    async fn test_get_options_unknown_name_ignored() {
+        let registry = test_registry();
+        let service = StateServiceImpl::new(registry, SessionId::new("test"));
+
+        let request = Request::new(GetOptionsRequest {
+            names: vec!["nonexistent".to_string()],
+        });
+        let response = service.get_options(request).await;
+
+        assert!(response.is_ok());
+        let resp = response.unwrap().into_inner();
+        assert!(resp.options.is_empty());
     }
 
     #[tokio::test]

--- a/server/modules/defaults/Cargo.toml
+++ b/server/modules/defaults/Cargo.toml
@@ -39,6 +39,7 @@ reovim-picker-files = { workspace = true }
 reovim-picker-buffers = { workspace = true }
 reovim-picker-commands = { workspace = true }
 reovim-picker-grep = { workspace = true }
+reovim-picker-options = { workspace = true }
 reovim-module-microscope = { workspace = true }
 
 # Explorer module

--- a/server/modules/defaults/src/lib.rs
+++ b/server/modules/defaults/src/lib.rs
@@ -59,7 +59,7 @@ use {
     reovim_module_vim_range_finder as vim_range_finder, reovim_module_vim_snippet as vim_snippet,
     reovim_module_whichkey as whichkey, reovim_picker_buffers as picker_buffers,
     reovim_picker_commands as picker_commands, reovim_picker_files as picker_files,
-    reovim_picker_grep as picker_grep,
+    reovim_picker_grep as picker_grep, reovim_picker_options as picker_options,
 };
 
 /// Default modules bundle.
@@ -119,6 +119,7 @@ impl DefaultsModule {
             Box::new(picker_buffers::PickerBuffersModule::new()),
             Box::new(picker_commands::PickerCommandsModule::new()),
             Box::new(picker_grep::PickerGrepModule::new()),
+            Box::new(picker_options::PickerOptionsModule::new()),
             // Picker orchestration (#522)
             Box::new(microscope::MicroscopeModule::new()),
             // Vim-microscope adapter - bridges vim keybindings to picker commands
@@ -200,6 +201,7 @@ impl Module for DefaultsModule {
             ModuleId::new("picker-buffers"),
             ModuleId::new("picker-commands"),
             ModuleId::new("picker-grep"),
+            ModuleId::new("picker-options"),
             // Picker orchestration (#522)
             ModuleId::new("microscope"),
             // Syntax highlighting modules (Epic #465 Phase 12.1, 12.2)
@@ -291,7 +293,7 @@ mod tests {
         // Utility modules (2): keymap, commands
         // Policy modules (3): editor, motions, vim
         // Extension bridge modules (3): cmdline, whichkey, notification
-        // Picker providers (4): picker-files, picker-buffers, picker-commands, picker-grep
+        // Picker providers (5): picker-files, picker-buffers, picker-commands, picker-grep, picker-options
         // Picker orchestration (1): microscope
         // Syntax modules (2): treesitter-rust, treesitter-markdown
         // Code intelligence modules (3): lsp, lsp-navigation, vim-lsp
@@ -301,8 +303,8 @@ mod tests {
         // Explorer (1): explorer
         // Vim adapter modules (5): vim-microscope, vim-explorer, vim-completion, vim-range-finder, vim-snippet
         // Tetromino (1): tetromino
-        // Total: 34 modules
-        assert_eq!(deps.len(), 34);
+        // Total: 35 modules
+        assert_eq!(deps.len(), 35);
     }
 
     #[test]
@@ -312,7 +314,7 @@ mod tests {
         // Utility modules (2): keymap, commands
         // Policy modules (3): editor, motions, vim
         // Extension bridge modules (3): cmdline, whichkey, notification
-        // Picker providers (4): picker-files, picker-buffers, picker-commands, picker-grep
+        // Picker providers (5): picker-files, picker-buffers, picker-commands, picker-grep, picker-options
         // Picker orchestration (1): microscope
         // Syntax modules (2): treesitter-rust, treesitter-markdown
         // Code intelligence modules (3): lsp, lsp-navigation, vim-lsp
@@ -323,7 +325,7 @@ mod tests {
         // Vim adapter modules (5): vim-microscope, vim-explorer, vim-completion, vim-range-finder, vim-snippet
         // Tetromino (1): tetromino
         // Total: 33 modules
-        assert_eq!(modules.len(), 34);
+        assert_eq!(modules.len(), 35);
     }
 
     #[test]

--- a/server/modules/lsp-navigation/src/picker.rs
+++ b/server/modules/lsp-navigation/src/picker.rs
@@ -191,6 +191,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         assert!(picker.items(&ctx, &services()).is_empty());
     }

--- a/server/modules/microscope/src/commands.rs
+++ b/server/modules/microscope/src/commands.rs
@@ -7,7 +7,7 @@ use {
     reovim_driver_command_types::{CommandContext, CommandResult},
     reovim_driver_picker::{PickerAction, PickerContext, PickerRegistry, push_items},
     reovim_driver_session::{BufferApi, ExtensionApi, ModeApi, SessionRuntime, TransitionContext},
-    reovim_kernel::api::v1::CommandId,
+    reovim_kernel::api::v1::{CommandId, OptionScopeId},
 };
 
 use crate::{ids, modes::MicroscopeMode, state::MicroscopeState};
@@ -79,6 +79,27 @@ impl CommandHandler for OpenGrep {
     }
 }
 
+/// Open the option picker.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenOptions;
+
+impl reovim_driver_command::Command for OpenOptions {
+    fn id(&self) -> CommandId {
+        ids::OPEN_OPTIONS
+    }
+
+    fn description(&self) -> &'static str {
+        "Open option picker"
+    }
+}
+
+impl CommandHandler for OpenOptions {
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn execute(&self, runtime: &mut SessionRuntime<'_>, _args: &CommandContext) -> CommandResult {
+        open_picker(runtime, "options", "Options", "> ")
+    }
+}
+
 /// Open the command picker.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OpenCommands;
@@ -127,6 +148,7 @@ impl CommandHandler for NextItem {
         }
         if state.matched_count > 0 {
             state.selected = (state.selected + 1) % state.matched_count as usize;
+            state.update_preview();
         }
         CommandResult::Success
     }
@@ -156,6 +178,7 @@ impl CommandHandler for PrevItem {
         if state.matched_count > 0 {
             let count = state.matched_count as usize;
             state.selected = (state.selected + count - 1) % count;
+            state.update_preview();
         }
         CommandResult::Success
     }
@@ -308,11 +331,45 @@ fn open_picker(
             svc.list_all()
                 .iter()
                 .map(|c| reovim_driver_picker::CommandInfo {
-                    qualified_name: c.id.name().to_string(),
+                    qualified_name: c.id.to_string(),
                     description: c.description.clone(),
                 })
                 .collect()
         });
+
+    // Collect option info from OptionRegistry (needed by option picker).
+    let options: Vec<_> = {
+        let registry = &runtime.kernel().options;
+        registry
+            .list_all()
+            .iter()
+            .filter_map(|name| {
+                let spec = registry.get_spec(name)?;
+                let current = registry
+                    .get(name, OptionScopeId::Global)
+                    .unwrap_or_else(|| spec.default.clone());
+                Some(reovim_driver_picker::OptionInfo {
+                    name: name.clone(),
+                    short_form: spec.short_form.as_ref().map(ToString::to_string),
+                    description: spec.description.to_string(),
+                    type_name: current.type_name().to_string(),
+                    current_value: current.to_string(),
+                    default_value: spec.default.to_string(),
+                    constraint: format_constraint(&spec.constraint),
+                    scope: spec.scope.display_name().to_string(),
+                    owner: spec.owner().map(|m| m.as_str().to_string()),
+                    choices: if let reovim_kernel::api::v1::OptionValue::Choice {
+                        choices, ..
+                    } = &spec.default
+                    {
+                        Some(choices.clone())
+                    } else {
+                        None
+                    },
+                })
+            })
+            .collect()
+    };
 
     // Fetch items from the picker.
     let items = services
@@ -325,6 +382,7 @@ fn open_picker(
                     query: String::new(),
                     buffers,
                     commands,
+                    options,
                 };
                 picker.items(&ctx, &services)
             } else {
@@ -356,6 +414,21 @@ fn open_picker(
     CommandResult::Success
 }
 
+/// Format an `OptionConstraint` as a human-readable string.
+///
+/// Returns `None` for unconstrained options.
+fn format_constraint(c: &reovim_kernel::api::v1::OptionConstraint) -> Option<String> {
+    match (c.min, c.max, c.min_length, c.max_length) {
+        (Some(min), Some(max), _, _) => Some(format!("{min}..{max}")),
+        (Some(min), None, _, _) => Some(format!(">={min}")),
+        (None, Some(max), _, _) => Some(format!("<={max}")),
+        (_, _, Some(min_len), Some(max_len)) => Some(format!("len {min_len}..{max_len}")),
+        (_, _, Some(min_len), None) => Some(format!("len >={min_len}")),
+        (_, _, None, Some(max_len)) => Some(format!("len <={max_len}")),
+        _ => None,
+    }
+}
+
 /// Close the picker and return to the previous mode via pop.
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn close_picker(runtime: &mut SessionRuntime<'_>) {
@@ -377,6 +450,7 @@ pub fn command_handlers() -> Vec<Box<dyn CommandHandler>> {
         Box::new(OpenBuffers),
         Box::new(OpenGrep),
         Box::new(OpenCommands),
+        Box::new(OpenOptions),
         Box::new(NextItem),
         Box::new(PrevItem),
         Box::new(SelectItem),
@@ -418,6 +492,13 @@ mod tests {
     }
 
     #[test]
+    fn open_options_metadata() {
+        let cmd = OpenOptions;
+        assert_eq!(cmd.id(), ids::OPEN_OPTIONS);
+        assert!(!cmd.description().is_empty());
+    }
+
+    #[test]
     fn next_item_metadata() {
         let cmd = NextItem;
         assert_eq!(cmd.id(), ids::NEXT_ITEM);
@@ -455,7 +536,7 @@ mod tests {
     #[test]
     fn command_handlers_not_empty() {
         let handlers = command_handlers();
-        assert_eq!(handlers.len(), 9);
+        assert_eq!(handlers.len(), 10);
     }
 
     #[test]
@@ -466,5 +547,35 @@ mod tests {
         deduped.sort_by_key(CommandId::name);
         deduped.dedup_by_key(|id| id.name());
         assert_eq!(ids.len(), deduped.len());
+    }
+
+    #[test]
+    fn format_constraint_range() {
+        let c = reovim_kernel::api::v1::OptionConstraint::range(3, 50);
+        assert_eq!(format_constraint(&c), Some("3..50".to_owned()));
+    }
+
+    #[test]
+    fn format_constraint_min() {
+        let c = reovim_kernel::api::v1::OptionConstraint::min(0);
+        assert_eq!(format_constraint(&c), Some(">=0".to_owned()));
+    }
+
+    #[test]
+    fn format_constraint_max() {
+        let c = reovim_kernel::api::v1::OptionConstraint::max(100);
+        assert_eq!(format_constraint(&c), Some("<=100".to_owned()));
+    }
+
+    #[test]
+    fn format_constraint_string_length() {
+        let c = reovim_kernel::api::v1::OptionConstraint::string_length(0, 10);
+        assert_eq!(format_constraint(&c), Some("len 0..10".to_owned()));
+    }
+
+    #[test]
+    fn format_constraint_none() {
+        let c = reovim_kernel::api::v1::OptionConstraint::none();
+        assert_eq!(format_constraint(&c), None);
     }
 }

--- a/server/modules/microscope/src/ids.rs
+++ b/server/modules/microscope/src/ids.rs
@@ -29,6 +29,9 @@ pub const NEXT_ITEM: CommandId = CommandId::new(MODULE, "next-item");
 /// Move selection to the previous item.
 pub const PREV_ITEM: CommandId = CommandId::new(MODULE, "prev-item");
 
+/// Open the option picker.
+pub const OPEN_OPTIONS: CommandId = CommandId::new(MODULE, "open-options");
+
 /// Delete the character before the cursor in the query.
 pub const BACKSPACE: CommandId = CommandId::new(MODULE, "backspace");
 
@@ -48,6 +51,7 @@ mod tests {
             OPEN_BUFFERS,
             OPEN_GREP,
             OPEN_COMMANDS,
+            OPEN_OPTIONS,
             SELECT_ITEM,
             CLOSE,
             NEXT_ITEM,
@@ -66,6 +70,7 @@ mod tests {
             OPEN_BUFFERS.name(),
             OPEN_GREP.name(),
             OPEN_COMMANDS.name(),
+            OPEN_OPTIONS.name(),
             SELECT_ITEM.name(),
             CLOSE.name(),
             NEXT_ITEM.name(),

--- a/server/modules/microscope/src/state.rs
+++ b/server/modules/microscope/src/state.rs
@@ -143,6 +143,7 @@ impl MicroscopeState {
                 query: self.query.clone(),
                 buffers: Vec::new(),
                 commands: Vec::new(),
+                options: Vec::new(),
             };
             let items = picker.items(&ctx, services);
             self.engine.restart();
@@ -177,6 +178,24 @@ impl MicroscopeState {
             self.selected = 0;
         } else {
             self.selected = self.selected.min(self.matched_count as usize - 1);
+        }
+
+        self.update_preview();
+    }
+
+    /// Fetch preview content for the currently selected item.
+    ///
+    /// Called after selection changes (next/prev) and after engine refresh
+    /// to keep the preview panel in sync with the highlighted item.
+    pub fn update_preview(&mut self) {
+        if let Some(services) = &self.services
+            && let Some(registry) = services.get::<PickerRegistry>()
+            && let Some(picker) = registry.get(&self.picker_name)
+            && self.selected < self.full_items.len()
+        {
+            self.preview = picker.preview(&self.full_items[self.selected], services);
+        } else {
+            self.preview = None;
         }
     }
 }

--- a/server/modules/picker-buffers/src/lib.rs
+++ b/server/modules/picker-buffers/src/lib.rs
@@ -155,6 +155,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         }
     }
 
@@ -203,6 +204,7 @@ mod tests {
                 },
             ],
             commands: vec![],
+            options: vec![],
         };
 
         let items = picker.items(&ctx, &services());

--- a/server/modules/picker-commands/src/lib.rs
+++ b/server/modules/picker-commands/src/lib.rs
@@ -152,6 +152,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         }
     }
 
@@ -198,6 +199,7 @@ mod tests {
                     description: "Quit the editor".to_owned(),
                 },
             ],
+            options: vec![],
         };
 
         let items = picker.items(&ctx, &services());

--- a/server/modules/picker-files/src/lib.rs
+++ b/server/modules/picker-files/src/lib.rs
@@ -261,6 +261,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         }
     }
 

--- a/server/modules/picker-grep/src/lib.rs
+++ b/server/modules/picker-grep/src/lib.rs
@@ -322,6 +322,7 @@ mod tests {
             query: String::new(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         assert!(picker.items(&ctx, &services()).is_empty());
     }
@@ -461,6 +462,7 @@ mod tests {
             query: "unique_grep_test_marker".to_owned(),
             buffers: vec![],
             commands: vec![],
+            options: vec![],
         };
         let items = picker.items(&ctx, &services());
         // rg may or may not be installed; if it is, we get results.

--- a/server/modules/picker-options/Cargo.toml
+++ b/server/modules/picker-options/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "reovim-picker-options"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Option picker module for reovim - browse and inspect editor options"
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+dynamic = []  # Enable FFI entry points for standalone dynamic loading
+
+[dependencies]
+reovim-kernel = { workspace = true }
+reovim-driver-picker = { workspace = true }
+reovim-driver-session = { workspace = true }
+reovim-module-macros = { workspace = true }
+
+[lints]
+workspace = true

--- a/server/modules/picker-options/src/lib.rs
+++ b/server/modules/picker-options/src/lib.rs
@@ -1,0 +1,498 @@
+#![cfg_attr(coverage_nightly, allow(unused_features))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! Option picker module for reovim.
+//!
+//! Provides a picker to browse and inspect editor options.
+//! Registers `OptionsPicker` in the `PickerRegistry` during module init.
+//! The preview panel shows detailed option metadata (type, value,
+//! default, constraint, scope, owner).
+
+use std::sync::Arc;
+
+use {
+    reovim_driver_picker::{
+        Picker, PickerAction, PickerContext, PickerData, PickerItem, PickerRegistry, PreviewContent,
+    },
+    reovim_kernel::api::v1::{Module, ModuleContext, ModuleError, ModuleId, ProbeResult, Version},
+};
+
+// ============================================================================
+// OptionsPicker
+// ============================================================================
+
+/// Picker that lists registered editor options.
+///
+/// Reads `ctx.options` and produces items for each option.
+/// The preview panel shows full metadata: type, value, default,
+/// constraint, scope, and owner module.
+pub struct OptionsPicker;
+
+impl OptionsPicker {
+    /// Create a new instance.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OptionsPicker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Picker for OptionsPicker {
+    fn name(&self) -> &'static str {
+        "options"
+    }
+
+    fn title(&self) -> &'static str {
+        "Options"
+    }
+
+    fn items(
+        &self,
+        ctx: &PickerContext,
+        _services: &reovim_kernel::api::v1::ServiceRegistry,
+    ) -> Vec<PickerItem> {
+        ctx.options
+            .iter()
+            .map(|opt| {
+                let display = opt
+                    .owner
+                    .as_ref()
+                    .map_or_else(|| opt.name.clone(), |owner| format!("[{owner}] {}", opt.name));
+                let detail = format!("{} = {}", opt.type_name, opt.current_value);
+                // Encode full metadata into PickerData::Text for preview().
+                let data = build_preview_data(opt);
+                PickerItem {
+                    display,
+                    detail: Some(detail),
+                    data: PickerData::Text(data),
+                    icon: None,
+                }
+            })
+            .collect()
+    }
+
+    fn on_select(&self, _item: &PickerItem) -> PickerAction {
+        PickerAction::Close
+    }
+
+    fn preview(
+        &self,
+        item: &PickerItem,
+        _services: &reovim_kernel::api::v1::ServiceRegistry,
+    ) -> Option<PreviewContent> {
+        let PickerData::Text(ref data) = item.data else {
+            return None;
+        };
+
+        let lines: Vec<String> = data.lines().map(String::from).collect();
+        if lines.is_empty() {
+            return None;
+        }
+
+        Some(PreviewContent {
+            lines,
+            highlight_line: Some(0),
+            file_path: None,
+        })
+    }
+}
+
+// ============================================================================
+// Preview data builder
+// ============================================================================
+
+/// Build a multi-line preview string from option metadata.
+///
+/// Each line is a key-value pair showing the option's full specification.
+/// This string is stored in `PickerData::Text` and split back into lines
+/// by `preview()` for display.
+fn build_preview_data(opt: &reovim_driver_picker::OptionInfo) -> String {
+    let mut lines = Vec::with_capacity(10);
+
+    lines.push(format!("  {}", opt.name));
+    if let Some(ref short) = opt.short_form {
+        lines.push(format!("  alias: {short}"));
+    }
+    lines.push(String::new());
+    lines.push(format!("  {}", opt.description));
+    lines.push(String::new());
+    lines.push(format!("  Type:     {}", opt.type_name));
+    lines.push(format!("  Value:    {}", opt.current_value));
+    lines.push(format!("  Default:  {}", opt.default_value));
+    lines.push(format!("  Scope:    {}", opt.scope));
+
+    if let Some(ref constraint) = opt.constraint {
+        lines.push(format!("  Range:    {constraint}"));
+    }
+
+    if let Some(ref owner) = opt.owner {
+        lines.push(format!("  Module:   {owner}"));
+    }
+
+    if let Some(ref choices) = opt.choices {
+        lines.push(format!("  Choices:  {}", choices.join(", ")));
+    }
+
+    lines.join("\n")
+}
+
+// ============================================================================
+// Module implementation
+// ============================================================================
+
+/// Option picker module.
+///
+/// Registers `OptionsPicker` in `PickerRegistry` during init.
+pub struct PickerOptionsModule;
+
+impl PickerOptionsModule {
+    /// Create a new instance.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PickerOptionsModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Module for PickerOptionsModule {
+    fn id(&self) -> ModuleId {
+        ModuleId::new("picker-options")
+    }
+
+    fn name(&self) -> &'static str {
+        "Option Picker"
+    }
+
+    fn version(&self) -> Version {
+        Version::new(0, 1, 0)
+    }
+
+    fn init(&mut self, ctx: &ModuleContext) -> ProbeResult {
+        let registry = ctx.services.get_or_create::<PickerRegistry>();
+        registry.register(Arc::new(OptionsPicker));
+        ProbeResult::Success
+    }
+
+    fn exit(&mut self) -> Result<(), ModuleError> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "dynamic")]
+reovim_module_macros::declare_module!(PickerOptionsModule);
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use reovim_driver_picker::OptionInfo;
+
+    use super::*;
+
+    fn services() -> reovim_kernel::api::v1::ServiceRegistry {
+        reovim_kernel::api::v1::ServiceRegistry::new()
+    }
+
+    fn empty_ctx() -> PickerContext {
+        PickerContext {
+            cwd: PathBuf::from("."),
+            query: String::new(),
+            buffers: vec![],
+            commands: vec![],
+            options: vec![],
+        }
+    }
+
+    #[test]
+    fn name_and_title() {
+        let picker = OptionsPicker::new();
+        assert_eq!(picker.name(), "options");
+        assert_eq!(picker.title(), "Options");
+    }
+
+    #[test]
+    fn is_static() {
+        let picker = OptionsPicker::new();
+        assert!(picker.is_static());
+    }
+
+    #[test]
+    fn default_prompt() {
+        let picker = OptionsPicker::new();
+        assert_eq!(picker.prompt(), "> ");
+    }
+
+    #[test]
+    fn items_empty_context() {
+        let picker = OptionsPicker::new();
+        let items = picker.items(&empty_ctx(), &services());
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn items_with_options() {
+        let picker = OptionsPicker::new();
+        let ctx = PickerContext {
+            cwd: PathBuf::from("."),
+            query: String::new(),
+            buffers: vec![],
+            commands: vec![],
+            options: vec![
+                OptionInfo {
+                    name: "number".to_owned(),
+                    short_form: Some("nu".to_owned()),
+                    description: "Show line numbers".to_owned(),
+                    type_name: "bool".to_owned(),
+                    current_value: "false".to_owned(),
+                    default_value: "false".to_owned(),
+                    constraint: None,
+                    scope: "window".to_owned(),
+                    owner: Some("options".to_owned()),
+                    choices: None,
+                },
+                OptionInfo {
+                    name: "picker_height".to_owned(),
+                    short_form: None,
+                    description: "Maximum height of the picker window".to_owned(),
+                    type_name: "integer".to_owned(),
+                    current_value: "15".to_owned(),
+                    default_value: "15".to_owned(),
+                    constraint: Some("3..50".to_owned()),
+                    scope: "global".to_owned(),
+                    owner: Some("microscope".to_owned()),
+                    choices: None,
+                },
+            ],
+        };
+        let items = picker.items(&ctx, &services());
+        assert_eq!(items.len(), 2);
+
+        // Option with owner shows "[module] name" format.
+        assert_eq!(items[0].display, "[options] number");
+        assert_eq!(items[0].detail.as_deref(), Some("bool = false"));
+
+        assert_eq!(items[1].display, "[microscope] picker_height");
+        assert_eq!(items[1].detail.as_deref(), Some("integer = 15"));
+    }
+
+    #[test]
+    fn items_without_owner() {
+        let picker = OptionsPicker::new();
+        let ctx = PickerContext {
+            cwd: PathBuf::from("."),
+            query: String::new(),
+            buffers: vec![],
+            commands: vec![],
+            options: vec![OptionInfo {
+                name: "orphan".to_owned(),
+                short_form: None,
+                description: "No owner".to_owned(),
+                type_name: "string".to_owned(),
+                current_value: "value".to_owned(),
+                default_value: "default".to_owned(),
+                constraint: None,
+                scope: "global".to_owned(),
+                owner: None,
+                choices: None,
+            }],
+        };
+        let items = picker.items(&ctx, &services());
+        assert_eq!(items[0].display, "orphan");
+    }
+
+    #[test]
+    fn on_select_closes() {
+        let picker = OptionsPicker::new();
+        let item = PickerItem {
+            display: "number".to_owned(),
+            detail: None,
+            data: PickerData::Text("number".to_owned()),
+            icon: None,
+        };
+        assert!(matches!(picker.on_select(&item), PickerAction::Close));
+    }
+
+    #[test]
+    fn preview_text_data() {
+        let picker = OptionsPicker::new();
+        let data = build_preview_data(&OptionInfo {
+            name: "number".to_owned(),
+            short_form: Some("nu".to_owned()),
+            description: "Show line numbers".to_owned(),
+            type_name: "bool".to_owned(),
+            current_value: "false".to_owned(),
+            default_value: "false".to_owned(),
+            constraint: None,
+            scope: "window".to_owned(),
+            owner: Some("options".to_owned()),
+            choices: None,
+        });
+        let item = PickerItem {
+            display: "[options] number".to_owned(),
+            detail: Some("bool = false".to_owned()),
+            data: PickerData::Text(data),
+            icon: None,
+        };
+        let preview = picker.preview(&item, &services());
+        assert!(preview.is_some());
+        let preview = preview.unwrap();
+        assert!(preview.lines[0].contains("number"));
+        assert!(preview.lines.iter().any(|l| l.contains("Type:")));
+        assert!(preview.lines.iter().any(|l| l.contains("alias: nu")));
+        assert!(preview.lines.iter().any(|l| l.contains("Module:")));
+        assert_eq!(preview.highlight_line, Some(0));
+    }
+
+    #[test]
+    fn preview_wrong_data() {
+        let picker = OptionsPicker::new();
+        let item = PickerItem {
+            display: "x".to_owned(),
+            detail: None,
+            data: PickerData::BufferId(1),
+            icon: None,
+        };
+        assert!(picker.preview(&item, &services()).is_none());
+    }
+
+    #[test]
+    #[allow(clippy::default_constructed_unit_structs)]
+    fn default_impl() {
+        let picker = OptionsPicker::default();
+        assert_eq!(picker.name(), "options");
+    }
+
+    #[test]
+    fn build_preview_data_full() {
+        let info = OptionInfo {
+            name: "picker_border".to_owned(),
+            short_form: None,
+            description: "Border style for picker window".to_owned(),
+            type_name: "choice".to_owned(),
+            current_value: "rounded".to_owned(),
+            default_value: "rounded".to_owned(),
+            constraint: None,
+            scope: "global".to_owned(),
+            owner: Some("microscope".to_owned()),
+            choices: Some(vec![
+                "none".to_owned(),
+                "single".to_owned(),
+                "double".to_owned(),
+                "rounded".to_owned(),
+            ]),
+        };
+        let data = build_preview_data(&info);
+        assert!(data.contains("picker_border"));
+        assert!(data.contains("Type:"));
+        assert!(data.contains("choice"));
+        assert!(data.contains("Choices:"));
+        assert!(data.contains("none, single, double, rounded"));
+        assert!(data.contains("Module:"));
+        assert!(data.contains("microscope"));
+    }
+
+    #[test]
+    fn build_preview_data_minimal() {
+        let info = OptionInfo {
+            name: "simple".to_owned(),
+            short_form: None,
+            description: "A simple option".to_owned(),
+            type_name: "bool".to_owned(),
+            current_value: "true".to_owned(),
+            default_value: "true".to_owned(),
+            constraint: None,
+            scope: "global".to_owned(),
+            owner: None,
+            choices: None,
+        };
+        let data = build_preview_data(&info);
+        assert!(data.contains("simple"));
+        assert!(!data.contains("alias:"));
+        assert!(!data.contains("Range:"));
+        assert!(!data.contains("Module:"));
+        assert!(!data.contains("Choices:"));
+    }
+
+    #[test]
+    fn build_preview_data_with_constraint() {
+        let info = OptionInfo {
+            name: "height".to_owned(),
+            short_form: Some("h".to_owned()),
+            description: "Height setting".to_owned(),
+            type_name: "integer".to_owned(),
+            current_value: "15".to_owned(),
+            default_value: "15".to_owned(),
+            constraint: Some("3..50".to_owned()),
+            scope: "global".to_owned(),
+            owner: None,
+            choices: None,
+        };
+        let data = build_preview_data(&info);
+        assert!(data.contains("alias: h"));
+        assert!(data.contains("Range:    3..50"));
+    }
+
+    // -- Module tests --
+
+    #[test]
+    fn module_id() {
+        let module = PickerOptionsModule::new();
+        assert_eq!(module.id().as_str(), "picker-options");
+    }
+
+    #[test]
+    fn module_name() {
+        let module = PickerOptionsModule::new();
+        assert_eq!(module.name(), "Option Picker");
+    }
+
+    #[test]
+    fn module_version() {
+        let module = PickerOptionsModule::new();
+        let version = module.version();
+        assert_eq!(version.major, 0);
+        assert_eq!(version.minor, 1);
+    }
+
+    #[test]
+    #[allow(clippy::default_constructed_unit_structs)]
+    fn module_default() {
+        let module = PickerOptionsModule::default();
+        assert_eq!(module.id().as_str(), "picker-options");
+    }
+
+    #[test]
+    fn module_exit() {
+        let mut module = PickerOptionsModule::new();
+        assert!(module.exit().is_ok());
+    }
+
+    #[test]
+    fn module_init_registers_picker() {
+        let services = Arc::new(reovim_kernel::api::v1::ServiceRegistry::new());
+        let ctx = ModuleContext::new(
+            reovim_kernel::api::v1::KernelContext::default(),
+            services.clone(),
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp"),
+        );
+
+        let mut module = PickerOptionsModule::new();
+        let result = module.init(&ctx);
+        assert!(matches!(result, ProbeResult::Success));
+
+        let registry = services.get::<PickerRegistry>();
+        assert!(registry.is_some());
+        let reg = registry.unwrap();
+        assert!(reg.get("options").is_some());
+    }
+}

--- a/server/modules/vim-microscope/src/lib.rs
+++ b/server/modules/vim-microscope/src/lib.rs
@@ -89,6 +89,10 @@ impl Module for VimMicroscopeModule {
                 .with_modes(&["vim:normal"])
                 .with_category("picker")
                 .with_description("Open command picker"),
+            KeybindingRegistration::new("<Space>o", microscope::OPEN_OPTIONS)
+                .with_modes(&["vim:normal"])
+                .with_category("picker")
+                .with_description("Open option picker"),
         ]
     }
 }
@@ -152,7 +156,7 @@ mod tests {
     #[test]
     fn keybindings_count() {
         let module = VimMicroscopeModule::new();
-        assert_eq!(module.keybindings().len(), 4);
+        assert_eq!(module.keybindings().len(), 5);
     }
 
     #[test]
@@ -163,6 +167,7 @@ mod tests {
         assert!(keys.contains(&"<Space>b"));
         assert!(keys.contains(&"<Space>g"));
         assert!(keys.contains(&"<Space>;"));
+        assert!(keys.contains(&"<Space>o"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implement `GetOptions` gRPC endpoint for querying editor options (#597)
- Add option picker module with detail panel and module ID display (#599)

## Changes

### GetOptions gRPC endpoint (#597)
- Implement `GetOptions` RPC handler in server returning registered option specs
- Wire up option registry data to gRPC response format

### Option picker with detail panel (#599)
- New `picker-options` crate providing fuzzy finder for editor options via `<Space>o`
- Display format: `[module] option_name` with `type = value` detail
- Preview panel renders full metadata: type, current value, default, constraint, scope, owner module, description, and available choices
- Fix command picker showing local name instead of qualified name (e.g., `save` -> `editor:save`)
- Fix preview panel never refreshing on navigation (NextItem/PrevItem now call `update_preview()`)
- Add `OptionInfo` to `PickerContext` for option metadata collection
- Register `picker-options` in defaults module bundle

## Test plan
- [x] `./scripts/check.sh` passes (fmt + clippy + tests)
- [x] 272 tests pass across 9 affected crates
- [x] New picker-options crate has 19 unit tests covering all code paths
- [x] Go Poll: Mission Control A+, Telemetry A, Flight Director A

Closes #597, Closes #599