### PR TITLE
Allow building on other *nix

### DIFF
--- a/server/lib/drivers/module-loader/src/discovery.rs
+++ b/server/lib/drivers/module-loader/src/discovery.rs
@@ -64,7 +64,13 @@ fn env_search_paths() -> Option<Vec<PathBuf>> {
 /// Get shared library extension for the current platform.
 #[must_use]
 pub const fn library_extension() -> &'static str {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+    ))]
     {
         "so"
     }


### PR DESCRIPTION
## Summary

Add support for other *nix platforms.

## Issue

Closes #748

## Test Plan

Test build on native x86_64 NetBSD system using Rust-1.95.0 beta7.
Passed `cargo clippy` without warnings.

## Checklist

- [x] Issue linked above
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (if applicable)
