### PR TITLE
fix(ci): use show-env in test steps to match build target dir (#588)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# Nextest configuration
+# https://nexte.st/docs/configuration/
+
+[profile.default]
+# Local development: catch stuck tests early
+slow-timeout = { period = "30s", terminate-after = 3 }
+fail-fast = true
+
+[profile.ci]
+# CI: more lenient timeout, run all tests to see full failure picture
+slow-timeout = { period = "60s", terminate-after = 2 }
+fail-fast = false

--- a/.github/actions/setup-coverage/action.yml
+++ b/.github/actions/setup-coverage/action.yml
@@ -1,0 +1,27 @@
+name: Setup Coverage Toolchain
+description: Install nightly Rust with llvm-tools, cargo-llvm-cov, and protoc
+
+inputs:
+  nightly:
+    description: Nightly toolchain version
+    required: true
+  install-nextest:
+    description: Also install cargo-nextest
+    default: "false"
+  github-token:
+    description: GitHub token for protoc download
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        toolchain: ${{ inputs.nightly }}
+        components: llvm-tools-preview
+    - uses: taiki-e/install-action@cargo-llvm-cov
+    - if: inputs.install-nextest == 'true'
+      uses: taiki-e/install-action@nextest
+    - uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,13 +148,15 @@ jobs:
         run: find target -name '*.profraw' -delete 2>/dev/null || true
       - name: Run unit tests with coverage
         run: |
-          RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}" \
-          cargo +${{ env.NIGHTLY }} llvm-cov --no-clean nextest --lib --workspace \
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          cargo +${{ env.NIGHTLY }} nextest run --lib --workspace \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
             --exclude reovim-bench \
             --exclude perf-report \
-            --exclude reovim-server \
+            --exclude reovim-server
+          cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path mcdc-unit.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-unit.info
@@ -191,13 +193,15 @@ jobs:
         run: find target -name '*.profraw' -delete 2>/dev/null || true
       - name: Run integration tests with coverage
         run: |
-          RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}" \
-          cargo +${{ env.NIGHTLY }} llvm-cov --no-clean nextest --test '*' --workspace \
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          cargo +${{ env.NIGHTLY }} nextest run --test '*' --workspace \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
             --exclude reovim-bench \
             --exclude perf-report \
-            --exclude reovim-server \
+            --exclude reovim-server
+          cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path mcdc-integration.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-integration.info
@@ -234,8 +238,10 @@ jobs:
         run: find target -name '*.profraw' -delete 2>/dev/null || true
       - name: Run server tests with coverage
         run: |
-          RUSTFLAGS="${{ env.SERVER_RUSTFLAGS }}" \
-          cargo +${{ env.NIGHTLY }} llvm-cov --no-clean nextest -p reovim-server \
+          export RUSTFLAGS="${{ env.SERVER_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
+          cargo +${{ env.NIGHTLY }} nextest run -p reovim-server
+          cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path server-lcov.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh server-lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
           cargo +${{ env.NIGHTLY }} clippy
           --all-targets --all-features --workspace -- -D warnings
 
-  # ─── MSRV Check (non-blocking, parallel) ───
-  msrv:
-    name: MSRV Check
+  # ─── Stable Checks (MSRV + doc tests, non-blocking) ───
+  stable-checks:
+    name: Stable Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,22 +51,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: MSRV check (key crates)
         run: cargo +1.92 check -p reovim-app -p reovim-kernel -p reovim-server
+      - name: Doc tests
+        run: cargo +1.92 test --doc --workspace
 
-  # ─── Build: MC/DC variant ───
+  # ─── Build: MC/DC variant (starts immediately, no lint gate) ───
   build-mcdc:
     name: Build (MC/DC)
     runs-on: ubuntu-latest
-    needs: [lint]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-coverage
         with:
-          toolchain: ${{ env.NIGHTLY }}
-          components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nightly: ${{ env.NIGHTLY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build workspace + tests + bins (instrumented)
         run: |
           export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
@@ -91,21 +88,16 @@ jobs:
             ~/.cargo/git
           key: mcdc-${{ hashFiles('Cargo.lock') }}
 
-  # ─── Build: Server variant ───
+  # ─── Build: Server variant (starts immediately, no lint gate) ───
   build-server:
     name: Build (Server)
     runs-on: ubuntu-latest
-    needs: [lint]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-coverage
         with:
-          toolchain: ${{ env.NIGHTLY }}
-          components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nightly: ${{ env.NIGHTLY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build server + app binary + tests (instrumented)
         run: |
           export RUSTFLAGS="${{ env.SERVER_RUSTFLAGS }}"
@@ -124,18 +116,14 @@ jobs:
   test-mcdc-unit:
     name: MC/DC Unit
     runs-on: ubuntu-latest
-    needs: [build-mcdc]
+    needs: [lint, build-mcdc]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-coverage
         with:
-          toolchain: ${{ env.NIGHTLY }}
-          components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nightly: ${{ env.NIGHTLY }}
+          install-nextest: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore build cache
         uses: actions/cache/restore@v4
         with:
@@ -177,18 +165,14 @@ jobs:
   test-mcdc-integration:
     name: MC/DC Integration
     runs-on: ubuntu-latest
-    needs: [build-mcdc]
+    needs: [lint, build-mcdc]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-coverage
         with:
-          toolchain: ${{ env.NIGHTLY }}
-          components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nightly: ${{ env.NIGHTLY }}
+          install-nextest: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore build cache
         uses: actions/cache/restore@v4
         with:
@@ -230,18 +214,14 @@ jobs:
   test-server:
     name: Server Coverage
     runs-on: ubuntu-latest
-    needs: [build-server]
+    needs: [lint, build-server]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/setup-coverage
         with:
-          toolchain: ${{ env.NIGHTLY }}
-          components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          nightly: ${{ env.NIGHTLY }}
+          install-nextest: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore build cache
         uses: actions/cache/restore@v4
         with:
@@ -265,23 +245,6 @@ jobs:
         with:
           name: server-lcov
           path: server-lcov.info
-
-  # ─── Doc Tests ───
-  doc-tests:
-    name: Doc Tests
-    runs-on: ubuntu-latest
-    needs: [lint]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.92"
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run doc tests
-        run: cargo test --doc --workspace
 
   # ─── Upload: Merge + Codecov ───
   coverage-upload:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,11 @@ jobs:
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
+          # Remove server objects before report — LLVM #119558 SIGSEGV on
+          # MC/DC data from async trait impls in grpc service files.
+          # Server coverage is handled separately in the test-server job.
+          find target -name '*reovim_server*' -delete 2>/dev/null || true
           cargo +${{ env.NIGHTLY }} llvm-cov report \
-            --workspace \
-            --exclude reovim-module-macros \
-            --exclude reovim-driver-ffi-python \
-            --exclude reovim-bench \
-            --exclude perf-report \
-            --exclude reovim-server \
             --lcov --output-path mcdc-unit.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-unit.info
@@ -207,13 +205,11 @@ jobs:
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
+          # Remove server objects before report — LLVM #119558 SIGSEGV on
+          # MC/DC data from async trait impls in grpc service files.
+          # Server coverage is handled separately in the test-server job.
+          find target -name '*reovim_server*' -delete 2>/dev/null || true
           cargo +${{ env.NIGHTLY }} llvm-cov report \
-            --workspace \
-            --exclude reovim-module-macros \
-            --exclude reovim-driver-ffi-python \
-            --exclude reovim-bench \
-            --exclude perf-report \
-            --exclude reovim-server \
             --lcov --output-path mcdc-integration.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-integration.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,10 +156,14 @@ jobs:
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
-          # Remove server objects before report — LLVM #119558 SIGSEGV on
+          # Remove objects containing server code — LLVM #119558 SIGSEGV on
           # MC/DC data from async trait impls in grpc service files.
           # Server coverage is handled separately in the test-server job.
+          # 1. reovim_server rlib/rmeta (server crate as dependency)
+          # 2. reovim binary + deps (app binary links server transitively)
           find target -name '*reovim_server*' -delete 2>/dev/null || true
+          rm -f target/debug/reovim
+          find target/debug/deps -maxdepth 1 -name 'reovim-*' -delete 2>/dev/null || true
           cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path mcdc-unit.info
       - name: Filter test code
@@ -205,10 +209,14 @@ jobs:
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
-          # Remove server objects before report — LLVM #119558 SIGSEGV on
+          # Remove objects containing server code — LLVM #119558 SIGSEGV on
           # MC/DC data from async trait impls in grpc service files.
           # Server coverage is handled separately in the test-server job.
+          # 1. reovim_server rlib/rmeta (server crate as dependency)
+          # 2. reovim binary + deps (app binary links server transitively)
           find target -name '*reovim_server*' -delete 2>/dev/null || true
+          rm -f target/debug/reovim
+          find target/debug/deps -maxdepth 1 -name 'reovim-*' -delete 2>/dev/null || true
           cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path mcdc-integration.info
       - name: Filter test code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
             --exclude perf-report \
             --exclude reovim-server
           cargo +${{ env.NIGHTLY }} llvm-cov report \
+            --workspace \
+            --exclude reovim-module-macros \
+            --exclude reovim-driver-ffi-python \
+            --exclude reovim-bench \
+            --exclude perf-report \
+            --exclude reovim-server \
             --lcov --output-path mcdc-unit.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-unit.info
@@ -202,6 +208,12 @@ jobs:
             --exclude perf-report \
             --exclude reovim-server
           cargo +${{ env.NIGHTLY }} llvm-cov report \
+            --workspace \
+            --exclude reovim-module-macros \
+            --exclude reovim-driver-ffi-python \
+            --exclude reovim-bench \
+            --exclude perf-report \
+            --exclude reovim-server \
             --lcov --output-path mcdc-integration.info
       - name: Filter test code
         run: ./scripts/lcov-filter-tests.sh mcdc-integration.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   NIGHTLY: "nightly-2026-03-01"
   MCDC_RUSTFLAGS: "--cfg coverage_nightly -Z coverage-options=condition"
   SERVER_RUSTFLAGS: "--cfg coverage_nightly"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
 jobs:
   # ─── Gate: Lint (fmt + clippy) ───
@@ -112,11 +113,15 @@ jobs:
             ~/.cargo/git
           key: server-${{ hashFiles('Cargo.lock') }}
 
-  # ─── Test: MC/DC Unit Tests ───
+  # ─── Test: MC/DC Unit Tests (sharded) ───
   test-mcdc-unit:
-    name: MC/DC Unit
+    name: MC/DC Unit (${{ matrix.partition }}/2)
     runs-on: ubuntu-latest
     needs: [lint, build-mcdc]
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-coverage
@@ -134,21 +139,25 @@ jobs:
           key: mcdc-${{ hashFiles('Cargo.lock') }}
       - name: Clean stale profraw files
         run: find target -name '*.profraw' -delete 2>/dev/null || true
-      - name: Run unit tests with coverage
+      - name: Run unit tests
         run: |
           export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
           eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           cargo +${{ env.NIGHTLY }} nextest run --lib --workspace \
+            --profile ci \
+            --partition count:${{ matrix.partition }}/2 \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
+      - name: Generate coverage report
+        run: |
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           # Remove objects containing server code — LLVM #119558 SIGSEGV on
           # MC/DC data from async trait impls in grpc service files.
           # Server coverage is handled separately in the test-server job.
-          # 1. reovim_server rlib/rmeta (server crate as dependency)
-          # 2. reovim binary + deps (app binary links server transitively)
           find target -name '*reovim_server*' -delete 2>/dev/null || true
           rm -f target/debug/reovim
           find target/debug/deps -maxdepth 1 -name 'reovim-*' -delete 2>/dev/null || true
@@ -158,7 +167,7 @@ jobs:
         run: ./scripts/lcov-filter-tests.sh mcdc-unit.info
       - uses: actions/upload-artifact@v4
         with:
-          name: mcdc-unit-lcov
+          name: mcdc-unit-lcov-${{ matrix.partition }}
           path: mcdc-unit.info
 
   # ─── Test: MC/DC Integration Tests ───
@@ -183,21 +192,24 @@ jobs:
           key: mcdc-${{ hashFiles('Cargo.lock') }}
       - name: Clean stale profraw files
         run: find target -name '*.profraw' -delete 2>/dev/null || true
-      - name: Run integration tests with coverage
+      - name: Run integration tests
         run: |
           export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
           eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           cargo +${{ env.NIGHTLY }} nextest run --test '*' --workspace \
+            --profile ci \
             --exclude reovim-module-macros \
             --exclude reovim-driver-ffi-python \
             --exclude reovim-bench \
             --exclude perf-report \
             --exclude reovim-server
+      - name: Generate coverage report
+        run: |
+          export RUSTFLAGS="${{ env.MCDC_RUSTFLAGS }}"
+          eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
           # Remove objects containing server code — LLVM #119558 SIGSEGV on
           # MC/DC data from async trait impls in grpc service files.
           # Server coverage is handled separately in the test-server job.
-          # 1. reovim_server rlib/rmeta (server crate as dependency)
-          # 2. reovim binary + deps (app binary links server transitively)
           find target -name '*reovim_server*' -delete 2>/dev/null || true
           rm -f target/debug/reovim
           find target/debug/deps -maxdepth 1 -name 'reovim-*' -delete 2>/dev/null || true
@@ -236,7 +248,7 @@ jobs:
         run: |
           export RUSTFLAGS="${{ env.SERVER_RUSTFLAGS }}"
           eval "$(cargo +${{ env.NIGHTLY }} llvm-cov show-env --sh)"
-          cargo +${{ env.NIGHTLY }} nextest run -p reovim-server
+          cargo +${{ env.NIGHTLY }} nextest run -p reovim-server --profile ci
           cargo +${{ env.NIGHTLY }} llvm-cov report \
             --lcov --output-path server-lcov.info
       - name: Filter test code
@@ -255,7 +267,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: mcdc-unit-lcov
+          name: mcdc-unit-lcov-1
+      - name: Rename shard 1
+        run: mv mcdc-unit.info mcdc-unit-1.info
+      - uses: actions/download-artifact@v4
+        with:
+          name: mcdc-unit-lcov-2
+      - name: Rename shard 2
+        run: mv mcdc-unit.info mcdc-unit-2.info
       - uses: actions/download-artifact@v4
         with:
           name: mcdc-integration-lcov
@@ -263,7 +282,7 @@ jobs:
         with:
           name: server-lcov
       - name: Merge reports
-        run: cat mcdc-unit.info mcdc-integration.info server-lcov.info > lcov.info
+        run: cat mcdc-unit-1.info mcdc-unit-2.info mcdc-integration.info server-lcov.info > lcov.info
       - name: Generate reports
         run: |
           ./scripts/coverage-report.sh lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   Extract `setup-coverage` composite action for DRY nightly+llvm-cov+protoc setup
   across 5 coverage jobs. Test jobs still require lint to pass before running.
 
+- **CI test speed optimization (#588)**: Shard MC/DC unit tests across 2 runners
+  using nextest `--partition count:N/2`, reducing critical path by ~40s. Add
+  `.config/nextest.toml` with default and CI profiles (slow-timeout, fail-fast).
+  Split monolithic test+report steps for timing visibility. Set
+  `CARGO_PROFILE_DEV_DEBUG=line-tables-only` in CI for faster builds and smaller
+  cache.
+
 - **OptionSpec ownership tracking (#571)**: Add `owner: Option<ModuleId>` field to
   `OptionSpec` with `.with_owner()` builder, mirroring the `CommandId` ownership pattern.
   `OptionRegistry` gains `unregister_by_module()` for module lifecycle cleanup and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ For old changelog, see `changelog/CHANGELOG-{version}.md`
   `arduino/setup-protoc@v3`. Merge fmt into lint job, split MSRV to non-blocking
   parallel job checking key crates only (`reovim-app`, `reovim-kernel`, `reovim-server`).
 
+- **CI pipeline parallelism (#588)**: Remove lint gate from build jobs so builds
+  start immediately in parallel with lint (~70s critical path savings). Merge
+  doc-tests into stable-checks job (shares MSRV toolchain, saves one runner).
+  Extract `setup-coverage` composite action for DRY nightly+llvm-cov+protoc setup
+  across 5 coverage jobs. Test jobs still require lint to pass before running.
+
 - **OptionSpec ownership tracking (#571)**: Add `owner: Option<ModuleId>` field to
   `OptionSpec` with `.with_owner()` builder, mirroring the `CommandId` ownership pattern.
   `OptionRegistry` gains `unregister_by_module()` for module lifecycle cleanup and


### PR DESCRIPTION
## Summary

- Root cause: `cargo llvm-cov nextest` internally passes `--target-dir target/llvm-cov-target`, while `show-env + cargo build` in the build steps uses `target/` directly. Cached artifacts at `target/` were invisible to test jobs, causing full recompilation (305 crates) despite cache hits.
- Fix: all 3 test steps now use `show-env + cargo nextest run + cargo llvm-cov report` instead of `cargo llvm-cov --no-clean nextest`, matching the build steps' target directory.

## Changes

- MC/DC Unit, MC/DC Integration, Server Coverage test steps rewritten to use `show-env` approach
- Removed `--no-clean` flag (no longer needed with consistent `show-env` environment)
- Stale caches deleted to ensure fresh cache creation

## Verification

- Locally confirmed: `show-env + cargo build` then `show-env + cargo test` produces `Fresh` (0 recompiles)
- `cargo llvm-cov test -v` confirms it passes `--target-dir target/llvm-cov-target` internally

Refs #588